### PR TITLE
[GStreamer][WebRTC] VAAPI encoders support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -862,8 +862,12 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
         }
     }
 
-    // FIXME: Probe for video/H265 capabilies.
-    // FIXME: Probe for video/AV1 capabilies.
+    if (factories.hasElementForMediaType(codecElement, "video/x-h265") && factories.hasElementForMediaType(rtpElement, "video/x-h265")) {
+        // FIXME: Probe for video/H265 encoder capabilities.
+        capabilities.codecs.append({ .mimeType = "video/H265"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = { } });
+    }
+
+    // FIXME: Probe for video/AV1 capabilities.
 
     if (factories.hasElementForMediaType(codecElement, "video/x-vp8") && factories.hasElementForMediaType(rtpElement, "video/x-vp8"))
         capabilities.codecs.append({ .mimeType = "video/VP8"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = { } });

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -120,6 +120,9 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
         if (!profile)
             profile = "baseline";
         gst_caps_set_simple(encoderCaps.get(), "profile", G_TYPE_STRING, profile, nullptr);
+    } else if (encoding == "h265"_s) {
+        encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
+        // FIXME: profile tier level?
     } else {
         GST_ERROR_OBJECT(m_bin.get(), "Unsupported outgoing video encoding: %s", encodingName);
         return false;


### PR DESCRIPTION
#### 9e4ed340f4374475d4e0a97df381235bcd972444
<pre>
[GStreamer][WebRTC] VAAPI encoders support
<a href="https://bugs.webkit.org/show_bug.cgi?id=249941">https://bugs.webkit.org/show_bug.cgi?id=249941</a>

Reviewed by Xabier Rodriguez-Calvar.

Basic support for H.264 and H.265 VAAPI encoders. The H.265 probing is very minimal at the moment.
Support for VP8/VP9/AV1 will be added later on (I don&apos;t have GPUs supporting those codecs).

Implicitely depends on <a href="https://github.com/WebKit/WebKit/pull/8094">https://github.com/WebKit/WebKit/pull/8094</a> and
<a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3616.">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3616.</a>

The videorate element in the encoder bin was triggering issues and flakyness in some tests. I think
it&apos;s not really required actually, but a videoscale is good to have though.

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp:
(webrtcVideoEncoderSetEncoder):
(webkit_webrtc_video_encoder_class_init):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/258666@main">https://commits.webkit.org/258666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4bd308b8f4bb28a188f37c5f33d0c848d7d1675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111072 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171277 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1800 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108834 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92313 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36731 "Found 1 new test failure: imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78622 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4485 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25232 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1681 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44719 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5951 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6315 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->