### PR TITLE
[GPU Process] [FormControls] Add ControlParts for SliderTrack and SliderThumb

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1754,6 +1754,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ProgressBarPart.h
     platform/graphics/controls/SearchFieldCancelButtonPart.h
     platform/graphics/controls/SearchFieldPart.h
+    platform/graphics/controls/SliderThumbPart.h
+    platform/graphics/controls/SliderTrackPart.h
     platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
     platform/graphics/controls/ToggleButtonPart.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2207,6 +2207,7 @@ platform/graphics/controls/ControlPartType.cpp
 platform/graphics/controls/ControlStyle.cpp
 platform/graphics/controls/MeterPart.cpp
 platform/graphics/controls/ProgressBarPart.cpp
+platform/graphics/controls/SliderTrackPart.cpp
 platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
 platform/graphics/displaylists/DisplayList.cpp
 platform/graphics/displaylists/DisplayListDrawingContext.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -472,6 +472,8 @@ platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SearchControlMac.mm
 platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
 platform/graphics/mac/controls/SearchFieldMac.mm
+platform/graphics/mac/controls/SliderThumbMac.mm
+platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -34,6 +34,8 @@ class PlatformControl;
 class ProgressBarPart;
 class SearchFieldCancelButtonPart;
 class SearchFieldPart;
+class SliderThumbPart;
+class SliderTrackPart;
 class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
@@ -52,6 +54,8 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
@@ -84,6 +84,9 @@ TextStream& operator<<(TextStream& ts, ControlStyle::State state)
     case ControlStyle::State::ListButtonPressed:
         ts << "list-button-pressed";
         break;
+    case ControlStyle::State::VerticalWritingMode:
+        ts << "vertical-writing-mode";
+        break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.h
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.h
@@ -52,11 +52,13 @@ struct ControlStyle {
         ReadOnly            = 1 << 14,
         ListButton          = 1 << 15,
         ListButtonPressed   = 1 << 16,
+        VerticalWritingMode = 1 << 17,
     };
     OptionSet<State> states;
     unsigned fontSize { 12 };
     float zoomFactor { 1 };
     Color accentColor;
+    Color textColor;
 };
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, ControlStyle::State);

--- a/Source/WebCore/platform/graphics/controls/SliderThumbPart.h
+++ b/Source/WebCore/platform/graphics/controls/SliderThumbPart.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SliderThumbPart final : public ControlPart {
+public:
+    static Ref<SliderThumbPart> create(ControlPartType type)
+    {
+        return adoptRef(*new SliderThumbPart(type));
+    }
+
+private:
+    SliderThumbPart(ControlPartType type)
+        : ControlPart(type)
+    {
+        ASSERT(type == ControlPartType::SliderThumbHorizontal || type == ControlPartType::SliderThumbVertical);
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSliderThumb(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SliderTrackPart.h"
+
+#include "ControlFactory.h"
+#include "GraphicsContext.h"
+
+namespace WebCore {
+
+Ref<SliderTrackPart> SliderTrackPart::create(ControlPartType type, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios)
+{
+    return adoptRef(*new SliderTrackPart(type, thumbSize, trackBounds, WTFMove(tickRatios)));
+}
+
+SliderTrackPart::SliderTrackPart(ControlPartType type, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios)
+    : ControlPart(type)
+    , m_thumbSize(thumbSize)
+    , m_trackBounds(trackBounds)
+    , m_tickRatios(WTFMove(tickRatios))
+{
+    ASSERT(type == ControlPartType::SliderHorizontal || type == ControlPartType::SliderVertical);
+}
+
+#if ENABLE(DATALIST_ELEMENT)
+void SliderTrackPart::drawTicks(GraphicsContext& context, const FloatRect& rect, const ControlStyle& style) const
+{
+    if (m_tickRatios.isEmpty())
+        return;
+
+    static constexpr IntSize sliderTickSize = { 1, 3 };
+    static constexpr int sliderTickOffsetFromTrackCenter = -9;
+
+    bool isHorizontal = type() == ControlPartType::SliderHorizontal;
+
+    auto trackBounds = m_trackBounds;
+    trackBounds.moveBy(IntPoint(rect.location()));
+
+    auto tickSize = isHorizontal? sliderTickSize : sliderTickSize.transposedSize();
+    tickSize.scale(style.zoomFactor);
+
+    FloatPoint tickLocation;
+    float tickRegionMargin = 0;
+    float tickRegionWidth = 0;
+    float offsetFromTrackCenter = sliderTickOffsetFromTrackCenter * style.zoomFactor;
+
+    if (isHorizontal) {
+        tickLocation = { 0, rect.center().y() + offsetFromTrackCenter };
+        tickRegionMargin = trackBounds.x() + (m_thumbSize.width() - tickSize.width()) / 2.0;
+        tickRegionWidth = trackBounds.width() - m_thumbSize.width();
+    } else {
+        tickLocation = { rect.center().x() + offsetFromTrackCenter, 0 };
+        tickRegionMargin = trackBounds.y() + (m_thumbSize.height() - tickSize.height()) / 2.0;
+        tickRegionWidth = trackBounds.height() - m_thumbSize.height();
+    }
+
+    auto tickRect = FloatRect { tickLocation, tickSize };
+
+    GraphicsContextStateSaver stateSaver(context);
+    context.setFillColor(style.textColor);
+
+    bool isVerticalWritingMode = style.states.contains(ControlStyle::State::VerticalWritingMode);
+    bool isRightToLeft = style.states.contains(ControlStyle::State::RightToLeft);
+    bool isReversedInlineDirection = (!isHorizontal && !isVerticalWritingMode) || isRightToLeft;
+
+    for (auto tickRatio : m_tickRatios) {
+        double value = isReversedInlineDirection ? 1.0 - tickRatio : tickRatio;
+        double tickPosition = round(tickRegionMargin + tickRegionWidth * value);
+        if (isHorizontal)
+            tickRect.setX(tickPosition);
+        else
+            tickRect.setY(tickPosition);
+        context.fillRect(tickRect);
+    }
+}
+#endif
+
+std::unique_ptr<PlatformControl> SliderTrackPart::createPlatformControl()
+{
+    return controlFactory().createPlatformSliderTrack(*this);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/SliderTrackPart.h
+++ b/Source/WebCore/platform/graphics/controls/SliderTrackPart.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlPart.h"
+#include "IntRect.h"
+
+namespace WebCore {
+
+class SliderTrackPart : public ControlPart {
+public:
+    WEBCORE_EXPORT static Ref<SliderTrackPart> create(ControlPartType, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios);
+
+    IntSize thumbSize() const { return m_thumbSize; }
+    IntRect trackBounds() const { return m_trackBounds; }
+    const Vector<double>& tickRatios() const { return m_tickRatios; }
+
+#if ENABLE(DATALIST_ELEMENT)
+    void drawTicks(GraphicsContext&, const FloatRect&, const ControlStyle&) const;
+#endif
+
+private:
+    SliderTrackPart(ControlPartType, const IntSize& thumbSize, const IntRect& trackBounds, Vector<double>&& tickRatios);
+
+    std::unique_ptr<PlatformControl> createPlatformControl() override;
+
+    IntSize m_thumbSize;
+    IntRect m_trackBounds;
+    Vector<double> m_tickRatios;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SliderTrackPart) \
+    static bool isType(const WebCore::ControlPart& part) { return part.type() == WebCore::ControlPartType::SliderHorizontal || part.type() == WebCore::ControlPartType::SliderVertical; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -44,6 +44,8 @@ public:
     std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) override;
     std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) override;
     std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) override;
@@ -56,6 +58,7 @@ private:
     NSLevelIndicatorCell *levelIndicatorCell() const;
     NSPopUpButtonCell *popUpButtonCell() const;
     NSSearchFieldCell *searchFieldCell() const;
+    NSSliderCell *sliderCell() const;
     NSTextFieldCell *textFieldCell() const;
 
     mutable RetainPtr<WebControlView> m_drawingView;
@@ -67,6 +70,7 @@ private:
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
     mutable RetainPtr<NSPopUpButtonCell> m_popUpButtonCell;
     mutable RetainPtr<NSSearchFieldCell> m_searchFieldCell;
+    mutable RetainPtr<NSSliderCell> m_sliderCell;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -34,6 +34,8 @@
 #import "ProgressBarMac.h"
 #import "SearchFieldCancelButtonMac.h"
 #import "SearchFieldMac.h"
+#import "SliderThumbMac.h"
+#import "SliderTrackMac.h"
 #import "TextAreaMac.h"
 #import "TextFieldMac.h"
 #import "ToggleButtonMac.h"
@@ -163,6 +165,17 @@ NSSearchFieldCell *ControlFactoryMac::searchFieldCell() const
     return m_searchFieldCell.get();
 }
 
+NSSliderCell *ControlFactoryMac::sliderCell() const
+{
+    if (!m_sliderCell) {
+        m_sliderCell = adoptNS([[NSSliderCell alloc] init]);
+        [m_sliderCell setSliderType:NSSliderTypeLinear];
+        [m_sliderCell setControlSize:NSControlSizeSmall];
+        [m_sliderCell setFocusRingType:NSFocusRingTypeExterior];
+    }
+    return m_sliderCell.get();
+}
+
 NSTextFieldCell *ControlFactoryMac::textFieldCell() const
 {
     if (!m_textFieldCell) {
@@ -208,6 +221,16 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchField(Se
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart& part)
 {
     return makeUnique<SearchFieldCancelButtonMac>(part, *this, searchFieldCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderThumb(SliderThumbPart& part)
+{
+    return makeUnique<SliderThumbMac>(part, *this, sliderCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderTrack(SliderTrackPart& part)
+{
+    return makeUnique<SliderTrackMac>(part, *this);
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextAreaPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class SliderThumbMac : public ControlMac {
+public:
+    SliderThumbMac(SliderThumbPart&, ControlFactoryMac&, NSSliderCell *);
+
+private:
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
+
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+
+    RetainPtr<NSSliderCell> m_sliderCell;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SliderThumbMac.h"
+
+#if PLATFORM(MAC)
+
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "SliderThumbPart.h"
+
+namespace WebCore {
+
+SliderThumbMac::SliderThumbMac(SliderThumbPart& owningPart, ControlFactoryMac& controlFactory, NSSliderCell *sliderCell)
+    : ControlMac(owningPart, controlFactory)
+    , m_sliderCell(sliderCell)
+{
+    ASSERT(m_owningPart.type() == ControlPartType::SliderThumbHorizontal || m_owningPart.type() == ControlPartType::SliderThumbVertical);
+}
+
+void SliderThumbMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    ControlMac::updateCellStates(rect, style);
+
+    updateEnabledState(m_sliderCell.get(), style);
+    updateFocusedState(m_sliderCell.get(), style);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+
+    if (style.states.contains(ControlStyle::State::Pressed))
+        [m_sliderCell startTrackingAt:NSPoint() inView:view];
+    else
+        [m_sliderCell stopTracking:NSPoint() at:NSPoint() inView:view mouseIsUp:YES];
+}
+
+FloatRect SliderThumbMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    if (m_owningPart.type() == ControlPartType::SliderThumbHorizontal)
+        return bounds;
+
+    // Make the height of the vertical slider slightly larger so NSSliderCell will draw a vertical slider.
+    static constexpr float verticalSliderHeightPadding = 0.1f;
+    return { bounds.location(), bounds.size() + FloatSize { 0, verticalSliderHeightPadding * style.zoomFactor } };
+}
+
+void SliderThumbMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+    LocalCurrentGraphicsContext localContext(context);
+    
+    auto logicalRect = rectForBounds(rect, style);
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    if (style.zoomFactor != 1) {
+        logicalRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    // Never draw a focus ring for the slider thumb.
+    auto styleForDrawing = style;
+    styleForDrawing.states.remove(ControlStyle::State::Focused);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+
+    drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, m_sliderCell.get(), view, true);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+#import "SliderTrackPart.h"
+
+namespace WebCore {
+
+class SliderTrackMac : public ControlMac {
+public:
+    SliderTrackMac(SliderTrackPart&, ControlFactoryMac&);
+
+private:
+    const SliderTrackPart& owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart); }
+
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SliderTrackMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ColorSpaceCG.h"
+#import "FloatRoundedRect.h"
+#import "LocalCurrentGraphicsContext.h"
+
+namespace WebCore {
+
+SliderTrackMac::SliderTrackMac(SliderTrackPart& part, ControlFactoryMac& controlFactory)
+    : ControlMac(part, controlFactory)
+{
+}
+
+FloatRect SliderTrackMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    static constexpr int sliderTrackWidth = 5;
+    float trackWidth = sliderTrackWidth * style.zoomFactor;
+
+    auto& sliderTrackPart = owningSliderTrackPart();
+    auto rect = bounds;
+    
+    // Set the height/width and align the location in the center of the difference.
+    if (sliderTrackPart.type() == ControlPartType::SliderHorizontal) {
+        rect.setHeight(trackWidth);
+        rect.setY(rect.y() + (bounds.height() - rect.height()) / 2);
+    } else {
+        rect.setWidth(trackWidth);
+        rect.setX(rect.x() + (bounds.width() - rect.width()) / 2);
+    }
+
+    return rect;
+}
+
+static void trackGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
+{
+    static const float dark[4] = { 0.0f, 0.0f, 0.0f, 0.678f };
+    static const float light[4] = { 0.0f, 0.0f, 0.0f, 0.13f };
+    float a = inData[0];
+    int i = 0;
+    for (i = 0; i < 4; i++)
+        outData[i] = (1.0f - a) * dark[i] + a * light[i];
+}
+
+void SliderTrackMac::draw(GraphicsContext& context, const FloatRect& rect, float, const ControlStyle& style)
+{
+    static constexpr int sliderTrackRadius = 2;
+    static constexpr IntSize sliderRadius(sliderTrackRadius, sliderTrackRadius);
+
+    LocalCurrentGraphicsContext localContext(context);
+    CGContextRef cgContext = localContext.cgContext();
+    CGColorSpaceRef cspace = sRGBColorSpaceRef();
+
+    auto& sliderTrackPart = owningSliderTrackPart();
+
+#if ENABLE(DATALIST_ELEMENT)
+    sliderTrackPart.drawTicks(context, rect, style);
+#endif
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto logicalRect = rectForBounds(rect, style);
+    CGContextClipToRect(cgContext, logicalRect);
+
+    struct CGFunctionCallbacks mainCallbacks = { 0, trackGradientInterpolate, NULL };
+    RetainPtr<CGFunctionRef> mainFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &mainCallbacks));
+    RetainPtr<CGShadingRef> mainShading;
+    if (sliderTrackPart.type() == ControlPartType::SliderVertical)
+        mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(logicalRect.x(),  logicalRect.maxY()), CGPointMake(logicalRect.maxX(), logicalRect.maxY()), mainFunction.get(), false, false));
+    else
+        mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(logicalRect.x(),  logicalRect.y()), CGPointMake(logicalRect.x(), logicalRect.maxY()), mainFunction.get(), false, false));
+
+    context.clipRoundedRect(FloatRoundedRect(logicalRect, sliderRadius, sliderRadius, sliderRadius, sliderRadius));
+    cgContext = localContext.cgContext();
+    CGContextDrawShading(cgContext, mainShading.get());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -118,10 +118,8 @@ private:
 
     void adjustProgressBarStyle(RenderStyle&, const Element*) const final;
 
-    bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) final;
     void adjustSliderTrackStyle(RenderStyle&, const Element*) const final;
 
-    bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) final;
     void adjustSliderThumbStyle(RenderStyle&, const Element*) const final;
 
     void adjustSearchFieldStyle(RenderStyle&, const Element*) const final;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -111,6 +111,8 @@
 #include <WebCore/ShareData.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/SkewTransformOperation.h>
+#include <WebCore/SliderThumbPart.h>
+#include <WebCore/SliderTrackPart.h>
 #include <WebCore/SystemImage.h>
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextAreaPart.h>
@@ -1557,6 +1559,9 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
 
     case WebCore::ControlPartType::SliderHorizontal:
     case WebCore::ControlPartType::SliderVertical:
+        encoder << downcast<WebCore::SliderTrackPart>(part);
+        break;
+
     case WebCore::ControlPartType::SearchField:
 #if ENABLE(APPLE_PAY)
     case WebCore::ControlPartType::ApplePayButton:
@@ -1638,8 +1643,13 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     }
 
     case WebCore::ControlPartType::SliderHorizontal:
-    case WebCore::ControlPartType::SliderVertical:
+    case WebCore::ControlPartType::SliderVertical: {
+        std::optional<Ref<WebCore::SliderTrackPart>> sliderTrackPart;
+        decoder >> sliderTrackPart;
+        if (sliderTrackPart)
+            return WTFMove(*sliderTrackPart);
         break;
+    }
 
     case WebCore::ControlPartType::SearchField:
         return WebCore::SearchFieldPart::create();
@@ -1681,7 +1691,7 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
 
     case WebCore::ControlPartType::SliderThumbHorizontal:
     case WebCore::ControlPartType::SliderThumbVertical:
-        break;
+        return WebCore::SliderThumbPart::create(*type);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2356,7 +2356,8 @@ enum class WebCore::FetchHeadersGuard : uint8_t {
     LargeControls,
     ReadOnly,
     ListButton,
-    ListButtonPressed
+    ListButtonPressed,
+    VerticalWritingMode
 };
 
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ControlStyle {
@@ -2364,6 +2365,7 @@ enum class WebCore::FetchHeadersGuard : uint8_t {
     unsigned fontSize;
     float zoomFactor;
     WebCore::Color accentColor;
+    WebCore::Color textColor;
 };
 
 enum class WebCore::ControlPartType : uint8_t {
@@ -2428,6 +2430,13 @@ enum class WebCore::ControlPartType : uint8_t {
     double position();
     Seconds animationStartTime();
 };
+
+[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SliderTrackPart {
+    WebCore::ControlPartType type();
+    WebCore::IntSize thumbSize();
+    WebCore::IntRect trackBounds();
+    Vector<double> tickRatios();
+}
 
 enum class WebCore::HasInsecureContent : bool
 


### PR DESCRIPTION
#### 763b293216be504ad2cffa1429628f6ce5f08bc9
<pre>
[GPU Process] [FormControls] Add ControlParts for SliderTrack and SliderThumb
<a href="https://bugs.webkit.org/show_bug.cgi?id=249921">https://bugs.webkit.org/show_bug.cgi?id=249921</a>
rdar://103737847

Reviewed by Aditya Keerthi.

These ControlParts will handle drawing the SliderTrack and the SliderThumb form
controls (i.e. &lt;input type=&quot;range&quot; ...&gt;). For macOS, AppKit will be used to draw
the platform controls through SliderTrackMac and SliderThumbMac.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/ControlStyle.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/controls/ControlStyle.h:
* Source/WebCore/platform/graphics/controls/SliderThumbPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlStyle.h.
* Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp: Added.
(WebCore::SliderTrackPart::create):
(WebCore::SliderTrackPart::SliderTrackPart):
(WebCore::SliderTrackPart::drawTicks const):
(WebCore::SliderTrackPart::createPlatformControl):
* Source/WebCore/platform/graphics/controls/SliderTrackPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlStyle.h.
(WebCore::SliderTrackPart::thumbSize const):
(WebCore::SliderTrackPart::trackBounds const):
(WebCore::SliderTrackPart::tickRatios const):
(isType):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::sliderCell const):
(WebCore::ControlFactoryMac::createPlatformSliderThumb):
(WebCore::ControlFactoryMac::createPlatformSliderTrack):
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlStyle.h.
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm: Added.
(WebCore::SliderThumbMac::SliderThumbMac):
(WebCore::SliderThumbMac::updateCellStates):
(WebCore::SliderThumbMac::rectForBounds const):
(WebCore::SliderThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlStyle.h.
(WebCore::SliderTrackMac::owningSliderTrackPart const):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm: Added.
(WebCore::SliderTrackMac::SliderTrackMac):
(WebCore::SliderTrackMac::rectForBounds const):
(WebCore::trackGradientInterpolate):
(WebCore::SliderTrackMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::createSliderTrackPartForRenderer):
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::extractControlStyleStatesForRenderer const):
(WebCore::RenderTheme::extractControlStyleForRenderer const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::TrackGradientInterpolate): Deleted.
(WebCore::RenderThemeMac::paintSliderTrack): Deleted.
(WebCore::RenderThemeMac::paintSliderThumb): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/258522@main">https://commits.webkit.org/258522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b0d3b88793ba6274a691b8d02099a66f365417c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111519 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2254 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107976 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92709 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24191 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45111 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5841 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6751 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->