### PR TITLE
Fix incorrect custom pseudo-scrollbar sizes caused by scroller style changes on Mac.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -291,6 +291,9 @@ fast/visual-viewport/rubberbanding-viewport-rects-header-footer.html  [ Skip ]
 # DataDetectors tests only make sense on Mac
 fast/events/do-not-drag-and-drop-data-detectors-link.html [ Skip ]
 
+# Testing against scroller style changes only makes sense on Mac
+scrollbars/custom-scrollbar-scroller-style-change.html [ Skip ]
+
 # A rounding error may cause 90deg 3d-rotated elements to count as painted
 imported/w3c/web-platform-tests/paint-timing/fcp-only/fcp-invisible-3d-rotate-descendant.html
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -77,6 +77,8 @@ fast/harness/uiscriptcontroller [ Pass ]
 
 fast/events/do-not-drag-and-drop-data-detectors-link.html [ Pass ]
 
+scrollbars/custom-scrollbar-scroller-style-change.html [ Pass ]
+
 http/tests/gzip-content-encoding [ Pass ]
 
 http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Pass ]

--- a/LayoutTests/scrollbars/custom-scrollbar-scroller-style-change-expected.txt
+++ b/LayoutTests/scrollbars/custom-scrollbar-scroller-style-change-expected.txt
@@ -1,0 +1,9 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x216
+  RenderBlock {HTML} at (0,0) size 800x216
+    RenderBody {BODY} at (8,8) size 784x200
+layer at (8,8) size 200x200 clip at (8,8) size 152x152 scrollWidth 400 scrollHeight 400
+  RenderBlock {DIV} at (0,0) size 200x200
+layer at (8,8) size 400x400 backgroundClip at (8,8) size 152x152 clip at (8,8) size 152x152
+  RenderBlock {DIV} at (0,0) size 400x400 [bgcolor=#008000]

--- a/LayoutTests/scrollbars/custom-scrollbar-scroller-style-change.html
+++ b/LayoutTests/scrollbars/custom-scrollbar-scroller-style-change.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false ] -->
+<html>
+<head>
+    <title>Scroller style changes should not change the size of custom scrollbars.</title>
+    <style>
+        ::-webkit-scrollbar {
+            width: 48px;
+            height: 48px;
+        }
+
+        ::-webkit-scrollbar-track {
+            background-color: #E3E3E3;
+        }
+
+        ::-webkit-scrollbar-thumb {
+            background: black;
+        }
+
+        .scroll-container {
+            overflow: scroll;
+            width: 200px;
+            height: 200px;
+        }
+
+        .overflowing {
+            width: 400px;
+            height: 400px;
+            background: green;
+        }
+
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+        }
+
+        function doTest() {
+            if (window.internals)
+                internals.setUsesOverlayScrollbars(true);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                doTest()
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <!-- The scrollbars below should always sized 48x48 regardless of any scroller style changes. -->
+    <div class="scroll-container">
+        <div class="overflowing composited"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -954,7 +954,8 @@ void ScrollbarsControllerMac::updateScrollerStyle()
 
     NSScrollerStyle newStyle = [m_scrollerImpPair scrollerStyle];
 
-    if (Scrollbar* verticalScrollbar = scrollableArea().verticalScrollbar()) {
+    Scrollbar* verticalScrollbar = scrollableArea().verticalScrollbar();
+    if (verticalScrollbar && !verticalScrollbar->isCustomScrollbar()) {
         verticalScrollbar->invalidate();
 
         NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
@@ -971,7 +972,8 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         verticalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 
-    if (Scrollbar* horizontalScrollbar = scrollableArea().horizontalScrollbar()) {
+    Scrollbar* horizontalScrollbar = scrollableArea().horizontalScrollbar();
+    if (horizontalScrollbar && !horizontalScrollbar->isCustomScrollbar()) {
         horizontalScrollbar->invalidate();
 
         NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -352,8 +352,6 @@
 
 #if PLATFORM(MAC)
 #include "GraphicsChecksMac.h"
-#include "NSScrollerImpDetails.h"
-#include "ScrollbarThemeMac.h"
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -3984,18 +3982,12 @@ JSC::JSValue Internals::evaluateInWorldIgnoringException(const String& name, con
     return scriptController.executeScriptInWorldIgnoringException(world, source);
 }
 
+#if !PLATFORM(MAC)
 void Internals::setUsesOverlayScrollbars(bool enabled)
 {
     WebCore::DeprecatedGlobalSettings::setUsesOverlayScrollbars(enabled);
-#if PLATFORM(MAC)
-    ScrollerStyle::setUseOverlayScrollbars(enabled);
-    ScrollbarTheme& theme = ScrollbarTheme::theme();
-    if (theme.isMockTheme())
-        return;
-
-    static_cast<ScrollbarThemeMac&>(theme).preferencesChanged();
-#endif
 }
+#endif
 
 void Internals::forceReload(bool endToEnd)
 {


### PR DESCRIPTION
#### 560abdc4b29416fc6052fa10fafd84f00c7a4244
<pre>
Fix incorrect custom pseudo-scrollbar sizes caused by scroller style changes on Mac.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249892">https://bugs.webkit.org/show_bug.cgi?id=249892</a>

Reviewed by Simon Fraser.

Scroller style changes can cause custom pseudo-scrollbar sizes (set by
`width` or `height` property using `::-webkit-scrollbar`) to be
overridden by AppKit defaults. This could cause unexpected visual
appearances, especially when the scroller is thinner than the defaults.

This usually happens when the user enters or leaves the trackpad-only
setup (connecting or disconnecting the mouse for laptops would be a
typical case). Manually toggling the scroller appearance in the system
settings would be another way to reproduce this issue.

This patch resolves the above issue by explicitly checking for custom
scrollbars before replacing them with standard implementations when
processing scroller style updates.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/scrollbars/custom-scrollbar-scroller-style-change-expected.txt: Added.
* LayoutTests/scrollbars/custom-scrollbar-scroller-style-change.html: Added.
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setUsesOverlayScrollbars):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::setUsesOverlayScrollbars):

Canonical link: <a href="https://commits.webkit.org/259389@main">https://commits.webkit.org/259389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c1046546c07b1be873582aa23076a75b9edac0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111454 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171629 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2186 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109191 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37188 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78914 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4827 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25563 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2000 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6476 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6686 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->