### PR TITLE
[JSC] Refactor Wasm::Table and fix memory leak

### DIFF
--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -220,6 +220,7 @@ public:
 };
 
 enum UndefinedWriteBarrierTagType { UndefinedWriteBarrierTag };
+enum NullWriteBarrierTagType { NullWriteBarrierTag };
 template <>
 class WriteBarrier<Unknown, RawValueTraits<Unknown>> : public WriteBarrierBase<Unknown, RawValueTraits<Unknown>> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -231,6 +232,10 @@ public:
     WriteBarrier(UndefinedWriteBarrierTagType)
     {
         this->setWithoutWriteBarrier(jsUndefined());
+    }
+    WriteBarrier(NullWriteBarrierTagType)
+    {
+        this->setWithoutWriteBarrier(jsNull());
     }
 
     WriteBarrier(VM& vm, const JSCell* owner, JSValue value)

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -519,7 +519,7 @@ struct WasmToWasmImportableFunction {
 
     // FIXME: Pack type index and code pointer into one 64-bit value. See <https://bugs.webkit.org/show_bug.cgi?id=165511>.
     TypeIndex typeIndex { TypeDefinition::invalidIndex };
-    LoadLocation entrypointLoadLocation;
+    LoadLocation entrypointLoadLocation { };
 };
 using FunctionIndexSpace = Vector<WasmToWasmImportableFunction>;
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -753,9 +753,9 @@ static bool setWasmTableElement(Instance* instance, unsigned tableIndex, uint32_
         if (isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction)) {
             ASSERT(!!wasmFunction || !!wasmWrapperFunction);
             if (wasmFunction)
-                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), FuncRefTable::Function { wasmFunction->importableFunction(), &wasmFunction->instance()->instance() });
+                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmFunction->importableFunction(), &wasmFunction->instance()->instance());
             else
-                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), FuncRefTable::Function { wasmWrapperFunction->importableFunction(), &wasmWrapperFunction->instance()->instance() });
+                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmWrapperFunction->importableFunction(), &wasmWrapperFunction->instance()->instance());
         } else if (value.isNull())
             instance->table(tableIndex)->clear(index);
         else

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -34,6 +34,24 @@
 
 namespace JSC { namespace Wasm {
 
+template<typename Visitor> constexpr decltype(auto) Table::visitDerived(Visitor&& visitor)
+{
+    switch (type()) {
+    case TableElementType::Externref:
+        return std::invoke(std::forward<Visitor>(visitor), static_cast<ExternRefTable&>(*this));
+    case TableElementType::Funcref:
+        return std::invoke(std::forward<Visitor>(visitor), static_cast<FuncRefTable&>(*this));
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+template<typename Visitor> constexpr decltype(auto) Table::visitDerived(Visitor&& visitor) const
+{
+    return const_cast<Table&>(*this).visitDerived([&](auto& value) {
+        return std::invoke(std::forward<Visitor>(visitor), std::as_const(value));
+    });
+}
+
 uint32_t Table::allocatedLength(uint32_t length)
 {
     return WTF::roundUpToPowerOfTwo(length);
@@ -45,6 +63,14 @@ void Table::setLength(uint32_t length)
     ASSERT(isValidLength(length));
 }
 
+void Table::operator delete(Table* table, std::destroying_delete_t)
+{
+    table->visitDerived([](auto& table) {
+        std::destroy_at(&table);
+        std::decay_t<decltype(table)>::freeAfterDestruction(&table);
+    });
+}
+
 Table::Table(uint32_t initial, std::optional<uint32_t> maximum, TableElementType type)
     : m_type(type)
     , m_maximum(maximum)
@@ -52,15 +78,6 @@ Table::Table(uint32_t initial, std::optional<uint32_t> maximum, TableElementType
 {
     setLength(initial);
     ASSERT(!m_maximum || *m_maximum >= m_length);
-
-    // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
-    // But for now, we're not doing that.
-    // FIXME this over-allocates and could be smarter about not committing all of that memory https://bugs.webkit.org/show_bug.cgi?id=181425
-    m_jsValues = MallocPtr<WriteBarrier<Unknown>, VMMalloc>::malloc(sizeof(WriteBarrier<Unknown>) * Checked<size_t>(allocatedLength(m_length)));
-    for (uint32_t i = 0; i < allocatedLength(m_length); ++i) {
-        new (&m_jsValues.get()[i]) WriteBarrier<Unknown>();
-        m_jsValues.get()[i].setStartingValue(jsNull());
-    }
 }
 
 RefPtr<Table> Table::tryCreate(uint32_t initial, std::optional<uint32_t> maximum, TableElementType type)
@@ -68,10 +85,10 @@ RefPtr<Table> Table::tryCreate(uint32_t initial, std::optional<uint32_t> maximum
     if (!isValidLength(initial))
         return nullptr;
     switch (type) {
+    case TableElementType::Externref:
+        return adoptRef(new ExternRefTable(initial, maximum));
     case TableElementType::Funcref:
         return adoptRef(new FuncRefTable(initial, maximum));
-    case TableElementType::Externref:
-        return adoptRef(new Table(initial, maximum));
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -112,14 +129,25 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
         return true;
     };
 
-    if (auto* funcRefTable = asFuncrefTable()) {
-        if (!checkedGrow(funcRefTable->m_importableFunctions, [](auto&) { }))
-            return std::nullopt;
-    }
-
     VM& vm = m_owner->vm();
-    if (!checkedGrow(m_jsValues, [&](WriteBarrier<Unknown>& slot) { slot.set(vm, m_owner, defaultValue); }))
-        return std::nullopt;
+    switch (type()) {
+    case TableElementType::Externref: {
+        bool success = checkedGrow(static_cast<ExternRefTable*>(this)->m_jsValues, [&](auto& slot) {
+            slot.set(vm, m_owner, defaultValue);
+        });
+        if (UNLIKELY(!success))
+            return std::nullopt;
+        break;
+    }
+    case TableElementType::Funcref: {
+        bool success = checkedGrow(static_cast<FuncRefTable*>(this)->m_importableFunctions, [&](auto& slot) {
+            slot.m_value.set(vm, m_owner, defaultValue);
+        });
+        if (UNLIKELY(!success))
+            return std::nullopt;
+        break;
+    }
+    }
 
     setLength(newLength);
     return newLength;
@@ -137,12 +165,9 @@ void Table::clear(uint32_t index)
 {
     RELEASE_ASSERT(index < length());
     RELEASE_ASSERT(m_owner);
-    if (auto* funcRefTable = asFuncrefTable()) {
-        funcRefTable->m_importableFunctions.get()[index] = FuncRefTable::Function { };
-        ASSERT(funcRefTable->m_importableFunctions.get()[index].m_function.typeIndex == Wasm::TypeDefinition::invalidIndex); // We rely on this in compiled code.
-        ASSERT(!funcRefTable->m_importableFunctions.get()[index].m_instance);
-    }
-    m_jsValues.get()[index].setStartingValue(jsNull());
+    visitDerived([&](auto& table) {
+        table.clear(index);
+    });
 }
 
 void Table::set(uint32_t index, JSValue value)
@@ -150,15 +175,18 @@ void Table::set(uint32_t index, JSValue value)
     RELEASE_ASSERT(index < length());
     RELEASE_ASSERT(isExternrefTable());
     RELEASE_ASSERT(m_owner);
-    clear(index);
-    m_jsValues.get()[index].set(m_owner->vm(), m_owner, value);
+    visitDerived([&](auto& table) {
+        table.set(index, value);
+    });
 }
 
 JSValue Table::get(uint32_t index) const
 {
     RELEASE_ASSERT(index < length());
     RELEASE_ASSERT(m_owner);
-    return m_jsValues.get()[index].get();
+    return visitDerived([&](auto& table) {
+        return table.get(index);
+    });
 }
 
 template<typename Visitor>
@@ -166,8 +194,20 @@ void Table::visitAggregateImpl(Visitor& visitor)
 {
     RELEASE_ASSERT(m_owner);
     Locker locker { m_owner->cellLock() };
-    for (unsigned i = 0; i < m_length; ++i)
-        visitor.append(m_jsValues.get()[i]);
+    switch (type()) {
+    case TableElementType::Externref: {
+        auto* table = static_cast<ExternRefTable*>(this);
+        for (unsigned i = 0; i < m_length; ++i)
+            visitor.append(table->m_jsValues.get()[i]);
+        break;
+    }
+    case TableElementType::Funcref: {
+        auto* table = static_cast<FuncRefTable*>(this);
+        for (unsigned i = 0; i < m_length; ++i)
+            visitor.append(table->m_importableFunctions.get()[i].m_value);
+        break;
+    }
+    }
 }
 
 DEFINE_VISIT_AGGREGATE(Table);
@@ -185,6 +225,27 @@ FuncRefTable* Table::asFuncrefTable()
     return m_type == TableElementType::Funcref ? static_cast<FuncRefTable*>(this) : nullptr;
 }
 
+ExternRefTable::ExternRefTable(uint32_t initial, std::optional<uint32_t> maximum)
+    : Table(initial, maximum, TableElementType::Externref)
+{
+    // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
+    // But for now, we're not doing that.
+    // FIXME this over-allocates and could be smarter about not committing all of that memory https://bugs.webkit.org/show_bug.cgi?id=181425
+    m_jsValues = MallocPtr<WriteBarrier<Unknown>, VMMalloc>::malloc(sizeof(WriteBarrier<Unknown>) * Checked<size_t>(allocatedLength(m_length)));
+    for (uint32_t i = 0; i < allocatedLength(m_length); ++i)
+        new (&m_jsValues.get()[i]) WriteBarrier<Unknown>(NullWriteBarrierTag);
+}
+
+void ExternRefTable::clear(uint32_t index)
+{
+    m_jsValues.get()[index].setStartingValue(jsNull());
+}
+
+void ExternRefTable::set(uint32_t index, JSValue value)
+{
+    m_jsValues.get()[index].set(m_owner->vm(), m_owner, value);
+}
+
 FuncRefTable::FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum)
     : Table(initial, maximum, TableElementType::Funcref)
 {
@@ -196,17 +257,21 @@ FuncRefTable::FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum)
         new (&m_importableFunctions.get()[i]) Function();
         ASSERT(m_importableFunctions.get()[i].m_function.typeIndex == Wasm::TypeDefinition::invalidIndex); // We rely on this in compiled code.
         ASSERT(!m_importableFunctions.get()[i].m_instance);
+        ASSERT(m_importableFunctions.get()[i].m_value.isNull());
     }
 }
 
-void FuncRefTable::setFunction(uint32_t index, JSObject* optionalWrapper, Function function)
+void FuncRefTable::setFunction(uint32_t index, JSObject* optionalWrapper, WasmToWasmImportableFunction function, Instance* instance)
 {
     RELEASE_ASSERT(index < length());
     RELEASE_ASSERT(m_owner);
-    clear(index);
+    auto& slot = m_importableFunctions.get()[index];
+    slot.m_function = function;
+    slot.m_instance = instance;
     if (optionalWrapper)
-        m_jsValues.get()[index].set(m_owner->vm(), m_owner, optionalWrapper);
-    m_importableFunctions.get()[index] = function;
+        slot.m_value.set(m_owner->vm(), m_owner, optionalWrapper);
+    else
+        slot.m_value.setWithoutWriteBarrier(jsNull());
 }
 
 const FuncRefTable::Function& FuncRefTable::function(uint32_t index) const
@@ -221,7 +286,22 @@ void FuncRefTable::copyFunction(const FuncRefTable* srcTable, uint32_t dstIndex,
         return;
     }
 
-    setFunction(dstIndex, jsCast<JSObject*>(srcTable->get(srcIndex)), srcTable->function(srcIndex));
+    auto& function = srcTable->function(srcIndex);
+    setFunction(dstIndex, jsCast<JSObject*>(srcTable->get(srcIndex)), function.m_function, function.m_instance);
+}
+
+void FuncRefTable::clear(uint32_t index)
+{
+    m_importableFunctions.get()[index] = FuncRefTable::Function { };
+    ASSERT(m_importableFunctions.get()[index].m_function.typeIndex == Wasm::TypeDefinition::invalidIndex); // We rely on this in compiled code.
+    ASSERT(!m_importableFunctions.get()[index].m_instance);
+    ASSERT(m_importableFunctions.get()[index].m_value.isNull());
+}
+
+void FuncRefTable::set(uint32_t index, JSValue value)
+{
+    clear(index);
+    m_importableFunctions.get()[index].m_value.set(m_owner->vm(), m_owner, value);
 }
 
 } } // namespace JSC::Table

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -80,44 +80,67 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
 
+    void operator delete(Table*, std::destroying_delete_t);
+
 protected:
     Table(uint32_t initial, std::optional<uint32_t> maximum, TableElementType = TableElementType::Externref);
+
+    template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&);
+    template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&) const;
 
     void setLength(uint32_t);
 
     uint32_t m_length;
     const TableElementType m_type;
     const std::optional<uint32_t> m_maximum;
-
-    MallocPtr<WriteBarrier<Unknown>, VMMalloc> m_jsValues;
     JSObject* m_owner;
 };
 
-class FuncRefTable : public Table {
+class ExternRefTable final : public Table {
 public:
+    friend class Table;
+
+    void clear(uint32_t);
+    void set(uint32_t, JSValue);
+    JSValue get(uint32_t index) const { return m_jsValues.get()[index].get(); }
+
+private:
+    ExternRefTable(uint32_t initial, std::optional<uint32_t> maximum);
+
+    MallocPtr<WriteBarrier<Unknown>, VMMalloc> m_jsValues;
+};
+
+class FuncRefTable final : public Table {
+public:
+    friend class Table;
+
     JS_EXPORT_PRIVATE ~FuncRefTable() = default;
 
     // call_indirect needs to do an Instance check to potentially context switch when calling a function to another instance. We can hold raw pointers to Instance here because the embedder ensures that Table keeps all the instances alive. We couldn't hold a Ref here because it would cause cycles.
     struct Function {
         WasmToWasmImportableFunction m_function;
         Instance* m_instance { nullptr };
+        WriteBarrier<Unknown> m_value { NullWriteBarrierTag };
 
         static ptrdiff_t offsetOfFunction() { return OBJECT_OFFSETOF(Function, m_function); }
         static ptrdiff_t offsetOfInstance() { return OBJECT_OFFSETOF(Function, m_instance); }
+        static ptrdiff_t offsetOfValue() { return OBJECT_OFFSETOF(Function, m_value); }
     };
 
-    void setFunction(uint32_t, JSObject*, Function);
+    void setFunction(uint32_t, JSObject*, WasmToWasmImportableFunction, Instance*);
     const Function& function(uint32_t) const;
     void copyFunction(const FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 
     static ptrdiff_t offsetOfFunctions() { return OBJECT_OFFSETOF(FuncRefTable, m_importableFunctions); }
 
+    void clear(uint32_t);
+    void set(uint32_t, JSValue);
+    JSValue get(uint32_t index) const { return m_importableFunctions.get()[index].m_value.get(); }
+
 private:
     FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum);
 
     MallocPtr<Function, VMMalloc> m_importableFunctions;
-
-    friend class Table;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -110,7 +110,7 @@ void JSWebAssemblyTable::set(uint32_t index, WebAssemblyFunctionBase* function)
     RELEASE_ASSERT(index < length());
     RELEASE_ASSERT(m_table->asFuncrefTable());
     auto& subThis = *static_cast<Wasm::FuncRefTable*>(&m_table.get());
-    subThis.setFunction(index, function, Wasm::FuncRefTable::Function { function->importableFunction(), &function->instance()->instance() });
+    subThis.setFunction(index, function, function->importableFunction(), &function->instance()->instance());
 }
 
 void JSWebAssemblyTable::clear(uint32_t index)


### PR DESCRIPTION
#### 55bd5e05561eb0c7c119fce0c90d5c1c1b24fab9
<pre>
[JSC] Refactor Wasm::Table and fix memory leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=249861">https://bugs.webkit.org/show_bug.cgi?id=249861</a>
rdar://103682266

Reviewed by Mark Lam.

This patch refactors Wasm::Table and fixes memory leak.
Previously, FuncRefTable&apos;s destructor is not called so
it was leaking memory for functions. This patch integrates
std::destroying_delete so that we can call derived class&apos;
destructor correctly. We also introduce ExternRefTable so
we allocate combined memory (jsValue + functions) for FuncRefTable.

* Source/JavaScriptCore/runtime/WriteBarrier.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::setWasmTableElement):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::visitDerived):
(JSC::Wasm::Table::visitDerived const):
(JSC::Wasm::Table::operator delete):
(JSC::Wasm::Table::Table):
(JSC::Wasm::Table::tryCreate):
(JSC::Wasm::Table::grow):
(JSC::Wasm::Table::clear):
(JSC::Wasm::Table::set):
(JSC::Wasm::Table::get const):
(JSC::Wasm::Table::visitAggregateImpl):
(JSC::Wasm::ExternRefTable::ExternRefTable):
(JSC::Wasm::ExternRefTable::clear):
(JSC::Wasm::ExternRefTable::set):
(JSC::Wasm::FuncRefTable::FuncRefTable):
(JSC::Wasm::FuncRefTable::setFunction):
(JSC::Wasm::FuncRefTable::copyFunction):
(JSC::Wasm::FuncRefTable::clear):
(JSC::Wasm::FuncRefTable::set):
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::FuncRefTable::Function::offsetOfFunction): Deleted.
(JSC::Wasm::FuncRefTable::Function::offsetOfInstance): Deleted.
(JSC::Wasm::FuncRefTable::offsetOfFunctions): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::set):

Canonical link: <a href="https://commits.webkit.org/258325@main">https://commits.webkit.org/258325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d13390f4d5212cf20955f9508e6da74d19128b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110809 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1576 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108610 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8858 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90752 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91942 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4276 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88092 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1865 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29343 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10427 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90994 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6104 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20336 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3014 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->