### PR TITLE
Reset algorithm is incorrect for select element with first option disabled

### DIFF
--- a/LayoutTests/fast/forms/select-ask-for-reset-expected.txt
+++ b/LayoutTests/fast/forms/select-ask-for-reset-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Removing a SELECT tree from another tree should not reset selection.
+PASS Reset should select the first option element in the list of options that is not disabled to true
+

--- a/LayoutTests/fast/forms/select-ask-for-reset.html
+++ b/LayoutTests/fast/forms/select-ask-for-reset.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#ask-for-a-reset">
+<div id="log"></div>
+<script>
+test(function() {
+    var select = document.createElement('select');
+    document.body.appendChild(select);
+    select.innerHTML = '<option>foo</option>';
+    assert_equals(select.selectedIndex, 0);
+    select.value = '';
+    assert_equals(select.selectedIndex, -1);
+    document.body.removeChild(select);
+    // removeChild shouldn't change selection because it didn't change the
+    // option list.
+    assert_equals(select.selectedIndex, -1);
+}, 'Removing a SELECT tree from another tree should not reset selection.');
+test(function() {
+    var form = document.createElement('form');
+    document.body.appendChild(form);
+    var select = document.createElement('select');
+    form.appendChild(select);
+    select.innerHTML = '<option disabled>Apple</option><option>Banana</option><option>Cherry</option>';
+    assert_equals(select.selectedIndex, 1);
+    form.reset();
+    assert_equals(select.selectedIndex, 1);
+}, 'Reset should select the first option element in the list of options that is not disabled to true');
+</script>
+</body>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2010-2022 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -1091,7 +1091,7 @@ void HTMLSelectElement::reset()
         } else
             option.setSelectedState(false);
 
-        if (!firstOption)
+        if (!firstOption && !option.isDisabledFormControl())
             firstOption = &option;
     }
 


### PR DESCRIPTION
#### 5aa94a8e95f6432c20524bae9b665148b454e6c9
<pre>
Reset algorithm is incorrect for select element with first option disabled

Reset algorithm is incorrect for select element with first option disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=249849">https://bugs.webkit.org/show_bug.cgi?id=249849</a>

Reviewed by Tim Nguyen.

This patch is to align WebKit with Blink / Chromium, Gecko / Firefox and Web-Specification.

Web-Spec - <a href="https://www.w3.org/TR/html5/forms.html#ask-for-a-reset">https://www.w3.org/TR/html5/forms.html#ask-for-a-reset</a>

Partial Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/5b2038755e5c1e046642373d6b3add2452b8eb2e">https://chromium.googlesource.com/chromium/src.git/+/5b2038755e5c1e046642373d6b3add2452b8eb2e</a>

As per the spec, the user agent must set the selectedness of the first option element in the list
of options in tree order that is not disabled, if any, to true.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElement::reset): Update &apos;if&apos; to also disallow selecting disabled option
* LayoutTests/fast/forms/select-ask-for-reset.html: Add Test Case
* LayoutTests/fast/forms/select-ask-for-reset-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258313@main">https://commits.webkit.org/258313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90f5f85c1353c15e60cbb0b8e5811420f2acb5f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110765 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171015 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1541 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108576 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35355 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78353 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24985 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1442 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5708 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6071 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->