### PR TITLE
media/audioSession/audioSessionType.html is flaky

### DIFF
--- a/LayoutTests/media/audioSession/audioSessionType.html
+++ b/LayoutTests/media/audioSession/audioSessionType.html
@@ -10,6 +10,20 @@
     <body>
         <audio id="audio"></audio>
         <script>
+async function ensureCategory(expected, counter)
+{
+    if (internals.audioSessionCategory() == expected)
+        return "";
+
+    if (!counter)
+        counter = 0;
+    else if (counter > 100)
+        return `ensureCategory failed, expected was ${expected} and current value is ${internals.audioSessionCategory()}`;
+
+    await new Promise(resolve => setTimeout(resolve, 20));
+    return ensureCategory(expected, ++counter);
+}
+
 promise_test(async (test) => {
     assert_equals(navigator.audioSession.type, "auto");
     
@@ -21,7 +35,7 @@ promise_test(async (test) => {
 
 
     assert_equals(navigator.audioSession.type, "auto");
-    assert_equals(internals.audioSessionCategory(), "MediaPlayback");
+    assert_equals(await ensureCategory("MediaPlayback"), "", "initial MediaPlayback");
 
     navigator.audioSession.type = "ambient";
     assert_equals(internals.audioSessionCategory(), "AmbientSound");
@@ -39,8 +53,7 @@ promise_test(async (test) => {
     assert_equals(internals.audioSessionCategory(), "SoloAmbientSound");
 
     navigator.audioSession.type = "auto";
-    await new Promise(resolve => setTimeout(resolve, 50));
-    assert_equals(internals.audioSessionCategory(), "MediaPlayback");
+    assert_equals(await ensureCategory("MediaPlayback"), "", "final MediaPlayback");
 }, "AudioSession type");
         </script>
     </body>


### PR DESCRIPTION
#### 7598f5a99fa221d4c542a8715fa0cc5655444789
<pre>
media/audioSession/audioSessionType.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=249998">https://bugs.webkit.org/show_bug.cgi?id=249998</a>
rdar://problem/103810613

Reviewed by Eric Carlson.

The category is set based on media element state.
When a media element is playing, its category should be MediaPlayback.
But this is racy with how the test is written (promise returned by play).
To make the test more predictable, we check internals.audioSessionCategory until it has the expected value.

* LayoutTests/media/audioSession/audioSessionType.html:

Canonical link: <a href="https://commits.webkit.org/258426@main">https://commits.webkit.org/258426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aec95c1df4382186642832ec6c8c1b8cd276ac69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111252 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171456 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1981 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109006 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92478 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23926 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1829 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44878 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5783 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6489 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->