### PR TITLE
CSS Nesting: nested selector matching

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6183,5 +6183,3 @@ webkit.org/b/245905 imported/w3c/web-platform-tests/css/css-text/line-breaking/l
 # CSS Nesting
 imported/w3c/web-platform-tests/css/css-nesting/conditional-properties.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-001-expected.txt
@@ -1,4 +1,4 @@
 Test passes if color is green.
 
-FAIL CSS Selectors nested invalidation on changed parent assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS CSS Selectors nested invalidation on changed parent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-002-expected.txt
@@ -1,4 +1,4 @@
 Test passes if color is green.
 
-FAIL CSS Selectors nested invalidation on changed child assert_equals: expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
+PASS CSS Selectors nested invalidation on changed child
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-003-expected.txt
@@ -1,4 +1,4 @@
 Test passes if color is green.
 
-FAIL CSS Selectors nested invalidation with :has() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS CSS Selectors nested invalidation with :has()
 

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -36,7 +36,8 @@ namespace WebCore {
 CSSSelectorList::CSSSelectorList(const CSSSelectorList& other)
 {
     unsigned otherComponentCount = other.componentCount();
-    ASSERT_WITH_SECURITY_IMPLICATION(otherComponentCount);
+    if (!otherComponentCount)
+        return;
 
     m_selectorArray = makeUniqueArray<CSSSelector>(otherComponentCount);
     for (unsigned i = 0; i < otherComponentCount; ++i)
@@ -70,7 +71,7 @@ CSSSelectorList::CSSSelectorList(Vector<std::unique_ptr<CSSParserSelector>>&& se
             if (current != first)
                 m_selectorArray[arrayIndex].setNotFirstInTagHistory();
             current = current->tagHistory();
-            ASSERT(!m_selectorArray[arrayIndex].isLastInSelectorList());
+            ASSERT(!m_selectorArray[arrayIndex].isLastInSelectorList() || (flattenedSize == arrayIndex + 1));
             if (current)
                 m_selectorArray[arrayIndex].setNotLastInTagHistory();
             ++arrayIndex;

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -723,7 +723,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         // Normal element pseudo class checking.
         switch (selector.pseudoClassType()) {
             // Pseudo classes:
-        case CSSSelector::PseudoClassParent:
+        case CSSSelector::PseudoClassNestingParent:
             // This pseudo selector should have been replaced earlier.
         case CSSSelector::PseudoClassNot:
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -36,6 +36,7 @@
 #include "CSSMediaRule.h"
 #include "CSSNamespaceRule.h"
 #include "CSSPageRule.h"
+#include "CSSParserSelector.h"
 #include "CSSPropertyRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
@@ -227,6 +228,7 @@ StyleRule::StyleRule(const StyleRule& o)
     : StyleRuleBase(o)
     , m_properties(o.properties().mutableCopy())
     , m_selectorList(o.m_selectorList)
+    , m_resolvedSelectorList(o.m_resolvedSelectorList)
     , m_nestedRules(o.m_nestedRules)
     , m_isSplitRule(o.m_isSplitRule)
     , m_isLastRuleInSplitRule(o.m_isLastRuleInSplitRule)

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -110,6 +110,12 @@ public:
     ~StyleRule();
 
     const CSSSelectorList& selectorList() const { return m_selectorList; }
+    const CSSSelectorList& resolvedSelectorList() const
+    { 
+        if (!m_resolvedSelectorList.isEmpty())
+            return m_resolvedSelectorList;
+        return m_selectorList;
+    }
 
     const StyleProperties& properties() const { return m_properties.get(); }
     MutableStyleProperties& mutableProperties();
@@ -133,6 +139,7 @@ public:
     static unsigned averageSizeInBytes();
     void setProperties(Ref<StyleProperties> properties) { m_properties = properties; }
     void setNestedRules(Vector<Ref<StyleRule>> nestedRules) { m_nestedRules = nestedRules; }
+    void setResolvedSelectorList(CSSSelectorList&& resolvedSelectorList) const { m_resolvedSelectorList = WTFMove(resolvedSelectorList); }
     const Vector<Ref<StyleRule>>& nestedRules() const { return m_nestedRules; }
     void appendNestedRule(Ref<StyleRule> rule) { m_nestedRules.append(rule); }
 
@@ -145,8 +152,7 @@ private:
 
     mutable Ref<StyleProperties> m_properties;
     CSSSelectorList m_selectorList;
-
-    // CSS Nesting
+    mutable CSSSelectorList m_resolvedSelectorList { };
     Vector<Ref<StyleRule>> m_nestedRules;
 
 #if ENABLE(CSS_SELECTOR_JIT)

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -105,6 +105,14 @@ CSSParserSelector::CSSParserSelector(const QualifiedName& tagQName)
 {
 }
 
+CSSParserSelector::CSSParserSelector(const CSSSelector& selector) 
+{
+    m_selector = makeUnique<CSSSelector>(selector);
+    if (auto next = selector.tagHistory())
+        m_tagHistory = makeUnique<CSSParserSelector>(*next);
+}
+
+
 CSSParserSelector::~CSSParserSelector()
 {
     if (!m_tagHistory)

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -40,10 +40,16 @@ public:
     static std::unique_ptr<CSSParserSelector> parsePagePseudoSelector(StringView);
 
     CSSParserSelector();
+
+    // Recursively copy the selector chain.
+    CSSParserSelector(const CSSSelector&);
+
     explicit CSSParserSelector(const QualifiedName&);
+
     ~CSSParserSelector();
 
     std::unique_ptr<CSSSelector> releaseSelector() { return WTFMove(m_selector); }
+    CSSSelector* selector() { return m_selector.get(); }
 
     void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector->setValue(value, matchLowerCase); }
 
@@ -90,6 +96,7 @@ public:
     void appendTagHistory(CSSParserSelectorCombinator, std::unique_ptr<CSSParserSelector>);
     void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
     std::unique_ptr<CSSParserSelector> releaseTagHistory();
+
 
 private:
     std::unique_ptr<CSSSelector> m_selector;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -57,6 +57,7 @@ public:
     CSSSelectorList consumeNestedSelectorList(CSSParserTokenRange&);
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSParserContext&);
+    static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList& parentResolvedSelectorList);
 
 private:
     template<typename ConsumeSelector> CSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1168,7 +1168,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         }
     case CSSSelector::PseudoClassHost:
         return FunctionType::CannotCompile;
-    case CSSSelector::PseudoClassParent: // Should have already been replaced by the actual parent selector at this point.
+    case CSSSelector::PseudoClassNestingParent: // Should have already been replaced by the actual parent selector at this point.
     case CSSSelector::PseudoClassUnknown:
         ASSERT_NOT_REACHED();
         return FunctionType::CannotMatchAnything;

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -46,7 +46,12 @@ public:
 
     const StyleRule& styleRule() const { return *m_styleRule; }
 
-    const CSSSelector* selector() const { return m_styleRule->selectorList().selectorAt(m_selectorIndex); }
+    const CSSSelector* selector() const
+    { 
+        auto& selectorList = m_styleRule->resolvedSelectorList();
+        return selectorList.selectorAt(m_selectorIndex);
+    }
+
 #if ENABLE(CSS_SELECTOR_JIT)
     CompiledSelector& compiledSelector() const { return m_styleRule->compiledSelectorForListIndex(m_selectorListIndex); }
 #endif

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -34,7 +34,7 @@ public:
     ~RuleSetBuilder();
 
     void addRulesFromSheet(const StyleSheetContents&, const MQ::MediaQueryList& sheetQuery = { });
-    void addStyleRule(const StyleRule&);
+    void addStyleRule(const StyleRule&, const CSSSelectorList* parentResolvedSelectorList = nullptr);
 
 private:
     RuleSetBuilder(const MQ::MediaQueryEvaluator&);


### PR DESCRIPTION
#### 8972793414d954d8dd57676c6f8f2298a001e73e
<pre>
CSS Nesting: nested selector matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=249746">https://bugs.webkit.org/show_bug.cgi?id=249746</a>
rdar://103147183

Reviewed by Antti Koivisto.

This patch implements nested selector matching by
creating the flat equivalent of the nested selector
at rule set builder time.
All the following steps (matching, selector jit compilation,...)
should be automatically working because they will operate on regular flat selector,
without any parent selector inside them.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-003-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::RareData::RareData):
(WebCore::CSSSelector::RareData::deepCopy const):
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::visitAllSimpleSelectors const):
(WebCore::CSSSelector::resolveNestingParentSelectors):
(WebCore::CSSSelector::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::selectorList):
(WebCore::CSSSelector::setNotLastInSelectorList):
(WebCore::CSSSelector::isFirstInTagHistory const):
(WebCore::CSSSelector::isLastInTagHistory const):
(WebCore::CSSSelector::setLastInTagHistory):
(WebCore::CSSSelector::tagHistory):
(WebCore::CSSSelector::CSSSelector): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::StyleRule):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::CSSParserSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::selector):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeRelativeNestedSelector):
(WebCore::CSSSelectorParser::consumeNesting):
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::selector const):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/258367@main">https://commits.webkit.org/258367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8543ac2d57fa72d08bdc968ca648bf0c18f4cf53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111004 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171207 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1731 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94076 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108766 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92250 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78560 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25168 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1617 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5735 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6247 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->