### PR TITLE
[GStreamer][WebRTC] Video encoder capabilities probing support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -32,6 +32,7 @@
 #include <wtf/text/StringToIntegerConversion.h>
 
 #if USE(GSTREAMER_WEBRTC)
+#include "GStreamerVideoEncoder.h"
 #include <gst/rtp/rtp.h>
 #endif
 
@@ -232,6 +233,7 @@ GStreamerRegistryScanner::GStreamerRegistryScanner(bool isMediaSource)
     }
 
     GST_DEBUG_CATEGORY_INIT(webkit_media_gst_registry_scanner_debug, "webkitregistryscanner", 0, "WebKit GStreamer registry scanner");
+    registerWebKitGStreamerElements();
 
     ElementFactories factories(OptionSet<ElementFactories::Type>::fromRaw(static_cast<unsigned>(ElementFactories::Type::All)));
     initializeDecoders(factories);
@@ -822,26 +824,42 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
     }
 
     auto factories = ElementFactories({ codecElement, rtpElement });
+    auto codecLookupResult = factories.hasElementForMediaType(codecElement, "video/x-h264");
+    if (codecLookupResult && factories.hasElementForMediaType(rtpElement, "video/x-h264")) {
+        GRefPtr<GstElement> element;
+        if (configuration == Configuration::Decoding)
+            element = gst_element_factory_create(codecLookupResult.factory.get(), nullptr);
+        else
+            element = gst_element_factory_make("webrtcvideoencoder", nullptr);
 
-    if (factories.hasElementForMediaType(codecElement, "video/x-h264") && factories.hasElementForMediaType(rtpElement, "video/x-h264")) {
-        // FIXME: Profile levels are hardcoded here for the time being. It might be a good idea to
-        // actually probe those on the selected encoder.
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f"_s });
-        capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { },
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f"_s });
+        if (element) {
+            Vector<String> profiles = {
+                "42e01f"_s,
+                "640c1f"_s,
+                "42001f"_s,
+                "4d001f"_s,
+            };
+
+            for (auto& profileLevelId : profiles) {
+                auto spsAsInteger = parseInteger<uint64_t>(profileLevelId, 16).value_or(0);
+                uint8_t sps[3];
+                sps[0] = spsAsInteger >> 16;
+                sps[1] = (spsAsInteger >> 8) & 0xff;
+                sps[2] = spsAsInteger & 0xff;
+
+                auto caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+                gst_codec_utils_h264_caps_set_level_and_profile(caps.get(), sps, 3);
+
+                if (WEBKIT_IS_WEBRTC_VIDEO_ENCODER(element.get())) {
+                    if (!webrtcVideoEncoderSupportsFormat(WEBKIT_WEBRTC_VIDEO_ENCODER(element.get()), caps))
+                        continue;
+                } else if (!gst_element_factory_can_sink_any_caps(gst_element_get_factory(element.get()), caps.get()))
+                    continue;
+
+                capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = makeString("level-asymmetry-allowed=1;packetization-mode=1;profile-level-id="_s, profileLevelId) });
+                capabilities.codecs.append({ .mimeType = "video/H264"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = makeString("level-asymmetry-allowed=1;packetization-mode=0;profile-level-id="_s, profileLevelId) });
+            }
+        }
     }
 
     // FIXME: Probe for video/H265 capabilies.

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.h
@@ -44,4 +44,5 @@ struct _WebKitWebrtcVideoEncoderClass {
 
 GType webkit_webrtc_video_encoder_get_type(void);
 
+bool webrtcVideoEncoderSupportsFormat(WebKitWebrtcVideoEncoder*, const GRefPtr<GstCaps>&);
 bool webrtcVideoEncoderSetFormat(WebKitWebrtcVideoEncoder*, GRefPtr<GstCaps>&&);


### PR DESCRIPTION
#### 2295aff2e623a55981e391a4e411073a855e9e56
<pre>
[GStreamer][WebRTC] Video encoder capabilities probing support
<a href="https://bugs.webkit.org/show_bug.cgi?id=249936">https://bugs.webkit.org/show_bug.cgi?id=249936</a>

Reviewed by Xabier Rodriguez-Calvar.

The registry scanner is now able to check the H.264 encoding capabilies of the host. Also, when more
than one platform encoder is capable of encoding to the target format, only the one with the highest
rank is selected.

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp:
(webrtcVideoEncoderFindForFormat):
(webrtcVideoEncoderSupportsFormat):
(webrtcVideoEncoderSetFormat):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.h:

Canonical link: <a href="https://commits.webkit.org/258663@main">https://commits.webkit.org/258663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fe025ce5f11b6e565fcfd9eb5b449695096654a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111888 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2657 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109591 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108398 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24509 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25928 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2379 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5948 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7098 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->