### PR TITLE
Outline on container with negative z-index child is drawn both outside container and in the scrolling content.

### DIFF
--- a/LayoutTests/compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases-expected.txt
+++ b/LayoutTests/compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases-expected.txt
@@ -37,7 +37,7 @@ Scrolled contents
                       (offsetFromRenderer width=1 height=1)
                       (bounds 305.00 1020.00)
                       (drawsContent 1)
-                      (paintingPhases [foreground, overflow-contents])
+                      (paintingPhases [foreground, overflow-contents, composited-scroll])
                     )
                   )
                 )

--- a/LayoutTests/platform/ios-wk2/compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases-expected.txt
@@ -37,7 +37,7 @@ Scrolled contents
                       (offsetFromRenderer width=1 height=1)
                       (bounds 320.00 1020.00)
                       (drawsContent 1)
-                      (paintingPhases [foreground, overflow-contents])
+                      (paintingPhases [foreground, overflow-contents, composited-scroll])
                     )
                   )
                 )

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -979,6 +979,8 @@ TextStream& operator<<(TextStream& ts, GraphicsLayerPaintingPhase phase)
     switch (phase) {
     case GraphicsLayerPaintingPhase::Background: ts << "background"; break;
     case GraphicsLayerPaintingPhase::Foreground: ts << "foreground"; break;
+    case GraphicsLayerPaintingPhase::Outline: ts << "outline"; break;
+    case GraphicsLayerPaintingPhase::NegativeZDescendants: ts << "negative-z descendants"; break;
     case GraphicsLayerPaintingPhase::Mask: ts << "mask"; break;
     case GraphicsLayerPaintingPhase::ClipPath: ts << "clip-path"; break;
     case GraphicsLayerPaintingPhase::OverflowContents: ts << "overflow-contents"; break;

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -40,14 +40,16 @@ class GraphicsLayer;
 class IntPoint;
 class IntRect;
 
-enum class GraphicsLayerPaintingPhase {
+enum class GraphicsLayerPaintingPhase : uint16_t {
     Background            = 1 << 0,
     Foreground            = 1 << 1,
-    Mask                  = 1 << 2,
-    ClipPath              = 1 << 3,
-    OverflowContents      = 1 << 4,
-    CompositedScroll      = 1 << 5,
-    ChildClippingMask     = 1 << 6,
+    Outline               = 1 << 2,
+    NegativeZDescendants  = 1 << 3,
+    Mask                  = 1 << 4,
+    ClipPath              = 1 << 5,
+    OverflowContents      = 1 << 6,
+    CompositedScroll      = 1 << 7,
+    ChildClippingMask     = 1 << 8,
 };
 
 enum AnimatedPropertyID {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -613,22 +613,24 @@ public:
 
     int zIndex() const { return renderer().style().usedZIndex(); }
 
-    enum class PaintLayerFlag : uint16_t {
-        HaveTransparency                      = 1 << 0,
-        AppliedTransform                      = 1 << 1,
-        TemporaryClipRects                    = 1 << 2,
-        PaintingReflection                    = 1 << 3,
-        PaintingOverlayScrollbars             = 1 << 4,
-        PaintingCompositingBackgroundPhase    = 1 << 5,
-        PaintingCompositingForegroundPhase    = 1 << 6,
-        PaintingCompositingMaskPhase          = 1 << 7,
-        PaintingCompositingClipPathPhase      = 1 << 8,
-        PaintingCompositingScrollingPhase     = 1 << 9,
-        PaintingOverflowContents              = 1 << 10,
-        PaintingRootBackgroundOnly            = 1 << 11,
-        PaintingSkipRootBackground            = 1 << 12,
-        PaintingChildClippingMaskPhase        = 1 << 13,
-        CollectingEventRegion                 = 1 << 14,
+    enum class PaintLayerFlag {
+        HaveTransparency                                = 1 << 0,
+        AppliedTransform                                = 1 << 1,
+        TemporaryClipRects                              = 1 << 2,
+        PaintingReflection                              = 1 << 3,
+        PaintingOverlayScrollbars                       = 1 << 4,
+        PaintingCompositingBackgroundPhase              = 1 << 5,
+        PaintingCompositingForegroundPhase              = 1 << 6,
+        PaintingCompositingOutlinePhase                 = 1 << 7,
+        PaintingCompositingNegativeZDescendantsPhase    = 1 << 8,
+        PaintingCompositingMaskPhase                    = 1 << 9,
+        PaintingCompositingClipPathPhase                = 1 << 10,
+        PaintingCompositingScrollingPhase               = 1 << 11,
+        PaintingOverflowContents                        = 1 << 12,
+        PaintingRootBackgroundOnly                      = 1 << 13,
+        PaintingSkipRootBackground                      = 1 << 14,
+        PaintingChildClippingMaskPhase                  = 1 << 15,
+        CollectingEventRegion                           = 1 << 16,
     };
     static constexpr OptionSet<PaintLayerFlag> paintLayerPaintingCompositingAllPhasesFlags() { return { PaintLayerFlag::PaintingCompositingBackgroundPhase, PaintLayerFlag::PaintingCompositingForegroundPhase }; }
 
@@ -1373,6 +1375,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayer&);
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayer::ClipRectsContext&);
 WTF::TextStream& operator<<(WTF::TextStream&, IndirectCompositingReason);
 WTF::TextStream& operator<<(WTF::TextStream&, PaintBehavior);
+WTF::TextStream& operator<<(WTF::TextStream&, RenderLayer::PaintLayerFlag);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### a05259e61024d912f7402d1cfc77a25af8064a19
<pre>
Outline on container with negative z-index child is drawn both outside container and in the scrolling content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249457">https://bugs.webkit.org/show_bug.cgi?id=249457</a>
rdar://103663858

Reviewed by NOBODY (OOPS!).

130068@main attempted to fix outline painting in composited scrollers, but missed a configuration where
a composited scroller has negative z-index, composited child. In this case the composited scroller gets
a &quot;foreground&quot; layer to paint the content above the negative z-index child, and this foreground layer
(which scrolls) had the outline painted into erroneously.

The primary fix here is to set the &quot;CompositedScroll&quot; GraphicsLayerPaintingPhase on this &quot;foreground&quot;
layer, and then use that to avoid painting the outline.

Rename `isPaintingScrollingContent` and `isPaintingOverflowContents` to `isPaintingCompositedScrollingLayer`
and `isPaintingCompositedScrollingContents` which are more accurate, and expand a confusing line
of boolean logic into a lambda.

Finally, clear the `PaintingCompositingScrollingPhase` phase when painting descendants, since we need
to detect that we&apos;re painting the composited scrolling layer itself, and not descendants.

* LayoutTests/compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases-expected.txt:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayer):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):
(WebCore::RenderLayerBacking::updatePaintingPhases):
(WebCore::RenderLayerBacking::paintIntoLayer):
(WebCore::RenderLayerBacking::paintFlagsForLayer const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05259e61024d912f7402d1cfc77a25af8064a19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101812 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111148 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171353 "Found 33 new test failures: fast/block/float/float-box-with-negative-horizontal-margin.html, fast/block/float/zero-size-float-avoider-incorrect-position.html, fast/borders/hidpi-outline-on-subpixel-position.html, fast/css/sticky/sticky-side-margins.html, fast/forms/fieldset/fieldset-overflow-auto.html, fast/forms/fieldset/fieldset-overflow-hidden.html, fast/forms/fieldset/fieldset-positioned-children.html, fast/forms/fieldset/fieldset-self-painting-legend.html, fast/forms/fieldset/fieldset-writing-modes.html, fast/inline/hidpi-selection-gap-on-subpixel-position.html ... (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1874 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108908 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107592 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9120 "Found 1 new test failure: compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92386 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36887 "Found 280 new test failures: fast/block/float/float-box-with-negative-horizontal-margin.html, fast/block/float/zero-size-float-avoider-incorrect-position.html, fast/borders/hidpi-outline-on-subpixel-position.html, fast/css/sticky/sticky-side-margins.html, fast/forms/fieldset/fieldset-overflow-auto.html, fast/forms/fieldset/fieldset-overflow-hidden.html, fast/forms/fieldset/fieldset-positioned-children.html, fast/forms/fieldset/fieldset-self-painting-legend.html, fast/forms/fieldset/fieldset-writing-modes.html, fast/repaint/layer-child-outline.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91008 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23812 "Found 60 new test failures: compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases.html, fast/block/float/float-box-with-negative-horizontal-margin.html, fast/block/float/zero-size-float-avoider-incorrect-position.html, fast/borders/hidpi-outline-hairline-painting.html, fast/borders/hidpi-outline-on-subpixel-position.html, fast/css/sticky/sticky-side-margins.html, fast/forms/fieldset/fieldset-overflow-auto.html, fast/forms/fieldset/fieldset-overflow-hidden.html, fast/forms/fieldset/fieldset-positioned-children.html, fast/forms/fieldset/fieldset-self-painting-legend.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4555 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25300 "Found 1 new test failure: compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4635 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1740 "Found 1 new test failure: compositing/overflow/stacking-context-composited-scroller-with-foreground-paint-phases.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44787 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6386 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->