### PR TITLE
[JSC] Enable Wasm SIMD x64 tests

### DIFF
--- a/JSTests/wasm/stress/simd-kitchen-sink.js
+++ b/JSTests/wasm/stress/simd-kitchen-sink.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/v8/exceptions-simd.js
+++ b/JSTests/wasm/v8/exceptions-simd.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-10309.js
+++ b/JSTests/wasm/v8/regress/regress-10309.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1054466.js
+++ b/JSTests/wasm/v8/regress/regress-1054466.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1065599.js
+++ b/JSTests/wasm/v8/regress/regress-1065599.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1070078.js
+++ b/JSTests/wasm/v8/regress/regress-1070078.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1081030.js
+++ b/JSTests/wasm/v8/regress/regress-1081030.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-10831.js
+++ b/JSTests/wasm/v8/regress/regress-10831.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1111522.js
+++ b/JSTests/wasm/v8/regress/regress-1111522.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1112124.js
+++ b/JSTests/wasm/v8/regress/regress-1112124.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1116019.js
+++ b/JSTests/wasm/v8/regress/regress-1116019.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1124885.js
+++ b/JSTests/wasm/v8/regress/regress-1124885.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1132461.js
+++ b/JSTests/wasm/v8/regress/regress-1132461.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1161555.js
+++ b/JSTests/wasm/v8/regress/regress-1161555.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1161654.js
+++ b/JSTests/wasm/v8/regress/regress-1161654.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1161954.js
+++ b/JSTests/wasm/v8/regress/regress-1161954.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1165966.js
+++ b/JSTests/wasm/v8/regress/regress-1165966.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1179182.js
+++ b/JSTests/wasm/v8/regress/regress-1179182.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1187831.js
+++ b/JSTests/wasm/v8/regress/regress-1187831.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1188975.js
+++ b/JSTests/wasm/v8/regress/regress-1188975.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 //@ requireOptions("--useWebAssemblySIMD=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1199662.js
+++ b/JSTests/wasm/v8/regress/regress-1199662.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1231950.js
+++ b/JSTests/wasm/v8/regress/regress-1231950.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1242300.js
+++ b/JSTests/wasm/v8/regress/regress-1242300.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1242689.js
+++ b/JSTests/wasm/v8/regress/regress-1242689.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1264462.js
+++ b/JSTests/wasm/v8/regress/regress-1264462.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1271244.js
+++ b/JSTests/wasm/v8/regress/regress-1271244.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1271456.js
+++ b/JSTests/wasm/v8/regress/regress-1271456.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1271538.js
+++ b/JSTests/wasm/v8/regress/regress-1271538.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1282224.js
+++ b/JSTests/wasm/v8/regress/regress-1282224.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1283042.js
+++ b/JSTests/wasm/v8/regress/regress-1283042.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1283395.js
+++ b/JSTests/wasm/v8/regress/regress-1283395.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1284980.js
+++ b/JSTests/wasm/v8/regress/regress-1284980.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1286253.js
+++ b/JSTests/wasm/v8/regress/regress-1286253.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1289678.js
+++ b/JSTests/wasm/v8/regress/regress-1289678.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1290079.js
+++ b/JSTests/wasm/v8/regress/regress-1290079.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-9447.js
+++ b/JSTests/wasm/v8/regress/regress-9447.js
@@ -1,5 +1,5 @@
-//@ skip if $architecture != "arm64"
 //@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-crbug-1338980.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1338980.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-crbug-1355070.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1355070.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-crbug-1356718.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1356718.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64"
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
#### 582891096f66bea0e74ed670b0d4c1d8f3295798
<pre>
[JSC] Enable Wasm SIMD x64 tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249836">https://bugs.webkit.org/show_bug.cgi?id=249836</a>
rdar://103663385

Reviewed by Justin Michaud and Mark Lam.

* JSTests/wasm/stress/simd-kitchen-sink.js:
* JSTests/wasm/v8/exceptions-simd.js:
* JSTests/wasm/v8/regress/regress-10309.js:
* JSTests/wasm/v8/regress/regress-1054466.js:
* JSTests/wasm/v8/regress/regress-1065599.js:
* JSTests/wasm/v8/regress/regress-1070078.js:
* JSTests/wasm/v8/regress/regress-1081030.js:
* JSTests/wasm/v8/regress/regress-10831.js:
* JSTests/wasm/v8/regress/regress-1111522.js:
* JSTests/wasm/v8/regress/regress-1112124.js:
* JSTests/wasm/v8/regress/regress-1116019.js:
* JSTests/wasm/v8/regress/regress-1124885.js:
* JSTests/wasm/v8/regress/regress-1132461.js:
* JSTests/wasm/v8/regress/regress-1161555.js:
* JSTests/wasm/v8/regress/regress-1161654.js:
* JSTests/wasm/v8/regress/regress-1161954.js:
* JSTests/wasm/v8/regress/regress-1165966.js:
* JSTests/wasm/v8/regress/regress-1179182.js:
* JSTests/wasm/v8/regress/regress-1187831.js:
* JSTests/wasm/v8/regress/regress-1188975.js:
* JSTests/wasm/v8/regress/regress-1199662.js:
* JSTests/wasm/v8/regress/regress-1231950.js:
* JSTests/wasm/v8/regress/regress-1242300.js:
* JSTests/wasm/v8/regress/regress-1242689.js:
* JSTests/wasm/v8/regress/regress-1264462.js:
* JSTests/wasm/v8/regress/regress-1271244.js:
* JSTests/wasm/v8/regress/regress-1271456.js:
* JSTests/wasm/v8/regress/regress-1271538.js:
* JSTests/wasm/v8/regress/regress-1282224.js:
* JSTests/wasm/v8/regress/regress-1283042.js:
* JSTests/wasm/v8/regress/regress-1283395.js:
* JSTests/wasm/v8/regress/regress-1284980.js:
* JSTests/wasm/v8/regress/regress-1286253.js:
* JSTests/wasm/v8/regress/regress-1289678.js:
* JSTests/wasm/v8/regress/regress-1290079.js:
* JSTests/wasm/v8/regress/regress-9447.js:
* JSTests/wasm/v8/regress/regress-crbug-1338980.js:
* JSTests/wasm/v8/regress/regress-crbug-1355070.js:
* JSTests/wasm/v8/regress/regress-crbug-1356718.js:

Canonical link: <a href="https://commits.webkit.org/258303@main">https://commits.webkit.org/258303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eba1442981f9ba6dc57b78e8afa019a05e8c3238

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110727 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1468 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93844 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108544 "Hash eba14429 for PR 8041 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35322 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90695 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78322 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91882 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24958 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88028 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1803 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1379 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29320 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44447 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90930 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6040 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20312 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3006 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->