### PR TITLE
Splitting text can leave 'start' and 'end' Positions without renderers

### DIFF
--- a/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash-expected.txt
+++ b/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS apply-inline-style-to-element-with-no-renderer-crash
+

--- a/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html
+++ b/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg>
+    <text>
+        <tspan id="tspan">
+            <tspan id="tspan2">%uef5f%u9776%u638a</tspan>
+            <textPath id="textPath"></textPath>
+        </tspan>
+    </text>
+</svg>
+<div id="log"></div>
+<script>
+// crbug.com/339185: If we create an anchor element using execCommand('CreateLink') in an SVG namespace it won't get a renderer because the command will create
+// an HTML rather than an SVG anchor. Our subsequent attempt to apply an inline style on the should fail rather than result in a crash.
+test(function() {
+    tspan = document.getElementById("tspan");
+    tspan2 = document.getElementById("tspan2");
+    textPath = document.getElementById("textPath");
+
+    colorprofile = document.createElementNS('http://www.w3.org/2000/svg', 'color_profile');
+    li = document.createElement('li');
+    colorprofile.appendChild(li);
+    document.implementation.createDocument('' ,'' ,null).adoptNode(colorprofile)
+
+    input=document.createElement('input');
+    textPath.parentNode.insertBefore(input, textPath);
+    window.getSelection().setBaseAndExtent(input, 0, null, 0);
+
+    document.designMode='on';
+    document.execCommand('Transpose');
+    document.execCommand('selectall');
+    document.execCommand('CreateLink', 0, '#');
+    document.execCommand('CreateLink', 0, '#');
+    document.execCommand('Undo');
+    document.designMode='off'
+    document.execCommand('Undo');
+    document.execCommand('Undo');
+    document.designMode='on';
+    document.execCommand('italic');
+});
+</script>

--- a/LayoutTests/platform/mac-wk1/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash-expected.txt
@@ -1,0 +1,4 @@
+%uef5f%u9776%u63
+
+PASS apply-inline-style-to-element-with-no-renderer-crash
+

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -589,6 +589,8 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
             splitTextAtStart(start, end);
         start = startPosition();
         end = endPosition();
+        if (start.isNull() || end.isNull())
+            return;
         startDummySpanAncestor = dummySpanAncestorForNode(start.deprecatedNode());
     }
 
@@ -601,6 +603,8 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
             splitTextAtEnd(start, end);
         start = startPosition();
         end = endPosition();
+        if (start.isNull() || end.isNull())
+            return;
         endDummySpanAncestor = dummySpanAncestorForNode(end.deprecatedNode());
     }
 
@@ -1259,6 +1263,8 @@ bool ApplyStyleCommand::shouldSplitTextElement(Element* element, EditingStyle& s
 
 bool ApplyStyleCommand::isValidCaretPositionInTextNode(const Position& position)
 {
+    ASSERT(position.isNotNull());
+    
     Node* node = position.containerNode();
     if (position.anchorType() != Position::PositionIsOffsetInAnchor || !is<Text>(node))
         return false;


### PR DESCRIPTION
#### 43e2b46ed602ea589134da0e5e6172fe5edd3159
<pre>
Splitting text can leave &apos;start&apos; and &apos;end&apos; Positions without renderers

Splitting text can leave &apos;start&apos; and &apos;end&apos; Positions without renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=249898">https://bugs.webkit.org/show_bug.cgi?id=249898</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/d538920cd38e1a59c914f81f63757642466c4f46">https://chromium.googlesource.com/chromium/blink/+/d538920cd38e1a59c914f81f63757642466c4f46</a>

When establishing new start and end positions in ApplyStyleCommand::applyInlineStyle()
be sure to return early if either of them end up null, just as we do if either of
them are null initially.

In this test case execCommand(&apos;CreateLink&apos;) adds an anchor HTML element in an SVG
namespace so the text underneath validly does not receive a renderer. Without a renderer
the text won&apos;t get a visible position value for the command so there&apos;s nothing to do but
bail.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(ApplyStyleCommand::applyInlineStyle): Add early return if &apos;start&apos; or &apos;end&apos; positions are null
(ApplyStyleCommand::shouldSplitTextElement): Add ASSERT for position to be not null
* LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html: Add Test Case
* LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash-expected.txt: Add Test Case Expectation
* LayoutTests/platform/mac-wk1/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash-expected.txt

Canonical link: <a href="https://commits.webkit.org/258358@main">https://commits.webkit.org/258358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f2be242439536347433b67c62587d47616da24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110885 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171102 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1627 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108661 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35426 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4323 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25077 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1521 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5729 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6152 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->