### PR TITLE
Focus unfocusable node upon reference fragment navigation

### DIFF
--- a/LayoutTests/fast/dom/fragment-activation-focuses-target-expected.txt
+++ b/LayoutTests/fast/dom/fragment-activation-focuses-target-expected.txt
@@ -2,7 +2,6 @@ This tests that if an in-page link is activated, focus control is transferred to
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-
 Verify that the focus is on the link.
 PASS document.activeElement is link1
 Click the link and verify that focus has moved to the fragment.
@@ -11,17 +10,28 @@ Move focus back to the link and verify.
 PASS document.activeElement is link1
 Send an enter key event which should also trigger focus to move to the fragment.
 PASS document.activeElement is document.getElementById('fragment1')
-Verify Tab behaves correctly after following the link.
-PASS document.activeElement is document.getElementById('fragment3')
-PASS document.activeElement is document.getElementById('fragment1')
 Activate a link that does not have a focusable fragment and verify that the currently focused element is unfocused.
 PASS document.activeElement is link2
 PASS document.activeElement is document.body
+Activate a link that does not refer to an existing fragment and verify that the currently focused element remains focused.
+PASS document.activeElement is link3
+PASS document.activeElement is link3
+Activate a link to #top and verify that the link remains focused
+PASS document.activeElement is link4
+PASS document.activeElement is link4
+Activate a link to # and verify that the link remains focused
+PASS document.activeElement is link5
+PASS document.activeElement is link5
+Activate a link to an INPUT elemnt, verify that the INPUT is editable
+PASS document.activeElement is link6
+PASS document.activeElement is input1
+PASS input1.value is "abcXdef"
 PASS successfullyParsed is true
 
 TEST COMPLETE
-link1 link2
+
+link1 link2 link3 link4 link5 link6
+
 
 fragment1
 fragment2
-fragment3

--- a/LayoutTests/fast/dom/fragment-activation-focuses-target.html
+++ b/LayoutTests/fast/dom/fragment-activation-focuses-target.html
@@ -1,58 +1,82 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/js-test.js"></script>
 </head>
 <body>
+    <a href="#fragment1" id="link1" tabindex="0">link1</a>
+    <a href="#fragment2" id="link2" tabindex="0">link2</a>
+    <a href="#fragment3" id="link3" tabindex="0">link3</a>
+    <a href="#top" id="link4" tabindex="0">link4</a>
+    <a href="#" id="link5" tabindex="0">link5</a>
+    <a href="#input1" id="link6" tabindex="0">link6</a>
+    <br><br>
+    <div id="fragment1" name="fragment1" tabindex="0">fragment1</div>
+    <div id="fragment2" name="fragment2">fragment2</div>
+    <input id="input1" value="abcdef">
+    <script>
+        description("This tests that if an in-page link is activated, focus control is transferred to the fragment if possible.");
 
-<a href="#fragment1" id="link1" tabindex="0">link1</a>
-<a href="#fragment2" id="link2" tabindex="0">link2</a>
+        var link1 = document.getElementById("link1");
+        link1.focus();
+        debug("Verify that the focus is on the link.");
+        shouldBe("document.activeElement", "link1");
 
-<br><br>
+        link1.click();
+        debug("Click the link and verify that focus has moved to the fragment.");
+        shouldBe("document.activeElement", "document.getElementById('fragment1')");
 
-<div id="fragment1" name="fragment1" tabindex="0">fragment1</div>
-<div id="fragment2" name="fragment2">fragment2</div>
-<div id="fragment3" name="fragment3" tabindex="0">fragment3</div>
+        debug("Move focus back to the link and verify.");
+        link1.focus();
+        shouldBe("document.activeElement", "link1");
 
-<script>
+        if (window.testRunner) {
+            debug("Send an enter key event which should also trigger focus to move to the fragment.");
+            eventSender.keyDown("Enter");
+            shouldBe("document.activeElement", "document.getElementById('fragment1')");
+        }
 
-description("This tests that if an in-page link is activated, focus control is transferred to the fragment if possible.");
+        debug("Activate a link that does not have a focusable fragment and verify that the currently focused element is unfocused.");
+        var link2 = document.getElementById("link2");
+        link2.focus();
+        shouldBe("document.activeElement", "link2");
+        link2.click();
+        shouldBe("document.activeElement", "document.body");
 
-var link1 = document.getElementById("link1");
-link1.focus();
-debug("Verify that the focus is on the link.");
-shouldBe("document.activeElement", "link1");
+        debug("Activate a link that does not refer to an existing fragment and verify that the currently focused element remains focused.");
+        var link3 = document.getElementById("link3");
+        link3.focus();
+        shouldBe("document.activeElement", "link3");
+        link3.click();
+        shouldBe("document.activeElement", "link3");
 
-link1.click();
-debug("Click the link and verify that focus has moved to the fragment.");
-shouldBe("document.activeElement", "document.getElementById('fragment1')");
+        debug("Activate a link to #top and verify that the link remains focused");
+        var link4 = document.getElementById("link4");
+        link4.focus();
+        shouldBe("document.activeElement", "link4");
+        link4.click();
+        shouldBe("document.activeElement", "link4");
 
-debug("Move focus back to the link and verify.");
-link1.focus();
-shouldBe("document.activeElement", "link1");
+        debug("Activate a link to # and verify that the link remains focused");
+        var link5 = document.getElementById("link5");
+        link5.focus();
+        shouldBe("document.activeElement", "link5");
+        link5.click();
+        shouldBe("document.activeElement", "link5");
 
-if (window.testRunner) {
-  debug("Send an enter key event which should also trigger focus to move to the fragment.");
-  eventSender.keyDown("\r");
-  shouldBe("document.activeElement", "document.getElementById('fragment1')");
-
-  debug("Verify Tab behaves correctly after following the link.");
-  eventSender.keyDown("\t");
-  shouldBe("document.activeElement", "document.getElementById('fragment3')");
-  eventSender.keyDown("\t", ["shiftKey"]);
-  shouldBe("document.activeElement", "document.getElementById('fragment1')");
-}
-
-debug("Activate a link that does not have a focusable fragment and verify that the currently focused element is unfocused.");
-var link2 = document.getElementById("link2");
-link2.focus();
-shouldBe("document.activeElement", "link2");
-link2.click();
-shouldBe("document.activeElement", "document.body");
-
-var successfullyParsed = true;
-
-</script>
-<script src="../../resources/js-test-post.js"></script>
+        debug("Activate a link to an INPUT elemnt, verify that the INPUT is editable");
+        var input1 = document.getElementById("input1");
+        input1.setSelectionRange(3, 3);
+        var link6 = document.getElementById("link6");
+        link6.focus();
+        shouldBe("document.activeElement", "link6");
+        link6.click();
+        shouldBe("document.activeElement", "input1");
+        if (window.eventSender) {
+            eventSender.keyDown('X');
+            shouldBeEqualToString("input1.value", "abcXdef");
+        }
+        var successfullyParsed = true;
+    </script>
 </body>
 </html>

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -3,10 +3,10 @@
  *                     1999 Lars Knoll <knoll@kde.org>
  *                     1999 Antti Koivisto <koivisto@kde.org>
  *                     2000 Dirk Mueller <mueller@kde.org>
- * Copyright (C) 2004-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
- * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -2356,16 +2356,9 @@ bool FrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
         scrollPositionAnchor = m_frame->document();
     maintainScrollPositionAtAnchor(scrollPositionAnchor.get());
     
-    // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
-    if (anchorElement) {
-        if (anchorElement->isFocusable())
-            document.setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, FocusVisibility::Visible });
-        else {
-            document.setFocusedElement(nullptr);
-            document.setFocusNavigationStartingNode(anchorElement.get());
-        }
-    }
-    
+    // If anchor is not focusable, setFocusedElement() will still clear focus, which matches the behavior of other browsers.
+    if (anchorElement)
+        document.setFocusNavigationStartingNode(anchorElement.get());    
     return true;
 }
 


### PR DESCRIPTION
<pre>
Focus unfocusable node upon reference fragment navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=249907">https://bugs.webkit.org/show_bug.cgi?id=249907</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit behavior with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/c877739dd8de5aef84a3b3a560c920973fd8c4a4">https://chromium.googlesource.com/chromium/blink/+/c877739dd8de5aef84a3b3a560c920973fd8c4a4</a>

Currently, when the page navigates to a non-focusable reference fragment, the currently
focused element does not change. In Firefox/IE, the focus is moved to the referenced element
even when this element is non-focusable.

This patch changes the behavior of WebKit: When the pages navigates to a reference fragment
that refers to a non-focusable node, then the focus is removed from the previously focused
element.

W3C Bug - <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=26907">https://www.w3.org/Bugs/Public/show_bug.cgi?id=26907</a>

* Source/WebCore/page/FrameView.cpp:
(FrameView::scrollToFragmentInternal): Update Comment and remove "isFocusable" condition
* LayoutTests/fast/dom/fragment-activation-focuses-target.html: Rebaselined
* LayoutTests/fast/dom/fragment-activation-focuses-target-expected.txt: Ditto
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec5cc493ec27abeb5b80f26314d80489a75769d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111223 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171424 "Found 3 new test failures: fast/custom-elements/custom-element-reaction-within-disallowed-scope.html, fast/dom/fragment-activation-focuses-target.html, fast/parser/adoption-agency-unload-iframe-4.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1952 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108978 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107671 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9181 "Found 3 new test failures: fast/custom-elements/custom-element-reaction-within-disallowed-scope.html, fast/parser/adoption-agency-unload-iframe-4.html, http/tests/security/move-iframe-within-focus-handler-inside-removal.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92445 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36981 "Found 4 new test failures: fast/custom-elements/custom-element-reaction-within-disallowed-scope.html, fast/dom/fragment-activation-focuses-target.html, fast/parser/adoption-agency-unload-iframe-4.html, http/tests/security/move-iframe-within-focus-handler-inside-removal.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91066 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23873 "Found 4 new test failures: fast/custom-elements/custom-element-reaction-within-disallowed-scope.html, fast/dom/fragment-activation-focuses-target.html, fast/parser/adoption-agency-unload-iframe-4.html, http/tests/security/move-iframe-within-focus-handler-inside-removal.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78744 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4622 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25359 "Found 4 new test failures: fast/custom-elements/custom-element-reaction-within-disallowed-scope.html, fast/dom/fragment-activation-focuses-target.html, fast/parser/adoption-agency-unload-iframe-4.html, http/tests/security/move-iframe-within-focus-handler-inside-removal.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4709 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1799 "Found 4 new test failures: fast/custom-elements/custom-element-reaction-within-disallowed-scope.html, fast/dom/fragment-activation-focuses-target.html, fast/parser/adoption-agency-unload-iframe-4.html, http/tests/security/move-iframe-within-focus-handler-inside-removal.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44846 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6461 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->