### PR TITLE
REGRESSION (258266@main): LayoutTestHelper gets installed to a wrong path on iOS

### DIFF
--- a/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj
+++ b/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj
@@ -1225,7 +1225,6 @@
 			baseConfigurationReference = A1103B5B1892498F00738C87 /* LayoutTestHelper.xcconfig */;
 			buildSettings = {
 				PRODUCT_NAME = LayoutTestHelper;
-				SKIP_INSTALL = NO;
 			};
 			name = Production;
 		};

--- a/Tools/DumpRenderTree/mac/Configurations/LayoutTestHelper.xcconfig
+++ b/Tools/DumpRenderTree/mac/Configurations/LayoutTestHelper.xcconfig
@@ -28,9 +28,13 @@
 OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Carbon -framework Cocoa -framework OpenGL -framework IOKit;
 STRIP_STYLE = debugging;
 
-SKIP_INSTALL[sdk=embedded*] = YES;
-
 EXCLUDED_SOURCE_FILE_NAMES = $(EXCLUDED_PRODUCT_DEPENDENCY_NAMES_$(WK_WHICH_BUILD_SYSTEM));
 EXCLUDED_PRODUCT_DEPENDENCY_NAMES_legacy = WebKit.framework;
 
-INSTALL_PATH = $(PRODUCTION_PUBLIC_FRAMEWORKS_DIR)/WebKit.framework/Versions/A/Resources;
+WEBKIT_FRAMEWORK_RESOURCES_PATH = WebKit.framework;
+WEBKIT_FRAMEWORK_RESOURCES_PATH[sdk=macosx*] = WebKit.framework/Versions/A/Resources;
+
+INSTALL_PATH = $(INSTALL_PATH_$(CONFIGURATION))
+INSTALL_PATH_Release = $(INSTALL_PATH);
+INSTALL_PATH_Debug = $(INSTALL_PATH);
+INSTALL_PATH_Production = $(INSTALL_PATH_PREFIX)$(SYSTEM_LIBRARY_DIR)/Frameworks/$(WEBKIT_FRAMEWORK_RESOURCES_PATH);


### PR DESCRIPTION
#### e961efa584fb8555060d8ee475821a073b372e56
<pre>
REGRESSION (258266@main): LayoutTestHelper gets installed to a wrong path on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=249963">https://bugs.webkit.org/show_bug.cgi?id=249963</a>
rdar://103784296

Unreviewed build fix.

258266@main simplified INSTALL_PATH for LayoutTestHelper under the assumption that it&apos;s
only installed on macOS. But the Xcode project itself overrode SKIP_INSTALL, despite what
the xcconfig said. This effectively reverts this part of the change, also removing the
project override.

* Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj:
* Tools/DumpRenderTree/mac/Configurations/LayoutTestHelper.xcconfig:

Canonical link: <a href="https://commits.webkit.org/258365@main">https://commits.webkit.org/258365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48996b1325747c8fc767933e520466b26f4007d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111005 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1732 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108767 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8993 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90886 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4419 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1618 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10582 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5733 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6248 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->