### PR TITLE
Unreviewed non-unified-sources build fix

### DIFF
--- a/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
+++ b/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <optional>
+
 namespace WebCore {
 
 class WorkerBadgeProxy {

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSBackgroundRepeatValue.h"
 
+#include "CSSValuePool.h"
 #include "Rect.h"
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -34,6 +34,7 @@
 #include "CSSParserTokenRange.h"
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
+#include "StyleRule.h"
 #include <memory>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -45,6 +45,7 @@
 #include "CSSCursorImageValue.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSFilterImageValue.h"
+#include "CSSFontPaletteValuesOverrideColorsValue.h"
 #include "CSSFontVariantAlternatesValue.h"
 #include "CSSFontVariantLigaturesParser.h"
 #include "CSSFontVariantNumericParser.h"

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "JSDOMPromiseDeferred.h"
 #include "NavigatorBase.h"
 #include "Supplementable.h"
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -26,13 +26,13 @@
 #pragma once
 
 #include "CacheStorageRecord.h"
+#include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
 #include <WebCore/RetrieveRecordsOptions.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebKit {
 
-class CacheStorageStore;
 class CacheStorageManager;
 
 class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache> {

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -27,6 +27,7 @@
 
 #include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
+#include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
@@ -24,6 +24,9 @@
  */
 #pragma once
 
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
@@ -150,7 +150,7 @@ std::optional<WebWheelEventAndSteps> WebWheelEventCoalescer::nextEventToDispatch
     return coalescedWebEventAndSteps;
 }
 
-bool WebWheelEventCoalescer::shouldDispatchEvent(const NativeWebWheelEvent& event, OptionSet<WheelEventProcessingSteps> processingSteps)
+bool WebWheelEventCoalescer::shouldDispatchEvent(const NativeWebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps)
 {
     LOG_WITH_STREAM(WheelEvents, stream << "WebWheelEventCoalescer::shouldDispatchEvent " << platform(event) << " (" << m_wheelEventQueue.size() << " events in the queue, " << m_eventsBeingProcessed.size() << " event sequences being processed)");
 

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.h
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.h
@@ -34,14 +34,14 @@ namespace WebKit {
 
 struct NativeWebWheelEventAndSteps {
     NativeWebWheelEvent event;
-    OptionSet<WheelEventProcessingSteps> processingSteps;
+    OptionSet<WebCore::WheelEventProcessingSteps> processingSteps;
 };
 
 struct WebWheelEventAndSteps {
     WebWheelEvent event;
-    OptionSet<WheelEventProcessingSteps> processingSteps;
+    OptionSet<WebCore::WheelEventProcessingSteps> processingSteps;
     
-    WebWheelEventAndSteps(const WebWheelEvent& event, OptionSet<WheelEventProcessingSteps> processingSteps)
+    WebWheelEventAndSteps(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps)
         : event(event)
         , processingSteps(processingSteps)
     { }
@@ -56,7 +56,7 @@ class WebWheelEventCoalescer {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     // If this returns true, use nextEventToDispatch() to get the event to dispatch.
-    bool shouldDispatchEvent(const NativeWebWheelEvent&, OptionSet<WheelEventProcessingSteps>);
+    bool shouldDispatchEvent(const NativeWebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>);
     std::optional<WebWheelEventAndSteps> nextEventToDispatch();
 
     NativeWebWheelEvent takeOldestEventBeingProcessed();

--- a/Source/WebKit/UIProcess/SubframePageProxy.cpp
+++ b/Source/WebKit/UIProcess/SubframePageProxy.cpp
@@ -26,7 +26,10 @@
 #include "config.h"
 #include "SubframePageProxy.h"
 
+#include "WebFrameProxy.h"
 #include "WebPageProxy.h"
+#include "WebPageProxyMessages.h"
+#include "WebProcessProxy.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -37,6 +37,10 @@ class Encoder;
 
 namespace WebKit {
 
+class WebFrameProxy;
+class WebPageProxy;
+class WebProcessProxy;
+
 class SubframePageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -37,7 +37,6 @@
 
 namespace WebKit {
 using namespace WebCore::DOMCacheEngine;
-using namespace CacheStorage;
 
 WebCacheStorageConnection::WebCacheStorageConnection(WebCacheStorageProvider& provider)
     : m_provider(provider)


### PR DESCRIPTION
#### 57d89c89af08cc8a92b8487eeca5e7048262f618
<pre>
Unreviewed non-unified-sources build fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=249903">https://bugs.webkit.org/show_bug.cgi?id=249903</a>

Unreviewed, adjusting inclusions, namespace qualifiers and other
bits to get basic non-unified-sources build working.

* Source/WebCore/Modules/badge/WorkerBadgeProxy.h:
* Source/WebCore/css/CSSBackgroundRepeatValue.cpp:
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/page/WorkerNavigator.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageStore.h:
* Source/WebKit/Shared/WebWheelEventCoalescer.cpp:
(WebKit::WebWheelEventCoalescer::shouldDispatchEvent):
* Source/WebKit/Shared/WebWheelEventCoalescer.h:
(WebKit::WebWheelEventAndSteps::WebWheelEventAndSteps):
* Source/WebKit/UIProcess/SubframePageProxy.cpp:
* Source/WebKit/UIProcess/SubframePageProxy.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:

Canonical link: <a href="https://commits.webkit.org/258340@main">https://commits.webkit.org/258340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eddf9e4eca8fbfa1bac9f924b1f7330e8205ad8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110877 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171101 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1626 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108660 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35424 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78422 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4322 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1519 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44552 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5717 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6151 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->