### PR TITLE
"<CATransformLayer> changing property contentsScale in transform-only layer, will have no effect" logging

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -449,8 +449,12 @@ void GraphicsLayerCA::initialize(Type layerType)
         platformLayerType = PlatformCALayer::LayerType::LayerTypeTiledBackingLayer;
         break;
     }
+
     m_layer = createPlatformCALayer(platformLayerType, this);
-    noteLayerPropertyChanged(ContentsScaleChanged);
+
+    if (platformLayerType != PlatformCALayer::LayerType::LayerTypeTransformLayer)
+        noteLayerPropertyChanged(ContentsScaleChanged);
+
     noteLayerPropertyChanged(CoverageRectChanged);
 }
 


### PR DESCRIPTION
#### c2f1bd3f763bca4b4b769f0dad4334ec28a25832
<pre>
&quot;&lt;CATransformLayer&gt; changing property contentsScale in transform-only layer, will have no effect&quot; logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=249946">https://bugs.webkit.org/show_bug.cgi?id=249946</a>
rdar://103762578

Reviewed by Tim Horton.

In 253606@main I made it possible for the primary layer of a GraphicsLayer to be a CATransformLayer.
However, we had existing code that unconditionally cause -contentsScale and -rasterizationScale to
be set on all CALayers, and these don&apos;t make sense on a CATransformLayer, which never has painted
content.

So conditionalize calling `noteLayerPropertyChanged(ContentsScaleChanged)` to only happen on
non-transform layers.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::initialize):

Canonical link: <a href="https://commits.webkit.org/258364@main">https://commits.webkit.org/258364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0630e3bdfdba19c33f1ab587b165e9dde79b1dd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110983 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171186 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1711 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108745 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92230 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78540 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25148 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1599 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5732 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6228 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->