### PR TITLE
Remove CSSKeyframesRule.insertRule()

### DIFF
--- a/LayoutTests/animations/CSSKeyframesRule-parameters-expected.txt
+++ b/LayoutTests/animations/CSSKeyframesRule-parameters-expected.txt
@@ -4,7 +4,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS keyframes.__proto__ is CSSKeyframesRule.prototype
-PASS keyframes.insertRule() threw exception TypeError: Not enough arguments.
 PASS keyframes.appendRule() threw exception TypeError: Not enough arguments.
 PASS keyframes.deleteRule() threw exception TypeError: Not enough arguments.
 PASS keyframes.findRule() threw exception TypeError: Not enough arguments.

--- a/LayoutTests/animations/CSSKeyframesRule-parameters.html
+++ b/LayoutTests/animations/CSSKeyframesRule-parameters.html
@@ -16,7 +16,6 @@ description("Tests that the parameters are mandatory in CSSKeyframesRule API.");
 var keyframes = document.styleSheets.item(0).cssRules.item(0);
 shouldBe("keyframes.__proto__", "CSSKeyframesRule.prototype");
 
-shouldThrow("keyframes.insertRule()");
 shouldThrow("keyframes.appendRule()");
 shouldThrow("keyframes.deleteRule()");
 shouldThrow("keyframes.findRule()");

--- a/LayoutTests/animations/change-keyframes-expected.txt
+++ b/LayoutTests/animations/change-keyframes-expected.txt
@@ -1,5 +1,3 @@
-CONSOLE MESSAGE: CSSKeyframesRule 'insertRule' function is deprecated.  Use 'appendRule' instead.
-CONSOLE MESSAGE: CSSKeyframesRule 'insertRule' function is deprecated.  Use 'appendRule' instead.
 This test performs an animation of the left property and makes sure it is animating. Then it stops the animation, changes the keyframes to an animation of the top property, restarts the animation and makes sure top is animating.
 PASS - "left" property for "box" element at 0.5s saw something close to: 200
 PASS - "top" property for "box" element at 1s saw something close to: 100

--- a/LayoutTests/animations/change-keyframes.html
+++ b/LayoutTests/animations/change-keyframes.html
@@ -53,9 +53,9 @@
         keyframes.deleteRule("40%");
         keyframes.deleteRule("60%");
         keyframes.deleteRule("100%");
-        keyframes.insertRule("0% { top: 50px; }");
+        keyframes.appendRule("0% { top: 50px; }");
         keyframes.appendRule("10% { top: 100px; }");
-        keyframes.insertRule("90% { top: 100px; }");
+        keyframes.appendRule("90% { top: 100px; }");
         keyframes.appendRule("100% { top: 150px; }");
         document.getElementById('box').style.webkitAnimationName = "anim";
     }

--- a/LayoutTests/http/tests/css/resources/shared-stylesheet-mutation.js
+++ b/LayoutTests/http/tests/css/resources/shared-stylesheet-mutation.js
@@ -107,7 +107,7 @@ function executeTests(createCSSOMObjectBeforeTest)
     mutationTest(12, "sheet.insertRule('"+importRule+"', 0)", 'green');
 
     mutationTest(13, 'sheet.cssRules[2].selectorText = "foo"', 'red');
-    mutationTest(14, 'sheet.cssRules[3].insertRule("40% { left: 40px; }")', 'red');
+    mutationTest(14, 'sheet.cssRules[3].appendRule("40% { left: 40px; }")', 'red');
     mutationTest(15, 'sheet.cssRules[3].deleteRule("100%")', 'red');
     mutationTest(16, 'sheet.cssRules[4].style.setProperty("font-family", "Bar", "")', 'red');
 

--- a/LayoutTests/http/tests/css/shared-stylesheet-mutation-preconstruct-expected.txt
+++ b/LayoutTests/http/tests/css/shared-stylesheet-mutation-preconstruct-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: CSSKeyframesRule 'insertRule' function is deprecated.  Use 'appendRule' instead.
 The test loads the same stylesheet to different frames and then mutates them. The mutations should not affect other frames.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -134,15 +134,6 @@ void CSSKeyframesRule::appendRule(const String& ruleText)
     m_childRuleCSSOMWrappers.grow(length());
 }
 
-void CSSKeyframesRule::insertRule(const String& ruleText)
-{
-    if (CSSStyleSheet* parent = parentStyleSheet()) {
-        if (Document* ownerDocument = parent->ownerDocument())
-            ownerDocument->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "CSSKeyframesRule 'insertRule' function is deprecated.  Use 'appendRule' instead."_s);
-    }
-    appendRule(ruleText);
-}
-
 void CSSKeyframesRule::deleteRule(const String& s)
 {
     ASSERT(m_childRuleCSSOMWrappers.size() == m_keyframesRule->keyframes().size());

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -80,7 +80,6 @@ public:
 
     CSSRuleList& cssRules();
 
-    void insertRule(const String& rule);
     void appendRule(const String& rule);
     void deleteRule(const String& key);
     CSSKeyframeRule* findRule(const String& key);

--- a/Source/WebCore/css/CSSKeyframesRule.idl
+++ b/Source/WebCore/css/CSSKeyframesRule.idl
@@ -32,7 +32,6 @@
     attribute [AtomString] DOMString name;
     readonly attribute CSSRuleList cssRules;
     
-    undefined insertRule(DOMString rule);
     undefined appendRule(DOMString rule);
     undefined deleteRule(DOMString key);
     CSSKeyframeRule? findRule(DOMString key);


### PR DESCRIPTION
#### c26a65e62e3999f70665e1aaa493acc9938891ae
<pre>
Remove CSSKeyframesRule.insertRule()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247364">https://bugs.webkit.org/show_bug.cgi?id=247364</a>
rdar://102141002

Reviewed by Antoine Quint.

Removes insertRule. It was removed from Gecko, 10 years ago.
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=841896">https://bugzilla.mozilla.org/show_bug.cgi?id=841896</a>
It was first deprecated in Blink and removed from Blink 7 years ago.
<a href="https://groups.google.com/a/chromium.org/g/blink-dev/c/wW7w8Hro78s/m/JDULF2oM9iIJ">https://groups.google.com/a/chromium.org/g/blink-dev/c/wW7w8Hro78s/m/JDULF2oM9iIJ</a>
GitHub Search doesn&apos;t return meaningful instances of insertRule.

* LayoutTests/animations/change-keyframes-expected.txt:
* LayoutTests/animations/change-keyframes.html:
* LayoutTests/animations/CSSKeyframesRule-parameters-expected.txt:
* LayoutTests/animations/CSSKeyframesRule-parameters.html:
* LayoutTests/http/tests/css/resources/shared-stylesheet-mutation.js:
(executeTests):
* LayoutTests/http/tests/css/shared-stylesheet-mutation-preconstruct-expected.txt:
* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::CSSKeyframesRule::insertRule): Deleted.
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSKeyframesRule.idl:

Canonical link: <a href="https://commits.webkit.org/258361@main">https://commits.webkit.org/258361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdd3e8a66a9f0ace2747ecf5a222ccfbb56df1f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110976 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171179 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1704 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108738 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92221 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78520 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1592 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44627 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6221 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3023 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->