### PR TITLE
Remove unneeded content extension logging

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(CONTENT_EXTENSIONS)
 
 #include "ContentExtensionError.h"
-#include "Logging.h"
 #include "ResourceRequest.h"
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <JavaScriptCore/JavaScript.h>
@@ -817,7 +816,6 @@ void RedirectAction::URLTransformAction::QueryTransform::applyToURL(URL& url) co
         // Removal takes precedence over replacement.
         if (keysToRemove.contains(key)) {
             modifiedQuery = true;
-            RELEASE_LOG(ContentExtensions, "QueryTransform::applyToURL - removing %s", key.utf8().data());
             continue;
         }
 

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -48,7 +48,6 @@ namespace WebCore {
     M(ClipRects) \
     M(Compositing) \
     M(CompositingOverlap) \
-    M(ContentExtensions) \
     M(ContentFiltering) \
     M(ContentObservation) \
     M(DatabaseTracker) \


### PR DESCRIPTION
#### cf203f4511ff5d596126af5057da721eb625901f
<pre>
Remove unneeded content extension logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=249959">https://bugs.webkit.org/show_bug.cgi?id=249959</a>
rdar://103780523

Reviewed by Wenson Hsieh.

This removes some content extension query transform logging
which is no longer needed.

* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::QueryTransform::applyToURL const):
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/258383@main">https://commits.webkit.org/258383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c348b6dd8ee9bab123c79d0b948a6b9295955e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111003 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171206 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1730 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108765 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36572 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1616 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5741 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6246 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->