### PR TITLE
[GPU Process] [FormControls] Add ControlParts for SearchField and SearchFieldCancelButton

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1749,6 +1749,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/MeterPart.h
     platform/graphics/controls/PlatformControl.h
     platform/graphics/controls/ProgressBarPart.h
+    platform/graphics/controls/SearchFieldCancelButtonPart.h
+    platform/graphics/controls/SearchFieldPart.h
     platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
     platform/graphics/controls/ToggleButtonPart.h

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -936,6 +936,7 @@
 		63E369F921AFA83F001C14BC /* NSProgressSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSProgressSPI.h; sourceTree = "<group>"; };
 		71B1141F26823ACD004D6701 /* SystemPreviewSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemPreviewSPI.h; sourceTree = "<group>"; };
 		72BA2A872951462500678507 /* NSTextFieldCellSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSTextFieldCellSPI.h; sourceTree = "<group>"; };
+		72C9483A2959517C006ECB96 /* NSSearchFieldCellSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSSearchFieldCellSPI.h; sourceTree = "<group>"; };
 		7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoSPI.h; sourceTree = "<group>"; };
 		7A3A6A7F20CADB4600317AAE /* NSImageSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSImageSPI.h; sourceTree = "<group>"; };
 		7B47F2A128587B9700E793C8 /* CoreGraphicsSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreGraphicsSoftLink.h; sourceTree = "<group>"; };
@@ -1207,6 +1208,7 @@
 				0C77857D1F45130F00F4EBB6 /* NSScrollingInputFilterSPI.h */,
 				0C77857E1F45130F00F4EBB6 /* NSScrollingMomentumCalculatorSPI.h */,
 				A1175B591F6B4A8400C4B9F0 /* NSScrollViewSPI.h */,
+				72C9483A2959517C006ECB96 /* NSSearchFieldCellSPI.h */,
 				44EEA0FE2747438900594A83 /* NSServicesRolloverButtonCellSPI.h */,
 				0C77857F1F45130F00F4EBB6 /* NSSharingServicePickerSPI.h */,
 				0C7785801F45130F00F4EBB6 /* NSSharingServiceSPI.h */,

--- a/Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <AppKit/NSSearchFieldCell.h>
+
+@interface NSSearchFieldCell ()
+@property (getter=isCenteredLook) BOOL centeredLook;
+@end

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -468,6 +468,9 @@ platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/MenuListMac.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm
+platform/graphics/mac/controls/SearchControlMac.mm
+platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+platform/graphics/mac/controls/SearchFieldMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm

--- a/Source/WebCore/platform/ControlStates.h
+++ b/Source/WebCore/platform/ControlStates.h
@@ -52,7 +52,7 @@ public:
         Enabled = 1 << 3,
         Checked = 1 << 4,
         Default = 1 << 5,
-        WindowInactive = 1 << 6,
+        WindowActive = 1 << 6,
         Indeterminate = 1 << 7,
         SpinUp = 1 << 8, // Sub-state for HoverState and PressedState.
         Presenting = 1 << 9,

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -31,6 +31,8 @@ class MeterPart;
 class MenuListPart;
 class PlatformControl;
 class ProgressBarPart;
+class SearchFieldCancelButtonPart;
+class SearchFieldPart;
 class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
@@ -47,6 +49,8 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/SearchFieldCancelButtonPart.h
+++ b/Source/WebCore/platform/graphics/controls/SearchFieldCancelButtonPart.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SearchFieldCancelButtonPart final : public ControlPart {
+public:
+    static Ref<SearchFieldCancelButtonPart> create()
+    {
+        return adoptRef(*new SearchFieldCancelButtonPart());
+    }
+
+private:
+    SearchFieldCancelButtonPart()
+        : ControlPart(ControlPartType::SearchFieldCancelButton)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSearchFieldCancelButton(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/SearchFieldPart.h
+++ b/Source/WebCore/platform/graphics/controls/SearchFieldPart.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SearchFieldPart final : public ControlPart {
+public:
+    static Ref<SearchFieldPart> create()
+    {
+        return adoptRef(*new SearchFieldPart());
+    }
+
+private:
+    SearchFieldPart()
+        : ControlPart(ControlPartType::SearchField)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSearchField(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -41,6 +41,8 @@ public:
     std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) override;
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
     std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) override;
@@ -50,6 +52,7 @@ private:
     NSButtonCell *radioCell() const;
     NSLevelIndicatorCell *levelIndicatorCell() const;
     NSPopUpButtonCell *popUpButtonCell() const;
+    NSSearchFieldCell *searchFieldCell() const;
     NSTextFieldCell *textFieldCell() const;
 
     mutable RetainPtr<WebControlView> m_drawingView;
@@ -58,6 +61,7 @@ private:
     mutable RetainPtr<NSButtonCell> m_radioCell;
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
     mutable RetainPtr<NSPopUpButtonCell> m_popUpButtonCell;
+    mutable RetainPtr<NSSearchFieldCell> m_searchFieldCell;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -31,10 +31,13 @@
 #import "MenuListMac.h"
 #import "MeterMac.h"
 #import "ProgressBarMac.h"
+#import "SearchFieldCancelButtonMac.h"
+#import "SearchFieldMac.h"
 #import "TextAreaMac.h"
 #import "TextFieldMac.h"
 #import "ToggleButtonMac.h"
 #import "ToggleButtonPart.h"
+#import <pal/spi/mac/NSSearchFieldCellSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 
@@ -117,7 +120,20 @@ NSPopUpButtonCell *ControlFactoryMac::popUpButtonCell() const
     return m_popUpButtonCell.get();
 }
 
-NSTextFieldCell* ControlFactoryMac::textFieldCell() const
+NSSearchFieldCell *ControlFactoryMac::searchFieldCell() const
+{
+    if (!m_searchFieldCell) {
+        m_searchFieldCell = adoptNS([[NSSearchFieldCell alloc] initTextCell:@""]);
+        [m_searchFieldCell setBezelStyle:NSTextFieldRoundedBezel];
+        [m_searchFieldCell setBezeled:YES];
+        [m_searchFieldCell setEditable:YES];
+        [m_searchFieldCell setFocusRingType:NSFocusRingTypeExterior];
+        [m_searchFieldCell setCenteredLook:NO];
+    }
+    return m_searchFieldCell.get();
+}
+
+NSTextFieldCell *ControlFactoryMac::textFieldCell() const
 {
     if (!m_textFieldCell) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
@@ -147,6 +163,16 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMeter(MeterPar
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformProgressBar(ProgressBarPart& part)
 {
     return makeUnique<ProgressBarMac>(part, *this);
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchField(SearchFieldPart& part)
+{
+    return makeUnique<SearchFieldMac>(part, *this, searchFieldCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart& part)
+{
+    return makeUnique<SearchFieldCancelButtonMac>(part, *this, searchFieldCell());
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextAreaPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -244,6 +244,9 @@ void ControlMac::drawCell(GraphicsContext& context, const FloatRect& rect, float
 #if ENABLE(DATALIST_ELEMENT)
 void ControlMac::drawListButton(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
 {
+    if (!style.states.contains(ControlStyle::State::ListButton))
+        return;
+
     // We can't paint an NSComboBoxCell since they are not height-resizable.
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 

--- a/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class SearchControlMac : public ControlMac {
+public:
+    SearchControlMac(ControlPart&, ControlFactoryMac&, NSSearchFieldCell *);
+
+protected:
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
+
+    RetainPtr<NSSearchFieldCell> m_searchFieldCell;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SearchControlMac.h"
+
+#if PLATFORM(MAC)
+
+namespace WebCore {
+
+SearchControlMac::SearchControlMac(ControlPart& part, ControlFactoryMac& controlFactory, NSSearchFieldCell *searchFieldCell)
+    : ControlMac(part, controlFactory)
+    , m_searchFieldCell(searchFieldCell)
+{
+    ASSERT(m_searchFieldCell);
+}
+
+void SearchControlMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    ControlMac::updateCellStates(rect, style);
+
+    [m_searchFieldCell setPlaceholderString:@""];
+    [m_searchFieldCell setControlSize:controlSizeForFont(style)];
+
+    // Update the various states we respond to.
+    updateEnabledState(m_searchFieldCell.get(), style);
+    updateFocusedState(m_searchFieldCell.get(), style);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "SearchControlMac.h"
+
+namespace WebCore {
+
+class SearchFieldCancelButtonPart;
+
+class SearchFieldCancelButtonMac : public SearchControlMac {
+public:
+    SearchFieldCancelButtonMac(SearchFieldCancelButtonPart& owningPart, ControlFactoryMac&, NSSearchFieldCell *);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
+
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const final;
+
+    void updateCellStates(const FloatRect&, const ControlStyle&) final;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SearchFieldCancelButtonMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "SearchFieldCancelButtonPart.h"
+
+namespace WebCore {
+
+SearchFieldCancelButtonMac::SearchFieldCancelButtonMac(SearchFieldCancelButtonPart& owningPart, ControlFactoryMac& controlFactory, NSSearchFieldCell *searchFieldCell)
+    : SearchControlMac(owningPart, controlFactory, searchFieldCell)
+{
+    ASSERT(searchFieldCell);
+}
+
+IntSize SearchFieldCancelButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const IntSize sizes[] = {
+        { 22, 22 },
+        { 19, 19 },
+        { 15, 15 },
+        { 22, 22 }
+    };
+    return sizes[controlSize];
+}
+
+FloatRect SearchFieldCancelButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    auto sizeBasedOnFontSize = sizeForSystemFont(style);
+    auto diff = bounds.size() - FloatSize(sizeBasedOnFontSize);
+    if (diff.isZero())
+        return bounds;
+
+    // Vertically centered and right aligned.
+    auto location = bounds.location() + FloatSize { diff.width(), diff.height() / 2 };
+    return { location, sizeBasedOnFontSize };
+}
+
+void SearchFieldCancelButtonMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    bool enabled = style.states.contains(ControlStyle::State::Enabled);
+    bool readOnly = style.states.contains(ControlStyle::State::ReadOnly);
+
+    if (!enabled && !readOnly)
+        updatePressedState([m_searchFieldCell cancelButtonCell], style);
+    else if ([[m_searchFieldCell cancelButtonCell] isHighlighted])
+        [[m_searchFieldCell cancelButtonCell] setHighlighted:NO];
+
+    SearchControlMac::updateCellStates(rect, style);
+}
+
+void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    LocalCurrentGraphicsContext localContext(context);
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto logicalRect = rectForBounds(rect, style);
+    if (style.zoomFactor != 1) {
+        logicalRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    // Never draw a focus ring for the cancel button.
+    auto styleForDrawing = style;
+    styleForDrawing.states.remove(ControlStyle::State::Focused);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+
+    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, [m_searchFieldCell cancelButtonCell], view, true);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "SearchControlMac.h"
+
+namespace WebCore {
+
+class SearchFieldPart;
+
+class SearchFieldMac : public SearchControlMac {
+public:
+    SearchFieldMac(SearchFieldPart& owningPart, ControlFactoryMac&, NSSearchFieldCell *);
+
+private:
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SearchFieldMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "SearchFieldPart.h"
+
+namespace WebCore {
+
+SearchFieldMac::SearchFieldMac(SearchFieldPart& owningPart, ControlFactoryMac& controlFactory, NSSearchFieldCell *searchFieldCell)
+    : SearchControlMac(owningPart, controlFactory, searchFieldCell)
+{
+    ASSERT(searchFieldCell);
+}
+
+void SearchFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    LocalCurrentGraphicsContext localContext(context);
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto logicalRect = rect;
+    if (style.zoomFactor != 1) {
+        logicalRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+
+    [m_searchFieldCell setSearchButtonCell:nil];
+
+    drawCell(context, logicalRect, deviceScaleFactor, style, m_searchFieldCell.get(), view, true);
+
+    [m_searchFieldCell resetSearchButtonCell];
+    
+#if ENABLE(DATALIST_ELEMENT)
+    drawListButton(context, rect, deviceScaleFactor, style);
+#endif
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
@@ -86,8 +86,7 @@ void TextFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float d
     }
 
 #if ENABLE(DATALIST_ELEMENT)
-    if (states.contains(ControlStyle::State::ListButton))
-        drawListButton(context, rect, deviceScaleFactor, style);
+    drawListButton(context, rect, deviceScaleFactor, style);
 #endif
 }
 

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -641,7 +641,7 @@ NSView *ThemeMac::ensuredView(ScrollView* scrollView, const ControlStates& contr
         [themeView _setSemanticContext:NSViewSemanticContextForm];
 #endif
 
-    themeWindowHasKeyAppearance = !controlStates.states().contains(ControlStates::States::WindowInactive);
+    themeWindowHasKeyAppearance = controlStates.states().contains(ControlStates::States::WindowActive);
 
     return themeView;
 }

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -74,7 +74,7 @@ public:
     RefPtr<ControlPart> createControlPart(const RenderObject&) const;
 
     OptionSet<ControlStyle::State> extractControlStyleStatesForRenderer(const RenderObject&) const;
-    ControlStyle extractControlStyleForRenderer(const RenderObject&) const;
+    ControlStyle extractControlStyleForRenderer(const RenderBox&) const;
 
     // These methods are called to paint the widget as a background of the RenderObject. A widget's foreground, e.g., the
     // text of a button, is always rendered by the engine itself. The boolean return value indicates
@@ -385,7 +385,7 @@ protected:
 public:
     void updateControlStatesForRenderer(const RenderBox&, ControlStates&) const;
     OptionSet<ControlStates::States> extractControlStatesForRenderer(const RenderObject&) const;
-    bool isActive(const RenderObject&) const;
+    bool isWindowActive(const RenderObject&) const;
     bool isChecked(const RenderObject&) const;
     bool isIndeterminate(const RenderObject&) const;
     bool isEnabled(const RenderObject&) const;

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -124,11 +124,9 @@ private:
     bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) final;
     void adjustSliderThumbStyle(RenderStyle&, const Element*) const final;
 
-    bool paintSearchField(const RenderObject&, const PaintInfo&, const IntRect&) final;
     void adjustSearchFieldStyle(RenderStyle&, const Element*) const final;
 
     void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const IntRect&) final;
 
     void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const final;
     bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) final;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -98,6 +98,8 @@
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingCoordinator.h>
+#include <WebCore/SearchFieldCancelButtonPart.h>
+#include <WebCore/SearchFieldPart.h>
 #include <WebCore/SearchPopupMenu.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SerializedAttachmentData.h>
@@ -1636,7 +1638,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
 
     case WebCore::ControlPartType::SliderHorizontal:
     case WebCore::ControlPartType::SliderVertical:
+        break;
+
     case WebCore::ControlPartType::SearchField:
+        return WebCore::SearchFieldPart::create();
+
 #if ENABLE(APPLE_PAY)
     case WebCore::ControlPartType::ApplePayButton:
 #endif
@@ -1667,7 +1673,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::SearchFieldDecoration:
     case WebCore::ControlPartType::SearchFieldResultsDecoration:
     case WebCore::ControlPartType::SearchFieldResultsButton:
+        break;
+
     case WebCore::ControlPartType::SearchFieldCancelButton:
+        return WebCore::SearchFieldCancelButtonPart::create();
+
     case WebCore::ControlPartType::SliderThumbHorizontal:
     case WebCore::ControlPartType::SliderThumbVertical:
         break;


### PR DESCRIPTION
#### d9e61bbb56beb116a6f42f89a97f6ed0adbbb8c0
<pre>
[GPU Process] [FormControls] Add ControlParts for SearchField and SearchFieldCancelButton
<a href="https://bugs.webkit.org/show_bug.cgi?id=249890">https://bugs.webkit.org/show_bug.cgi?id=249890</a>
rdar://103703733

Reviewed by Aditya Keerthi.

These ControlParts will handle drawing the SearchField form control and its cancel
button (i.e. `&lt;input type=&quot;search&quot;&gt;`). For macOS, AppKit will be used to draw the
platform controls.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h: Added.
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ControlStates.h:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/SearchFieldCancelButtonPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/controls/SearchFieldPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::searchFieldCell const):
(WebCore::ControlFactoryMac::createPlatformSearchField):
(WebCore::ControlFactoryMac::createPlatformSearchFieldCancelButton):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::updateEnabledState):
(WebCore::ControlMac::updateFocusedState):
(WebCore::ControlMac::updatePressedState):
* Source/WebCore/platform/graphics/mac/controls/SearchControlMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/SearchControlMac.mm: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
(WebCore::SearchControlMac::SearchControlMac):
(WebCore::SearchControlMac::updateCellStates):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm: Added.
(WebCore::SearchFieldCancelButtonMac::SearchFieldCancelButtonMac):
(WebCore::SearchFieldCancelButtonMac::cellSize const):
(WebCore::SearchFieldCancelButtonMac::rectForBounds const):
(WebCore::SearchFieldCancelButtonMac::updateCellStates):
(WebCore::SearchFieldCancelButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm: Copied from Source/WebCore/platform/graphics/mac/controls/ControlMac.h.
(WebCore::SearchFieldMac::SearchFieldMac):
(WebCore::SearchFieldMac::draw):
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::ensuredView):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::extractControlStyleStatesForRenderer const):
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::extractControlStatesForRenderer const):
(WebCore::RenderTheme::isWindowActive const):
(WebCore::RenderTheme::isDefault const):
(WebCore::RenderTheme::isActive const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::updatePressedState):
(WebCore::RenderThemeMac::paintSearchField): Deleted.
(WebCore::RenderThemeMac::paintSearchFieldCancelButton): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258462@main">https://commits.webkit.org/258462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd8ad080de09d2b50f5a90f430cf4ecec3c0cbaa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111370 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2101 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109114 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107827 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4754 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4859 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44977 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5807 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6608 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->