### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for Button

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1742,6 +1742,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/angle/ANGLEUtilities.h
     platform/graphics/angle/GraphicsContextGLANGLE.h
 
+    platform/graphics/controls/ButtonPart.h
     platform/graphics/controls/ControlFactory.h
     platform/graphics/controls/ControlPart.h
     platform/graphics/controls/ControlPartType.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -462,6 +462,7 @@ platform/graphics/mac/SimpleFontDataCoreText.cpp
 platform/graphics/mac/SwitchingGPUClient.cpp
 platform/graphics/mac/WebKitNSImageExtras.mm
 platform/graphics/mac/WebLayer.mm
+platform/graphics/mac/controls/ButtonMac.mm
 platform/graphics/mac/controls/ButtonControlMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm

--- a/Source/WebCore/platform/graphics/controls/ButtonPart.h
+++ b/Source/WebCore/platform/graphics/controls/ButtonPart.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class ButtonPart final : public ControlPart {
+public:
+    static Ref<ButtonPart> create(ControlPartType type)
+    {
+        return adoptRef(*new ButtonPart(type));
+    }
+
+private:
+    ButtonPart(ControlPartType type)
+        : ControlPart(type)
+    {
+        ASSERT(type == ControlPartType::Button
+            || type == ControlPartType::DefaultButton
+            || type == ControlPartType::PushButton
+            || type == ControlPartType::SquareButton);
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformButton(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -27,6 +27,7 @@
 
 namespace WebCore {
 
+class ButtonPart;
 class MeterPart;
 class MenuListPart;
 class PlatformControl;
@@ -40,12 +41,12 @@ class ToggleButtonPart;
 class ControlFactory {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ControlFactory() = default;
     virtual ~ControlFactory() = default;
 
     WEBCORE_EXPORT static std::unique_ptr<ControlFactory> createControlFactory();
     static ControlFactory& sharedControlFactory();
 
+    virtual std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
@@ -54,6 +55,9 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;
+
+protected:
+    ControlFactory() = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ButtonControlMac.h"
+
+namespace WebCore {
+
+class ButtonPart;
+
+class ButtonMac final : public ButtonControlMac {
+public:
+    ButtonMac(ButtonPart& owningPart, ControlFactoryMac&, NSButtonCell *);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const final;
+
+    NSBezelStyle bezelStyle(const FloatRect&, const ControlStyle&) const;
+
+    void updateCellStates(const FloatRect&, const ControlStyle&) final;
+
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const final;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ButtonMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ButtonPart.h"
+#import "ControlFactoryMac.h"
+#import "GraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+ButtonMac::ButtonMac(ButtonPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
+    : ButtonControlMac(owningPart, controlFactory, buttonCell)
+{
+    ASSERT(m_owningPart.type() == ControlPartType::Button
+        || m_owningPart.type() == ControlPartType::DefaultButton
+        || m_owningPart.type() == ControlPartType::PushButton
+        || m_owningPart.type() == ControlPartType::SquareButton);
+}
+
+IntSize ButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    // Buttons really only constrain height. They respect width.
+    static const IntSize cellSizes[] = {
+        { 0, 21 },
+        { 0, 18 },
+        { 0, 15 },
+        { 0, 28 }
+    };
+    return cellSizes[controlSize];
+}
+
+IntOutsets ButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
+{
+    // FIXME: These values may need to be reevaluated. They appear to have been originally chosen
+    // to reflect the size of shadows around native form controls on macOS, but as of macOS 10.15,
+    // these margins extend well past the boundaries of a native button cell's shadows.
+    static const IntOutsets cellOutsets[] = {
+        // top right bottom left
+        { 4, 6, 7, 6 },
+        { 4, 5, 6, 5 },
+        { 0, 1, 1, 1 },
+        { 4, 6, 7, 6 },
+    };
+    return cellOutsets[controlSize];
+}
+
+NSBezelStyle ButtonMac::bezelStyle(const FloatRect& rect, const ControlStyle& style) const
+{
+    if (m_owningPart.type() == ControlPartType::SquareButton)
+        return NSBezelStyleShadowlessSquare;
+
+    auto controlSize = style.states.contains(ControlStyle::State::LargeControls) ? NSControlSizeLarge : NSControlSizeRegular;
+    auto size = cellSize(controlSize, style);
+
+    if (rect.height() > size.height() * style.zoomFactor)
+        return NSBezelStyleShadowlessSquare;
+
+    return NSBezelStyleRounded;
+}
+
+void ButtonMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    ButtonControlMac::updateCellStates(rect, style);
+    [m_buttonCell setBezelStyle:bezelStyle(rect, style)];
+}
+
+FloatRect ButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    if ([m_buttonCell bezelStyle] != NSBezelStyleRounded)
+        return bounds;
+
+    auto controlSize = [m_buttonCell controlSize];
+    auto size = cellSize(controlSize, style);
+    auto outsets = cellOutsets(controlSize, style);
+
+    size.scale(style.zoomFactor);
+    size.setWidth(bounds.width());
+
+    auto rect = bounds;
+    auto delta = rect.height() - size.height();
+    if (delta > 0)
+        rect.expand(0, delta / 2);
+
+    return inflatedRect(rect, size, outsets, style);
+}
+
+void ButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto inflatedRect = rectForBounds(rect, style);
+
+    if (style.zoomFactor != 1) {
+        inflatedRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *window = [view window];
+    auto *previousDefaultButtonCell = [window defaultButtonCell];
+
+    // Setup the window default button cell.
+    if (style.states.contains(ControlStyle::State::Default))
+        [window setDefaultButtonCell:m_buttonCell.get()];
+    else if ([previousDefaultButtonCell isEqual:m_buttonCell.get()])
+        [window setDefaultButtonCell:nil];
+
+    drawCell(context, inflatedRect, deviceScaleFactor, style, m_buttonCell.get(), view, true);
+
+    // Restore the window default button cell.
+    if (![previousDefaultButtonCell isEqual:m_buttonCell.get()])
+        [window setDefaultButtonCell:previousDefaultButtonCell];
+
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -32,12 +32,13 @@
 
 namespace WebCore {
 
-class ControlFactoryMac : public ControlFactory {
+class ControlFactoryMac final : public ControlFactory {
 public:
     using ControlFactory::ControlFactory;
 
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
+    std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) final;
     std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) override;
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
     std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) override;
@@ -48,6 +49,8 @@ public:
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) override;
 
 private:
+    NSButtonCell *buttonCell() const;
+    NSButtonCell *defaultButtonCell() const;
     NSButtonCell *checkboxCell() const;
     NSButtonCell *radioCell() const;
     NSLevelIndicatorCell *levelIndicatorCell() const;
@@ -57,6 +60,8 @@ private:
 
     mutable RetainPtr<WebControlView> m_drawingView;
 
+    mutable RetainPtr<NSButtonCell> m_buttonCell;
+    mutable RetainPtr<NSButtonCell> m_defaultButtonCell;
     mutable RetainPtr<NSButtonCell> m_checkboxCell;
     mutable RetainPtr<NSButtonCell> m_radioCell;
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "ButtonMac.h"
 #import "MenuListMac.h"
 #import "MeterMac.h"
 #import "ProgressBarMac.h"
@@ -65,6 +66,35 @@ NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle
     UNUSED_PARAM(style);
 #endif
     return m_drawingView.get();
+}
+
+static RetainPtr<NSButtonCell> createButtonCell()
+{
+    auto buttonCell = adoptNS([[NSButtonCell alloc] init]);
+    [buttonCell setTitle:nil];
+    [buttonCell setButtonType:NSButtonTypeMomentaryPushIn];
+    return buttonCell;
+}
+
+NSButtonCell* ControlFactoryMac::buttonCell() const
+{
+    if (!m_buttonCell) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        m_buttonCell = createButtonCell();
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
+    return m_buttonCell.get();
+}
+
+NSButtonCell* ControlFactoryMac::defaultButtonCell() const
+{
+    if (!m_defaultButtonCell) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        m_defaultButtonCell = createButtonCell();
+        [m_defaultButtonCell setKeyEquivalent:@"\r"];
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
+    return m_defaultButtonCell.get();
 }
 
 static RetainPtr<NSButtonCell> createToggleButtonCell()
@@ -148,6 +178,11 @@ NSTextFieldCell *ControlFactoryMac::textFieldCell() const
         END_BLOCK_OBJC_EXCEPTIONS
     }
     return m_textFieldCell.get();
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformButton(ButtonPart& part)
+{
+    return makeUnique<ButtonMac>(part, *this, part.type() == ControlPartType::DefaultButton ? defaultButtonCell() : buttonCell());
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMenuList(MenuListPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -28,6 +28,7 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import "ProgressBarPart.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -29,8 +29,11 @@
 #if PLATFORM(MAC)
 
 #import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "ProgressBarPart.h"
+#import <pal/spi/mac/CoreUISPI.h>
+#import <pal/spi/mac/NSAppearanceSPI.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "RenderTheme.h"
 
+#include "ButtonPart.h"
 #include "CSSValueKeywords.h"
 #include "ColorBlending.h"
 #include "ColorLuminance.h"
@@ -512,7 +513,7 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     case ControlPartType::SquareButton:
     case ControlPartType::Button:
     case ControlPartType::DefaultButton:
-        break;
+        return ButtonPart::create(type);
 
     case ControlPartType::Menulist:
         return MenuListPart::create();

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -222,14 +222,18 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Contr
 #if ENABLE(APPLE_PAY)
     case ControlPartType::ApplePayButton:
 #endif
+    case ControlPartType::Button:
     case ControlPartType::Checkbox:
+    case ControlPartType::DefaultButton:
     case ControlPartType::Listbox:
     case ControlPartType::Menulist:
     case ControlPartType::Meter:
     case ControlPartType::ProgressBar:
     case ControlPartType::Radio:
+    case ControlPartType::PushButton:
     case ControlPartType::SearchField:
     case ControlPartType::SearchFieldCancelButton:
+    case ControlPartType::SquareButton:
     case ControlPartType::TextArea:
     case ControlPartType::TextField:
         return true;
@@ -247,13 +251,17 @@ RenderThemeMac::RenderThemeMac()
 bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& renderer) const
 {
     ControlPartType type = renderer.style().effectiveAppearance();
-    return type == ControlPartType::Checkbox
+    return type == ControlPartType::Button
+        || type == ControlPartType::Checkbox
+        || type == ControlPartType::DefaultButton
         || type == ControlPartType::Menulist
         || type == ControlPartType::Meter
         || type == ControlPartType::ProgressBar
+        || type == ControlPartType::PushButton
         || type == ControlPartType::Radio
         || type == ControlPartType::SearchField
-        || type == ControlPartType::SearchFieldCancelButton;
+        || type == ControlPartType::SearchFieldCancelButton
+        || type == ControlPartType::SquareButton;
 }
 
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/BlobPart.h>
+#include <WebCore/ButtonPart.h>
 #include <WebCore/ByteArrayPixelBuffer.h>
 #include <WebCore/COEPInheritenceViolationReportBody.h>
 #include <WebCore/CORPViolationReportBody.h>
@@ -1612,8 +1613,8 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::SquareButton:
     case WebCore::ControlPartType::Button:
     case WebCore::ControlPartType::DefaultButton:
-        break;
-            
+        return WebCore::ButtonPart::create(*type);
+
     case WebCore::ControlPartType::Menulist:
         return WebCore::MenuListPart::create();
 


### PR DESCRIPTION
#### 13bd3d0bfff1b515cfc56ab9a9f9f249891f5831
<pre>
[GPU Process] [FormControls] Add a ControlPart for Button
<a href="https://bugs.webkit.org/show_bug.cgi?id=249878">https://bugs.webkit.org/show_bug.cgi?id=249878</a>
rdar://103692353

Reviewed by Aditya Keerthi.

ButtonPart will handle drawing the button form control. This covers the parts&apos;
types: Button, PushButton, DefaultButton and SquareButton. The following HTML
markup shows different buttons in the page:

&lt;button&gt;
&lt;input type=&quot;button&quot;&gt;
&lt;input type=&quot;submit&quot;&gt;
&lt;input type=&quot;reset&quot;&gt;
&lt;input type=&quot;file&quot;&gt;

On macOS, AppKit will be used to draw the platform controls through ButtonMac.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ButtonPart.h: Copied from Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h.
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/PlatformControl.h:
(WebCore::PlatformControl::rectForBounds const):
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.h: Copied from Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h.
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm: Added.
(WebCore::ButtonMac::ButtonMac):
(WebCore::ButtonMac::cellSize const):
(WebCore::ButtonMac::cellOutsets const):
(WebCore::ButtonMac::bezelStyle const):
(WebCore::ButtonMac::updateCellStates):
(WebCore::ButtonMac::rectForBounds const):
(WebCore::ButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::createButtonCell):
(WebCore::ControlFactoryMac::buttonCell const):
(WebCore::ControlFactoryMac::defaultButtonCell const):
(WebCore::ControlFactoryMac::createPlatformButton):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::setFocusRingClipRect):
(WebCore::ControlMac::inflatedRect):
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::button):
(WebCore::ThemeMac::paint):
(WebCore::paintButton): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258492@main">https://commits.webkit.org/258492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2b466ccd143c8406c37f77ca34baa134fe9ea4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111420 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171596 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2151 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109156 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78886 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25528 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1970 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5824 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6654 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->