### PR TITLE
Fix Decimal.floor() + Decimal.ceiling() for many non-integral values

### DIFF
--- a/LayoutTests/fast/forms/input-number-floor-ceiling-stepup-expected.txt
+++ b/LayoutTests/fast/forms/input-number-floor-ceiling-stepup-expected.txt
@@ -1,0 +1,11 @@
+stepUp() Precision Non-integrals
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+StepUp Precision Non-integrals
+PASS stepUpExplicitBounds("1.3", "", "0.2", "1.51", 1) is "1.7"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-number-floor-ceiling-stepup.html
+++ b/LayoutTests/fast/forms/input-number-floor-ceiling-stepup.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description('stepUp() Precision Non-integrals');
+
+var input = document.createElement('input');
+var changeEventCounter = 0;
+input.onchange = function() { ++changeEventCounter; };
+
+function setInputAttributes(min, max, step, value) {
+    input.min = min;
+    input.max = max;
+    input.step = step;
+    input.value = value;
+}
+
+function stepUpExplicitBounds(min, max, step, value, stepCount) {
+    setInputAttributes(min, max, step, value);
+    if (typeof stepCount !== 'undefined')
+        input.stepUp(stepCount);
+    else
+        input.stepUp();
+    return input.value;
+}
+
+var input = document.createElement('input');
+
+input.type = 'number';
+debug('StepUp Precision Non-integrals');
+shouldBe('stepUpExplicitBounds("1.3", "", "0.2", "1.51", 1)', '"1.7"');
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -619,6 +619,11 @@ Decimal::AlignedOperands Decimal::alignOperands(const Decimal& lhs, const Decima
     return alignedOperands;
 }
 
+static bool isMultiplePowersOfTen(uint64_t coefficient, int n)
+{
+    return !coefficient || !(coefficient % scaleUp(1, n));
+}
+
 // Round toward positive infinity.
 // Note: Mac ports defines ceil(x) as wtf_ceil(x), so we can't use name "ceil" here.
 Decimal Decimal::ceiling() const
@@ -635,10 +640,9 @@ Decimal Decimal::ceiling() const
     if (numberOfDigits <= numberOfDropDigits)
         return isPositive() ? Decimal(1) : zero(Positive);
 
-    result = scaleDown(result, numberOfDropDigits - 1);
-    if (sign() == Positive && result % 10 > 0)
-        result += 10;
-    result /= 10;
+    result = scaleDown(result, numberOfDropDigits);
+    if (isPositive() && !isMultiplePowersOfTen(m_data.coefficient(), numberOfDropDigits))
+        ++result;
     return Decimal(sign(), 0, result);
 }
 
@@ -677,10 +681,9 @@ Decimal Decimal::floor() const
     if (numberOfDigits < numberOfDropDigits)
         return isPositive() ? zero(Positive) : Decimal(-1);
 
-    result = scaleDown(result, numberOfDropDigits - 1);
-    if (isNegative() && result % 10 > 0)
-        result += 10;
-    result /= 10;
+    result = scaleDown(result, numberOfDropDigits);
+    if (isNegative() && !isMultiplePowersOfTen(m_data.coefficient(), numberOfDropDigits))
+        ++result;
     return Decimal(sign(), 0, result);
 }
 


### PR DESCRIPTION
<pre>
Fix Decimal.floor() + Decimal.ceiling() for many non-integral values
<a href="https://bugs.webkit.org/show_bug.cgi?id=249771">https://bugs.webkit.org/show_bug.cgi?id=249771</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit behavior with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=162197">https://src.chromium.org/viewvc/blink?view=revision&revision=162197</a>

Extend the check for an integral value to consider all the digits being truncated, and
not just the rightmost/most-significant one, when rounding the result towards positive
and negative infinity for floor() and ceiling(), respectively.

* Source/WebCore/platform/Decimal.cpp:
- Add new bool "isMultiplePowersOfTen"
(Decimal::ceiling): Update to account for all digits
(Decimal::floor): Ditto
* LayoutTests/fast/forms/input-number-floor-ceiling-stepup.html: Add Test Case
* LayoutTests/fast/forms/input-number-floor-ceiling-stepup-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40bc1ab0fde2ea7e4505bafcc4bd9ca1dd9781a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110739 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170994 "Found 1 new test failure: fast/forms/input-number-floor-ceiling-stepup.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1542 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108556 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107249 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8809 "Found 1 new test failure: fast/forms/input-number-floor-ceiling-stepup.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92051 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35334 "Found 1 new test failure: fast/forms/input-number-floor-ceiling-stepup.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90706 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23460 "Found 1 new test failure: fast/forms/input-number-floor-ceiling-stepup.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78332 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4227 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24970 "Found 1 new test failure: fast/forms/input-number-floor-ceiling-stepup.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4290 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1443 "Found 1 new test failure: fast/forms/input-number-floor-ceiling-stepup.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44459 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6052 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->