### PR TITLE
[GStreamer][MediaStream] Minor logging and include fixes

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -369,13 +369,13 @@ public:
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData& audioData, const AudioStreamDescription&, size_t) final
     {
-        if (!m_parent)
+        if (!m_parent || !m_isObserving)
             return;
 
         const auto& data = static_cast<const GStreamerAudioData&>(audioData);
         auto sample = data.getSample();
         if (m_trackEnabled.load()) {
-            GST_TRACE_OBJECT(m_parent, "Pushing audio sample from enabled track");
+            GST_TRACE_OBJECT(m_src.get(), "Pushing audio sample from enabled track");
             pushSample(sample.get());
             return;
         }
@@ -392,7 +392,7 @@ public:
             m_silentSample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         }
 
-        GST_TRACE_OBJECT(m_parent, "Pushing audio silence from disabled track");
+        GST_TRACE_OBJECT(m_src.get(), "Pushing audio silence from disabled track");
         pushSample(m_silentSample.get());
     }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeMediaSourceCenterGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeMediaSourceCenterGStreamer.cpp
@@ -26,9 +26,7 @@
 #include "RealtimeMediaSourceCenter.h"
 
 #include "GStreamerAudioCaptureSource.h"
-#include "GStreamerCaptureDevice.h"
 #include "GStreamerVideoCaptureSource.h"
-#include <wtf/MainThread.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 8c81bbe3f8e2b05b2da1d69d014609f54bd0cb6d
<pre>
[GStreamer][MediaStream] Minor logging and include fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=249939">https://bugs.webkit.org/show_bug.cgi?id=249939</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp: The audio sample
handling and logging is now more coherent with the video frames handling code path.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeMediaSourceCenterGStreamer.cpp: Remove
un-needed includes.

Canonical link: <a href="https://commits.webkit.org/258660@main">https://commits.webkit.org/258660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/955d727d31dd2456b0cc0123136b8b0cf47cefc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110970 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171173 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1698 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108732 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36905 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4387 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25133 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1586 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44621 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5943 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6216 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->