### PR TITLE
[GStreamer][MediaStream] Misc media capture improvements

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -118,15 +118,13 @@ GstFlowReturn GStreamerAudioCaptureSource::newSampleCallback(GstElement* sink, G
 {
     auto sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
 
-    // FIXME - figure out a way to avoid copying (on write) the data.
     auto* buffer = gst_sample_get_buffer(sample.get());
+    auto bufferSize = gst_buffer_get_size(buffer);
+    MediaTime presentationTime(GST_TIME_AS_USECONDS(GST_BUFFER_PTS(buffer)), G_USEC_PER_SEC);
+
     GStreamerAudioData frames(WTFMove(sample));
     GStreamerAudioStreamDescription description(frames.getAudioInfo());
-
-    source->audioSamplesAvailable(
-        MediaTime(GST_TIME_AS_USECONDS(GST_BUFFER_PTS(buffer)), G_USEC_PER_SEC),
-        frames, description, gst_buffer_get_size(buffer) / description.getInfo().bpf);
-
+    source->audioSamplesAvailable(presentationTime, frames, description, bufferSize / description.getInfo().bpf);
     return GST_FLOW_OK;
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -56,7 +56,7 @@ public:
     void play();
     void stop();
     GstCaps* caps();
-    void addSink(GstElement *newSink);
+
     GstElement* makeElement(const char* factoryName);
     virtual GstElement* createSource();
     GstElement* source() { return m_src.get();  }
@@ -77,7 +77,6 @@ protected:
     GRefPtr<GstElement> m_sink;
     GRefPtr<GstElement> m_src;
     GRefPtr<GstElement> m_valve;
-    GRefPtr<GstElement> m_tee;
     GRefPtr<GstElement> m_capsfilter;
     GRefPtr<GstDevice> m_device;
     GRefPtr<GstCaps> m_caps;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -22,7 +22,6 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
-#include "GStreamerAudioCaptureSource.h"
 #include "GStreamerRegistryScanner.h"
 #include "MediaStreamTrack.h"
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -23,7 +23,6 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "GStreamerRegistryScanner.h"
-#include "GStreamerVideoCaptureSource.h"
 #include "GStreamerVideoEncoder.h"
 #include <wtf/glib/WTFGType.h>
 


### PR DESCRIPTION
#### 4f70db078a9a41587d03e48b9c8b52b60e5d13d8
<pre>
[GStreamer][MediaStream] Misc media capture improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=249938">https://bugs.webkit.org/show_bug.cgi?id=249938</a>

Reviewed by Xabier Rodriguez-Calvar.

Video frame metadata was attached only for mock sources. There&apos;s no need for a tee in the capturer
pipeline because there&apos;s never more than one client. Multiple observers watch for samples received
by the sink. And a few other drive-by and coding style cleanups.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::newSampleCallback):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::initializeDebugCategory):
(WebCore::GStreamerAudioCapturer::GStreamerAudioCapturer):
(WebCore::GStreamerAudioCapturer::createConverter):
(WebCore::GStreamerAudioCapturer::setSampleRate):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::createSource):
(WebCore::GStreamerCapturer::setupPipeline):
(WebCore::GStreamerCapturer::makeElement):
(WebCore::GStreamerCapturer::addSink): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:

Canonical link: <a href="https://commits.webkit.org/258662@main">https://commits.webkit.org/258662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2546d7553b5446b0f47ac2c531b37624f6223117

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110969 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171172 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1697 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108731 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37104 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23640 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78825 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25137 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1585 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44625 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5942 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6215 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->