### PR TITLE
REGRESSION(258347@main): [GTK] fails to build

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -347,6 +347,11 @@ GENERATE_API_HEADERS(WebKitWebExtension_HEADER_TEMPLATES
     "-DENABLE_2022_GLIB_API=$<BOOL:${ENABLE_2022_GLIB_API}>"
 )
 
+if (NOT USE_GTK4)
+    list(REMOVE_ITEM WebKitGTK_INSTALLED_HEADERS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit.h)
+    list(REMOVE_ITEM WebKitWebExtension_INSTALLED_HEADERS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit-web-extension.h)
+endif ()
+
 if (USE_GTK4)
     set(WebKitGTK_ENUM_HEADER_TEMPLATE ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitEnumTypesGtk4.h.in)
 else ()
@@ -457,35 +462,6 @@ target_include_directories(webkit${WEBKITGTK_API_INFIX}gtkinjectedbundle SYSTEM 
 
 if (COMPILER_IS_GCC_OR_CLANG)
     WEBKIT_ADD_TARGET_CXX_FLAGS(webkit${WEBKITGTK_API_INFIX}gtkinjectedbundle -Wno-unused-parameter)
-endif ()
-
-# For GTK 3 builds, we have to maintain webkit2/webkit2.h and webkit2/webkit-web-extension.h for API
-# compatibility. These are the only headers still installed under webkit2/. Install them manually.
-if (NOT USE_GTK4)
-    file(MAKE_DIRECTORY ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2)
-    add_custom_command(
-        OUTPUT ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h
-        DEPENDS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit.h
-        COMMAND ${CMAKE_COMMAND} -E copy ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit.h ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/
-        VERBATIM
-    )
-
-    add_custom_command(
-        OUTPUT ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit-web-extension.h
-        DEPENDS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit-web-extension.h
-        COMMAND ${CMAKE_COMMAND} -E copy ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit-web-extension.h ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/
-        VERBATIM
-    )
-
-    list(APPEND WebKit_SOURCES ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit-web-extension.h)
-
-    list(REMOVE_ITEM WebKitGTK_INSTALLED_HEADERS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit.h)
-    list(REMOVE_ITEM WebKitWebExtension_INSTALLED_HEADERS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit-web-extension.h)
-
-    install(FILES ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h
-                  ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit-web-extension.h
-            DESTINATION "${WEBKITGTK_HEADER_INSTALL_DIR}/webkit2"
-    )
 endif ()
 
 install(TARGETS webkit${WEBKITGTK_API_INFIX}gtkinjectedbundle

--- a/Source/WebKit/PlatformGTKDeprecated.cmake
+++ b/Source/WebKit/PlatformGTKDeprecated.cmake
@@ -4,6 +4,8 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 
 add_definitions(-DWEBKIT_DOM_USE_UNSTABLE_API)
 
+file(MAKE_DIRECTORY ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2)
+
 list(APPEND WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMimeInfo.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
@@ -135,6 +137,8 @@ set(WebKitDOM_SOURCES_FOR_INTROSPECTION
 )
 
 list(APPEND WebKitGTK_FAKE_API_HEADERS
+    ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h
+    ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit-web-extension.h
     ${WebKitGTK_FRAMEWORK_HEADERS_DIR}/webkitgtk-webextension/webkitdom
 )
 
@@ -145,6 +149,27 @@ list(APPEND WebKit_INCLUDE_DIRECTORIES
 
 install(FILES ${WebKitDOM_INSTALLED_HEADERS}
     DESTINATION "${WEBKITGTK_HEADER_INSTALL_DIR}/webkitdom"
+)
+
+# For GTK 3 builds, we have to maintain webkit2/webkit2.h and webkit2/webkit-web-extension.h for API
+# compatibility. These are the only headers still installed under webkit2/. Install them manually.
+install(FILES ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h
+              ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit-web-extension.h
+    DESTINATION "${WEBKITGTK_HEADER_INSTALL_DIR}/webkit2"
+)
+
+add_custom_command(
+    OUTPUT ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h
+    DEPENDS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit.h
+    COMMAND ${CMAKE_COMMAND} -E copy ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit.h ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit2.h
+    VERBATIM
+)
+
+add_custom_command(
+    OUTPUT ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/webkit-web-extension.h
+    DEPENDS ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit-web-extension.h
+    COMMAND ${CMAKE_COMMAND} -E copy ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/webkit-web-extension.h ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2/
+    VERBATIM
 )
 
 add_custom_command(


### PR DESCRIPTION
#### bb8eb25480c671d74b164ad43bed4f1d29cee50e
<pre>
REGRESSION(258347@main): [GTK] fails to build
<a href="https://bugs.webkit.org/show_bug.cgi?id=249929">https://bugs.webkit.org/show_bug.cgi?id=249929</a>

Reviewed by Michael Catanzaro.

I was copying the webkit.h header without renaming it as webkit2.h. This
patch fixes it and also moves the code to PlatformGTKDeprecated.cmake
doing the copy as part of the fake api headers generation.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformGTKDeprecated.cmake:

Canonical link: <a href="https://commits.webkit.org/258354@main">https://commits.webkit.org/258354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0063b67d514a3c7e8976dc125f1b67e653ef8f29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110968 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1696 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108730 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92212 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90852 "Found 2 new API test failures: TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment, TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78506 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4385 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25130 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1584 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44618 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6214 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3021 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->