### PR TITLE
Incorrect caret movement in some RTL contenteditable elements

### DIFF
--- a/LayoutTests/editing/selection/skip-non-editable-rtl-expected.txt
+++ b/LayoutTests/editing/selection/skip-non-editable-rtl-expected.txt
@@ -1,0 +1,41 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of BODY > HTML > #document to 12 of BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldEndEditingInDOMRange:range from 0 of BODY > HTML > #document to 12 of BODY > HTML > #document
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of TD > TR > TBODY > TABLE > BODY > HTML > #document to 1 of TD > TR > TBODY > TABLE > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldEndEditingInDOMRange:range from 0 of TD > TR > TBODY > TABLE > BODY > HTML > #document to 1 of TD > TR > TBODY > TABLE > BODY > HTML > #document
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of BODY > HTML > #document to 12 of BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldEndEditingInDOMRange:range from 0 of BODY > HTML > #document to 12 of BODY > HTML > #document
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of TD > TR > TBODY > TABLE > BODY > HTML > #document to 1 of TD > TR > TBODY > TABLE > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldEndEditingInDOMRange:range from 0 of TD > TR > TBODY > TABLE > BODY > HTML > #document to 1 of TD > TR > TBODY > TABLE > BODY > HTML > #document
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of BODY > HTML > #document to 12 of BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldEndEditingInDOMRange:range from 0 of BODY > HTML > #document to 12 of BODY > HTML > #document
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of TD > TR > TBODY > TABLE > BODY > HTML > #document to 1 of TD > TR > TBODY > TABLE > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+This tests moving the caret in content of mixed editability with direction RTL. The caret should jump to the next editable region that shares a common editable ancestor when it reaches non-editable content.
+
+editable content
+non-editable content	non-editable content	editable content
+editable content
+Success
+Success
+Success
+Success

--- a/LayoutTests/editing/selection/skip-non-editable-rtl.html
+++ b/LayoutTests/editing/selection/skip-non-editable-rtl.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<head>
+    <script>
+    if (window.testRunner)
+        testRunner.dumpEditingCallbacks();
+    </script>
+    
+    <style>
+    table, td {
+        border: 1px solid #aaa;
+    }
+    </style>
+    
+    <script>
+    function log(str) {
+        var li = document.createElement("li");
+        li.appendChild(document.createTextNode(str));
+        var console = document.getElementById("console");
+        console.appendChild(li);
+    }
+    
+    function assert(bool) {
+        if (!bool)
+            log("Failure");
+        else
+            log("Success");
+    }
+    </script>
+    </head>
+    
+    <body contentEditable="true" dir="rtl">
+    <p>This tests moving the caret in content of mixed editability with direction RTL.  The caret should jump to the next editable region that shares a common editable ancestor when it reaches non-editable content.</p>
+    <div id="e1">editable content</div>
+    <table cellpadding="5" contentEditable="false">
+    <tr>
+    <td>non-editable content</td>
+    <td>non-editable content</td>
+    <td id="e2" contentEditable="true">editable content</td>
+    </table>
+    <div id="e3">editable content</div>
+    
+    <ul id="console"></ul>
+    </body>
+    
+    <script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+        
+    var s = window.getSelection();
+    var e1 = document.getElementById("e1");
+    var e2 = document.getElementById("e2");
+    var e3 = document.getElementById("e3");
+    
+    s.collapse(e1.firstChild, e1.firstChild.length);
+    s.modify("move", "forward", "character");
+    s.modify("move", "forward", "character");
+    assert(s.anchorNode == e2.firstChild && s.anchorOffset == 0);
+    
+    s.modify("move", "backward", "character");
+    s.modify("move", "backward", "character");
+    assert(s.anchorNode == e1.firstChild && s.anchorOffset == e1.firstChild.length);
+        
+    s.collapse(e2.firstChild, e2.firstChild.length);
+    s.modify("move", "forward", "character");
+    s.modify("move", "forward", "character");
+    assert(s.anchorNode == e3.firstChild && s.anchorOffset == 0);
+    
+    s.modify("move", "backward", "character");
+    s.modify("move", "backward", "character");
+    assert(s.anchorNode == e2.firstChild && s.anchorOffset == e2.firstChild.length)
+    </script>

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Portions Copyright (c) 2011 Motorola Mobility, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -276,8 +277,7 @@ VisiblePosition VisiblePosition::left(bool stayInEditableContent, bool* reachedB
     if (!stayInEditableContent)
         return left;
 
-    // FIXME: This may need to do something different from "before".
-    return honorEditingBoundaryAtOrBefore(left, reachedBoundary);
+    return directionOfEnclosingBlock(left.deepEquivalent()) == TextDirection::LTR ? honorEditingBoundaryAtOrBefore(left, reachedBoundary) : honorEditingBoundaryAtOrAfter(left, reachedBoundary);
 }
 
 Position VisiblePosition::rightVisuallyDistinctCandidate() const
@@ -446,8 +446,7 @@ VisiblePosition VisiblePosition::right(bool stayInEditableContent, bool* reached
     if (!stayInEditableContent)
         return right;
 
-    // FIXME: This may need to do something different from "after".
-    return honorEditingBoundaryAtOrAfter(right, reachedBoundary);
+    return directionOfEnclosingBlock(right.deepEquivalent()) == TextDirection::LTR ? honorEditingBoundaryAtOrAfter(right, reachedBoundary) : honorEditingBoundaryAtOrBefore(right, reachedBoundary);
 }
 
 VisiblePosition VisiblePosition::honorEditingBoundaryAtOrBefore(const VisiblePosition& position, bool* reachedBoundary) const


### PR DESCRIPTION
#### f61cf23abe063f69ce6408c47a6454825ce011e8
<pre>
Incorrect caret movement in some RTL contenteditable elements

Incorrect caret movement in some RTL contenteditable elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=249905">https://bugs.webkit.org/show_bug.cgi?id=249905</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=183843

Content editable when mixed in direction RTL, it was not moving caret because
editing boundary was not calculated correctly. In RTL scenario, nodes
need to be calculated from after or before for left and right respectively.
Based on the direction of the block calculates appropriate editing boundary.

* Source/WebCore/editing/VisiblePosition.cpp:
(VisiblePosition::left): Remove &apos;FIXME&apos; and respect direction
(VisiblePosition::right): Remove &apos;FIXME&apos; and respect direction
* LayoutTests/editing/selection/skip-non-editable-rtl.html: Add Test Case
* LayoutTests/editing/selection/skip-non-editable-rtl-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258398@main">https://commits.webkit.org/258398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/421fb9621ba6a14f8928aab76d0de74736881d88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111013 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171216 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1740 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108775 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36604 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90894 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78568 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4427 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25177 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1625 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44665 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5752 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6256 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->