### PR TITLE
[@property] Fallback that does not match syntax should make var() invalid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
@@ -10,7 +10,7 @@ FAIL Values are absolutized when substituting into properties with universal syn
 PASS Valid fallback does not invalidate var()-reference [<length>, 10px]
 PASS Valid fallback does not invalidate var()-reference [<length> | <color>, red]
 PASS Valid fallback does not invalidate var()-reference [<length> | none, none]
-FAIL Invalid fallback invalidates var()-reference [<length>, red] assert_equals: expected "" but got "40px"
-FAIL Invalid fallback invalidates var()-reference [<length> | none, nolength] assert_equals: expected "" but got "40px"
-FAIL Invalid fallback invalidates var()-reference [<length>, var(--novar)] assert_equals: expected "" but got "40px"
+PASS Invalid fallback invalidates var()-reference [<length>, red]
+PASS Invalid fallback invalidates var()-reference [<length> | none, nolength]
+PASS Invalid fallback invalidates var()-reference [<length>, var(--novar)]
 

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -61,9 +61,10 @@ public:
 private:
     explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&, const CSSParserContext&);
 
-    static bool resolveTokenRange(CSSParserTokenRange, Vector<CSSParserToken>&, Style::BuilderState&);
-    static bool resolveVariableReference(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, Style::BuilderState&);
-    static bool resolveVariableFallback(CSSParserTokenRange, Vector<CSSParserToken>&, Style::BuilderState&);
+    std::optional<Vector<CSSParserToken>> resolveTokenRange(CSSParserTokenRange, Style::BuilderState&) const;
+    bool resolveVariableReference(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, Style::BuilderState&) const;
+    enum class FallbackResult : uint8_t { None, Valid, Invalid };
+    std::pair<FallbackResult, Vector<CSSParserToken>> resolveVariableFallback(const AtomString& variableName, CSSParserTokenRange, Style::BuilderState&) const;
 
     Ref<CSSVariableData> m_data;
     mutable String m_stringValue;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -285,6 +285,15 @@ void CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const CSSCu
     parser.collectParsedCustomPropertyValueDependencies(syntax, isRoot, dependencies);
 }
 
+bool CSSPropertyParser::isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax& syntax, CSSParserTokenRange tokens, const CSSParserContext& context)
+{
+    if (syntax.isUniversal())
+        return true;
+
+    CSSPropertyParser parser { tokens, context, nullptr };
+    return !!parser.consumeCustomPropertyValueWithSyntax(syntax).first;
+}
+
 bool CSSPropertyParser::parseValueStart(CSSPropertyID propertyID, bool important)
 {
     if (consumeCSSWideKeyword(propertyID, important))

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -53,6 +53,7 @@ public:
     static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyInitialValue(const AtomString&, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&);
     static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, const CSSParserTokenRange&, Style::BuilderState&, const CSSParserContext&);
     static void collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
+    static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
 
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
 


### PR DESCRIPTION
#### 6dabb8f934a3f64c639eb12d8c24ddea1c16101e
<pre>
[@property] Fallback that does not match syntax should make var() invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=249981">https://bugs.webkit.org/show_bug.cgi?id=249981</a>
rdar://103799338

Reviewed by Sam Weinig.

The fallback value must match the syntax definition of the custom property being referenced,
otherwise the declaration is invalid at computed-value time.

<a href="https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references">https://drafts.css-houdini.org/css-properties-values-api/#fallbacks-in-var-references</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::resolveVariableFallback const):

Check the syntax of the fallback.

(WebCore::CSSVariableReferenceValue::resolveVariableReference const):
(WebCore::CSSVariableReferenceValue::resolveTokenRange const):
(WebCore::CSSVariableReferenceValue::resolveVariableReferences const):
(WebCore::CSSVariableReferenceValue::resolveVariableFallback): Deleted.
(WebCore::CSSVariableReferenceValue::resolveVariableReference): Deleted.
(WebCore::CSSVariableReferenceValue::resolveTokenRange): Deleted.

Make these non-static (so parser context is available) and did some return value cleanup.

* Source/WebCore/css/CSSVariableReferenceValue.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::isValidCustomPropertyValueForSyntax):
* Source/WebCore/css/parser/CSSPropertyParser.h:

Canonical link: <a href="https://commits.webkit.org/258373@main">https://commits.webkit.org/258373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9edf1da8fca893a7bed625808dd93e83b8e33fa5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111034 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171238 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1761 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108796 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9022 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90915 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78586 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4448 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1647 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10611 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5738 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6277 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->