### PR TITLE
Implementing CounterStyleRegistry for reference resolution

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -596,6 +596,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSConditionRule.h
     css/CSSCounterStyle.h
     css/CSSCounterStyleDescriptors.h
+    css/CSSCounterStyleRegistry.h
     css/CSSCounterStyleRule.h
     css/CSSCustomPropertyValue.h
     css/CSSFontFaceRule.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -744,6 +744,7 @@ css/CSSContainerRule.cpp
 css/CSSContentDistributionValue.cpp
 css/CSSCounterStyle.cpp
 css/CSSCounterStyleDescriptors.cpp
+css/CSSCounterStyleRegistry.cpp
 css/CSSCounterStyleRule.cpp
 css/CSSCrossfadeValue.cpp
 css/CSSCursorImageValue.cpp

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -70,7 +70,7 @@ String CSSCounterStyle::initialRepresentation(int)
 }
 String CSSCounterStyle::text(int value)
 {
-// FIXME: implement text representation for CounterStyle rdar://103648354.
+// FIXME: implement text representation for CSSCounterStyle rdar://103648354.
     return String::number(value);
 }
 bool CSSCounterStyle::isInRange(int value) const
@@ -165,5 +165,4 @@ void CSSCounterStyle::extendAndResolve(const CSSCounterStyle& extendedCounterSty
     if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::SpeakAs))
         setSpeakAs(extendedCounterStyle.speakAs());
 }
-
 }

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -86,7 +86,7 @@ private:
     bool shouldApplyNegativeSymbols(int);
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback
     Ref<CSSCounterStyle> fallback();
-    // Generates a CounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
+    // Generates a CSSCounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
     void applyPadSymbols(String&);
     void applyNegativeSymbols(String&);
     // Initial text representation for the counter, before applying pad and/or negative symbols. Suffix and Prefix are also not considered as described by https://www.w3.org/TR/css-counter-styles-3/#counter-styles.

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/OptionSet.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCounterStyleRegistry.h"
+
+#include "CSSCounterStyle.h"
+#include "CSSCounterStyleRule.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSValuePair.h"
+
+namespace WebCore {
+
+void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
+{
+    // FIXME: does this need thread-safety guards?
+    if (!hasUnresolvedReferences)
+        return;
+
+    for (auto& [name, counter] : m_authorCounterStyles) {
+        if (counter->isFallbackUnresolved())
+            resolveFallbackReference(*counter);
+        if (counter->isExtendsSystem() && counter->isExtendsUnresolved())
+            resolveExtendsReference(*counter);
+    }
+    hasUnresolvedReferences = false;
+}
+
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counterStyle)
+{
+    HashSet<CSSCounterStyle*> countersInChain;
+    resolveExtendsReference(counterStyle, countersInChain);
+}
+
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, HashSet<CSSCounterStyle*>& countersInChain)
+{
+    ASSERT(counter.isExtendsSystem() && counter.isExtendsUnresolved());
+    if (!(counter.isExtendsSystem() && counter.isExtendsUnresolved()))
+        return;
+
+    if (countersInChain.contains(&counter)) {
+        // Chain of references forms a circle. Treat all as extending decimal (https://www.w3.org/TR/css-counter-styles-3/#extends-system).
+        auto decimal = decimalCounter();
+        for (const auto counterInChain : countersInChain) {
+            ASSERT(counterInChain);
+            if (!counterInChain)
+                continue;
+            counterInChain->extendAndResolve(*decimal);
+        }
+        // Recursion return for circular chain.
+        return;
+    }
+    countersInChain.add(&counter);
+
+    auto extendedCounter = counterStyle(counter.extendsName());
+    ASSERT(extendedCounter);
+    if (!extendedCounter)
+        return;
+
+    if (extendedCounter->isExtendsSystem() && extendedCounter->isExtendsUnresolved())
+        resolveExtendsReference(*extendedCounter, countersInChain);
+
+    // Recursion return for non-circular chain. Calling resolveExtendsReference() for the extendedCounter might have already resolved this counter style if a circle was formed. If it is still unresolved, it should get resolved here.
+    if (counter.isExtendsUnresolved())
+        counter.extendAndResolve(*extendedCounter);
+}
+
+void CSSCounterStyleRegistry::resolveFallbackReference(CSSCounterStyle& counter)
+{
+    counter.setFallbackReference(counterStyle(counter.fallbackName()));
+}
+
+void CSSCounterStyleRegistry::addCounterStyle(const CSSCounterStyleDescriptors& descriptors)
+{
+    hasUnresolvedReferences = true;
+    m_authorCounterStyles.set(descriptors.m_name, CSSCounterStyle::create(descriptors, false));
+}
+
+RefPtr<CSSCounterStyle> CSSCounterStyleRegistry::decimalCounter() const
+{
+    auto& userAgentCounters = userAgentCounterStyles();
+    auto iterator = userAgentCounters.find("decimal"_s);
+    if (iterator != userAgentCounters.end())
+        return iterator->value.get();
+    // user agent counter style should always be populated with a counter named decimal
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+RefPtr<CSSCounterStyle> CSSCounterStyleRegistry::counterStyle(const AtomString& name)
+{
+    if (name.isEmpty())
+        return decimalCounter();
+
+    auto getCounter = [&](const CounterStyleMap& map, const AtomString& counterName) {
+        auto counterIterator = map.find(counterName);
+        return counterIterator != map.end() ? counterIterator->value.get() : nullptr;
+    };
+
+    auto authorCounter = getCounter(m_authorCounterStyles, name);
+    if (authorCounter)
+        return authorCounter;
+    auto userAgentCounter = getCounter(userAgentCounterStyles(), name);
+    if (userAgentCounter)
+        return userAgentCounter;
+
+    return decimalCounter();
+}
+
+RefPtr<CSSCounterStyle> CSSCounterStyleRegistry::resolvedCounterStyle(const AtomString& name)
+{
+    resolveReferencesIfNeeded();
+    return counterStyle(name);
+}
+
+CounterStyleMap& CSSCounterStyleRegistry::userAgentCounterStyles()
+{
+    // FIXME: counter-style should get pre-defined counters from UA stylesheet rdar://103021161.
+    auto initialStyles = []() {
+        CounterStyleMap map;
+        map.add("decimal"_s, CSSCounterStyle::createCounterStyleDecimal());
+        return map;
+    };
+
+    static NeverDestroyed<CounterStyleMap> counters = initialStyles();
+    return counters;
+}
+
+bool CSSCounterStyleRegistry::operator==(const CSSCounterStyleRegistry& other) const
+{
+    return m_authorCounterStyles == other.m_authorCounterStyles;
+}
+
+}

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCounterStyle.h"
+#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class StyleRuleCounterStyle;
+using CounterStyleMap = HashMap<AtomString, RefPtr<CSSCounterStyle>>;
+
+class CSSCounterStyleRegistry {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    RefPtr<CSSCounterStyle> resolvedCounterStyle(const AtomString&);
+    RefPtr<CSSCounterStyle> decimalCounter() const;
+    void addCounterStyle(const CSSCounterStyleDescriptors&);
+    void resolveReferencesIfNeeded();
+    bool operator==(const CSSCounterStyleRegistry& other) const;
+    CSSCounterStyleRegistry() = default;
+
+private:
+    static CounterStyleMap& userAgentCounterStyles();
+    void resolveFallbackReference(CSSCounterStyle&);
+    void resolveExtendsReference(CSSCounterStyle&);
+    void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&);
+    RefPtr<CSSCounterStyle> counterStyle(const AtomString&);
+
+    CounterStyleMap m_authorCounterStyles;
+    bool hasUnresolvedReferences { true };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -35,7 +35,6 @@
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
-
 StyleRuleCounterStyle::StyleRuleCounterStyle(const AtomString& name, Ref<StyleProperties>&& properties, CSSCounterStyleDescriptors&& descriptors)
     : StyleRuleBase(StyleRuleType::CounterStyle)
     , m_name(name)

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -40,6 +40,7 @@ public:
     Ref<StyleRuleCounterStyle> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     const StyleProperties& properties() const { return m_properties; }
+    const CSSCounterStyleDescriptors& descriptors() const { return m_descriptors; };
     RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID id) const { return m_properties->getPropertyCSSValue(id); }
     MutableStyleProperties& mutableProperties();
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9015,6 +9015,16 @@ const Style::CustomPropertyRegistry& Document::customPropertyRegistry() const
     return styleScope().customPropertyRegistry();
 }
 
+const CSSCounterStyleRegistry& Document::counterStyleRegistry() const
+{
+    return styleScope().counterStyleRegistry();
+}
+
+CSSCounterStyleRegistry& Document::counterStyleRegistry()
+{
+    return styleScope().counterStyleRegistry();
+}
+
 const FixedVector<CSSPropertyID>& Document::exposedComputedCSSPropertyIDs()
 {
     if (!m_exposedComputedCSSPropertyIDs.has_value()) {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -102,6 +102,7 @@ class AppHighlightStorage;
 class Attr;
 class CanvasBase;
 class CDATASection;
+class CSSCounterStyleRegistry;
 class CSSCustomPropertyValue;
 class CSSFontSelector;
 class CSSStyleDeclaration;
@@ -593,6 +594,8 @@ public:
     const ExtensionStyleSheets& extensionStyleSheets() const { return *m_extensionStyleSheets; }
 
     const Style::CustomPropertyRegistry& customPropertyRegistry() const;
+    const CSSCounterStyleRegistry& counterStyleRegistry() const;
+    CSSCounterStyleRegistry& counterStyleRegistry();
 
     bool gotoAnchorNeededAfterStylesheetsLoad() { return m_gotoAnchorNeededAfterStylesheetsLoad; }
     void setGotoAnchorNeededAfterStylesheetsLoad(bool b) { m_gotoAnchorNeededAfterStylesheetsLoad = b; }

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -26,9 +26,11 @@
 
 namespace WebCore {
 
+class CSSCounterStyle;
 class RenderListItem;
+class StyleRuleCounterStyle;
 
-String listMarkerText(ListStyleType, int value);
+String listMarkerText(ListStyleType, int value, CSSCounterStyle* = nullptr);
 
 // Used to render the list item's marker.
 // The RenderListMarker always has to be a child of a RenderListItem.
@@ -77,6 +79,8 @@ private:
 
     struct TextRunWithUnderlyingString;
     TextRunWithUnderlyingString textRun() const;
+
+    CSSCounterStyle* counterStyle() const;
 
     String m_textWithSuffix;
     uint8_t m_textWithoutSuffixLength { 0 };

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1148,7 +1148,6 @@ public:
     void setListStyleType(ListStyleType v) { m_inheritedFlags.listStyleType = static_cast<unsigned>(v); }
     void setListStyleImage(RefPtr<StyleImage>&&);
     void setListStylePosition(ListStylePosition v) { m_inheritedFlags.listStylePosition = static_cast<unsigned>(v); }
-
     void resetMargin() { SET_VAR(m_surroundData, margin, LengthBox(LengthType::Fixed)); }
     void setMarginTop(Length&& length) { SET_VAR(m_surroundData, margin.top(), WTFMove(length)); }
     void setMarginBottom(Length&& length) { SET_VAR(m_surroundData, margin.bottom(), WTFMove(length)); }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -667,6 +667,8 @@ enum class ListStyleType : uint8_t {
     TraditionalChineseInformal,
     TraditionalChineseFormal,
     EthiopicNumeric,
+    // FIXME: handle counter-style: rdar://102988393.
+    CustomCounterStyle,
     String,
     None
 };

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "StyleScope.h"
 
+#include "CSSCounterStyleRegistry.h"
 #include "CSSFontSelector.h"
 #include "CSSStyleSheet.h"
 #include "CustomPropertyRegistry.h"
@@ -68,6 +69,7 @@ Scope::Scope(Document& document)
     : m_document(document)
     , m_pendingUpdateTimer(*this, &Scope::pendingUpdateTimerFired)
     , m_customPropertyRegistry(makeUniqueRef<CustomPropertyRegistry>(*this))
+    , m_counterStyleRegistry(makeUniqueRef<CSSCounterStyleRegistry>())
 {
 }
 
@@ -76,6 +78,7 @@ Scope::Scope(ShadowRoot& shadowRoot)
     , m_shadowRoot(&shadowRoot)
     , m_pendingUpdateTimer(*this, &Scope::pendingUpdateTimerFired)
     , m_customPropertyRegistry(makeUniqueRef<CustomPropertyRegistry>(*this))
+    , m_counterStyleRegistry(makeUniqueRef<CSSCounterStyleRegistry>())
 {
 }
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -41,10 +41,12 @@
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/text/AtomStringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+class CSSCounterStyleRegistry;
 class CSSStyleSheet;
 class Document;
 class Element;
@@ -142,6 +144,8 @@ public:
 
     const CustomPropertyRegistry& customPropertyRegistry() const { return m_customPropertyRegistry.get(); }
     CustomPropertyRegistry& customPropertyRegistry() { return m_customPropertyRegistry.get(); }
+    const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
+    CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
 
 private:
     Scope& documentScope();
@@ -230,6 +234,7 @@ private:
     WeakHashMap<Element, LayoutSize, WeakPtrImplWithEventTargetData> m_queryContainerStates;
 
     UniqueRef<CustomPropertyRegistry> m_customPropertyRegistry;
+    UniqueRef<CSSCounterStyleRegistry> m_counterStyleRegistry;
 
     // FIXME: These (and some things above) are only relevant for the root scope.
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;


### PR DESCRIPTION
#### 316bd081ae8deaba9d8933e555c173593b3a1600
<pre>
Implementing CounterStyleRegistry for reference resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=249870">https://bugs.webkit.org/show_bug.cgi?id=249870</a>
rdar://problem/103685490

Reviewed by Antti Koivisto and Myles C. Maxfield.

CSSCounterStyleRegistry keeps a collection of CounterStyle objects.
It is able to resolve references among the objects as needed by
the fallback feature and the extended system.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Adding CSSCounterStyleRegistry .cpp and .h files.

* Source/WebCore/css/CSSCounterStyleRegistry.cpp: Added.
(WebCore::CounterStyleRegistry::resolveReferences):
Resolve fallback and extend references for all the CounterStyle objects
in the registry.

(WebCore::CounterStyleRegistry::resolveExtendsReference):
Resolve Extend references for the counter styles with unresolved
references in the registry as described by
<a href="https://www.w3.org/TR/css-counter-styles-3/#extends-system.">https://www.w3.org/TR/css-counter-styles-3/#extends-system.</a>

(WebCore::CounterStyleRegistry::resolveFallbackReference):
Resolve fallback references for all counter styles with unresolved
references in the registry as described by
<a href="https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback.">https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback.</a>

(WebCore::CounterStyleRegistry::create):
(WebCore::CounterStyleRegistry::addCounterStyle):
Add counter style to the registry.

(WebCore::CounterStyleRegistry::getDecimalCounter):
(WebCore::CounterStyleRegistry::counterStyleForName):
Get counter style for a given name.

(WebCore::CounterStyleRegistry::userAgentCounterStyles):
(WebCore::CounterStyleRegistry::operator== const):

* Source/WebCore/css/CSSCounterStyleRegistry.h: Added.
* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::toCounterStyleSystemEnum):
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSValueKeywords.in:
Adding CounterStyle as value to ListStyleType.

* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSystem):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::effectiveListMarkerType):
(WebCore::listMarkerSuffix):
(WebCore::listMarkerText):
(WebCore::RenderListMarker::updateContent):
(WebCore::RenderListMarker::counterStyle const):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::counterStyleRegistry const):
(WebCore::RenderStyle::setCounterStyleRegistry):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::initialCounterStyleRegistry):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
Adding CounterStyle as value to ListStyleType enum.

* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
Adding a CounterStyleRegistry member to RenderStyle such that
the counter styles can be availble during rendering.

* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
(): Deleted.

* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRules):
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):
Processing counter style rules and adding them as CounterStyle objects
to the CounterStyleRegistry hold by the StyleResolver.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueListStyleType):
(WebCore::Style::BuilderCustom::applyValueContent):
We can now handle custom-ident as list-style-type, as this is the
required type for describing a custom-style with an at-rule. For that
case, a CounterStyleRegistry will be recovered from the document&apos;s style
Scope and added to RenderStyle such that it can be used later for
rendering.  This branch will not be reached until custom-ident is added
as a type for list-style-type parser grammar in CSSProperties.json,
which will be defered until we can properly render the counter styles.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::ensureCounterStyleRegistry):
(WebCore::Style::Resolver::addCounterStyle):
(WebCore::Style::Resolver::counterStyleForName):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.h:
(WebCore::Style::Scope::resolverIfExists const):
(WebCore::Style::Scope::resolverIfExists): Deleted.
StyleResolver has now a CounterStyleRegistry for holding CounterStyle
objects added during the process of rules in RuleSetBuilder.
The registry will be recovered later when building the style for
list-style-type (StyleBuilderCustom.h)

Canonical link: <a href="https://commits.webkit.org/258510@main">https://commits.webkit.org/258510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f73c19bcc6089b1e0470bf88964e42adfbc6fe15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111475 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2208 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109210 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107929 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92674 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24155 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25579 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2017 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45076 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5834 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6707 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->