### PR TITLE
Refactor spots checking if the grid is Masonry

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1345,9 +1345,12 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
         // - Items placed at the first implicit line in the masonry axis.
         // - Items that have a specified definite placement in the grid axis.
         // - Items that span all grid axis tracks.
-        if (m_renderGrid->areMasonryRows() || m_renderGrid->areMasonryColumns()) {
+        if (m_renderGrid->isMasonry()) {
             bool skipTrackSizing = true;
-            auto gridAxisDirection = m_renderGrid->areMasonryRows() ? ForColumns : ForRows;
+
+            // m_direction shall always be the gridAxisDirection.
+            ASSERT(!isDirectionInMasonryDirection());
+            auto gridAxisDirection = m_direction;
             auto masonryAxisDirection = m_renderGrid->areMasonryRows() ? ForRows : ForColumns;
             auto span = GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, gridAxisDirection);
 
@@ -1360,7 +1363,7 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
                 skipTrackSizing = false;
 
             // Items that span all grid axis tracks.
-            if (!m_renderGrid->gridSpanForChild(*gridItem, gridAxisDirection).startLine() && m_renderGrid->gridSpanForChild(*gridItem, gridAxisDirection).integerSpan() == tracks(m_direction).size())
+            if (m_renderGrid->gridSpanForChild(*gridItem, gridAxisDirection).integerSpan() == tracks(gridAxisDirection).size())
                 skipTrackSizing = false;
 
             if (skipTrackSizing)
@@ -1634,10 +1637,10 @@ void GridTrackSizingAlgorithm::run()
     ASSERT(wasSetup());
     StateMachine stateMachine(*this);
 
-    if (m_renderGrid->areMasonryRows() && m_direction == ForRows)
+    if (m_renderGrid->isMasonry(m_direction))
         return;
-
-    if (m_renderGrid->areMasonryColumns() && m_direction == ForColumns)
+    
+    if (m_renderGrid->isMasonry(m_direction))
         return;
 
     if (m_renderGrid->isSubgrid(m_direction) && copyUsedTrackSizesForSubgrid())
@@ -1722,7 +1725,7 @@ GridTrackSizingAlgorithm::StateMachine::~StateMachine()
 
 bool GridTrackSizingAlgorithm::isDirectionInMasonryDirection() const
 {
-    return (m_renderGrid->areMasonryRows() && m_direction == ForRows) || (m_renderGrid->areMasonryColumns() && m_direction == ForColumns);
+    return m_renderGrid->isMasonry(m_direction);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -719,6 +719,22 @@ static GridArea insertIntoGrid(Grid& grid, RenderBox& child, const GridArea& are
     return clamped;
 }
 
+bool RenderGrid::isMasonry() const
+{
+    return areMasonryRows() || areMasonryColumns();
+}
+
+bool RenderGrid::isMasonry(GridTrackSizingDirection direction) const
+{
+    if (areMasonryRows() && direction == ForRows)
+        return true;
+    
+    if (areMasonryColumns() && direction == ForColumns)
+        return true;
+    
+    return false;
+}
+
 bool RenderGrid::areMasonryRows() const
 {
     // isSubgridRows will return false if the masonry axis is rows. Need to check style if we are a subgrid

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -103,6 +103,8 @@ public:
     // nested subgrids, where ancestor may not be our direct parent.
     bool isSubgridOf(GridTrackSizingDirection, const RenderGrid& ancestor);
 
+    bool isMasonry() const;
+    bool isMasonry(GridTrackSizingDirection) const;
     bool areMasonryRows() const;
     bool areMasonryColumns() const;
 


### PR DESCRIPTION
#### 46e8aa67857469452ae492cac0b7fc254218e6e6
<pre>
Refactor spots checking if the grid is Masonry
<a href="https://bugs.webkit.org/show_bug.cgi?id=249843">https://bugs.webkit.org/show_bug.cgi?id=249843</a>

Reviewed by Matt Woodrow.

Refactor out checking if a function isMasonry or not based on Matt&apos;s feedback in the
last patch.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::run):
(WebCore::GridTrackSizingAlgorithm::isDirectionInMasonryDirection const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::isMasonry const):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/258315@main">https://commits.webkit.org/258315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac2ad00fb7b0860690d4f098b3463cdd9baebcb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110779 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1550 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108583 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92077 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23487 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4251 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5709 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6078 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->