### PR TITLE
[GPU Process] [FormControls] Add ControlPart for ColorWell

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1744,6 +1744,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/angle/GraphicsContextGLANGLE.h
 
     platform/graphics/controls/ButtonPart.h
+    platform/graphics/controls/ColorWellPart.h
     platform/graphics/controls/ControlFactory.h
     platform/graphics/controls/ControlPart.h
     platform/graphics/controls/ControlPartType.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -464,6 +464,7 @@ platform/graphics/mac/WebKitNSImageExtras.mm
 platform/graphics/mac/WebLayer.mm
 platform/graphics/mac/controls/ButtonMac.mm
 platform/graphics/mac/controls/ButtonControlMac.mm
+platform/graphics/mac/controls/ColorWellMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/InnerSpinButtonMac.mm

--- a/Source/WebCore/platform/graphics/controls/ColorWellPart.h
+++ b/Source/WebCore/platform/graphics/controls/ColorWellPart.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(INPUT_TYPE_COLOR)
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class ColorWellPart final : public ControlPart {
+public:
+    static Ref<ColorWellPart> create()
+    {
+        return adoptRef(*new ColorWellPart());
+    }
+
+private:
+    ColorWellPart()
+        : ControlPart(ControlPartType::ColorWell)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformColorWell(*this);
+    }
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 class ButtonPart;
+class ColorWellPart;
 class InnerSpinButtonPart;
 class MeterPart;
 class MenuListPart;
@@ -52,6 +53,9 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) = 0;
+#if ENABLE(INPUT_TYPE_COLOR)
+    virtual std::unique_ptr<PlatformControl> createPlatformColorWell(ColorWellPart&) = 0;
+#endif
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) = 0;

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC) && ENABLE(INPUT_TYPE_COLOR)
+
+#import "ButtonControlMac.h"
+
+namespace WebCore {
+
+class ColorWellPart;
+
+class ColorWellMac : public ButtonControlMac {
+public:
+    ColorWellMac(ColorWellPart& owningPart, ControlFactoryMac&, NSButtonCell *);
+
+private:
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC) && ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ColorWellMac.h"
+
+#if PLATFORM(MAC) && ENABLE(INPUT_TYPE_COLOR)
+
+#import "ColorWellPart.h"
+#import "ControlFactoryMac.h"
+#import "LocalCurrentGraphicsContext.h"
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+ColorWellMac::ColorWellMac(ColorWellPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
+    : ButtonControlMac(owningPart, controlFactory, buttonCell)
+{
+}
+
+void ColorWellMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    ButtonControlMac::updateCellStates(rect, style);
+    [m_buttonCell setBezelStyle:NSBezelStyleTexturedSquare];
+}
+
+void ColorWellMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    GraphicsContextStateSaver stateSaver(context);
+    LocalCurrentGraphicsContext localContext(context);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *window = [view window];
+    auto *previousDefaultButtonCell = [window defaultButtonCell];
+
+    // The ColorWell can't be the window default button cell.
+    if ([previousDefaultButtonCell isEqual:m_buttonCell.get()])
+        [window setDefaultButtonCell:nil];
+
+    drawCell(context, rect, deviceScaleFactor, style, m_buttonCell.get(), view, true);
+
+    // Restore the window default button cell.
+    if (![previousDefaultButtonCell isEqual:m_buttonCell.get()])
+        [window setDefaultButtonCell:previousDefaultButtonCell];
+
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC) && ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -38,7 +38,11 @@ public:
 
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
+private:
     std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) final;
+#if ENABLE(INPUT_TYPE_COLOR)
+    std::unique_ptr<PlatformControl> createPlatformColorWell(ColorWellPart&) final;
+#endif
     std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&) final;
     std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) final;
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) final;
@@ -51,7 +55,6 @@ public:
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
 
-private:
     NSButtonCell *buttonCell() const;
     NSButtonCell *defaultButtonCell() const;
     NSButtonCell *checkboxCell() const;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "ButtonMac.h"
+#import "ColorWellMac.h"
 #import "InnerSpinButtonMac.h"
 #import "MenuListMac.h"
 #import "MeterMac.h"
@@ -208,6 +209,13 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMenuList(MenuL
 {
     return makeUnique<MenuListMac>(part, *this, popUpButtonCell());
 }
+
+#if ENABLE(INPUT_TYPE_COLOR)
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformColorWell(ColorWellPart& part)
+{
+    return makeUnique<ColorWellMac>(part, *this, buttonCell());
+}
+#endif
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMeter(MeterPart& part)
 {

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "ControlFactoryMac.h"
 #import "GraphicsContext.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -59,7 +59,6 @@ private:
 
     bool controlRequiresPreWhiteSpace(ControlPartType type) const final { return type == ControlPartType::PushButton; }
 
-    void paint(ControlPartType, ControlStates&, GraphicsContext&, const FloatRect&, float zoomFactor, ScrollView*, float deviceScaleFactor, float pageScaleFactor, bool useSystemAppearance, bool useDarkAppearance, const Color& tintColor) final;
     void inflateControlPaintRect(ControlPartType, const ControlStates&, FloatRect&, float zoomFactor) const final;
 
     bool userPrefersReducedMotion() const final;

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -602,45 +602,6 @@ bool ThemeMac::drawCellOrFocusRingWithViewIntoContext(NSCell *cell, GraphicsCont
     return needsRepaint;
 }
 
-// Color Well
-
-#if ENABLE(INPUT_TYPE_COLOR)
-static void paintColorWell(ControlStates& controlStates, GraphicsContext& context, const FloatRect& zoomedRect, float zoomFactor, ScrollView* scrollView, float deviceScaleFactor)
-{
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-
-    // Determine the width and height needed for the control and prepare the cell for painting.
-    auto states = controlStates.states();
-    NSButtonCell *buttonCell = button(ControlPartType::ColorWell, controlStates, IntSize(zoomedRect.size()), zoomFactor);
-    GraphicsContextStateSaver stateSaver(context);
-
-    NSControlSize controlSize = [buttonCell controlSize];
-    IntSize zoomedSize = buttonSizes()[controlSize];
-    zoomedSize.setWidth(zoomedRect.width()); // Buttons don't ever constrain width, so the zoomed width can just be honored.
-    zoomedSize.setHeight(zoomedSize.height() * zoomFactor);
-    FloatRect inflatedRect = zoomedRect;
-
-    LocalCurrentGraphicsContext localContext(context);
-
-    NSView *view = ThemeMac::ensuredView(scrollView, controlStates);
-    NSWindow *window = [view window];
-    NSButtonCell *previousDefaultButtonCell = [window defaultButtonCell];
-
-    bool needsRepaint = ThemeMac::drawCellOrFocusRingWithViewIntoContext(buttonCell, context, inflatedRect, view, true, states.contains(ControlStates::States::Focused), deviceScaleFactor);
-    if ([previousDefaultButtonCell isEqual:buttonCell])
-        [window setDefaultButtonCell:nil];
-
-    controlStates.setNeedsRepaint(needsRepaint);
-
-    [buttonCell setControlView:nil];
-
-    if (![previousDefaultButtonCell isEqual:buttonCell])
-        [window setDefaultButtonCell:previousDefaultButtonCell];
-
-    END_BLOCK_OBJC_EXCEPTIONS
-}
-#endif
-
 // Theme overrides
 
 int ThemeMac::baselinePositionAdjustment(ControlPartType type) const
@@ -794,24 +755,6 @@ void ThemeMac::inflateControlPaintRect(ControlPartType type, const ControlStates
         break;
     }
     END_BLOCK_OBJC_EXCEPTIONS
-}
-
-void ThemeMac::paint(ControlPartType type, ControlStates& states, GraphicsContext& context, const FloatRect& zoomedRect, float zoomFactor, ScrollView* scrollView, float deviceScaleFactor, float pageScaleFactor, bool useSystemAppearance, bool useDarkAppearance, const Color& tintColor)
-{
-    UNUSED_PARAM(useSystemAppearance);
-    UNUSED_PARAM(pageScaleFactor);
-
-    LocalDefaultSystemAppearance localAppearance(useDarkAppearance, tintColor);
-
-    switch (type) {
-#if ENABLE(INPUT_TYPE_COLOR)
-    case ControlPartType::ColorWell:
-        paintColorWell(states, context, zoomedRect, zoomFactor, scrollView, deviceScaleFactor);
-        break;
-#endif
-    default:
-        break;
-    }
 }
 
 bool ThemeMac::userPrefersReducedMotion() const

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -25,6 +25,7 @@
 #include "CSSValueKeywords.h"
 #include "ColorBlending.h"
 #include "ColorLuminance.h"
+#include "ColorWellPart.h"
 #include "ControlStates.h"
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
@@ -599,8 +600,11 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
         return TextFieldPart::create();
 
     case ControlPartType::CapsLockIndicator:
+        break;
+
 #if ENABLE(INPUT_TYPE_COLOR)
     case ControlPartType::ColorWell:
+        return ColorWellPart::create();
 #endif
 #if ENABLE(SERVICE_CONTROLS)
     case ControlPartType::ImageControlsButton:

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -224,6 +224,9 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Contr
 #endif
     case ControlPartType::Button:
     case ControlPartType::Checkbox:
+#if ENABLE(INPUT_TYPE_COLOR)
+    case ControlPartType::ColorWell:
+#endif
     case ControlPartType::DefaultButton:
     case ControlPartType::InnerSpinButton:
     case ControlPartType::Listbox:
@@ -258,6 +261,9 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
     ControlPartType type = renderer.style().effectiveAppearance();
     return type == ControlPartType::Button
         || type == ControlPartType::Checkbox
+#if ENABLE(INPUT_TYPE_COLOR)
+        || type == ControlPartType::ColorWell
+#endif
         || type == ControlPartType::DefaultButton
         || type == ControlPartType::InnerSpinButton
         || type == ControlPartType::Menulist

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -44,6 +44,7 @@
 #include <WebCore/CSPViolationReportBody.h>
 #include <WebCore/CacheQueryOptions.h>
 #include <WebCore/CacheStorageConnection.h>
+#include <WebCore/ColorWellPart.h>
 #include <WebCore/CompositionUnderline.h>
 #include <WebCore/ControlPart.h>
 #include <WebCore/Credential.h>
@@ -1674,6 +1675,7 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::CapsLockIndicator:
 #if ENABLE(INPUT_TYPE_COLOR)
     case WebCore::ControlPartType::ColorWell:
+        return WebCore::ColorWellPart::create();
 #endif
 #if ENABLE(SERVICE_CONTROLS)
     case WebCore::ControlPartType::ImageControlsButton:


### PR DESCRIPTION
#### 9f94ffa7eeaf4fcd2bb5c97643f78663db9a69e1
<pre>
[GPU Process] [FormControls] Add ControlPart for ColorWell
<a href="https://bugs.webkit.org/show_bug.cgi?id=249928">https://bugs.webkit.org/show_bug.cgi?id=249928</a>
rdar://103748580

Reviewed by Aditya Keerthi.

The ColorWellPart will handle drawing the form control `&lt;input type=&quot;color&quot;&gt;` On
macOS, AppKit will be used to draw the platform control through ColorWellMac.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ColorWellPart.h: Added.
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h: Added.
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm: Added.
(WebCore::ColorWellMac::ColorWellMac):
(WebCore::ColorWellMac::updateCellStates):
(WebCore::ColorWellMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::createPlatformColorWell):
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::paintColorWell): Deleted.
(WebCore::ThemeMac::paint): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258550@main">https://commits.webkit.org/258550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5906abf10817c795341260ce8d33997a3b53e0c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111592 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171786 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2335 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109303 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37264 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24250 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4939 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2107 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45170 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5873 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6827 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->