### PR TITLE
Remove hspace and vspace attributes from input field

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/unmapped-attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/unmapped-attributes-expected.txt
@@ -54,12 +54,12 @@ PASS <input width> should not be mapped to style width in CSS1Compat mode
 PASS <input width> should not be mapped to style width in BackCompat mode
 PASS <input height> should not be mapped to style height in CSS1Compat mode
 PASS <input height> should not be mapped to style height in BackCompat mode
-FAIL <input hspace> should not be mapped to style marginLeft in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input hspace> should not be mapped to style marginLeft in BackCompat mode assert_equals: expected "0px" but got "200px"
-FAIL <input hspace> should not be mapped to style marginRight in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input hspace> should not be mapped to style marginRight in BackCompat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginTop in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginTop in BackCompat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginBottom in CSS1Compat mode assert_equals: expected "0px" but got "200px"
-FAIL <input vspace> should not be mapped to style marginBottom in BackCompat mode assert_equals: expected "0px" but got "200px"
+PASS <input hspace> should not be mapped to style marginLeft in CSS1Compat mode
+PASS <input hspace> should not be mapped to style marginLeft in BackCompat mode
+PASS <input hspace> should not be mapped to style marginRight in CSS1Compat mode
+PASS <input hspace> should not be mapped to style marginRight in BackCompat mode
+PASS <input vspace> should not be mapped to style marginTop in CSS1Compat mode
+PASS <input vspace> should not be mapped to style marginTop in BackCompat mode
+PASS <input vspace> should not be mapped to style marginBottom in CSS1Compat mode
+PASS <input vspace> should not be mapped to style marginBottom in BackCompat mode
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -677,11 +677,15 @@ bool HTMLInputElement::hasPresentationalHintsForAttribute(const QualifiedName& n
 void HTMLInputElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     if (name == vspaceAttr) {
-        addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
-        addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
+        if (isImageButton()) {
+            addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
+            addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
+        }
     } else if (name == hspaceAttr) {
+        if (isImageButton()) {
         addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
+        }
     } else if (name == alignAttr) {
         if (m_inputType->shouldRespectAlignAttribute())
             applyAlignmentAttributeToStyle(value, style);


### PR DESCRIPTION
#### 90658791ba8b0a5fcb2ef76235b2ef1aeccf5a7a
<pre>
Remove hspace and vspace attributes from input field
<a href="https://bugs.webkit.org/show_bug.cgi?id=244279">https://bugs.webkit.org/show_bug.cgi?id=244279</a>
rdar://99356718

Reviewed by Antti Koivisto.

Removes hspace and vspace attribute mapping to CSS, but keeps it
in the case of input of type=image as mandated by the WPT test in
<a href="http://wpt.live/html/rendering/unmapped-attributes.html">http://wpt.live/html/rendering/unmapped-attributes.html</a>
but still passing
<a href="http://wpt.live/html/rendering/dimension-attributes.html">http://wpt.live/html/rendering/dimension-attributes.html</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/unmapped-attributes-expected.txt:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::collectPresentationalHintsForAttribute):

Canonical link: <a href="https://commits.webkit.org/258360@main">https://commits.webkit.org/258360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd22a4cf9c30591b3abacec1fc881784b65e8bd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110997 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171200 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1724 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108759 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92241 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25159 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4486 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44647 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6240 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3022 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->