### PR TITLE
Getting input.value for number inputs (type=number) with over 39 characters returns an empty string

### DIFF
--- a/LayoutTests/fast/forms/number/number-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/number/number-stepup-stepdown-expected.txt
@@ -1,4 +1,4 @@
-Check stepUp() and stepDown() bahevior for number type.
+Check stepUp() and stepDown() behavior for number type.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -144,12 +144,12 @@ PASS stepDown("1", "1", "0") is "0"
 PASS stepDown("0", "1", "0") is "0"
 PASS stepDown("1", "1", "0", 2) is "0"
 PASS input.value is "0"
-PASS stepDown("1", "3.40282346e+38", "", 2) is "-3.40282346e+38"
+PASS stepDown("1", "1.797693134862315e+308", "", 2) is "-1.797693134862315e+308"
 PASS stepUp("-1", "1", "0") is "0"
 PASS stepUp("0", "1", "0") is "0"
 PASS stepUp("-1", "1", "0", 2) is "0"
 PASS input.value is "0"
-PASS stepUp("1", "3.40282346e+38", "", 2) is "3.40282346e+38"
+PASS stepUp("1", "1.797693134862315e+308", "", 2) is "1.797693134862315e+308"
 
 stepDown()/stepUp() for stepMismatch values
 PASS stepUp("1", "2", "") is "3"
@@ -159,8 +159,8 @@ PASS stepDown("19", "10", "0") is "9"
 PASS stepUp("89", "10", "99") is "99"
 
 Huge value and small step
-PASS input.min = ""; stepUp("1e+38", "1", "", 999999) is "1e+38"
-PASS input.max = ""; stepDown("1e+38", "1", "", 999999) is "1e+38"
+PASS input.min = ""; stepUp("1e+308", "1", "", 999999) is "1e+308"
+PASS input.max = ""; stepDown("1e+308", "1", "", 999999) is "1e+308"
 
 Fractional numbers
 PASS input.min = ""; stepUp("0", "0.33333333333333333", "", 3) is "1"

--- a/LayoutTests/fast/forms/number/number-stepup-stepdown-from-renderer-expected.txt
+++ b/LayoutTests/fast/forms/number/number-stepup-stepdown-from-renderer-expected.txt
@@ -141,11 +141,11 @@ Overflow/underflow
 PASS stepDown("1", "1", "0") is "0"
 PASS stepDown("0", "1", "0") is "0"
 PASS stepDown("1", "1", "0", 2) is "0"
-PASS stepDown("1", "3.40282346e+38", "", 2) is "-3.40282346e+38"
+PASS stepDown("1", "1.797693134862315e+308", "", 2) is "-1.797693134862315e+308"
 PASS stepUp("-1", "1", "0") is "0"
 PASS stepUp("0", "1", "0") is "0"
 PASS stepUp("-1", "1", "0", 2) is "0"
-PASS stepUp("1", "3.40282346e+38", "", 2) is "3.40282346e+38"
+PASS stepUp("1", "1.797693134862315e+308", "", 2) is "1.797693134862315e+308"
 
 stepDown()/stepUp() for stepMismatch values
 PASS stepUp("1", "2", "") is "2"
@@ -158,8 +158,8 @@ PASS stepDown("7", "300", "") is "0"
 PASS stepDown("-7", "300", "") is "-300"
 
 Huge value and small step
-PASS input.min = ""; stepUp("1e+38", "1", "", 999) is "1e+38"
-PASS input.max = ""; stepDown("1e+38", "1", "", 999) is "1e+38"
+PASS input.min = ""; stepUp("1e+308", "1", "", 999) is "1e+308"
+PASS input.max = ""; stepDown("1e+308", "1", "", 999) is "1e+308"
 
 Fractional numbers
 PASS input.min = ""; stepUp("0", "0.33333333333333333", "", 3) is "1"

--- a/LayoutTests/fast/forms/number/number-stepup-stepdown-from-renderer.html
+++ b/LayoutTests/fast/forms/number/number-stepup-stepdown-from-renderer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -269,11 +269,11 @@ debug('Overflow/underflow');
 shouldBe('stepDown("1", "1", "0")', '"0"');
 shouldBe('stepDown("0", "1", "0")', '"0"');
 shouldBe('stepDown("1", "1", "0", 2)', '"0"');
-shouldBe('stepDown("1", "3.40282346e+38", "", 2)', '"-3.40282346e+38"');
+shouldBe('stepDown("1", "1.797693134862315e+308", "", 2)', '"-1.797693134862315e+308"');
 shouldBe('stepUp("-1", "1", "0")', '"0"');
 shouldBe('stepUp("0", "1", "0")', '"0"');
 shouldBe('stepUp("-1", "1", "0", 2)', '"0"');
-shouldBe('stepUp("1", "3.40282346e+38", "", 2)', '"3.40282346e+38"');
+shouldBe('stepUp("1", "1.797693134862315e+308", "", 2)', '"1.797693134862315e+308"');
 
 debug('');
 debug('stepDown()/stepUp() for stepMismatch values');
@@ -288,8 +288,8 @@ shouldBe('stepDown("-7", "300", "")', '"-300"');
 
 debug('');
 debug('Huge value and small step');
-shouldBe('input.min = ""; stepUp("1e+38", "1", "", 999)', '"1e+38"');
-shouldBe('input.max = ""; stepDown("1e+38", "1", "", 999)', '"1e+38"');
+shouldBe('input.min = ""; stepUp("1e+308", "1", "", 999)', '"1e+308"');
+shouldBe('input.max = ""; stepDown("1e+308", "1", "", 999)', '"1e+308"');
 
 debug('');
 debug('Fractional numbers');
@@ -324,6 +324,5 @@ shouldBe('stepDownExplicitBounds(-100, null, 3, 3)', '"2"');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/number/number-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/number/number-stepup-stepdown.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
-description('Check stepUp() and stepDown() bahevior for number type.');
+description('Check stepUp() and stepDown() behavior for number type.');
 
 var input = document.createElement('input');
 
@@ -223,12 +223,12 @@ shouldBe('stepDown("1", "1", "0")', '"0"');
 shouldBe('stepDown("0", "1", "0")', '"0"');
 shouldBe('stepDown("1", "1", "0", 2)', '"0"');
 shouldBe('input.value', '"0"');
-shouldBe('stepDown("1", "3.40282346e+38", "", 2)', '"-3.40282346e+38"'); 
+shouldBeEqualToString('stepDown("1", "1.797693134862315e+308", "", 2)', '-1.797693134862315e+308');
 shouldBe('stepUp("-1", "1", "0")', '"0"');
 shouldBe('stepUp("0", "1", "0")', '"0"');
 shouldBe('stepUp("-1", "1", "0", 2)', '"0"');
 shouldBe('input.value', '"0"');
-shouldBe('stepUp("1", "3.40282346e+38", "", 2)', '"3.40282346e+38"');
+shouldBeEqualToString('stepUp("1", "1.797693134862315e+308", "", 2)', '1.797693134862315e+308');
 
 debug('');
 debug('stepDown()/stepUp() for stepMismatch values');
@@ -240,8 +240,8 @@ shouldBe('stepUp("89", "10", "99")', '"99"');
 
 debug('');
 debug('Huge value and small step');
-shouldBe('input.min = ""; stepUp("1e+38", "1", "", 999999)', '"1e+38"');
-shouldBe('input.max = ""; stepDown("1e+38", "1", "", 999999)', '"1e+38"');
+shouldBe('input.min = ""; stepUp("1e+308", "1", "", 999999)', '"1e+308"');
+shouldBe('input.max = ""; stepDown("1e+308", "1", "", 999999)', '"1e+308"');
 
 debug('');
 debug('Fractional numbers');
@@ -262,6 +262,5 @@ shouldBe('stepUpExplicitBounds("4", "9", "0.005", "5.005", 12)', '"5.065"');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/number/number-valueasnumber-expected.txt
+++ b/LayoutTests/fast/forms/number/number-valueasnumber-expected.txt
@@ -13,7 +13,7 @@ PASS valueAsNumberFor("-1.2") is -1.2
 PASS valueAsNumberFor("1.2E10") is 1.2E10
 PASS valueAsNumberFor("1.2E-10") is 1.2E-10
 PASS valueAsNumberFor("1.2E+10") is 1.2E10
-PASS valueAsNumberFor("123456789012345678901234567890123456789") is 1.2345678901234568E+38
+PASS valueAsNumberFor("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789") is 1.2345678901234568E+308
 PASS valueAsNumberFor("0.12345678901234567890123456789012345678901234567890") is 0.123456789012345678
 valueAsNumber for invalid string values:
 PASS isNaN(valueAsNumberFor("")) is true
@@ -40,11 +40,11 @@ PASS setValueAsNumberAndGetValue(-0) is "0"
 PASS setValueAsNumberAndGetValue(-1.2) is "-1.2"
 PASS setValueAsNumberAndGetValue(1.2e10) is "12000000000"
 PASS setValueAsNumberAndGetValue(1.2e-10) is "1.2e-10"
-PASS setValueAsNumberAndGetValue(1.2345678901234567e+38) is "1.2345678901234567e+38"
-PASS setValueAsNumberAndGetValue("-3.40282346e+38") is "-3.40282346e+38"
-PASS setValueAsNumberAndGetValue("-3.40282348e+38") threw exception InvalidStateError: The object is in an invalid state..
-PASS setValueAsNumberAndGetValue("3.40282346e+38") is "3.40282346e+38"
-PASS setValueAsNumberAndGetValue("3.40282348e+38") threw exception InvalidStateError: The object is in an invalid state..
+PASS setValueAsNumberAndGetValue(1.2345678901234567e+308) is "1.2345678901234567e+308"
+PASS setValueAsNumberAndGetValue("-1.797693134862315e+308") is "-1.797693134862315e+308"
+PASS setValueAsNumberAndGetValue("-1.797693134862316e+308") threw exception NotSupportedError: The operation is not supported..
+PASS setValueAsNumberAndGetValue("1.797693134862315e+308") is "1.797693134862315e+308"
+PASS setValueAsNumberAndGetValue("1.797693134862316e+308") threw exception NotSupportedError: The operation is not supported..
 Tests to set invalid values to valueAsNumber:
 PASS setValueAsNumberAndGetValue(null) is "0"
 PASS setValueAsNumberAndGetValue("foo") threw exception NotSupportedError: The operation is not supported..

--- a/LayoutTests/fast/forms/number/number-valueasnumber.html
+++ b/LayoutTests/fast/forms/number/number-valueasnumber.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -30,7 +30,7 @@ shouldBe('valueAsNumberFor("-1.2")', '-1.2');
 shouldBe('valueAsNumberFor("1.2E10")', '1.2E10');
 shouldBe('valueAsNumberFor("1.2E-10")', '1.2E-10');
 shouldBe('valueAsNumberFor("1.2E+10")', '1.2E10');
-shouldBe('valueAsNumberFor("123456789012345678901234567890123456789")', '1.2345678901234568E+38');
+shouldBe('valueAsNumberFor("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789")', '1.2345678901234568E+308');
 shouldBe('valueAsNumberFor("0.12345678901234567890123456789012345678901234567890")', '0.123456789012345678');
 
 debug('valueAsNumber for invalid string values:');
@@ -53,28 +53,27 @@ debug('Too huge exponent to support');
 shouldBeTrue('isNaN(valueAsNumberFor("1.2E65535"))');
 
 debug('Tests for the valueAsNumber setter:');
-shouldBe('setValueAsNumberAndGetValue(0)', '"0"');
-shouldBe('setValueAsNumberAndGetValue(10)', '"10"');
-shouldBe('setValueAsNumberAndGetValue(01)', '"1"');
-shouldBe('setValueAsNumberAndGetValue(-0)', '"0"');
-shouldBe('setValueAsNumberAndGetValue(-1.2)', '"-1.2"');
-shouldBe('setValueAsNumberAndGetValue(1.2e10)', '"12000000000"');
-shouldBe('setValueAsNumberAndGetValue(1.2e-10)', '"1.2e-10"');
-shouldBe('setValueAsNumberAndGetValue(1.2345678901234567e+38)', '"1.2345678901234567e+38"');
-shouldBe('setValueAsNumberAndGetValue("-3.40282346e+38")', '"-3.40282346e+38"');
-shouldThrowErrorName('setValueAsNumberAndGetValue("-3.40282348e+38")', 'InvalidStateError');
-shouldBe('setValueAsNumberAndGetValue("3.40282346e+38")', '"3.40282346e+38"');
-shouldThrowErrorName('setValueAsNumberAndGetValue("3.40282348e+38")', 'InvalidStateError');
+shouldBeEqualToString('setValueAsNumberAndGetValue(0)', '0');
+shouldBeEqualToString('setValueAsNumberAndGetValue(10)', '10');
+shouldBeEqualToString('setValueAsNumberAndGetValue(01)', '1');
+shouldBeEqualToString('setValueAsNumberAndGetValue(-0)', '0');
+shouldBeEqualToString('setValueAsNumberAndGetValue(-1.2)', '-1.2');
+shouldBeEqualToString('setValueAsNumberAndGetValue(1.2e10)', '12000000000');
+shouldBeEqualToString('setValueAsNumberAndGetValue(1.2e-10)', '1.2e-10');
+shouldBeEqualToString('setValueAsNumberAndGetValue(1.2345678901234567e+308)', '1.2345678901234567e+308');
+shouldBeEqualToString('setValueAsNumberAndGetValue("-1.797693134862315e+308")', '-1.797693134862315e+308');
+shouldThrowErrorName('setValueAsNumberAndGetValue("-1.797693134862316e+308")', "NotSupportedError");
+shouldBe('setValueAsNumberAndGetValue("1.797693134862315e+308")', '"1.797693134862315e+308"');
+shouldThrowErrorName('setValueAsNumberAndGetValue("1.797693134862316e+308")', "NotSupportedError");
 
 debug('Tests to set invalid values to valueAsNumber:');
-shouldBe('setValueAsNumberAndGetValue(null)', '"0"');
-shouldThrowErrorName('setValueAsNumberAndGetValue("foo")', 'NotSupportedError');
-shouldThrowErrorName('setValueAsNumberAndGetValue(NaN)', 'NotSupportedError');
-shouldThrowErrorName('setValueAsNumberAndGetValue(Number.NaN)', 'NotSupportedError');
-shouldThrowErrorName('setValueAsNumberAndGetValue(Infinity)', 'NotSupportedError');
-shouldThrowErrorName('setValueAsNumberAndGetValue(Number.POSITIVE_INFINITY)', 'NotSupportedError');
-shouldThrowErrorName('setValueAsNumberAndGetValue(Number.NEGATIVE_INFINITY)', 'NotSupportedError');
+shouldBeEqualToString('setValueAsNumberAndGetValue(null)', '0');
+shouldThrowErrorName('setValueAsNumberAndGetValue("foo")', "NotSupportedError");
+shouldThrowErrorName('setValueAsNumberAndGetValue(NaN)', "NotSupportedError");
+shouldThrowErrorName('setValueAsNumberAndGetValue(Number.NaN)', "NotSupportedError");
+shouldThrowErrorName('setValueAsNumberAndGetValue(Infinity)', "NotSupportedError");
+shouldThrowErrorName('setValueAsNumberAndGetValue(Number.POSITIVE_INFINITY)', "NotSupportedError");
+shouldThrowErrorName('setValueAsNumberAndGetValue(Number.NEGATIVE_INFINITY)', "NotSupportedError");
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2014 Google Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -110,10 +110,6 @@ double NumberInputType::valueAsDouble() const
 
 ExceptionOr<void> NumberInputType::setValueAsDouble(double newValue, TextFieldEventBehavior eventBehavior) const
 {
-    // FIXME: We should use numeric_limits<double>::max for number input type.
-    const double floatMax = std::numeric_limits<float>::max();
-    if (newValue < -floatMax || newValue > floatMax)
-        return Exception { InvalidStateError };
     ASSERT(element());
     element()->setValue(serializeForNumberType(newValue), eventBehavior);
     return { };
@@ -121,10 +117,6 @@ ExceptionOr<void> NumberInputType::setValueAsDouble(double newValue, TextFieldEv
 
 ExceptionOr<void> NumberInputType::setValueAsDecimal(const Decimal& newValue, TextFieldEventBehavior eventBehavior) const
 {
-    // FIXME: We should use numeric_limits<double>::max for number input type.
-    const Decimal floatMax = Decimal::fromDouble(std::numeric_limits<float>::max());
-    if (newValue < -floatMax || newValue > floatMax)
-        return Exception { InvalidStateError };
     ASSERT(element());
     element()->setValue(serializeForNumberType(newValue), eventBehavior);
     return { };
@@ -151,8 +143,7 @@ StepRange NumberInputType::createStepRange(AnyStepHandling anyStepHandling) cons
     if (stepBase.isNaN())
         stepBase = parseToDecimalForNumberType(element()->attributeWithoutSynchronization(valueAttr), numberDefaultStepBase);
 
-    // FIXME: We should use numeric_limits<double>::max for number input type.
-    const Decimal floatMax = Decimal::fromDouble(std::numeric_limits<float>::max());
+    const Decimal doubleMax = Decimal::fromDouble(std::numeric_limits<double>::max());
     const Element& element = *this->element();
 
     RangeLimitations rangeLimitations = RangeLimitations::Invalid;
@@ -165,8 +156,8 @@ StepRange NumberInputType::createStepRange(AnyStepHandling anyStepHandling) cons
         }
         return defaultValue;
     };
-    Decimal minimum = extractBound(minAttr, -floatMax);
-    Decimal maximum = extractBound(maxAttr, floatMax);
+    Decimal minimum = extractBound(minAttr, -doubleMax);
+    Decimal maximum = extractBound(maxAttr, doubleMax);
 
     const Decimal step = StepRange::parseStep(anyStepHandling, stepDescription, element.attributeWithoutSynchronization(stepAttr));
     return StepRange(stepBase, rangeLimitations, minimum, maximum, step, stepDescription);

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2010-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,7 +99,7 @@ String serializeForNumberType(double number)
 
 Decimal parseToDecimalForNumberType(StringView string, const Decimal& fallbackValue)
 {
-    // See HTML5 2.5.4.3 `Real numbers.' and parseToDoubleForNumberType
+    // https://html.spec.whatwg.org/#floating-point-numbers and parseToDoubleForNumberType
     if (string.isEmpty())
         return fallbackValue;
 
@@ -111,11 +112,9 @@ Decimal parseToDecimalForNumberType(StringView string, const Decimal& fallbackVa
     if (!value.isFinite())
         return fallbackValue;
 
-    // Numbers are considered finite IEEE 754 single-precision floating point values.
-    // See HTML5 2.5.4.3 `Real numbers.'
-    // FIXME: We should use numeric_limits<double>::max for number input type.
-    const Decimal floatMax = Decimal::fromDouble(std::numeric_limits<float>::max());
-    if (value < -floatMax || value > floatMax)
+    // Numbers are considered finite IEEE 754 Double-precision floating point values.
+    const Decimal doubleMax = Decimal::fromDouble(std::numeric_limits<double>::max());
+    if (value < -doubleMax || value > doubleMax)
         return fallbackValue;
 
     // We return +0 for -0 case.
@@ -129,7 +128,7 @@ Decimal parseToDecimalForNumberType(StringView string)
 
 double parseToDoubleForNumberType(StringView string, double fallbackValue)
 {
-    // See HTML5 2.5.4.3 `Real numbers.'
+    // https://html.spec.whatwg.org/#floating-point-numbers
     if (string.isEmpty())
         return fallbackValue;
 
@@ -156,10 +155,8 @@ double parseToDoubleForNumberType(StringView string, double fallbackValue)
     if (!std::isfinite(value))
         return fallbackValue;
 
-    // Numbers are considered finite IEEE 754 single-precision floating point values.
-    // See HTML5 2.5.4.3 `Real numbers.'
-    if (-std::numeric_limits<float>::max() > value || value > std::numeric_limits<float>::max())
-        return fallbackValue;
+    // Numbers are considered finite IEEE 754 Double-precision floating point values.
+    ASSERT(-std::numeric_limits<double>::max() <= value || value < std::numeric_limits<double>::max());
 
     // The following expression converts -0 to +0.
     return value ? value : 0;


### PR DESCRIPTION
#### 134163e4e3101c02038c4447672158e4a2fac445
<pre>
Getting input.value for number inputs (type=number) with over 39 characters returns an empty string

Getting input.value for number inputs (type=number) with over 39 characters returns an empty string
<a href="https://bugs.webkit.org/show_bug.cgi?id=249783">https://bugs.webkit.org/show_bug.cgi?id=249783</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Blink / Chromium, Firefox / Gecko and Web-Specification.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=168513

Number input type maximum value increased from float to double.
Float allowed only max value of 3.402823466e38, it has now been
increased to 1.7976931348623158e+308, by using double.

InvalidStateError exception is removed from
NumberInputType::setValueAsDouble and
NumberInputType::setValueAsDecimal, as HTMLInputType::setValueAsNumber checks if value is infinite.

HTMLParserIdioms has also been updated as the functions are
triggered in NumberInputType functions and has check for max
values, thus updated.

* Source/WebCore/html/NumberInputType.cpp:
(NumberInputType::valueAsDouble):
- Updated Comment and also removed FIXME
(NumberInputType::valueAsDecimal):
- Updated Comment and also removed FIXME
(NumberInputType::createStepRange):
(1) Remove &quot;FIXME&quot;
(2) Use &quot;doubleMax&quot; instead of &quot;floatMax&quot;
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(parseToDecimalForNumberType):
(1) Updated Comment and also removed FIXME
(2) Use &quot;doubleMax&quot; instead of &quot;floatMax&quot;
(3) Update condition to ASSERT
* LayoutTests/fast/forms/number/number-valueasnumber.html: Updated
* LayoutTests/fast/forms/number/number-valueasnumber-expected.txt: Ditto
* LayoutTests/fast/forms/number/number-stepup-stepdown.html: Updated
* LayoutTests/fast/forms/number/number-stepup-stepdown-expected.txt: Ditto
* LayoutTests/fast/forms/number/number-stepup-stepdown-from-renderer.html: Updated
* LayoutTests/fast/forms/number/number-stepup-stepdown-from-renderer-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/258614@main">https://commits.webkit.org/258614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b93dcc4ea42526813d8ab9668d9f35ff2e5839a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111683 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171879 "Build was cancelled. Recent messages:Pull request contains relevant changes; Deleted stale build files; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2437 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109411 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37297 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24333 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2196 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5921 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6907 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->