### PR TITLE
[GPU Process] [FormControls] Add ControlPart for MenuList

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1745,6 +1745,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ControlPart.h
     platform/graphics/controls/ControlPartType.h
     platform/graphics/controls/ControlStyle.h
+    platform/graphics/controls/MenuListPart.h
     platform/graphics/controls/MeterPart.h
     platform/graphics/controls/PlatformControl.h
     platform/graphics/controls/ProgressBarPart.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -465,6 +465,7 @@ platform/graphics/mac/WebLayer.mm
 platform/graphics/mac/controls/ButtonControlMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
+platform/graphics/mac/controls/MenuListMac.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 class MeterPart;
+class MenuListPart;
 class PlatformControl;
 class ProgressBarPart;
 class TextAreaPart;
@@ -43,6 +44,7 @@ public:
     WEBCORE_EXPORT static std::unique_ptr<ControlFactory> createControlFactory();
     static ControlFactory& sharedControlFactory();
 
+    virtual std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/MenuListPart.h
+++ b/Source/WebCore/platform/graphics/controls/MenuListPart.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class MenuListPart final : public ControlPart {
+public:
+    static Ref<MenuListPart> create()
+    {
+        return adoptRef(*new MenuListPart());
+    }
+
+private:
+    MenuListPart()
+        : ControlPart(ControlPartType::Menulist)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformMenuList(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
@@ -45,29 +45,10 @@ void ButtonControlMac::updateCellStates(const FloatRect& rect, const ControlStyl
 
     const auto& states = style.states;
 
-    // Pressed state
-    bool oldPressed = [m_buttonCell isHighlighted];
-    bool pressed = states.contains(ControlStyle::State::Pressed);
-    if (pressed != oldPressed)
-        [m_buttonCell _setHighlighted:pressed animated:false];
-
-    // Enabled state
-    bool oldEnabled = [m_buttonCell isEnabled];
-    bool enabled = states.contains(ControlStyle::State::Enabled);
-    if (oldEnabled != enabled)
-        [m_buttonCell setEnabled:enabled];
-
-    // Checked and Indeterminate
-    bool oldIndeterminate = [m_buttonCell state] == NSControlStateValueMixed;
-    bool oldChecked = [m_buttonCell state] == NSControlStateValueOn;
-    bool indeterminate = states.contains(ControlStyle::State::Indeterminate);
-    bool checked = states.contains(ControlStyle::State::Checked);
-    if (oldIndeterminate != indeterminate || checked != oldChecked) {
-        NSControlStateValue newState = indeterminate ? NSControlStateValueMixed : (checked ? NSControlStateValueOn : NSControlStateValueOff);
-        [m_buttonCell _setState:newState animated:false];
-    }
-
-    // Presenting state
+    updatePressedState(m_buttonCell.get(), style);
+    updateEnabledState(m_buttonCell.get(), style);
+    updateCheckedState(m_buttonCell.get(), style);
+    
     if (states.contains(ControlStyle::State::Presenting))
         [m_buttonCell _setHighlighted:YES animated:NO];
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -38,6 +38,7 @@ public:
 
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
+    std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) override;
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
     std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
@@ -47,14 +48,16 @@ public:
 private:
     NSButtonCell *checkboxCell() const;
     NSButtonCell *radioCell() const;
-    NSLevelIndicatorCell* levelIndicatorCell() const;
-    NSTextFieldCell* textFieldCell() const;
+    NSLevelIndicatorCell *levelIndicatorCell() const;
+    NSPopUpButtonCell *popUpButtonCell() const;
+    NSTextFieldCell *textFieldCell() const;
 
     mutable RetainPtr<WebControlView> m_drawingView;
 
     mutable RetainPtr<NSButtonCell> m_checkboxCell;
     mutable RetainPtr<NSButtonCell> m_radioCell;
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
+    mutable RetainPtr<NSPopUpButtonCell> m_popUpButtonCell;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "MenuListMac.h"
 #import "MeterMac.h"
 #import "ProgressBarMac.h"
 #import "TextAreaMac.h"
@@ -71,7 +72,7 @@ static RetainPtr<NSButtonCell> createToggleButtonCell()
     return buttonCell;
 }
 
-NSButtonCell* ControlFactoryMac::checkboxCell() const
+NSButtonCell *ControlFactoryMac::checkboxCell() const
 {
     if (!m_checkboxCell) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
@@ -83,7 +84,7 @@ NSButtonCell* ControlFactoryMac::checkboxCell() const
     return m_checkboxCell.get();
 }
 
-NSButtonCell* ControlFactoryMac::radioCell() const
+NSButtonCell *ControlFactoryMac::radioCell() const
 {
     if (!m_radioCell) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
@@ -94,7 +95,7 @@ NSButtonCell* ControlFactoryMac::radioCell() const
     return m_radioCell.get();
 }
 
-NSLevelIndicatorCell* ControlFactoryMac::levelIndicatorCell() const
+NSLevelIndicatorCell *ControlFactoryMac::levelIndicatorCell() const
 {
     if (!m_levelIndicatorCell) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
@@ -103,6 +104,17 @@ NSLevelIndicatorCell* ControlFactoryMac::levelIndicatorCell() const
         END_BLOCK_OBJC_EXCEPTIONS
     }
     return m_levelIndicatorCell.get();
+}
+
+NSPopUpButtonCell *ControlFactoryMac::popUpButtonCell() const
+{
+    if (!m_popUpButtonCell) {
+        m_popUpButtonCell = adoptNS([[NSPopUpButtonCell alloc] initTextCell:@"" pullsDown:NO]);
+        [m_popUpButtonCell setUsesItemFromMenu:NO];
+        [m_popUpButtonCell setFocusRingType:NSFocusRingTypeExterior];
+        [m_popUpButtonCell setUserInterfaceLayoutDirection:NSUserInterfaceLayoutDirectionLeftToRight];
+    }
+    return m_popUpButtonCell.get();
 }
 
 NSTextFieldCell* ControlFactoryMac::textFieldCell() const
@@ -120,6 +132,11 @@ NSTextFieldCell* ControlFactoryMac::textFieldCell() const
         END_BLOCK_OBJC_EXCEPTIONS
     }
     return m_textFieldCell.get();
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMenuList(MenuListPart& part)
+{
+    return makeUnique<MenuListMac>(part, *this, popUpButtonCell());
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMeter(MeterPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -45,6 +45,11 @@ protected:
     static bool userPrefersContrast();
     static FloatRect inflatedRect(const FloatRect& bounds, const FloatSize&, const IntOutsets&, const ControlStyle&);
 
+    static void updateCheckedState(NSCell *, const ControlStyle&);
+    static void updateEnabledState(NSCell *, const ControlStyle&);
+    static void updateFocusedState(NSCell *, const ControlStyle&);
+    static void updatePressedState(NSCell *, const ControlStyle&);
+
     virtual IntSize cellSize(NSControlSize, const ControlStyle&) const { return { }; };
     virtual IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const { return { }; };
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -66,6 +66,56 @@ FloatRect ControlMac::inflatedRect(const FloatRect& bounds, const FloatSize& siz
     return unionRect(bounds, inflatedRect);
 }
 
+void ControlMac::updateCheckedState(NSCell *cell, const ControlStyle& style)
+{
+    bool oldIndeterminate = [cell state] == NSControlStateValueMixed;
+    bool indeterminate = style.states.contains(ControlStyle::State::Indeterminate);
+
+    bool oldChecked = [cell state] == NSControlStateValueOn;
+    bool checked = style.states.contains(ControlStyle::State::Checked);
+
+    if (oldIndeterminate == indeterminate && oldChecked == checked)
+        return;
+
+    auto newState = indeterminate ? NSControlStateValueMixed : (checked ? NSControlStateValueOn : NSControlStateValueOff);
+
+    if ([cell isKindOfClass:[NSButtonCell class]])
+        [(NSButtonCell *)cell _setState:newState animated:false];
+    else
+        [cell setState:newState];
+}
+
+void ControlMac::updateEnabledState(NSCell *cell, const ControlStyle& style)
+{
+    bool oldEnabled = [cell isEnabled];
+    bool enabled = style.states.contains(ControlStyle::State::Enabled);
+    if (enabled == oldEnabled)
+        return;
+    [cell setEnabled:enabled];
+}
+
+void ControlMac::updateFocusedState(NSCell *cell, const ControlStyle& style)
+{
+    bool oldFocused = [cell showsFirstResponder];
+    bool focused = style.states.contains(ControlStyle::State::Focused);
+    if (focused == oldFocused)
+        return;
+    [cell setShowsFirstResponder:focused];
+}
+
+void ControlMac::updatePressedState(NSCell *cell, const ControlStyle& style)
+{
+    bool oldPressed = [cell isHighlighted];
+    bool pressed = style.states.contains(ControlStyle::State::Pressed);
+    if (pressed == oldPressed)
+        return;
+
+    if ([cell isKindOfClass:[NSButtonCell class]])
+        [(NSButtonCell *)cell _setHighlighted:pressed animated:false];
+    else
+        [cell setHighlighted:pressed];
+}
+
 NSControlSize ControlMac::controlSizeForFont(const ControlStyle& style) const
 {
     bool supportsLargeFormControls = style.states.contains(ControlStyle::State::LargeControls);

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class MenuListPart;
+
+class MenuListMac : public ControlMac {
+public:
+    MenuListMac(MenuListPart& owningPart, ControlFactoryMac&, NSPopUpButtonCell *);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
+
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
+
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+
+    RetainPtr<NSPopUpButtonCell> m_popUpButtonCell;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MenuListMac.h"
+
+#if PLATFORM(MAC)
+
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "MenuListPart.h"
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+MenuListMac::MenuListMac(MenuListPart& owningPart, ControlFactoryMac& controlFactory, NSPopUpButtonCell *popUpButtonCell)
+    : ControlMac(owningPart, controlFactory)
+    , m_popUpButtonCell(popUpButtonCell)
+{
+    ASSERT(m_popUpButtonCell);
+}
+
+IntSize MenuListMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const IntSize sizes[] =
+    {
+        { 0, 21 },
+        { 0, 18 },
+        { 0, 15 },
+        { 0, 24 }
+    };
+    return sizes[controlSize];
+}
+
+IntOutsets MenuListMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const IntOutsets outsets[] = {
+        // top right bottom left
+        { 0, 3, 1, 3 },
+        { 0, 3, 2, 3 },
+        { 0, 1, 0, 1 },
+        { 0, 6, 2, 6 },
+    };
+    return outsets[controlSize];
+}
+
+void MenuListMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    ControlMac::updateCellStates(rect, style);
+
+    auto direction = style.states.contains(ControlStyle::State::RightToLeft) ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
+    [m_popUpButtonCell setUserInterfaceLayoutDirection:direction];
+
+    // Update the various states we respond to.
+    updateCheckedState(m_popUpButtonCell.get(), style);
+    updateEnabledState(m_popUpButtonCell.get(), style);
+    updatePressedState(m_popUpButtonCell.get(), style);
+
+    // Only update if we have to, since AppKit does work even if the size is the same.
+    auto controlSize = controlSizeForSize(rect.size(), style);
+    if (controlSize != [m_popUpButtonCell controlSize])
+        [m_popUpButtonCell setControlSize:controlSize];
+}
+
+FloatRect MenuListMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    int minimumMenuListSize = sizeForSystemFont(style).width();
+    if (bounds.width() < minimumMenuListSize)
+        return bounds;
+
+    auto controlSize = [m_popUpButtonCell controlSize];
+    auto size = cellSize(controlSize, style);
+    auto outsets = cellOutsets(controlSize, style);
+
+    size.scale(style.zoomFactor);
+    size.setWidth(bounds.width());
+
+    // Make enough room for the shadow.
+    return inflatedRect(bounds, size, outsets, style);
+}
+
+void MenuListMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    LocalCurrentGraphicsContext localContext(context);
+
+    auto inflatedRect = rectForBounds(rect, style);
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    if (style.zoomFactor != 1) {
+        inflatedRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+
+    drawCell(context, inflatedRect, deviceScaleFactor, style, m_popUpButtonCell.get(), view, true);
+
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -28,6 +28,7 @@
 
 #include <wtf/CompletionHandler.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/RunLoop.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -44,6 +44,7 @@
 #include "HTMLSelectElement.h"
 #include "HTMLTextAreaElement.h"
 #include "LocalizedStrings.h"
+#include "MenuListPart.h"
 #include "MeterPart.h"
 #include "Page.h"
 #include "PaintInfo.h"
@@ -509,7 +510,11 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     case ControlPartType::SquareButton:
     case ControlPartType::Button:
     case ControlPartType::DefaultButton:
+        break;
+
     case ControlPartType::Menulist:
+        return MenuListPart::create();
+
     case ControlPartType::MenulistButton:
         break;
 

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -111,7 +111,6 @@ private:
 
     void adjustTextAreaStyle(RenderStyle&, const Element*) const final;
 
-    bool paintMenuList(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     void adjustMenuListStyle(RenderStyle&, const Element*) const final;
 
     void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) final;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -228,6 +228,7 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Contr
 #endif
     case ControlPartType::Checkbox:
     case ControlPartType::Listbox:
+    case ControlPartType::Menulist:
     case ControlPartType::Meter:
     case ControlPartType::ProgressBar:
     case ControlPartType::Radio:
@@ -249,6 +250,7 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
 {
     ControlPartType type = renderer.style().effectiveAppearance();
     return type == ControlPartType::Checkbox
+        || type == ControlPartType::Menulist
         || type == ControlPartType::Meter
         || type == ControlPartType::ProgressBar
         || type == ControlPartType::Radio;
@@ -1141,39 +1143,6 @@ const int* RenderThemeMac::popupButtonPadding(NSControlSize size, bool isRTL) co
         { 2, 8, 3, 26 },
     };
     return isRTL ? paddingRTL[size] : paddingLTR[size];
-}
-
-bool RenderThemeMac::paintMenuList(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
-{
-    LocalCurrentGraphicsContext localContext(paintInfo.context());
-    setPopupButtonCellState(renderer, IntSize(rect.size()));
-
-    NSPopUpButtonCell* popupButton = this->popupButton();
-
-    float zoomLevel = renderer.style().effectiveZoom();
-    IntSize size = popupButtonSizes()[[popupButton controlSize]];
-    size.setHeight(size.height() * zoomLevel);
-    size.setWidth(rect.width());
-
-    // Now inflate it to account for the shadow.
-    FloatRect inflatedRect = rect;
-    if (rect.width() >= minimumMenuListSize(renderer.style()))
-        inflatedRect = inflateRect(rect, size, popupButtonMargins(), zoomLevel);
-
-    GraphicsContextStateSaver stateSaver(paintInfo.context());
-
-    if (zoomLevel != 1.0f) {
-        inflatedRect.setWidth(inflatedRect.width() / zoomLevel);
-        inflatedRect.setHeight(inflatedRect.height() / zoomLevel);
-        paintInfo.context().translate(inflatedRect.location());
-        paintInfo.context().scale(zoomLevel);
-        paintInfo.context().translate(-inflatedRect.location());
-    }
-
-    paintCellAndSetFocusedElementNeedsRepaintIfNecessary(popupButton, renderer, paintInfo, inflatedRect);
-    [popupButton setControlView:nil];
-
-    return false;
 }
 
 FloatSize RenderThemeMac::meterSizeForBounds(const RenderMeter& renderMeter, const FloatRect& bounds) const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -75,6 +75,7 @@
 #include <WebCore/Matrix3DTransformOperation.h>
 #include <WebCore/MatrixTransformOperation.h>
 #include <WebCore/MediaSelectionOption.h>
+#include <WebCore/MenuListPart.h>
 #include <WebCore/MeterPart.h>
 #include <WebCore/NotificationResources.h>
 #include <WebCore/Pasteboard.h>
@@ -1609,7 +1610,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::SquareButton:
     case WebCore::ControlPartType::Button:
     case WebCore::ControlPartType::DefaultButton:
+        break;
+            
     case WebCore::ControlPartType::Menulist:
+        return WebCore::MenuListPart::create();
+
     case WebCore::ControlPartType::MenulistButton:
         break;
 


### PR DESCRIPTION
#### f9b389be95cc3dc8143bbedd82fd530a1f2bcaaf
<pre>
[GPU Process] [FormControls] Add ControlPart for MenuList
<a href="https://bugs.webkit.org/show_bug.cgi?id=249978">https://bugs.webkit.org/show_bug.cgi?id=249978</a>
rdar://103795005

Reviewed by Aditya Keerthi.

This ControlPart will handle drawing the MenuList form control (i.e. &lt;select&gt;...&lt;/select&gt;).
For macOS, AppKit will be used to draw the platform control.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/MenuListPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm:
(WebCore::ButtonControlMac::updateCellStates):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::checkboxCell const):
(WebCore::ControlFactoryMac::radioCell const):
(WebCore::ControlFactoryMac::levelIndicatorCell const):
(WebCore::ControlFactoryMac::popUpButtonCell const):
(WebCore::ControlFactoryMac::createPlatformMenuList):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::updateCheckedState):
(WebCore::ControlMac::updateEnabledState):
(WebCore::ControlMac::updateFocusedState):
(WebCore::ControlMac::updatePressedState):
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm: Added.
(WebCore::MenuListMac::MenuListMac):
(WebCore::MenuListMac::cellSize const):
(WebCore::MenuListMac::cellOutsets const):
(WebCore::MenuListMac::updateCellStates):
(WebCore::MenuListMac::rectForBounds const):
(WebCore::MenuListMac::draw):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::paintMenuList): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258453@main">https://commits.webkit.org/258453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06aeb9769450be390afcaa022fd34f9bc10dd5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111330 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2060 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109085 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107780 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92535 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24014 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4724 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25446 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4817 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44934 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6565 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3053 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->