### PR TITLE
[JSC] Simplify Wasm Call IC generated code

### DIFF
--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -147,6 +147,17 @@ RegisterAtOffsetList WebAssemblyFunction::usedCalleeSaveRegisters() const
     return RegisterAtOffsetList { calleeSaves(), RegisterAtOffsetList::OffsetBaseType::FramePointerBased };
 }
 
+static size_t trampolineReservedStackSize()
+{
+    // If we are jumping to the function which can have stack-overflow check,
+    // then, trampoline does not need to do the check again if it is smaller than a threshold.
+    // 1. Caller of this trampoline ensures that at least our stack is lower than softStackLimit.
+    // 2. Callee may omit stack check if the frame size is less than reservedZoneSize and it does not have a call.
+    // Based on that, trampoline between 1 and 2 can use (softReservedZoneSize - reservedZoneSize) / 2 size safely at least.
+    // Note that minimumReservedZoneSize is 16KB, and we ensure that softReservedZoneSize - reservedZoneSize is at least 16KB.
+    return (Options::softReservedZoneSize() - Options::reservedZoneSize()) / 2;
+}
+
 CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 {
     if (Options::forceICFailure())
@@ -184,12 +195,7 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 
     jit.emitFunctionPrologue();
     jit.subPtr(MacroAssembler::TrustedImm32(totalFrameSize), MacroAssembler::stackPointerRegister);
-
-    for (const RegisterAtOffset& regAtOffset : registersToSpill) {
-        GPRReg reg = regAtOffset.reg().gpr();
-        ptrdiff_t offset = regAtOffset.offset();
-        jit.storePtr(reg, CCallHelpers::Address(GPRInfo::callFrameRegister, offset));
-    }
+    jit.emitSave(registersToSpill);
 
     JSValueRegs scratchJSR {
 #if USE(JSVALUE32_64)
@@ -198,19 +204,25 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
         Wasm::wasmCallingConvention().prologueScratchGPRs[1]
     };
     GPRReg stackLimitGPR = Wasm::wasmCallingConvention().prologueScratchGPRs[0];
-    jit.loadPtr(vm.addressOfSoftStackLimit(), stackLimitGPR);
 
     CCallHelpers::JumpList slowPath;
-    slowPath.append(jit.branchPtr(CCallHelpers::Above, MacroAssembler::stackPointerRegister, GPRInfo::callFrameRegister));
-    slowPath.append(jit.branchPtr(CCallHelpers::Below, MacroAssembler::stackPointerRegister, stackLimitGPR));
+
+    if (totalFrameSize >= trampolineReservedStackSize()) {
+        jit.loadPtr(vm.addressOfSoftStackLimit(), stackLimitGPR);
+
+        slowPath.append(jit.branchPtr(CCallHelpers::Above, MacroAssembler::stackPointerRegister, GPRInfo::callFrameRegister));
+        slowPath.append(jit.branchPtr(CCallHelpers::Below, MacroAssembler::stackPointerRegister, stackLimitGPR));
+    }
 
     // Ensure:
     // argCountPlusThis - 1 >= signature.argumentCount()
     // argCountPlusThis >= signature.argumentCount() + 1
     // FIXME: We should handle mismatched arity
     // https://bugs.webkit.org/show_bug.cgi?id=196564
-    slowPath.append(jit.branch32(CCallHelpers::Below,
-        CCallHelpers::payloadFor(CallFrameSlot::argumentCountIncludingThis), CCallHelpers::TrustedImm32(signature.argumentCount() + 1)));
+    if (signature.argumentCount() > 0) {
+        slowPath.append(jit.branch32(CCallHelpers::Below,
+            CCallHelpers::payloadFor(CallFrameSlot::argumentCountIncludingThis), CCallHelpers::TrustedImm32(signature.argumentCount() + 1)));
+    }
 
     if (usesTagRegisters())
         jit.emitMaterializeTagCheckRegisters();
@@ -351,22 +363,29 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 #if !CPU(ARM) // ARM has no pinned registers for Wasm Memory, so no need to set them up
     if (!!instance()->instance().module().moduleInformation().memory) {
         GPRReg baseMemory = pinnedRegs.baseMemoryPointer;
-        GPRReg scratchOrBoundsCheckingSize = InvalidGPRReg;
         auto mode = instance()->memoryMode();
 
-        if (isARM64E()) {
+        if (mode == MemoryMode::Signaling || (mode == MemoryMode::BoundsChecking && instance()->instance().memory()->sharingMode() == MemorySharingMode::Shared)) {
+            // Capacity and basePointer will not be changed.
             if (mode == MemoryMode::BoundsChecking)
-                scratchOrBoundsCheckingSize = pinnedRegs.boundsCheckingSizeRegister;
-            else
-                scratchOrBoundsCheckingSize = stackLimitGPR;
-            jit.loadPairPtr(scratchJSR.payloadGPR(), CCallHelpers::TrustedImm32(Wasm::Instance::offsetOfCachedMemory()), baseMemory, scratchOrBoundsCheckingSize);
+                jit.move(CCallHelpers::TrustedImm64(instance()->instance().memory()->mappedCapacity()), pinnedRegs.boundsCheckingSizeRegister);
+            jit.move(CCallHelpers::TrustedImmPtr(instance()->instance().memory()->memory()), baseMemory);
         } else {
-            if (mode == MemoryMode::BoundsChecking)
-                jit.loadPairPtr(scratchJSR.payloadGPR(), CCallHelpers::TrustedImm32(Wasm::Instance::offsetOfCachedMemory()), baseMemory, pinnedRegs.boundsCheckingSizeRegister);
-            else
-                jit.loadPtr(CCallHelpers::Address(scratchJSR.payloadGPR(), Wasm::Instance::offsetOfCachedMemory()), baseMemory);
+            GPRReg scratchOrBoundsCheckingSize = InvalidGPRReg;
+            if (isARM64E()) {
+                if (mode == MemoryMode::BoundsChecking)
+                    scratchOrBoundsCheckingSize = pinnedRegs.boundsCheckingSizeRegister;
+                else
+                    scratchOrBoundsCheckingSize = stackLimitGPR;
+                jit.loadPairPtr(scratchJSR.payloadGPR(), CCallHelpers::TrustedImm32(Wasm::Instance::offsetOfCachedMemory()), baseMemory, scratchOrBoundsCheckingSize);
+            } else {
+                if (mode == MemoryMode::BoundsChecking)
+                    jit.loadPairPtr(scratchJSR.payloadGPR(), CCallHelpers::TrustedImm32(Wasm::Instance::offsetOfCachedMemory()), baseMemory, pinnedRegs.boundsCheckingSizeRegister);
+                else
+                    jit.loadPtr(CCallHelpers::Address(scratchJSR.payloadGPR(), Wasm::Instance::offsetOfCachedMemory()), baseMemory);
+            }
+            jit.cageConditionallyAndUntag(Gigacage::Primitive, baseMemory, scratchOrBoundsCheckingSize, scratchJSR.payloadGPR());
         }
-        jit.cageConditionallyAndUntag(Gigacage::Primitive, baseMemory, scratchOrBoundsCheckingSize, scratchJSR.payloadGPR());
     }
 #endif
     // We use this callee to indicate how to unwind past these types of frames:
@@ -397,22 +416,12 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
     else
         jit.storePtr(GPRInfo::nonPreservedNonReturnGPR, vm.wasmContext.pointerToInstance());
 
-    auto emitRestoreCalleeSaves = [&] {
-        for (const RegisterAtOffset& regAtOffset : registersToSpill) {
-            GPRReg reg = regAtOffset.reg().gpr();
-            ASSERT(reg != GPRInfo::returnValueGPR);
-            ptrdiff_t offset = regAtOffset.offset();
-            jit.loadPtr(CCallHelpers::Address(GPRInfo::callFrameRegister, offset), reg);
-        }
-    };
-
-    emitRestoreCalleeSaves();
-
+    jit.emitRestore(registersToSpill, GPRInfo::callFrameRegister);
     jit.emitFunctionEpilogue();
     jit.ret();
 
     slowPath.link(&jit);
-    emitRestoreCalleeSaves();
+    jit.emitRestore(registersToSpill, GPRInfo::callFrameRegister);
     jit.move(CCallHelpers::TrustedImmPtr(this), GPRInfo::regT0);
     jit.emitFunctionEpilogue();
 #if CPU(ARM64E)


### PR DESCRIPTION
#### 061181925960bee67c6f9a8ff3f3391b6bfd1ccf
<pre>
[JSC] Simplify Wasm Call IC generated code
<a href="https://bugs.webkit.org/show_bug.cgi?id=249906">https://bugs.webkit.org/show_bug.cgi?id=249906</a>
rdar://103726311

Reviewed by Mark Lam.

This patch simplifies Wasm Call IC generated code.

1. Use emitSave / emitRestore to emit paired load / store.
2. Omit stack-overflow check for Wasm Call IC in most of cases. Because this IC is guaranteed that we will
   call wasm function, we can omit stack-overflow check if the stack frame size is smaller than the threshold.
3. When memory is signaling / shared, we embed memory base pointer and bound checking size directly since
   both values will not be changed for this type.
4. Omit argument count check for zero-argument case.

These optimization affects on generated code. And we observed 15% faster Runtime for JetStream2/richards-wasm.

* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::trampolineReservedStackSize):
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):

Canonical link: <a href="https://commits.webkit.org/258371@main">https://commits.webkit.org/258371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62f07b27d2931a08c4aa38ba0eb68f499c0fed77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111029 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1756 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108791 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107475 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92119 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4443 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88258 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2043 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4518 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10606 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91164 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6272 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/20359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3025 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->