### PR TITLE
[GStreamer][WebRTC] Improved statistics support

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -57,8 +57,10 @@ static inline void fillRTCRTPStreamStats(RTCStatsReport::RtpStreamStats& stats, 
     if (gst_structure_get_uint(structure, "ssrc", &value))
         stats.ssrc = value;
 
-    // FIXME:
-    // stats.kind
+    if (const char* kind = gst_structure_get_string(structure, "kind")) {
+        stats.kind = String::fromLatin1(kind);
+        stats.mediaType = stats.kind;
+    }
 }
 
 static inline void fillRTCCodecStats(RTCStatsReport::CodecStats& stats, const GstStructure* structure)
@@ -158,8 +160,21 @@ static inline void fillInboundRTPStreamStats(RTCStatsReport::InboundRtpStreamSta
     if (gst_structure_get_uint64(structure, "bytes-received", &bytesReceived))
         stats.bytesReceived = bytesReceived;
 
-    if (additionalStats && gst_structure_get_uint64(additionalStats, "frames-decoded", &value))
+    if (!additionalStats)
+        return;
+
+    if (gst_structure_get_uint64(additionalStats, "frames-decoded", &value))
         stats.framesDecoded = value;
+
+    if (gst_structure_get_uint64(additionalStats, "frames-dropped", &value))
+        stats.framesDropped = value;
+
+    unsigned size;
+    if (gst_structure_get_uint(additionalStats, "frame-width", &size))
+        stats.frameWidth = size;
+
+    if (gst_structure_get_uint(additionalStats, "frame-height", &size))
+        stats.frameHeight = size;
 
     // FIXME:
     // stats.fractionLost =
@@ -226,11 +241,13 @@ static inline void fillRTCTransportStats(RTCStatsReport::TransportStats& stats, 
 {
     fillRTCStats(stats, structure);
 
+    if (const char* selectedCandidatePairId = gst_structure_get_string(structure, "selected-candidate-pair-id"))
+        stats.selectedCandidatePairId = String::fromLatin1(selectedCandidatePairId);
+
     // FIXME
     // stats.bytesSent =
     // stats.bytesReceived =
     // stats.rtcpTransportStatsId =
-    // stats.selectedCandidatePairId =
     // stats.localCertificateId =
     // stats.remoteCertificateId =
     // stats.dtlsState =

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -405,6 +405,8 @@ protected:
     void incrementDecodedVideoFramesCount() { m_decodedVideoFrames++; }
     uint64_t decodedVideoFramesCount() const { return m_decodedVideoFrames; }
 
+    bool updateVideoSinkStatistics();
+
 private:
     class TaskAtMediaTimeScheduler {
     public:

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -53,6 +53,7 @@
 #include <wtf/text/WTFString.h>
 
 #if USE(GSTREAMER)
+#include "GUniquePtrGStreamer.h"
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GstEvent GstEvent;
@@ -118,7 +119,7 @@ public:
         virtual void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) = 0;
 
 #if USE(GSTREAMER_WEBRTC)
-        virtual std::optional<uint64_t> queryDecodedVideoFramesCount() { return std::nullopt; }
+        virtual GUniquePtr<GstStructure> queryAdditionalStats() { return nullptr; }
 #endif
     };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -410,17 +410,14 @@ public:
         return m_eosPending;
     }
 
-    std::optional<uint64_t> queryDecodedVideoFramesCount()
+    GUniquePtr<GstStructure> queryAdditionalStats()
     {
         auto query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("webkit-video-decoder-stats")));
         auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
-        if (gst_pad_peer_query(pad.get(), query.get())) {
-            uint64_t decodedFramesCount;
-            if (gst_structure_get_uint64(gst_query_get_structure(query.get()), "decoded-frames", &decodedFramesCount))
-                return decodedFramesCount;
-        }
+        if (gst_pad_peer_query(pad.get(), query.get()))
+            return GUniquePtr<GstStructure>(gst_structure_copy(gst_query_get_structure(query.get())));
 
-        return { };
+        return nullptr;
     }
 
 private:


### PR DESCRIPTION
#### ecd45a098ed578b77bf264bbd1954feef6030edb
<pre>
[GStreamer][WebRTC] Improved statistics support
<a href="https://bugs.webkit.org/show_bug.cgi?id=249940">https://bugs.webkit.org/show_bug.cgi?id=249940</a>

Reviewed by Xabier Rodriguez-Calvar.

Fill the `kind` attribute in RtpStreamStats and also a few more video frame related attributes for
inbound rtp stats. In order to support extended stats gathering, the queryDecodedVideoFramesCount()
virtual method in VideoFrameObserver was replaced by a more generic queryAdditionalStats method.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillRTCRTPStreamStats):
(WebCore::fillInboundRTPStreamStats):
(WebCore::fillRTCTransportStats):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSinkStatistics):
(WebCore::MediaPlayerPrivateGStreamer::videoPlaybackQualityMetrics):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::stats):

Canonical link: <a href="https://commits.webkit.org/258659@main">https://commits.webkit.org/258659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e10a1a88be1ded1528198f13a821aea11dac5977

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110974 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171177 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1702 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108736 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36983 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4390 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25138 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1590 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44626 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5944 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6219 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->