### PR TITLE
[text-group-align] Parse CSS property behind preference

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -308,6 +308,7 @@ PASS text-edge
 PASS text-emphasis-color
 PASS text-emphasis-position
 PASS text-emphasis-style
+PASS text-group-align
 PASS text-indent
 PASS text-justify
 PASS text-orientation

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-invalid-expected.txt
@@ -1,0 +1,13 @@
+
+PASS e.style['text-group-align'] = "auto" should not set the property value
+PASS e.style['text-group-align'] = "match-parent" should not set the property value
+PASS e.style['text-group-align'] = "justify" should not set the property value
+PASS e.style['text-group-align'] = "wrap" should not set the property value
+PASS e.style['text-group-align'] = "left right" should not set the property value
+PASS e.style['text-group-align'] = "center start" should not set the property value
+PASS e.style['text-group-align'] = "end start" should not set the property value
+PASS e.style['text-group-align'] = "none center" should not set the property value
+PASS e.style['text-group-align'] = "start center" should not set the property value
+PASS e.style['text-group-align'] = "right center" should not set the property value
+PASS e.style['text-group-align'] = "5px" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-invalid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text Module Test: parsing text-group-align with invalid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-group-align-property">
+<meta name="assert" content="text-group-align supports only the grammar 'none | start | end | left | right | center'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("text-group-align", "auto");
+test_invalid_value("text-group-align", "match-parent");
+test_invalid_value("text-group-align", "justify");
+test_invalid_value("text-group-align", "wrap");
+test_invalid_value("text-group-align", "left right");
+test_invalid_value("text-group-align", "center start");
+test_invalid_value("text-group-align", "end start");
+test_invalid_value("text-group-align", "none center");
+test_invalid_value("text-group-align", "start center");
+test_invalid_value("text-group-align", "right center");
+test_invalid_value("text-group-align", "5px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-valid-expected.txt
@@ -1,0 +1,13 @@
+
+PASS e.style['text-group-align'] = "none" should set the property value
+PASS e.style['text-group-align'] = "start" should set the property value
+PASS e.style['text-group-align'] = "end" should set the property value
+PASS e.style['text-group-align'] = "left" should set the property value
+PASS e.style['text-group-align'] = "right" should set the property value
+PASS e.style['text-group-align'] = "center" should set the property value
+PASS e.style['text-group-align'] = "initial" should set the property value
+PASS e.style['text-group-align'] = "inherit" should set the property value
+PASS e.style['text-group-align'] = "unset" should set the property value
+PASS e.style['text-group-align'] = "revert" should set the property value
+PASS e.style['text-group-align'] = "revert-layer" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-group-align-valid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text Module Test: parsing text-group-align with valid values</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-group-align-property">
+<meta name="assert" content="text-group-align supports the full grammar 'none | start | end | left | right | center'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("text-group-align", "none");
+test_valid_value("text-group-align", "start");
+test_valid_value("text-group-align", "end");
+test_valid_value("text-group-align", "left");
+test_valid_value("text-group-align", "right");
+test_valid_value("text-group-align", "center");
+test_valid_value("text-group-align", "initial");
+test_valid_value("text-group-align", "inherit");
+test_valid_value("text-group-align", "unset");
+test_valid_value("text-group-align", "revert");
+test_valid_value("text-group-align", "revert-layer");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -213,6 +213,9 @@ PASS text-emphasis-position: "over" onto "under left"
 PASS text-emphasis-style (type: discrete) has testAccumulation function
 PASS text-emphasis-style: "open dot" onto "circle"
 PASS text-emphasis-style: "circle" onto "open dot"
+PASS text-group-align (type: discrete) has testAccumulation function
+PASS text-group-align: "center" onto "none"
+PASS text-group-align: "none" onto "center"
 PASS text-overflow (type: discrete) has testAccumulation function
 PASS text-overflow: "ellipsis" onto "clip"
 PASS text-overflow: "clip" onto "ellipsis"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -213,6 +213,9 @@ PASS text-emphasis-position: "over" onto "under left"
 PASS text-emphasis-style (type: discrete) has testAddition function
 PASS text-emphasis-style: "open dot" onto "circle"
 PASS text-emphasis-style: "circle" onto "open dot"
+PASS text-group-align (type: discrete) has testAddition function
+PASS text-group-align: "center" onto "none"
+PASS text-group-align: "none" onto "center"
 PASS text-overflow (type: discrete) has testAddition function
 PASS text-overflow: "ellipsis" onto "clip"
 PASS text-overflow: "clip" onto "ellipsis"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -257,6 +257,10 @@ PASS text-emphasis-style (type: discrete) has testInterpolation function
 PASS text-emphasis-style uses discrete animation when animating between "circle" and "open dot" with linear easing
 PASS text-emphasis-style uses discrete animation when animating between "circle" and "open dot" with effect easing
 PASS text-emphasis-style uses discrete animation when animating between "circle" and "open dot" with keyframe easing
+PASS text-group-align (type: discrete) has testInterpolation function
+PASS text-group-align uses discrete animation when animating between "none" and "center" with linear easing
+PASS text-group-align uses discrete animation when animating between "none" and "center" with effect easing
+PASS text-group-align uses discrete animation when animating between "none" and "center" with keyframe easing
 PASS text-overflow (type: discrete) has testInterpolation function
 PASS text-overflow uses discrete animation when animating between "clip" and "ellipsis" with linear easing
 PASS text-overflow uses discrete animation when animating between "clip" and "ellipsis" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1293,6 +1293,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'circle', 'open dot' ] ] }
     ]
   },
+  'text-group-align': {
+    // https://drafts.csswg.org/css-text-4/#propdef-text-group-align
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'center' ] ] }
+    ]
+  },
   'text-indent': {
     // https://drafts.csswg.org/css-text-3/#propdef-text-indent
     types: [

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -307,6 +307,7 @@ PASS text-decoration-thickness
 PASS text-emphasis-color
 PASS text-emphasis-position
 PASS text-emphasis-style
+PASS text-group-align
 PASS text-indent
 PASS text-justify
 PASS text-orientation

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -308,6 +308,7 @@ PASS text-edge
 PASS text-emphasis-color
 PASS text-emphasis-position
 PASS text-emphasis-style
+PASS text-group-align
 PASS text-indent
 PASS text-justify
 PASS text-orientation

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -305,6 +305,7 @@ PASS text-decoration-thickness
 PASS text-emphasis-color
 PASS text-emphasis-position
 PASS text-emphasis-style
+PASS text-group-align
 PASS text-indent
 PASS text-justify
 PASS text-orientation

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -307,6 +307,7 @@ PASS text-edge
 PASS text-emphasis-color
 PASS text-emphasis-position
 PASS text-emphasis-style
+PASS text-group-align
 PASS text-indent
 PASS text-justify
 PASS text-orientation

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -210,6 +210,9 @@ PASS text-emphasis-position: "over" onto "under left"
 PASS text-emphasis-style (type: discrete) has testAccumulation function
 PASS text-emphasis-style: "open dot" onto "circle"
 PASS text-emphasis-style: "circle" onto "open dot"
+PASS text-group-align (type: discrete) has testAccumulation function
+PASS text-group-align: "center" onto "none"
+PASS text-group-align: "none" onto "center"
 PASS text-overflow (type: discrete) has testAccumulation function
 PASS text-overflow: "ellipsis" onto "clip"
 PASS text-overflow: "clip" onto "ellipsis"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -210,6 +210,9 @@ PASS text-emphasis-position: "over" onto "under left"
 PASS text-emphasis-style (type: discrete) has testAddition function
 PASS text-emphasis-style: "open dot" onto "circle"
 PASS text-emphasis-style: "circle" onto "open dot"
+PASS text-group-align (type: discrete) has testAddition function
+PASS text-group-align: "center" onto "none"
+PASS text-group-align: "none" onto "center"
 PASS text-overflow (type: discrete) has testAddition function
 PASS text-overflow: "ellipsis" onto "clip"
 PASS text-overflow: "clip" onto "ellipsis"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -253,6 +253,10 @@ PASS text-emphasis-style (type: discrete) has testInterpolation function
 PASS text-emphasis-style uses discrete animation when animating between "circle" and "open dot" with linear easing
 PASS text-emphasis-style uses discrete animation when animating between "circle" and "open dot" with effect easing
 PASS text-emphasis-style uses discrete animation when animating between "circle" and "open dot" with keyframe easing
+PASS text-group-align (type: discrete) has testInterpolation function
+PASS text-group-align uses discrete animation when animating between "none" and "center" with linear easing
+PASS text-group-align uses discrete animation when animating between "none" and "center" with effect easing
+PASS text-group-align uses discrete animation when animating between "none" and "center" with keyframe easing
 PASS text-overflow (type: discrete) has testInterpolation function
 PASS text-overflow uses discrete animation when animating between "clip" and "ellipsis" with linear easing
 PASS text-overflow uses discrete animation when animating between "clip" and "ellipsis" with effect easing

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -304,6 +304,7 @@ PASS text-decoration-thickness
 PASS text-emphasis-color
 PASS text-emphasis-position
 PASS text-emphasis-style
+PASS text-group-align
 PASS text-indent
 PASS text-justify
 PASS text-orientation

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -491,6 +491,18 @@ CSSTextAlignLastEnabled:
     WebCore:
       default: true
 
+CSSTextGroupAlignEnabled:
+  type: bool
+  humanReadableName: "CSS text-group-align property"
+  humanReadableDescription: "Enable text-group-align CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextJustifyEnabled:
   type: bool
   humanReadableName: "CSS text-justify property"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3540,6 +3540,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new PropertyWrapperVisitedAffectedColor(CSSPropertyTextEmphasisColor, &RenderStyle::textEmphasisColor, &RenderStyle::setTextEmphasisColor, &RenderStyle::visitedLinkTextEmphasisColor, &RenderStyle::setVisitedLinkTextEmphasisColor),
         new DiscretePropertyWrapper<OptionSet<TextEmphasisPosition>>(CSSPropertyTextEmphasisPosition, &RenderStyle::textEmphasisPosition, &RenderStyle::setTextEmphasisPosition),
         new TextEmphasisStyleWrapper,
+        new DiscretePropertyWrapper<TextGroupAlign>(CSSPropertyTextGroupAlign, &RenderStyle::textGroupAlign, &RenderStyle::setTextGroupAlign),
         new DiscretePropertyWrapper<TextJustify>(CSSPropertyTextJustify, &RenderStyle::textJustify, &RenderStyle::setTextJustify),
         new DiscretePropertyWrapper<TextOverflow>(CSSPropertyTextOverflow, &RenderStyle::textOverflow, &RenderStyle::setTextOverflow),
         new DiscretePropertyWrapper<OptionSet<TouchAction>>(CSSPropertyTouchAction, &RenderStyle::touchActions, &RenderStyle::setTouchActions),

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2329,6 +2329,57 @@ template<> inline CSSPrimitiveValue::operator TextAlignLast() const
     return TextAlignLast::Auto;
 }
 
+template<> inline CSSPrimitiveValue::CSSPrimitiveValue(TextGroupAlign e)
+    : CSSValue(PrimitiveClass)
+{
+    setPrimitiveUnitType(CSSUnitType::CSS_VALUE_ID);
+    switch (e) {
+    case TextGroupAlign::None:
+        m_value.valueID = CSSValueNone;
+        break;
+    case TextGroupAlign::Start:
+        m_value.valueID = CSSValueStart;
+        break;
+    case TextGroupAlign::End:
+        m_value.valueID = CSSValueEnd;
+        break;
+    case TextGroupAlign::Left:
+        m_value.valueID = CSSValueLeft;
+        break;
+    case TextGroupAlign::Right:
+        m_value.valueID = CSSValueRight;
+        break;
+    case TextGroupAlign::Center:
+        m_value.valueID = CSSValueCenter;
+        break;
+    }
+}
+
+template<> inline CSSPrimitiveValue::operator TextGroupAlign() const
+{
+    ASSERT(isValueID());
+
+    switch (m_value.valueID) {
+    case CSSValueNone:
+        return TextGroupAlign::None;
+    case CSSValueStart:
+        return TextGroupAlign::Start;
+    case CSSValueEnd:
+        return TextGroupAlign::End;
+    case CSSValueLeft:
+        return TextGroupAlign::Left;
+    case CSSValueRight:
+        return TextGroupAlign::Right;
+    case CSSValueCenter:
+        return TextGroupAlign::Center;
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return TextGroupAlign::None;
+}
+
 template<> inline CSSPrimitiveValue::CSSPrimitiveValue(TextJustify e)
     : CSSValue(PrimitiveClass)
 {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5136,6 +5136,23 @@
                 "url": "https://www.w3.org/TR/CSS2/text.html#propdef-text-decoration"
             }
         },
+        "text-group-align": {
+            "values": [
+                "none",
+                "start",
+                "end",
+                "left",
+                "right",
+                "center"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssTextGroupAlignEnabled"
+            },
+            "specification": {
+                "category": "css-text",
+                "url": "https://drafts.csswg.org/css-text-4/#text-group-align-property"
+            }
+        },
         "text-indent": {
             "inherited": true,
             "codegen-properties": {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3610,6 +3610,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         list->append(currentColorOrValidColor(style, style.textEmphasisColor()));
         return list;
     }
+    case CSSPropertyTextGroupAlign:
+        return cssValuePool.createValue(style.textGroupAlign());
     case CSSPropertyTextIndent: {
         auto textIndent = zoomAdjustedPixelValueForLength(style.textIndent(), style);
         if (style.textIndentLine() == TextIndentLine::EachLine || style.textIndentType() == TextIndentType::Hanging) {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -385,6 +385,7 @@ public:
     const Length& textIndent() const { return m_rareInheritedData->indent; }
     TextAlignMode textAlign() const { return static_cast<TextAlignMode>(m_inheritedFlags.textAlign); }
     TextAlignLast textAlignLast() const { return static_cast<TextAlignLast>(m_rareInheritedData->textAlignLast); }
+    TextGroupAlign textGroupAlign() const { return static_cast<TextGroupAlign>(m_rareNonInheritedData->textGroupAlign); }
     TextTransform textTransform() const { return static_cast<TextTransform>(m_inheritedFlags.textTransform); }
     OptionSet<TextDecorationLine> textDecorationsInEffect() const { return OptionSet<TextDecorationLine>::fromRaw(m_inheritedFlags.textDecorationLines); }
     OptionSet<TextDecorationLine> textDecorationLine() const { return OptionSet<TextDecorationLine>::fromRaw(m_visualData->textDecorationLine); }
@@ -1053,6 +1054,7 @@ public:
     void setTextIndent(Length&& length) { SET_VAR(m_rareInheritedData, indent, WTFMove(length)); }
     void setTextAlign(TextAlignMode v) { m_inheritedFlags.textAlign = static_cast<unsigned>(v); }
     void setTextAlignLast(TextAlignLast v) { SET_VAR(m_rareInheritedData, textAlignLast, static_cast<unsigned>(v)); }
+    void setTextGroupAlign(TextGroupAlign v) { SET_VAR(m_rareNonInheritedData, textGroupAlign, static_cast<unsigned>(v)); }
     void setTextTransform(TextTransform v) { m_inheritedFlags.textTransform = static_cast<unsigned>(v); }
     void addToTextDecorationsInEffect(OptionSet<TextDecorationLine> v) { m_inheritedFlags.textDecorationLines |= static_cast<unsigned>(v.toRaw()); }
     void setTextDecorationsInEffect(OptionSet<TextDecorationLine> v) { m_inheritedFlags.textDecorationLines = v.toRaw(); }
@@ -1703,6 +1705,7 @@ public:
     static Length initialLineHeight() { return Length(-100.0f, LengthType::Percent); }
     static TextAlignMode initialTextAlign() { return TextAlignMode::Start; }
     static TextAlignLast initialTextAlignLast() { return TextAlignLast::Auto; }
+    static TextGroupAlign initialTextGroupAlign() { return TextGroupAlign::None; }
     static OptionSet<TextDecorationLine> initialTextDecorationLine() { return OptionSet<TextDecorationLine> { }; }
     static TextDecorationStyle initialTextDecorationStyle() { return TextDecorationStyle::Solid; }
     static TextDecorationSkipInk initialTextDecorationSkipInk() { return TextDecorationSkipInk::Auto; }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1098,6 +1098,20 @@ TextStream& operator<<(TextStream& ts, TextEmphasisPosition position)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, TextGroupAlign textGroupAlign)
+{
+    switch (textGroupAlign) {
+    case TextGroupAlign::None: ts << "none"; break;
+    case TextGroupAlign::Start: ts << "start"; break;
+    case TextGroupAlign::End: ts << "end"; break;
+    case TextGroupAlign::Left: ts << "left"; break;
+    case TextGroupAlign::Right: ts << "right"; break;
+    case TextGroupAlign::Center: ts << "center"; break;
+    }
+
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, TextJustify justify)
 {
     switch (justify) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -774,6 +774,15 @@ enum class TextDecorationSkipInk : uint8_t {
     All
 };
 
+enum class TextGroupAlign : uint8_t {
+    None,
+    Start,
+    End,
+    Left,
+    Right,
+    Center
+};
+
 enum class TextUnderlinePosition : uint8_t {
     // FIXME: Implement support for 'under left' and 'under right' values.
     Auto,
@@ -1353,6 +1362,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisFill);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisMark);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisPosition);
+WTF::TextStream& operator<<(WTF::TextStream&, TextGroupAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, TextJustify);
 WTF::TextStream& operator<<(WTF::TextStream&, TextOrientation);
 WTF::TextStream& operator<<(WTF::TextStream&, TextOverflow);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -99,6 +99,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , effectiveAppearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
     , textDecorationStyle(static_cast<unsigned>(RenderStyle::initialTextDecorationStyle()))
     , textDecorationThickness(RenderStyle::initialTextDecorationThickness())
+    , textGroupAlign(static_cast<unsigned>(RenderStyle::initialTextGroupAlign()))
     , aspectRatioType(static_cast<unsigned>(RenderStyle::initialAspectRatioType()))
     , contentVisibility(static_cast<unsigned>(RenderStyle::initialContentVisibility()))
 #if ENABLE(CSS_COMPOSITING)
@@ -212,6 +213,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , effectiveAppearance(o.effectiveAppearance)
     , textDecorationStyle(o.textDecorationStyle)
     , textDecorationThickness(o.textDecorationThickness)
+    , textGroupAlign(o.textGroupAlign)
     , aspectRatioType(o.aspectRatioType)
     , contentVisibility(o.contentVisibility)
 #if ENABLE(CSS_COMPOSITING)
@@ -327,6 +329,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && effectiveAppearance == o.effectiveAppearance
         && textDecorationStyle == o.textDecorationStyle
         && textDecorationThickness == o.textDecorationThickness
+        && textGroupAlign == o.textGroupAlign
         && arePointingToEqualData(rotate, o.rotate)
         && arePointingToEqualData(scale, o.scale)
         && arePointingToEqualData(translate, o.translate)

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -218,6 +218,8 @@ public:
     unsigned textDecorationStyle : 3; // TextDecorationStyle
     TextDecorationThickness textDecorationThickness;
 
+    unsigned textGroupAlign : 3; // TextGroupAlign
+
     unsigned aspectRatioType : 2; // AspectRatioType
     unsigned contentVisibility : 2; // ContentVisibility
 


### PR DESCRIPTION
#### 47140adfdf0e35d0e3b1708969f431df87e6052c
<pre>
[text-group-align] Implement group alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=249839">https://bugs.webkit.org/show_bug.cgi?id=249839</a>
rdar://103663524

Reviewed by NOBODY (OOPS!).

* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::width const):
(WebCore::InlineIterator::LineBox::left const):
(WebCore::InlineIterator::LineBox::right const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::left const):
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::right const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::left const):
(WebCore::InlineIterator::LineBoxIteratorModernPath::right const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateInlineContentConstraints):
* Source/WebCore/page/FrameViewLayoutContext.cpp:
(WebCore::FrameViewLayoutContext::pushLayoutState):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::computeGroupAlignmentSpacing):
(WebCore::RenderBlockFlow::groupAlignmentExtraSpacing const):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
* Source/WebCore/rendering/RenderLayoutState.h:
(WebCore::RenderLayoutState::groupAlignSpacing):
(WebCore::RenderLayoutState::setGroupAlignSpacing):
(WebCore::RenderLayoutState::resetGroupAlignSpacing):
</pre>