### PR TITLE
CSS nesting: parse relative nested selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -13,6 +13,12 @@ PASS .foo {
   & > .bar { color: green; }
 }
 PASS .foo {
+  .test > & .bar { color: green; }
+}
+PASS .foo {
+  + .bar, .foo, > .lol { color: green; }
+}
+PASS .foo {
   &:is(.bar, &.baz) { color: green; }
 }
 PASS .foo {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
@@ -21,6 +21,8 @@
     `.foo {\n  &.bar { color: green; }\n}`,
     `.foo {\n  & .bar { color: green; }\n}`,
     `.foo {\n  & > .bar { color: green; }\n}`,
+    `.foo {\n  .test > & .bar { color: green; }\n}`,
+    [`.foo {\n  + .bar, .foo, > .lol { color: green; }\n}`,'.foo {\n  & + .bar, .foo, & > .lol { color: green; }\n}'],
     `.foo {\n  &:is(.bar, &.baz) { color: green; }\n}`,
     `.foo {\n  .bar& { color: green; }\n}`,
     `.foo {\n  .bar & { color: green; }\n}`,

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -136,6 +136,14 @@ void CSSParserSelector::setSelectorList(std::unique_ptr<CSSSelectorList> selecto
     m_selector->setSelectorList(WTFMove(selectorList));
 }
 
+CSSParserSelector* CSSParserSelector::leftmostSimpleSelector()
+{
+    auto selector = this;
+    while (auto next = selector->tagHistory())
+        selector = next;
+    return selector;
+}
+
 static bool selectorListMatchesPseudoElement(const CSSSelectorList* selectorList)
 {
     if (!selectorList)

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -82,6 +82,7 @@ public:
     bool needsImplicitShadowCombinatorForMatching() const;
 
     CSSParserSelector* tagHistory() const { return m_tagHistory.get(); }
+    CSSParserSelector* leftmostSimpleSelector();
     void setTagHistory(std::unique_ptr<CSSParserSelector> selector) { m_tagHistory = WTFMove(selector); }
     void clearTagHistory() { m_tagHistory.reset(); }
     void insertTagHistory(CSSSelector::RelationType before, std::unique_ptr<CSSParserSelector>, CSSSelector::RelationType after);

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -47,7 +47,13 @@ std::optional<CSSSelectorList> parseCSSSelector(CSSParserTokenRange range, const
 {
     CSSSelectorParser parser(context, styleSheet, isNestedContext);
     range.consumeWhitespace();
-    CSSSelectorList result = parser.consumeComplexSelectorList(range);
+    auto consume = [&] () {
+        if (context.cssNestingEnabled && isNestedContext == CSSSelectorParser::IsNestedContext::Yes)
+            return parser.consumeNestedSelectorList(range);
+
+        return parser.consumeComplexSelectorList(range);
+    };
+    CSSSelectorList result = consume();
     if (result.isEmpty() || !range.atEnd())
         return { };
     return result;
@@ -60,17 +66,18 @@ CSSSelectorParser::CSSSelectorParser(const CSSParserContext& context, StyleSheet
 {
 }
 
-CSSSelectorList CSSSelectorParser::consumeComplexSelectorList(CSSParserTokenRange& range)
+template <typename ConsumeSelector>
+CSSSelectorList CSSSelectorParser::consumeSelectorList(CSSParserTokenRange& range, ConsumeSelector&& consumeSelector)
 {
     Vector<std::unique_ptr<CSSParserSelector>> selectorList;
-    auto selector = consumeComplexSelector(range);
+    auto selector = consumeSelector(range);
     if (!selector)
         return { };
 
     selectorList.append(WTFMove(selector));
     while (!range.atEnd() && range.peek().type() == CommaToken) {
         range.consumeIncludingWhitespace();
-        selector = consumeComplexSelector(range);
+        selector = consumeSelector(range);
         if (!selector)
             return { };
         selectorList.append(WTFMove(selector));
@@ -80,6 +87,25 @@ CSSSelectorList CSSSelectorParser::consumeComplexSelectorList(CSSParserTokenRang
         return { };
 
     return CSSSelectorList { WTFMove(selectorList) };
+}
+
+CSSSelectorList CSSSelectorParser::consumeComplexSelectorList(CSSParserTokenRange& range)
+{
+    return consumeSelectorList(range, [&] (CSSParserTokenRange& range) {
+        return consumeComplexSelector(range);
+    });
+}
+
+CSSSelectorList CSSSelectorParser::consumeNestedSelectorList(CSSParserTokenRange& range)
+{
+    return consumeSelectorList(range, [&] (CSSParserTokenRange& range) {
+        auto selector = consumeComplexSelector(range);
+        if (selector)
+            return selector;
+
+        selector = consumeRelativeNestedSelector(range);
+        return selector;
+    });
 }
 
 template<typename ConsumeSelector>
@@ -132,7 +158,7 @@ CSSSelectorList CSSSelectorParser::consumeForgivingComplexSelectorList(CSSParser
 CSSSelectorList CSSSelectorParser::consumeForgivingRelativeSelectorList(CSSParserTokenRange& range)
 {
     return consumeForgivingSelectorList(range, [&](CSSParserTokenRange& range) {
-        return consumeRelativeSelector(range);
+        return consumeRelativeScopeSelector(range);
     });
 }
 
@@ -259,7 +285,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeComplexSelector(CSS
     return selector;
 }
 
-std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeSelector(CSSParserTokenRange& range)
+std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelector(CSSParserTokenRange& range)
 {
     auto scopeCombinator = consumeCombinator(range);
 
@@ -292,6 +318,27 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeSelector(CS
         end->setRelation(scopeCombinator);
         end->setTagHistory(WTFMove(scopeSelector));
     }
+
+    return selector;
+}
+
+std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeNestedSelector(CSSParserTokenRange& range)
+{
+    auto scopeCombinator = consumeCombinator(range);
+
+    ASSERT(scopeCombinator != CSSSelector::Subselector);
+    ASSERT(scopeCombinator != CSSSelector::DescendantSpace);
+
+    auto selector = consumeComplexSelector(range);
+    if (!selector)
+        return nullptr;
+
+    auto last = selector->leftmostSimpleSelector();
+    auto parentSelector = makeUnique<CSSParserSelector>();
+    parentSelector->setMatch(CSSSelector::Match::PseudoClass);
+    parentSelector->setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassParent);
+    last->setRelation(scopeCombinator);
+    last->setTagHistory(WTFMove(parentSelector));
 
     return selector;
 }
@@ -460,7 +507,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeSimpleSelector(CSSP
         selector = consumeId(range);
     else if (token.type() == DelimiterToken && token.delimiter() == '.')
         selector = consumeClass(range);
-    else if (token.type() == DelimiterToken && token.delimiter() == '&')
+    else if (token.type() == DelimiterToken && token.delimiter() == '&' && m_context.cssNestingEnabled)
         selector = consumeNesting(range);
     else if (token.type() == LeftBracketToken)
         selector = consumeAttribute(range);

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -54,10 +54,12 @@ public:
     CSSSelectorParser(const CSSParserContext&, StyleSheetContents*, IsNestedContext = IsNestedContext::No);
 
     CSSSelectorList consumeComplexSelectorList(CSSParserTokenRange&);
+    CSSSelectorList consumeNestedSelectorList(CSSParserTokenRange&);
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSParserContext&);
 
 private:
+    template<typename ConsumeSelector> CSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);
     template<typename ConsumeSelector> CSSSelectorList consumeForgivingSelectorList(CSSParserTokenRange&, ConsumeSelector&&);
 
     CSSSelectorList consumeForgivingComplexSelectorList(CSSParserTokenRange&);
@@ -66,7 +68,8 @@ private:
 
     std::unique_ptr<CSSParserSelector> consumeComplexSelector(CSSParserTokenRange&);
     std::unique_ptr<CSSParserSelector> consumeCompoundSelector(CSSParserTokenRange&);
-    std::unique_ptr<CSSParserSelector> consumeRelativeSelector(CSSParserTokenRange&);
+    std::unique_ptr<CSSParserSelector> consumeRelativeScopeSelector(CSSParserTokenRange&);
+    std::unique_ptr<CSSParserSelector> consumeRelativeNestedSelector(CSSParserTokenRange&);
 
     // This doesn't include element names, since they're handled specially.
     std::unique_ptr<CSSParserSelector> consumeSimpleSelector(CSSParserTokenRange&);


### PR DESCRIPTION
#### 5f782c40ce1b5abb601b25d1a070b655466335b1
<pre>
CSS nesting: parse relative nested selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=249893">https://bugs.webkit.org/show_bug.cgi?id=249893</a>
rdar://103712211

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html:
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::leftmostSimpleSelector):
* Source/WebCore/css/parser/CSSParserSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::parseCSSSelector):
(WebCore::CSSSelectorParser::consumeSelectorList):
(WebCore::CSSSelectorParser::consumeComplexSelectorList):
(WebCore::CSSSelectorParser::consumeNestedSelectorList):
(WebCore::CSSSelectorParser::consumeForgivingRelativeSelectorList):
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::CSSSelectorParser::consumeRelativeNestedSelector):
(WebCore::CSSSelectorParser::consumeSimpleSelector):
(WebCore::CSSSelectorParser::consumeRelativeSelector): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.h:

Canonical link: <a href="https://commits.webkit.org/258355@main">https://commits.webkit.org/258355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa363b71baba7b6051d731cc3cdeea71d336d0a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110978 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171181 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1706 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108740 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92226 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4467 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5726 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6223 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->