### PR TITLE
Add Masonry Track Sizing Tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block-expected.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+    
+<head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Verify definite blocks effect track-sizing algorithm.</title>
+    <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+</head>
+
+<body>
+<style>
+grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 50px 50px;
+  width: 300px;
+  height: 100px;
+}
+
+box1 {
+    height: 50px;
+    width: 30px;
+    background-color: blue;
+}
+
+box2 {
+    height: 50px;
+    background-color: red;
+}
+
+box3 {
+    height: 50px;
+    width: 100px;
+    grid-row: 2;
+    grid-column: 1;
+    background-color: purple;
+}
+
+box4 {
+    height: 50px;
+    background-color: green;
+}
+
+</style>
+
+<grid>
+    <box1>1</box1>
+    <box2>2</box2>
+    <box3>3</box3>
+    <box4>4</box4>
+</grid>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block-ref.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+    
+<head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Verify definite blocks effect track-sizing algorithm.</title>
+    <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+</head>
+
+<body>
+<style>
+grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 50px 50px;
+  width: 300px;
+  height: 100px;
+}
+
+box1 {
+    height: 50px;
+    width: 30px;
+    background-color: blue;
+}
+
+box2 {
+    height: 50px;
+    background-color: red;
+}
+
+box3 {
+    height: 50px;
+    width: 100px;
+    grid-row: 2;
+    grid-column: 1;
+    background-color: purple;
+}
+
+box4 {
+    height: 50px;
+    background-color: green;
+}
+
+</style>
+
+<grid>
+    <box1>1</box1>
+    <box2>2</box2>
+    <box3>3</box3>
+    <box4>4</box4>
+</grid>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    
+<head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Verify definite blocks effect track-sizing algorithm.</title>
+    <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+    <link rel="match" href="masonry-track-sizing-explicit-block-ref.html">
+</head>
+
+<body>
+<style>
+grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: masonry;
+  width: 300px;
+  height: 100px;
+}
+
+box1 {
+    height: 50px;
+    width: 30px;
+    background-color: blue;
+}
+
+box2 {
+    height: 50px;
+    background-color: red;
+}
+
+box3 {
+    height: 50px;
+    width: 100px;
+    grid-row: 2;
+    grid-column: 1;
+    background-color: purple;
+}
+
+box4 {
+    height: 50px;
+    background-color: green;
+}
+
+</style>
+
+<grid>
+    <box1>1</box1>
+    <box2>2</box2>
+    <box3>3</box3>
+    <box4>4</box4>
+</grid>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row-expected.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    
+<head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Verify that fully spanning blocks take presedence over indefinite ones.</title>
+    <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+</head>
+
+<body>
+<style>
+grid {
+  display: grid;
+  grid-template-columns: 50px 1fr;
+  grid-template-rows: auto auto auto;
+  width: 300px;
+  height: 100px;
+}
+
+box1 {
+    height: 50px;
+    width: 50px;
+    background-color: blue;
+}
+
+box2 {
+    height: 50px;
+    background-color: red;
+}
+
+box3 {
+    width: 100px;
+    height: 50px;
+    background-color: purple;
+    z-index: 1;
+}
+
+box4 {
+    height: 50px;
+    width: 300px;
+    grid-column-start: 1;
+    grid-column-end: 3;
+    background-color: green;
+}
+</style>
+
+<grid>
+    <box1>1</box1>
+    <box2>2</box2>
+    <box4>4</box4>
+    <box3>3</box3>
+</grid>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row-ref.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    
+<head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Verify that fully spanning blocks take presedence over indefinite ones.</title>
+    <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+</head>
+
+<body>
+<style>
+grid {
+  display: grid;
+  grid-template-columns: 50px 1fr;
+  grid-template-rows: auto auto auto;
+  width: 300px;
+  height: 100px;
+}
+
+box1 {
+    height: 50px;
+    width: 50px;
+    background-color: blue;
+}
+
+box2 {
+    height: 50px;
+    background-color: red;
+}
+
+box3 {
+    width: 100px;
+    height: 50px;
+    background-color: purple;
+    z-index: 1;
+}
+
+box4 {
+    height: 50px;
+    width: 300px;
+    grid-column-start: 1;
+    grid-column-end: 3;
+    background-color: green;
+}
+</style>
+
+<grid>
+    <box1>1</box1>
+    <box2>2</box2>
+    <box4>4</box4>
+    <box3>3</box3>
+</grid>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+    
+<head>
+    <meta charset="utf-8">
+    <title>CSS Grid Test: Verify that fully spanning blocks take presedence over indefinite ones.</title>
+    <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+    <link rel="match" href="masonry-track-sizing-span-row-ref.html">
+</head>
+
+<body>
+<style>
+grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: masonry;
+  width: 300px;
+  height: 100px;
+}
+
+box1 {
+    height: 50px;
+    width: 50px;
+    background-color: blue;
+}
+
+box2 {
+    height: 50px;
+    background-color: red;
+}
+
+box3 {
+    width: 100px;
+    height: 50px;
+    background-color: purple;
+    z-index: 1;
+}
+
+box4 {
+    height: 50px;
+    width: 300px;
+    grid-column-start: 1;
+    grid-column-end: 3;
+    background-color: green;
+}
+</style>
+
+<grid>
+    <box1>1</box1>
+    <box2>2</box2>
+    <box3>3</box3>
+    <box4>4</box4>
+</grid>
+
+</body>
+</html>


### PR DESCRIPTION
#### 7a79101a21e1462bee8dc459dfa4b6745c81ae3e
<pre>
Add Masonry Track Sizing Tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249860">https://bugs.webkit.org/show_bug.cgi?id=249860</a>

Reviewed by Brent Fulgham.

Add tests to ensure track sizing functionality is working for definite blocks and
full row spanning blocks.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html: Added.

Canonical link: <a href="https://commits.webkit.org/258409@main">https://commits.webkit.org/258409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9a9d70cbeea463144e8ca368f5cb2c18ba93bf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110793 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171035 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1562 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108596 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35374 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90741 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4263 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25007 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1464 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5768 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6090 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->