### PR TITLE
Restrict floats over setCurrentTime & setCurrentScale to finite values

### DIFF
--- a/LayoutTests/svg/animations/animate-setcurrenttime-expected.txt
+++ b/LayoutTests/svg/animations/animate-setcurrenttime-expected.txt
@@ -1,6 +1,11 @@
 SVG 1.1 dynamic animation tests
 
- PASS plain.x.animVal.value is 0
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS svg.setCurrentTime(test.time[0]) threw exception TypeError: The provided value is non-finite.
+PASS nestedsvg.setCurrentTime(test.time[1]) threw exception TypeError: The provided value is non-finite.
+PASS plain.x.animVal.value is 0
 PASS sequential.x.animVal.value is 0
 PASS accumulating.x.animVal.value is 0
 PASS repeating.x.animVal.value is 0
@@ -90,4 +95,7 @@ PASS sequential.x.animVal.value is 128
 PASS accumulating.x.animVal.value is 128
 PASS repeating.x.animVal.value is 128
 PASS nested.x.animVal.value is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/svg/animations/animate-setcurrenttime.html
+++ b/LayoutTests/svg/animations/animate-setcurrenttime.html
@@ -1,12 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-  <script src="../../resources/js-test-pre.js"></script>
+  <script src="../../resources/js-test.js"></script>
 </head>
 
 <body>
-  <h1>SVG 1.1 dynamic animation tests</h1>
-
   <svg id='outer-svg' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' xml:space='preserve'>
     <!-- sequential animations -->
     <rect id='plain' x='0' y='0' width='32' height='32' fill='green'>
@@ -37,6 +35,9 @@
     </svg>
 
     <script>
+    description("SVG 1.1 dynamic animation tests");
+    self.jsTestIsAsync = true;
+
     var svg = document.getElementById('outer-svg'),
         nestedsvg = document.getElementById('nested-svg');
     var tests, curIdx = 0;
@@ -46,22 +47,28 @@
     var accumulating = document.getElementById('accumulating');
     var repeating = document.getElementById('repeating');
     var nested = document.getElementById('nested');
+    var test;
 
     function runTest() {
-      var test = tests[curIdx++];
+      test = tests[curIdx++];
 
-      svg.setCurrentTime(test.time[0]);
-      nestedsvg.setCurrentTime(test.time[1]);
+      if (test.throws && test.throws[0])
+        shouldThrow("svg.setCurrentTime(test.time[0])");
+      else
+        svg.setCurrentTime(test.time[0]);
+
+      if (test.throws && test.throws[1])
+        shouldThrow("nestedsvg.setCurrentTime(test.time[1])");
+      else
+        nestedsvg.setCurrentTime(test.time[1]);
 
       setTimeout(function() {
         for (var attr in test.values) {
           shouldBe(attr + '.animVal.value', String(test.values[attr]));
         }
 
-        if (curIdx == tests.length) {
-          if (window.testRunner)
-            testRunner.notifyDone();
-        }
+        if (curIdx == tests.length)
+          finishJSTest();
         else
           runTest();
       }, 0);
@@ -73,7 +80,7 @@
 
       tests = [
         // Test invalid values.
-        { time: ['tintin', NaN], values: { 'plain.x':   0, 'sequential.x':   0, 'accumulating.x':   0, 'repeating.x':   0, 'nested.x':   0 } },
+        { time: ['tintin', NaN], throws: [true, true], values: { 'plain.x':   0, 'sequential.x':   0, 'accumulating.x':   0, 'repeating.x':   0, 'nested.x':   0 } },
 
         // Test out-of-range values.
         { time: [-1, -1], values: { 'plain.x':   0, 'sequential.x':   0, 'accumulating.x':   0, 'repeating.x':   0, 'nested.x':   0 } },
@@ -117,4 +124,3 @@
   <div id="console"></div>
 </body>
 </html>
-

--- a/LayoutTests/svg/dom/SVGSVGElement-currentScale-NaN-no-crash-expected.txt
+++ b/LayoutTests/svg/dom/SVGSVGElement-currentScale-NaN-no-crash-expected.txt
@@ -1,0 +1,11 @@
+Setting .currentScale to a non-finite should throw.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS svgElement.currentScale = NaN threw exception TypeError: The provided value is non-finite.
+PASS svgElement.currentScale = Infinity threw exception TypeError: The provided value is non-finite.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/dom/SVGSVGElement-currentScale-NaN-no-crash.html
+++ b/LayoutTests/svg/dom/SVGSVGElement-currentScale-NaN-no-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="200" height="200"></svg>
+<script>
+description("Setting .currentScale to a non-finite should throw.");
+
+self.jsTestIsAsync = true;
+
+if (window.testRunner) {
+     testRunner.dumpAsText();
+     testRunner.waitUntilDone();
+}
+
+function runTest()
+{
+    svgElement = document.getElementById("svg");
+    shouldThrow("svgElement.currentScale = NaN");
+    shouldThrow("svgElement.currentScale = Infinity");
+    finishJSTest();
+}
+window.onload = runTest;
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/dom/SVGSVGElement-currentTime-expected.txt
+++ b/LayoutTests/svg/dom/SVGSVGElement-currentTime-expected.txt
@@ -1,0 +1,11 @@
+Calling svgElement.setCurrentTime() with a non-finite value should throw.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS svgElement.setCurrentTime(NaN) threw exception TypeError: The provided value is non-finite.
+PASS svgElement.setCurrentTime(Infinity) threw exception TypeError: The provided value is non-finite.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/dom/SVGSVGElement-currentTime.html
+++ b/LayoutTests/svg/dom/SVGSVGElement-currentTime.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="200" height="200"></svg>
+<script>
+description("Calling svgElement.setCurrentTime() with a non-finite value should throw.");
+
+self.jsTestIsAsync = true;
+
+if (window.testRunner) {
+     testRunner.dumpAsText();
+     testRunner.waitUntilDone();
+}
+
+function runTest()
+{
+    svgElement = document.getElementById("svg");
+    shouldThrow("svgElement.setCurrentTime(NaN)");
+    shouldThrow("svgElement.setCurrentTime(Infinity)");
+    finishJSTest();
+}
+window.onload = runTest;
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2019 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -125,6 +126,7 @@ float SVGSVGElement::currentScale() const
 
 void SVGSVGElement::setCurrentScale(float scale)
 {
+    ASSERT(std::isfinite(scale));
     if (auto frame = frameForCurrentScale())
         frame->setPageZoomFactor(scale);
 }
@@ -546,8 +548,7 @@ float SVGSVGElement::getCurrentTime() const
 
 void SVGSVGElement::setCurrentTime(float seconds)
 {
-    if (!std::isfinite(seconds))
-        return;
+    ASSERT(std::isfinite(seconds));
     m_timeContainer->setElapsed(std::max(seconds, 0.0f));
 }
 

--- a/Source/WebCore/svg/SVGSVGElement.idl
+++ b/Source/WebCore/svg/SVGSVGElement.idl
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2010 Rob Buis <buis@kde.org>
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
- * Copyright (C) 2006-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -19,6 +19,8 @@
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02110-1301, USA.
  */
+
+// https://www.w3.org/TR/SVG2/struct.html#InterfaceSVGSVGElement
 
 [
     JSGenerateToNativeObject,
@@ -59,8 +61,8 @@
     undefined pauseAnimations();
     undefined unpauseAnimations();
     boolean animationsPaused();
-    unrestricted float getCurrentTime();
-    undefined setCurrentTime(optional unrestricted float seconds = NaN);
+    float getCurrentTime();
+    undefined setCurrentTime(float seconds);
 
     // Deprecated SVG redrawing
     unsigned long suspendRedraw(optional unsigned long maxWaitMilliseconds = 0);


### PR DESCRIPTION
#### e938348a700cfd5e7db4d10a905e8af922328996
<pre>
Restrict floats over setCurrentTime &amp; setCurrentScale to finite values

Restrict floats over setCurrentTime &amp; setCurrentScale to finite values
<a href="https://bugs.webkit.org/show_bug.cgi?id=249741">https://bugs.webkit.org/show_bug.cgi?id=249741</a>

Reviewed by Simon Fraser.

This patch is to align WebKit with Blink / Chromium, Gecko / Firefox and Web-Specification.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/b4e294d0dec2aeffa4d401e19916e753a7d74a75">https://chromium.googlesource.com/chromium/blink/+/b4e294d0dec2aeffa4d401e19916e753a7d74a75</a>

This patch modifies &quot;setCurrentTime&quot; and &quot;setCurrentScale&quot; to work with finite floats and also update IDL definition aligned with current web-standard and also aligned with other browsers.

* Source/WebCore/svg/SVGSVGElement.cpp:
(SVGSVGElement::currentScale): Add ASSERT for finite &apos;scale&apos;
(SVGSVGElement::getCurrentTime): Change &quot;if&quot; to ASSERT for finite seconds
* Source/WebCore/svg/SVGSVGElement.idl: Aligned with Web-Spec
* LayoutTests/svg/dom/SVGSVGElement-currentTime.html: Add Test Case
* LayoutTests/svg/dom/SVGSVGElement-currentTime-expected.txt: Add Test Case Expectation
* LayoutTests/svg/dom/SVGSVGElement-currentScale-NaN-no-crash.html: Add Test Case
* LayoutTests/svg/dom/SSVGSVGElement-currentScale-NaN-no-crash-expected.txt: Add Test Case Expectation
* LayoutTests/svg/animations/animate-setcurrentime.html: Rebaselined
* LayoutTests/svg/animations/animate-setcurrentime-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/258322@main">https://commits.webkit.org/258322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ceb39f5c9be3c77a8809df03505e046756f2cc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110782 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171025 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1553 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108586 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78363 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24997 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1455 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5710 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6081 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->