### PR TITLE
Scroller style changes overrides custom pseudo-scrollbar sizes.

### DIFF
--- a/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme
+++ b/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -954,7 +954,8 @@ void ScrollbarsControllerMac::updateScrollerStyle()
 
     NSScrollerStyle newStyle = [m_scrollerImpPair scrollerStyle];
 
-    if (Scrollbar* verticalScrollbar = scrollableArea().verticalScrollbar()) {
+    Scrollbar* verticalScrollbar = scrollableArea().verticalScrollbar();
+    if (verticalScrollbar && !verticalScrollbar->isCustomScrollbar()) {
         verticalScrollbar->invalidate();
 
         NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
@@ -971,7 +972,8 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         verticalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 
-    if (Scrollbar* horizontalScrollbar = scrollableArea().horizontalScrollbar()) {
+    Scrollbar* horizontalScrollbar = scrollableArea().horizontalScrollbar();
+    if (horizontalScrollbar && !horizontalScrollbar->isCustomScrollbar()) {
         horizontalScrollbar->invalidate();
 
         NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
@@ -124,7 +124,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
@@ -143,7 +143,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
#### 976012a7e0cd025382a9fd3a2420253bf127a1f4
<pre>
Scroller style changes overrides custom pseudo-scrollbar sizes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249892">https://bugs.webkit.org/show_bug.cgi?id=249892</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/976012a7e0cd025382a9fd3a2420253bf127a1f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34613 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171086 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1611 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108645 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107337 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4308 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4376 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10462 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6137 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->