### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for InnerSpinButton

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1748,6 +1748,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ControlPart.h
     platform/graphics/controls/ControlPartType.h
     platform/graphics/controls/ControlStyle.h
+    platform/graphics/controls/InnerSpinButtonPart.h
     platform/graphics/controls/MenuListPart.h
     platform/graphics/controls/MeterPart.h
     platform/graphics/controls/PlatformControl.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -466,6 +466,7 @@ platform/graphics/mac/controls/ButtonMac.mm
 platform/graphics/mac/controls/ButtonControlMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
+platform/graphics/mac/controls/InnerSpinButtonMac.mm
 platform/graphics/mac/controls/MenuListMac.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 class ButtonPart;
+class InnerSpinButtonPart;
 class MeterPart;
 class MenuListPart;
 class PlatformControl;
@@ -49,6 +50,7 @@ public:
     static ControlFactory& sharedControlFactory();
 
     virtual std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/InnerSpinButtonPart.h
+++ b/Source/WebCore/platform/graphics/controls/InnerSpinButtonPart.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class InnerSpinButtonPart final : public ControlPart {
+public:
+    static Ref<InnerSpinButtonPart> create()
+    {
+        return adoptRef(*new InnerSpinButtonPart());
+    }
+
+private:
+    InnerSpinButtonPart()
+        : ControlPart(ControlPartType::InnerSpinButton)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformInnerSpinButton(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,16 +39,17 @@ public:
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
     std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) final;
-    std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
-    std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
 
 private:
     NSButtonCell *buttonCell() const;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "ButtonMac.h"
+#import "InnerSpinButtonMac.h"
 #import "MenuListMac.h"
 #import "MeterMac.h"
 #import "ProgressBarMac.h"
@@ -196,6 +197,11 @@ NSTextFieldCell *ControlFactoryMac::textFieldCell() const
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformButton(ButtonPart& part)
 {
     return makeUnique<ButtonMac>(part, *this, part.type() == ControlPartType::DefaultButton ? defaultButtonCell() : buttonCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformInnerSpinButton(InnerSpinButtonPart& part)
+{
+    return makeUnique<InnerSpinButtonMac>(part, *this);
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMenuList(MenuListPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class InnerSpinButtonMac : public ControlMac {
+public:
+    InnerSpinButtonMac(InnerSpinButtonPart&, ControlFactoryMac&);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "InnerSpinButtonMac.h"
+
+#if PLATFORM(MAC)
+
+#import "GraphicsContext.h"
+#import "InnerSpinButtonPart.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import <pal/spi/mac/CoreUISPI.h>
+#import <pal/spi/mac/NSAppearanceSPI.h>
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+InnerSpinButtonMac::InnerSpinButtonMac(InnerSpinButtonPart& owningPart, ControlFactoryMac& controlFactory)
+    : ControlMac(owningPart, controlFactory)
+{
+}
+
+IntSize InnerSpinButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const IntSize sizes[] = {
+        { 19, 27 },
+        { 15, 22 },
+        { 13, 15 },
+        { 19, 27 }
+    };
+    return sizes[controlSize];
+}
+
+void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    // We don't use NSStepperCell because there are no ways to draw an
+    // NSStepperCell with the up button highlighted.
+
+    NSString *coreUIState;
+    auto states = style.states;
+    if (!states.contains(ControlStyle::State::Enabled))
+        coreUIState = (__bridge NSString *)kCUIStateDisabled;
+    else if (states.contains(ControlStyle::State::Pressed))
+        coreUIState = (__bridge NSString *)kCUIStatePressed;
+    else
+        coreUIState = (__bridge NSString *)kCUIStateActive;
+
+    NSString *coreUISize;
+    auto controlSize = controlSizeForSize(rect.size(), style);
+    if (controlSize == NSControlSizeMini)
+        coreUISize = (__bridge NSString *)kCUISizeMini;
+    else if (controlSize == NSControlSizeSmall)
+        coreUISize = (__bridge NSString *)kCUISizeSmall;
+    else
+        coreUISize = (__bridge NSString *)kCUISizeRegular;
+
+    IntRect logicalRect(rect);
+
+    GraphicsContextStateSaver stateSaver(context);
+    if (style.zoomFactor != 1) {
+        logicalRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    LocalCurrentGraphicsContext localContext(context);
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [[NSAppearance currentAppearance] _drawInRect:logicalRect context:localContext.cgContext() options:@{
+    ALLOW_DEPRECATED_DECLARATIONS_END
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetButtonLittleArrows,
+        (__bridge NSString *)kCUISizeKey: coreUISize,
+        (__bridge NSString *)kCUIStateKey: coreUIState,
+        (__bridge NSString *)kCUIValueKey: states.contains(ControlStyle::State::SpinUp) ? @1 : @0,
+        (__bridge NSString *)kCUIIsFlippedKey: @NO,
+        (__bridge NSString *)kCUIScaleKey: @1,
+        (__bridge NSString *)kCUIMaskOnlyKey: @NO
+    }];
+
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -28,10 +28,9 @@
 #if PLATFORM(MAC)
 
 #import "ControlMac.h"
+#import "MeterPart.h"
 
 namespace WebCore {
-
-class MeterPart;
 
 class MeterMac : public ControlMac {
 public:

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -518,53 +518,6 @@ static NSControlSize stepperControlSizeForFont(const FontCascade& font)
     return NSControlSizeMini;
 }
 
-static void paintStepper(ControlStates& controlStates, GraphicsContext& context, const FloatRect& zoomedRect, float zoomFactor, ScrollView*)
-{
-    // We don't use NSStepperCell because there are no ways to draw an
-    // NSStepperCell with the up button highlighted.
-
-    NSString *coreUIState;
-    auto states = controlStates.states();
-    if (!states.contains(ControlStates::States::Enabled))
-        coreUIState = (__bridge NSString *)kCUIStateDisabled;
-    else if (states.contains(ControlStates::States::Pressed))
-        coreUIState = (__bridge NSString *)kCUIStatePressed;
-    else
-        coreUIState = (__bridge NSString *)kCUIStateActive;
-
-    NSString *coreUISize;
-    auto controlSize = controlSizeFromPixelSize(stepperSizes(), IntSize(zoomedRect.size()), zoomFactor);
-    if (controlSize == NSControlSizeMini)
-        coreUISize = (__bridge NSString *)kCUISizeMini;
-    else if (controlSize == NSControlSizeSmall)
-        coreUISize = (__bridge NSString *)kCUISizeSmall;
-    else
-        coreUISize = (__bridge NSString *)kCUISizeRegular;
-
-    IntRect rect(zoomedRect);
-    GraphicsContextStateSaver stateSaver(context);
-    if (zoomFactor != 1.0f) {
-        rect.setWidth(rect.width() / zoomFactor);
-        rect.setHeight(rect.height() / zoomFactor);
-        context.translate(rect.location());
-        context.scale(zoomFactor);
-        context.translate(-rect.location());
-    }
-
-    LocalCurrentGraphicsContext localContext(context);
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[NSAppearance currentAppearance] _drawInRect:rect context:localContext.cgContext() options:@{
-    ALLOW_DEPRECATED_DECLARATIONS_END
-        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetButtonLittleArrows,
-        (__bridge NSString *)kCUISizeKey: coreUISize,
-        (__bridge NSString *)kCUIStateKey: coreUIState,
-        (__bridge NSString *)kCUIValueKey: states.contains(ControlStates::States::SpinUp) ? @1 : @0,
-        (__bridge NSString *)kCUIIsFlippedKey: @NO,
-        (__bridge NSString *)kCUIScaleKey: @1,
-        (__bridge NSString *)kCUIMaskOnlyKey: @NO
-    }];
-}
-
 // This will ensure that we always return a valid NSView, even if ScrollView doesn't have an associated document NSView.
 // If the ScrollView doesn't have an NSView, we will return a fake NSView set up in the way AppKit expects.
 NSView *ThemeMac::ensuredView(ScrollView* scrollView, const ControlStates& controlStates, bool useUnparentedView)
@@ -856,9 +809,6 @@ void ThemeMac::paint(ControlPartType type, ControlStates& states, GraphicsContex
         paintColorWell(states, context, zoomedRect, zoomFactor, scrollView, deviceScaleFactor);
         break;
 #endif
-    case ControlPartType::InnerSpinButton:
-        paintStepper(states, context, zoomedRect, zoomFactor, scrollView);
-        break;
     default:
         break;
     }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -44,6 +44,7 @@
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
 #include "HTMLTextAreaElement.h"
+#include "InnerSpinButtonPart.h"
 #include "LocalizedStrings.h"
 #include "MenuListPart.h"
 #include "MeterPart.h"
@@ -604,7 +605,11 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 #if ENABLE(SERVICE_CONTROLS)
     case ControlPartType::ImageControlsButton:
 #endif
+        break;
+
     case ControlPartType::InnerSpinButton:
+        return InnerSpinButtonPart::create();
+
 #if ENABLE(DATALIST_ELEMENT)
     case ControlPartType::ListButton:
 #endif

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -225,6 +225,7 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Contr
     case ControlPartType::Button:
     case ControlPartType::Checkbox:
     case ControlPartType::DefaultButton:
+    case ControlPartType::InnerSpinButton:
     case ControlPartType::Listbox:
     case ControlPartType::Menulist:
     case ControlPartType::Meter:
@@ -258,6 +259,7 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
     return type == ControlPartType::Button
         || type == ControlPartType::Checkbox
         || type == ControlPartType::DefaultButton
+        || type == ControlPartType::InnerSpinButton
         || type == ControlPartType::Menulist
         || type == ControlPartType::Meter
         || type == ControlPartType::ProgressBar

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -70,6 +70,7 @@
 #include <WebCore/IDBGetResult.h>
 #include <WebCore/IdentityTransformOperation.h>
 #include <WebCore/Image.h>
+#include <WebCore/InnerSpinButtonPart.h>
 #include <WebCore/JSDOMExceptionHandling.h>
 #include <WebCore/Length.h>
 #include <WebCore/LengthBox.h>
@@ -1677,7 +1678,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
 #if ENABLE(SERVICE_CONTROLS)
     case WebCore::ControlPartType::ImageControlsButton:
 #endif
+        break;
+
     case WebCore::ControlPartType::InnerSpinButton:
+        return WebCore::InnerSpinButtonPart::create();
+
 #if ENABLE(DATALIST_ELEMENT)
     case WebCore::ControlPartType::ListButton:
 #endif


### PR DESCRIPTION
#### a7cb32dd78298add87a55300a4a8992401cbf253
<pre>
[GPU Process] [FormControls] Add a ControlPart for InnerSpinButton
<a href="https://bugs.webkit.org/show_bug.cgi?id=249885">https://bugs.webkit.org/show_bug.cgi?id=249885</a>
rdar://103697514

Reviewed by Aditya Keerthi.

The InnerSpinButtonPart will handle drawing the stepper control part which is
displayed for the (&lt;input type=&quot;number&quot;&gt;) form control. On macOS, AppKit will
be used to draw the platform control through the class InnerSpinButtonMac.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/InnerSpinButtonPart.h: Copied from Source/WebCore/platform/graphics/mac/controls/MeterMac.h.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::createPlatformInnerSpinButton):
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h: Copied from Source/WebCore/platform/graphics/mac/controls/MeterMac.h.
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm: Added.
(WebCore::InnerSpinButtonMac::InnerSpinButtonMac):
(WebCore::InnerSpinButtonMac::cellSize const):
(WebCore::InnerSpinButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::paint):
(WebCore::paintStepper): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258525@main">https://commits.webkit.org/258525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeb1baee000102ad1b6232b16d157ad52c434c45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111550 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2287 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108015 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92736 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24218 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25640 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2081 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45138 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5846 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6784 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->