### PR TITLE
[GLIB] Many network process crashes when running WPT tests

### DIFF
--- a/Source/WTF/wtf/glib/RunLoopSourcePriority.h
+++ b/Source/WTF/wtf/glib/RunLoopSourcePriority.h
@@ -71,12 +71,6 @@ enum RunLoopSourcePriority {
 
     // Async IO network callbacks.
     AsyncIONetwork = 100,
-
-    // Disk cache read callbacks.
-    DiskCacheRead = 100,
-
-    // Disk cache write callbacks.
-    DiskCacheWrite = 200,
 };
 
 #else
@@ -98,8 +92,6 @@ enum RunLoopSourcePriority {
     ReleaseUnusedResourcesTimer = 0,
 
     AsyncIONetwork = 10,
-    DiskCacheRead = 10,
-    DiskCacheWrite = 20
 };
 
 #endif

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
@@ -34,7 +34,6 @@
 #if USE(GLIB)
 #include <wtf/glib/GRefPtr.h>
 
-typedef struct _GFileIOStream GFileIOStream;
 typedef struct _GInputStream GInputStream;
 typedef struct _GOutputStream GOutputStream;
 #endif
@@ -59,17 +58,13 @@ public:
 #if !USE(GLIB)
     bool isOpened() const { return FileSystem::isHandleValid(m_fileDescriptor); }
 #else
-    bool isOpened() const { return true; }
+    bool isOpened() const { return m_inputStream || m_outputStream; }
 #endif
 
     ~IOChannel();
 
 private:
     IOChannel(String&& filePath, IOChannel::Type, std::optional<WorkQueue::QOS>);
-
-#if USE(GLIB)
-    void readSyncInThread(size_t offset, size_t, WTF::WorkQueueBase&, Function<void(Data&, int error)>&&);
-#endif
 
     String m_path;
     Type m_type;
@@ -84,7 +79,7 @@ private:
 #if USE(GLIB)
     GRefPtr<GInputStream> m_inputStream;
     GRefPtr<GOutputStream> m_outputStream;
-    GRefPtr<GFileIOStream> m_ioStream;
+    WorkQueue::QOS m_qos;
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
@@ -35,9 +35,7 @@
 namespace WebKit {
 namespace NetworkCache {
 
-static const size_t gDefaultReadBufferSize = 4096;
-
-IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>)
+IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS> qos)
     : m_path(WTFMove(filePath))
     , m_type(type)
 {
@@ -51,14 +49,18 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
         GUniquePtr<char> birthtimeString(g_strdup_printf("%" G_GUINT64_FORMAT, WallTime::now().secondsSinceEpoch().secondsAs<uint64_t>()));
         g_file_set_attribute_string(file.get(), "xattr::birthtime", birthtimeString.get(), G_FILE_QUERY_INFO_NONE, nullptr, nullptr);
 #endif
+        m_qos = qos.value_or(WorkQueue::QOS::Background);
         break;
     }
     case Type::Write: {
-        m_ioStream = adoptGRef(g_file_open_readwrite(file.get(), nullptr, nullptr));
+        auto ioStream = adoptGRef(g_file_open_readwrite(file.get(), nullptr, nullptr));
+        m_outputStream = g_io_stream_get_output_stream(G_IO_STREAM(ioStream.get()));
+        m_qos = qos.value_or(WorkQueue::QOS::Background);
         break;
     }
     case Type::Read:
         m_inputStream = adoptGRef(G_INPUT_STREAM(g_file_read(file.get(), nullptr, nullptr)));
+        m_qos = qos.value_or(WorkQueue::QOS::Default);
         break;
     }
 }
@@ -66,72 +68,6 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
 IOChannel::~IOChannel()
 {
     RELEASE_ASSERT(!m_wasDeleted.exchange(true));
-}
-
-static void fillDataFromReadBuffer(GBytes* readBuffer, size_t size, Data& data)
-{
-    GRefPtr<GBytes> buffer;
-    if (size != g_bytes_get_size(readBuffer)) {
-        // The subbuffer does not copy the data.
-        buffer = adoptGRef(g_bytes_new_from_bytes(readBuffer, 0, size));
-    } else
-        buffer = readBuffer;
-
-    if (data.isNull()) {
-        // First chunk, we need to force the data to be copied.
-        data = { reinterpret_cast<const uint8_t*>(g_bytes_get_data(buffer.get(), nullptr)), size };
-    } else {
-        Data dataRead(WTFMove(buffer));
-        // Concatenate will copy the data.
-        data = concatenate(data, dataRead);
-    }
-}
-
-struct ReadAsyncData {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-    RefPtr<IOChannel> channel;
-    GRefPtr<GBytes> buffer;
-    Ref<WTF::WorkQueueBase> queue;
-    size_t bytesToRead;
-    Function<void(Data&, int error)> completionHandler;
-    Data data;
-};
-
-static void inputStreamReadReadyCallback(GInputStream* stream, GAsyncResult* result, gpointer userData)
-{
-    std::unique_ptr<ReadAsyncData> asyncData(static_cast<ReadAsyncData*>(userData));
-    gssize bytesRead = g_input_stream_read_finish(stream, result, nullptr);
-    if (bytesRead == -1) {
-        asyncData->queue->dispatch([asyncData = WTFMove(asyncData)] {
-            asyncData->completionHandler(asyncData->data, -1);
-        });
-        return;
-    }
-
-    if (!bytesRead) {
-        asyncData->queue->dispatch([asyncData = WTFMove(asyncData)] {
-            asyncData->completionHandler(asyncData->data, 0);
-        });
-        return;
-    }
-
-    ASSERT(bytesRead > 0);
-    fillDataFromReadBuffer(asyncData->buffer.get(), static_cast<size_t>(bytesRead), asyncData->data);
-
-    size_t pendingBytesToRead = asyncData->bytesToRead - asyncData->data.size();
-    if (!pendingBytesToRead) {
-        asyncData->queue->dispatch([asyncData = WTFMove(asyncData)] {
-            asyncData->completionHandler(asyncData->data, 0);
-        });
-        return;
-    }
-
-    size_t bytesToRead = std::min(pendingBytesToRead, g_bytes_get_size(asyncData->buffer.get()));
-    // Use a local variable for the data buffer to pass it to g_input_stream_read_async(), because ReadAsyncData is released.
-    auto* data = const_cast<void*>(g_bytes_get_data(asyncData->buffer.get(), nullptr));
-    g_input_stream_read_async(stream, data, bytesToRead, RunLoopSourcePriority::DiskCacheRead, nullptr,
-        reinterpret_cast<GAsyncReadyCallback>(inputStreamReadReadyCallback), asyncData.release());
 }
 
 void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Function<void(Data&, int error)>&& completionHandler)
@@ -145,117 +81,54 @@ void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Func
         return;
     }
 
-    if (!RunLoop::isMain()) {
-        readSyncInThread(offset, size, queue, WTFMove(completionHandler));
-        return;
-    }
+    Thread::create("IOChannel::read", [this, protectedThis = WTFMove(protectedThis), offset, size, queue = Ref { queue }, completionHandler = WTFMove(completionHandler)]() mutable {
+        GRefPtr<GFileInfo> info = adoptGRef(g_file_input_stream_query_info(G_FILE_INPUT_STREAM(m_inputStream.get()), G_FILE_ATTRIBUTE_STANDARD_SIZE, nullptr, nullptr));
+        if (info) {
+            auto fileSize = g_file_info_get_size(info.get());
+            if (fileSize && static_cast<guint64>(fileSize) <= std::numeric_limits<size_t>::max()) {
+                if (G_IS_SEEKABLE(m_inputStream.get()) && g_seekable_can_seek(G_SEEKABLE(m_inputStream.get())))
+                    g_seekable_seek(G_SEEKABLE(m_inputStream.get()), offset, G_SEEK_SET, nullptr, nullptr);
 
-    size_t bufferSize = std::min(size, gDefaultReadBufferSize);
-    uint8_t* bufferData = static_cast<uint8_t*>(fastMalloc(bufferSize));
-    GRefPtr<GBytes> buffer = adoptGRef(g_bytes_new_with_free_func(bufferData, bufferSize, fastFree, bufferData));
-    ReadAsyncData* asyncData = new ReadAsyncData { this, buffer.get(), queue, size, WTFMove(completionHandler), { } };
-
-    // FIXME: implement offset.
-    g_input_stream_read_async(m_inputStream.get(), bufferData, bufferSize, RunLoopSourcePriority::DiskCacheRead, nullptr,
-        reinterpret_cast<GAsyncReadyCallback>(inputStreamReadReadyCallback), asyncData);
-}
-
-void IOChannel::readSyncInThread(size_t offset, size_t size, WTF::WorkQueueBase& queue, Function<void(Data&, int error)>&& completionHandler)
-{
-    ASSERT(!RunLoop::isMain());
-
-    Thread::create("IOChannel::readSync", [this, protectedThis = Ref { *this }, size, queue = Ref { queue }, completionHandler = WTFMove(completionHandler)] () mutable {
-        size_t bufferSize = std::min(size, gDefaultReadBufferSize);
-        uint8_t* bufferData = static_cast<uint8_t*>(fastMalloc(bufferSize));
-        GRefPtr<GBytes> readBuffer = adoptGRef(g_bytes_new_with_free_func(bufferData, bufferSize, fastFree, bufferData));
-        Data data;
-        size_t pendingBytesToRead = size;
-        size_t bytesToRead = bufferSize;
-        do {
-            // FIXME: implement offset.
-            gssize bytesRead = g_input_stream_read(m_inputStream.get(), const_cast<void*>(g_bytes_get_data(readBuffer.get(), nullptr)), bytesToRead, nullptr, nullptr);
-            if (bytesRead == -1) {
-                queue->dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
-                    Data data;
-                    completionHandler(data, -1);
-                });
-                return;
+                size_t bufferSize = std::min<size_t>(size, fileSize - offset);
+                uint8_t* bufferData = static_cast<uint8_t*>(fastMalloc(bufferSize));
+                GRefPtr<GBytes> buffer = adoptGRef(g_bytes_new_with_free_func(bufferData, bufferSize, fastFree, bufferData));
+                gsize bytesRead;
+                if (g_input_stream_read_all(m_inputStream.get(), bufferData, bufferSize, &bytesRead, nullptr, nullptr)) {
+                    GRefPtr<GBytes> bytes = bufferSize == bytesRead ? buffer : adoptGRef(g_bytes_new_from_bytes(buffer.get(), 0, bytesRead));
+                    queue->dispatch([protectedThis = WTFMove(protectedThis), bytes = WTFMove(bytes), completionHandler = WTFMove(completionHandler)]() mutable {
+                        Data data(WTFMove(bytes));
+                        completionHandler(data, 0);
+                    });
+                    return;
+                }
             }
-
-            if (!bytesRead)
-                break;
-
-            ASSERT(bytesRead > 0);
-            fillDataFromReadBuffer(readBuffer.get(), static_cast<size_t>(bytesRead), data);
-
-            pendingBytesToRead = size - data.size();
-            bytesToRead = std::min(pendingBytesToRead, g_bytes_get_size(readBuffer.get()));
-        } while (pendingBytesToRead);
-
-        queue->dispatch([protectedThis = WTFMove(protectedThis), buffer = GRefPtr<GBytes>(data.bytes()), completionHandler = WTFMove(completionHandler)]() mutable {
-            Data data = { WTFMove(buffer) };
-            completionHandler(data, 0);
+        }
+        queue->dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
+            Data data;
+            completionHandler(data, -1);
         });
-    })->detach();
-}
-
-struct WriteAsyncData {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-    RefPtr<IOChannel> channel;
-    GRefPtr<GBytes> buffer;
-    Ref<WTF::WorkQueueBase> queue;
-    Function<void(int error)> completionHandler;
-};
-
-static void outputStreamWriteReadyCallback(GOutputStream* stream, GAsyncResult* result, gpointer userData)
-{
-    std::unique_ptr<WriteAsyncData> asyncData(static_cast<WriteAsyncData*>(userData));
-    gssize bytesWritten = g_output_stream_write_finish(stream, result, nullptr);
-    if (bytesWritten == -1) {
-        asyncData->queue->dispatch([asyncData = WTFMove(asyncData)] {
-            asyncData->completionHandler(-1);
-        });
-        return;
-    }
-
-    gssize pendingBytesToWrite = g_bytes_get_size(asyncData->buffer.get()) - bytesWritten;
-    if (!pendingBytesToWrite) {
-        asyncData->queue->dispatch([asyncData = WTFMove(asyncData)] {
-            asyncData->completionHandler(0);
-        });
-        return;
-    }
-
-    asyncData->buffer = adoptGRef(g_bytes_new_from_bytes(asyncData->buffer.get(), bytesWritten, pendingBytesToWrite));
-    // Use a local variable for the data buffer to pass it to g_output_stream_write_async(), because WriteAsyncData is released.
-    const auto* data = g_bytes_get_data(asyncData->buffer.get(), nullptr);
-    g_output_stream_write_async(stream, data, pendingBytesToWrite, RunLoopSourcePriority::DiskCacheWrite, nullptr,
-        reinterpret_cast<GAsyncReadyCallback>(outputStreamWriteReadyCallback), asyncData.release());
+    }, ThreadType::Unknown, m_qos)->detach();
 }
 
 void IOChannel::write(size_t offset, const Data& data, WTF::WorkQueueBase& queue, Function<void(int error)>&& completionHandler)
 {
     RefPtr<IOChannel> protectedThis(this);
-    if (!m_outputStream && !m_ioStream) {
+    if (!m_outputStream) {
         queue.dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
             completionHandler(-1);
         });
         return;
     }
 
-    GOutputStream* stream = m_outputStream ? m_outputStream.get() : g_io_stream_get_output_stream(G_IO_STREAM(m_ioStream.get()));
-    if (!stream) {
-        queue.dispatch([protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] {
-            completionHandler(-1);
+    GRefPtr<GBytes> buffer = offset ? adoptGRef(g_bytes_new_from_bytes(data.bytes(), offset, data.size() - offset)) : data.bytes();
+    Thread::create("IOChannel::write", [this, protectedThis = WTFMove(protectedThis), buffer = WTFMove(buffer), queue = Ref { queue }, completionHandler = WTFMove(completionHandler)]() mutable {
+        gsize buffersize;
+        const auto* bufferData = g_bytes_get_data(buffer.get(), &buffersize);
+        auto success = g_output_stream_write_all(m_outputStream.get(), bufferData, buffersize, nullptr, nullptr, nullptr);
+        queue->dispatch([protectedThis = WTFMove(protectedThis), success, completionHandler = WTFMove(completionHandler)] {
+            completionHandler(success ? 0 : -1);
         });
-        return;
-    }
-
-    WriteAsyncData* asyncData = new WriteAsyncData { this, data.bytes(), queue, WTFMove(completionHandler) };
-    // FIXME: implement offset.
-    g_output_stream_write_async(stream, g_bytes_get_data(asyncData->buffer.get(), nullptr), data.size(), RunLoopSourcePriority::DiskCacheWrite, nullptr,
-        reinterpret_cast<GAsyncReadyCallback>(outputStreamWriteReadyCallback), asyncData);
+    }, ThreadType::Unknown, m_qos)->detach();
 }
 
 } // namespace NetworkCache


### PR DESCRIPTION
#### 5b9af92f602ee677d977c4b49768c66f0862a903
<pre>
[GLIB] Many network process crashes when running WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=232629">https://bugs.webkit.org/show_bug.cgi?id=232629</a>

Reviewed by Michael Catanzaro.

Stop using GLib async APIs for network cache IOChannel implementation,
and use the sync API from a thread instead. The async API ends up doing
the job in a thread because file streams are not pollable. The problem
is that the internal GThreadPool tries to change the thread scheduler
setting and it fails when the current thread uses the idle scheduler,
which is the case of disk cache background threads. This reverts the
workaround introduced in 244519@main.

* Source/WTF/wtf/glib/RunLoopSourcePriority.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h:
(WebKit::NetworkCache::IOChannel::isOpened const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp:
(WebKit::NetworkCache::IOChannel::IOChannel):
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
(WebKit::NetworkCache::fillDataFromReadBuffer): Deleted.
(WebKit::NetworkCache::inputStreamReadReadyCallback): Deleted.
(WebKit::NetworkCache::IOChannel::readSyncInThread): Deleted.
(WebKit::NetworkCache::outputStreamWriteReadyCallback): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::Storage):
(WebKit::NetworkCache::qosForBackgroundIOQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/258379@main">https://commits.webkit.org/258379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9267abca75d7a80248b49bed8e22e2985c1ef7a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110996 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171199 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1723 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108758 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36556 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78552 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92086 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25160 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88225 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2010 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1609 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29361 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44648 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91131 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6239 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20354 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3031 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->