### PR TITLE
[WebGPU] WGPUBindGroupEntry::offset is not used while creating the bind group

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -45,9 +45,9 @@ public:
     {
         return adoptRef(*new BindGroupLayout(vertexArgumentEncoder, fragmentArgumentEncoder, computeArgumentEncoder, device));
     }
-    static Ref<BindGroupLayout> create(id<MTLBuffer> vertexArgumentBuffer, id<MTLBuffer> fragmentArgumentBuffer, id<MTLBuffer> computeArgumentBuffer, HashMap<uint32_t, uint32_t>&& stageMapTable, Device& device)
+    static Ref<BindGroupLayout> create(HashMap<uint32_t, uint32_t>&& stageMapTable, Device& device)
     {
-        return adoptRef(*new BindGroupLayout(vertexArgumentBuffer, fragmentArgumentBuffer, computeArgumentBuffer, WTFMove(stageMapTable), device));
+        return adoptRef(*new BindGroupLayout(WTFMove(stageMapTable), device));
     }
     static Ref<BindGroupLayout> createInvalid(Device& device)
     {
@@ -58,7 +58,7 @@ public:
 
     void setLabel(String&&);
 
-    bool isValid() const { return m_vertexArgumentEncoder || m_fragmentArgumentEncoder || m_computeArgumentEncoder; }
+    bool isValid() const { return m_shaderStageForBinding.size() || m_vertexArgumentEncoder || m_fragmentArgumentEncoder || m_computeArgumentEncoder; }
 
     NSUInteger encodedLength() const;
 
@@ -66,33 +66,18 @@ public:
     id<MTLArgumentEncoder> fragmentArgumentEncoder() const { return m_fragmentArgumentEncoder; }
     id<MTLArgumentEncoder> computeArgumentEncoder() const { return m_computeArgumentEncoder; }
 
-    id<MTLBuffer> vertexArgumentBuffer() const { return m_vertexArgumentBuffer; }
-    id<MTLBuffer> fragmentArgumentBuffer() const { return m_fragmentArgumentBuffer; }
-    id<MTLBuffer> computeArgumentBuffer() const { return m_computeArgumentBuffer; }
-
     Device& device() const { return m_device; }
 
-    uint32_t stageForBinding(uint32_t binding) const;
+    uint32_t stagesForBinding(uint32_t binding) const;
 
 private:
     BindGroupLayout(id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Device&);
-    BindGroupLayout(id<MTLBuffer> vertexArgumentBuffer, id<MTLBuffer> fragmentArgumentBuffer, id<MTLBuffer> computeArgumentBuffer, HashMap<uint32_t, uint32_t>&&, Device&);
+    BindGroupLayout(HashMap<uint32_t, uint32_t>&&, Device&);
     BindGroupLayout(Device&);
 
-    union {
-        const id<MTLArgumentEncoder> m_vertexArgumentEncoder { nil };
-        const id<MTLBuffer> m_vertexArgumentBuffer;
-    };
-
-    union {
-        const id<MTLArgumentEncoder> m_fragmentArgumentEncoder { nil };
-        const id<MTLBuffer> m_fragmentArgumentBuffer;
-    };
-
-    union {
-        const id<MTLArgumentEncoder> m_computeArgumentEncoder { nil };
-        const id<MTLBuffer> m_computeArgumentBuffer;
-    };
+    const id<MTLArgumentEncoder> m_vertexArgumentEncoder { nil };
+    const id<MTLArgumentEncoder> m_fragmentArgumentEncoder { nil };
+    const id<MTLArgumentEncoder> m_computeArgumentEncoder { nil };
 
     const Ref<Device> m_device;
     const HashMap<uint32_t, uint32_t> m_shaderStageForBinding;

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -124,31 +124,15 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
     if ([m_device argumentBuffersSupport] != MTLArgumentBuffersTier1) {
         HashMap<uint32_t, uint32_t> shaderStageForBinding;
 
-        NSUInteger vertexArgumentSize = 0;
-        NSUInteger fragmentArgumentSize = 0;
-        NSUInteger computeArgumentSize = 0;
-        constexpr auto uniformBufferElementSize = sizeof(float*);
         for (uint32_t i = 0; i < descriptor.entryCount; ++i) {
             const WGPUBindGroupLayoutEntry& entry = descriptor.entries[i];
             if (entry.nextInChain)
                 return BindGroupLayout::createInvalid(*this);
 
-            vertexArgumentSize += (entry.visibility & WGPUShaderStage_Vertex) ? uniformBufferElementSize : 0;
-            fragmentArgumentSize += (entry.visibility & WGPUShaderStage_Fragment) ? uniformBufferElementSize : 0;
-            computeArgumentSize += (entry.visibility & WGPUShaderStage_Compute) ? uniformBufferElementSize : 0;
             shaderStageForBinding.add(entry.binding + 1, entry.visibility);
         }
 
-        id<MTLBuffer> vertexArgumentBuffer = vertexArgumentSize ? safeCreateBuffer(vertexArgumentSize, MTLStorageModeShared) : nil;
-        id<MTLBuffer> fragmentArgumentBuffer = fragmentArgumentSize ? safeCreateBuffer(fragmentArgumentSize, MTLStorageModeShared) : nil;
-        id<MTLBuffer> computeArgumentBuffer = computeArgumentSize ? safeCreateBuffer(computeArgumentSize, MTLStorageModeShared) : nil;
-
-        auto label = fromAPI(descriptor.label);
-        vertexArgumentBuffer.label = label;
-        fragmentArgumentBuffer.label = label;
-        computeArgumentBuffer.label = label;
-
-        return BindGroupLayout::create(vertexArgumentBuffer, fragmentArgumentBuffer, computeArgumentBuffer, WTFMove(shaderStageForBinding), *this);
+        return BindGroupLayout::create(WTFMove(shaderStageForBinding), *this);
     }
 #endif // HAVE(TIER2_ARGUMENT_BUFFERS)
 
@@ -256,11 +240,8 @@ BindGroupLayout::BindGroupLayout(id<MTLArgumentEncoder> vertexArgumentEncoder, i
 {
 }
 
-BindGroupLayout::BindGroupLayout(id<MTLBuffer> vertexArgumentBuffer, id<MTLBuffer> fragmentArgumentBuffer, id<MTLBuffer> computeArgumentBuffer, HashMap<uint32_t, uint32_t>&& shaderStageForBinding, Device& device)
-    : m_vertexArgumentBuffer(vertexArgumentBuffer)
-    , m_fragmentArgumentBuffer(fragmentArgumentBuffer)
-    , m_computeArgumentBuffer(computeArgumentBuffer)
-    , m_device(device)
+BindGroupLayout::BindGroupLayout(HashMap<uint32_t, uint32_t>&& shaderStageForBinding, Device& device)
+    : m_device(device)
     , m_shaderStageForBinding(WTFMove(shaderStageForBinding))
 {
 }
@@ -270,9 +251,7 @@ BindGroupLayout::BindGroupLayout(Device& device)
 {
 }
 
-BindGroupLayout::~BindGroupLayout()
-{
-}
+BindGroupLayout::~BindGroupLayout() = default;
 
 void BindGroupLayout::setLabel(String&& label)
 {
@@ -290,7 +269,7 @@ NSUInteger BindGroupLayout::encodedLength() const
     return result;
 }
 
-uint32_t BindGroupLayout::stageForBinding(uint32_t binding) const
+uint32_t BindGroupLayout::stagesForBinding(uint32_t binding) const
 {
     ASSERT(m_shaderStageForBinding.contains(binding + 1));
     return m_shaderStageForBinding.find(binding + 1)->value;

--- a/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
@@ -1,0 +1,271 @@
+async function helloCube() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 8 * 4;
+    const vertexDataSize = vertexStride * 36;
+    
+    /* GPUBufferDescriptor */
+    const vertexDataBufferDescriptor = {
+        size: vertexDataSize,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
+    };
+
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    const vertexWriteArray = new Float32Array(vertexBuffer.getMappedRange());
+    vertexWriteArray.set([
+        // float4 position, float4 color
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,
+
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+    ]);
+    vertexBuffer.unmap();
+    
+    const uniformBufferSize = 16 + 256;
+    const uniformBuffer = device.createBuffer({
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    /*** Shader Setup ***/
+    
+    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {}}] });
+    const uniformBindGroup1 = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 0
+            },
+          },
+        ],
+      });
+    const uniformBindGroup2 = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 256
+            },
+          },
+        ],
+      });
+
+    const pipelineLayoutDesc = { bindGroupLayouts: [uniformBindGroupLayout] };
+    const layout = device.createPipelineLayout(pipelineLayoutDesc);
+/*
+    FIXME: Use WGSL once compiler is brought up
+    const wgslSource = `
+                     @vertex fn main(@builtin(vertex_index) VertexIndex: u32) -> @builtin(position) vec4<f32>
+                     {
+                         var pos = array<vec2<f32>, 3>(
+                             vec2<f32>( 0.0,  0.5),
+                             vec2<f32>(-0.5, -0.5),
+                             vec2<f32>( 0.5, -0.5)
+                         );
+                         return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                     }
+
+                     @fragment fn main() -> @location(0) vec4<f32>
+                     {
+                         return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+                     }
+    `;
+ */
+    const wgslSource = `
+                #include <metal_stdlib>
+                using namespace metal;
+                struct Vertex {
+                   float4 position [[position]];
+                   float4 color;
+                };
+    
+                struct VertexShaderArguments {
+                    device float *time [[id(0)]];
+                };
+    
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                {
+                    Vertex vout;
+                    float alpha = values.time[0];
+                    float beta = values.time[1];
+                    float gamma = values.time[2];
+                    float offset = values.time[3];
+                    float cA = cos(alpha);
+                    float sA = sin(alpha);
+                    float cB = cos(beta);
+                    float sB = sin(beta);
+                    float cG = cos(gamma);
+                    float sG = sin(gamma);
+    
+                    float4x4 m = float4x4(cA * cB,  sA * cB,   -sB, 0,
+                                          cA*sB*sG - sA*cG,  sA*sB*sG + cA*cG,   cB * sG, 0,
+                                             cA*sB*cG + sA*sG, sA*sB*cG - cA*sG, cB * cG, 0,
+                                              0,     0,     0, 1);
+                    vout.position = vertices[VertexIndex].position * m;
+                    vout.position.xy += float2(offset, offset);
+                    vout.position.z = (vout.position.z + 0.5) * 0.5;
+                    vout.color = vertices[VertexIndex].color;
+                    return vout;
+                }
+
+                fragment float4 fsmain(Vertex in [[stage_in]])
+                {
+                    return in.color;
+                }
+    `;
+
+    const shaderModule = device.createShaderModule({ code: wgslSource, isWHLSL: false, hints: [ {layout: layout }, ] });
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+    
+    /* GPURenderPipelineDescriptor */
+
+    const renderPipelineDescriptor = {
+        layout: layout,
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: {
+            topology: "triangle-list",
+            cullMode: "back"
+        },
+    };
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    function frameUpdate() {
+        const secondsBuffer = new Float32Array(4);
+        const d = new Date();
+        const seconds = d.getMilliseconds() / 1000.0 + d.getSeconds();
+        secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
+                          seconds*5 * (6.28318530718 / 60.0),
+                          seconds*1 * (6.28318530718 / 60.0),
+                          .3]);
+
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 16);
+        
+        secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0) + 3.14159265359,
+                          seconds*5 * (6.28318530718 / 60.0) + 3.14159265359,
+                          seconds*1 * (6.28318530718 / 60.0) + 3.14159265359,
+                          -.3]);
+        device.queue.writeBuffer(uniformBuffer, 256, secondsBuffer, 0, 16);
+
+        const canvas = document.querySelector("canvas");
+        canvas.width = 600;
+        canvas.height = 600;
+        
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+        view: renderAttachment,
+        loadOp: "clear",
+        storeOp: "store",
+        clearColor: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        const vertexBufferSlot = 0;
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.setBindGroup(1, uniformBindGroup1);
+        renderPassEncoder.draw(36); // 36 vertices
+        renderPassEncoder.setBindGroup(1, uniformBindGroup2);
+        renderPassEncoder.draw(36); // 36 vertices
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+
+        requestAnimationFrame(frameUpdate);
+    }
+
+    requestAnimationFrame(frameUpdate);
+}
+
+window.addEventListener("DOMContentLoaded", helloCube);

--- a/Websites/webkit.org/demos/webgpu/two-cubes.html
+++ b/Websites/webkit.org/demos/webgpu/two-cubes.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Two Cubes</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Two Cubes</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/two-cubes.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### 6a81017aa27aca988157447ba83d5d545f48b169
<pre>
[WebGPU] WGPUBindGroupEntry::offset is not used while creating the bind group
<a href="https://bugs.webkit.org/show_bug.cgi?id=249834">https://bugs.webkit.org/show_bug.cgi?id=249834</a>
&lt;radar://103606837&gt;

Reviewed by Myles C. Maxfield.

Use data offset member while creating the bind group.

This allows amongst other things sharing one buffer across
multiple bind groups where each bind group has a unique result.

Attached sample modeled after <a href="https://austin-eng.com/webgpu-samples/samples/twoCubes">https://austin-eng.com/webgpu-samples/samples/twoCubes</a>

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::sizeOfEntries):
(WebGPU::Device::createBindGroup):
Correct aliasing of buffers where multiple bind groups share
the same bind group layout.

* Source/WebGPU/WebGPU/BindGroupLayout.h:
(WebGPU::BindGroupLayout::create):
(WebGPU::BindGroupLayout::isValid const):
(WebGPU::BindGroupLayout::vertexArgumentBuffer const): Deleted.
(WebGPU::BindGroupLayout::fragmentArgumentBuffer const): Deleted.
(WebGPU::BindGroupLayout::computeArgumentBuffer const): Deleted.
Bind group layout shouldn&apos;t contain MTLBuffer instances since one
bind group layout can be shared amongst multiple bind groups.

* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
(WebGPU::BindGroupLayout::BindGroupLayout):
(WebGPU::BindGroupLayout::stagesForBinding const):
(WebGPU::BindGroupLayout::~BindGroupLayout): Deleted.
Can default this now that the union is removed.

(WebGPU::BindGroupLayout::stageForBinding const): Deleted.

* Websites/webkit.org/demos/webgpu/scripts/two-cubes.js: Added.
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/two-cubes.html: Added.
Sample creates two bind groups from the same buffer with different offsets.

Canonical link: <a href="https://commits.webkit.org/258513@main">https://commits.webkit.org/258513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d8eb62b570508c4aba37abd472c3ee65c5158be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110731 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1527 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108548 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35326 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78325 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4219 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24961 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1430 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5837 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6044 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->