### PR TITLE
Avoid -Wuse-after-free warnings in DOMMatrix with GCC 12

### DIFF
--- a/Source/WebCore/css/DOMMatrix.cpp
+++ b/Source/WebCore/css/DOMMatrix.cpp
@@ -159,11 +159,11 @@ Ref<DOMMatrix> DOMMatrix::scaleSelf(double scaleX, std::optional<double> scaleY,
 {
     if (!scaleY)
         scaleY = scaleX;
-    translateSelf(originX, originY, originZ);
+    m_matrix.translate3d(originX, originY, originZ);
     // Post-multiply a non-uniform scale transformation on the current matrix.
     // The 3D scale matrix is described in CSS Transforms with sx = scaleX, sy = scaleY and sz = scaleZ.
     m_matrix.scale3d(scaleX, scaleY.value(), scaleZ);
-    translateSelf(-originX, -originY, -originZ);
+    m_matrix.translate3d(-originX, -originY, -originZ);
     if (scaleZ != 1 || originZ)
         m_is2D = false;
     return *this;
@@ -172,12 +172,12 @@ Ref<DOMMatrix> DOMMatrix::scaleSelf(double scaleX, std::optional<double> scaleY,
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-scale3dself
 Ref<DOMMatrix> DOMMatrix::scale3dSelf(double scale, double originX, double originY, double originZ)
 {
-    translateSelf(originX, originY, originZ);
+    m_matrix.translate3d(originX, originY, originZ);
     // Post-multiply a uniform 3D scale transformation (m11 = m22 = m33 = scale) on the current matrix.
     // The 3D scale matrix is described in CSS Transforms with sx = sy = sz = scale. [CSS3-TRANSFORMS]
     m_matrix.scale3d(scale, scale, scale);
-    translateSelf(-originX, -originY, -originZ);
-    if (scale != 1)
+    m_matrix.translate3d(-originX, -originY, -originZ);
+    if (scale != 1 || originZ)
         m_is2D = false;
     return *this;
 }


### PR DESCRIPTION
#### bf1930f39d6cdd6b85f350454d0a1a99232ea848
<pre>
Avoid -Wuse-after-free warnings in DOMMatrix with GCC 12
<a href="https://bugs.webkit.org/show_bug.cgi?id=249910">https://bugs.webkit.org/show_bug.cgi?id=249910</a>

Reviewed by Michael Catanzaro.

GCC 12 sees issues with DOMMatrix::scaleSelf() and DOMMatrix::scale3dSelf()
calling the translateSelf() method that returns a Ref&lt;DOMMatrix&gt; that holds
a reference to the same DOMMatrix object.

That Ref&lt;DOMMatrix&gt; gets destroyed when going out of scope, providing the
never-taken codepath that destroys the DOMMatrix object if its reference
count would fall to zero. This doesn&apos;t happen because of expectation that
both methods initially start operation on the DOMMatrix object with a
greater-than-zero reference count. Only after that do the two methods
construct their own Ref&lt;DOMMatrix&gt; return value, which in theory would
work on freed memory if that never-taken codepath was indeed taken.

To avoid this, don&apos;t call translateSelf() but instead invoke directly
the proper TransformationMatrix operations.

* Source/WebCore/css/DOMMatrix.cpp:
(WebCore::DOMMatrix::scaleSelf):
(WebCore::DOMMatrix::scale3dSelf):

Canonical link: <a href="https://commits.webkit.org/258346@main">https://commits.webkit.org/258346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f689be956de8d6695a0810fadced8eb1c697909

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110894 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171111 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1636 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108670 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35433 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78432 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4331 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25073 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1529 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5725 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6160 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->