### PR TITLE
Remove some childTypeAllowed overrides

### DIFF
--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -54,11 +54,6 @@ Ref<Node> CDATASection::cloneNodeInternal(Document& targetDocument, CloningOpera
     return create(targetDocument, String { data() });
 }
 
-bool CDATASection::childTypeAllowed(NodeType) const
-{
-    return false;
-}
-
 Ref<Text> CDATASection::virtualCreate(String&& data)
 {
     return create(document(), WTFMove(data));

--- a/Source/WebCore/dom/CDATASection.h
+++ b/Source/WebCore/dom/CDATASection.h
@@ -37,7 +37,6 @@ private:
     String nodeName() const override;
     NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
-    bool childTypeAllowed(NodeType) const override;
     Ref<Text> virtualCreate(String&&) override;
 };
 

--- a/Source/WebCore/dom/Comment.cpp
+++ b/Source/WebCore/dom/Comment.cpp
@@ -54,9 +54,4 @@ Ref<Node> Comment::cloneNodeInternal(Document& targetDocument, CloningOperation)
     return create(targetDocument, String { data() });
 }
 
-bool Comment::childTypeAllowed(NodeType) const
-{
-    return false;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/Comment.h
+++ b/Source/WebCore/dom/Comment.h
@@ -37,7 +37,6 @@ private:
     String nodeName() const override;
     NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
-    bool childTypeAllowed(NodeType) const override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -186,11 +186,6 @@ RenderPtr<RenderText> Text::createTextRenderer(const RenderStyle& style)
     return createRenderer<RenderText>(*this, data());
 }
 
-bool Text::childTypeAllowed(NodeType) const
-{
-    return false;
-}
-
 Ref<Text> Text::virtualCreate(String&& data)
 {
     return create(document(), WTFMove(data));

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -67,7 +67,6 @@ private:
     String nodeName() const override;
     NodeType nodeType() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
-    bool childTypeAllowed(NodeType) const override;
     void setDataAndUpdate(const String&, unsigned offsetOfReplacedData, unsigned oldLength, unsigned newLength, UpdateLiveRanges) final;
 
     virtual Ref<Text> virtualCreate(String&&);


### PR DESCRIPTION
#### 8bacbc1a234bf3c1071d38df45e5e1a60112c5ec
<pre>
Remove some childTypeAllowed overrides
<a href="https://bugs.webkit.org/show_bug.cgi?id=250001">https://bugs.webkit.org/show_bug.cgi?id=250001</a>

Reviewed by Carlos Garcia Campos.

Remove some childTypeAllowed overrides since the
overrides are superfluous.

* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::childTypeAllowed const): Deleted.
* Source/WebCore/dom/CDATASection.h:
* Source/WebCore/dom/Comment.cpp:
(WebCore::Comment::childTypeAllowed const): Deleted.
* Source/WebCore/dom/Comment.h:
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::childTypeAllowed const): Deleted.
* Source/WebCore/dom/Text.h:

Canonical link: <a href="https://commits.webkit.org/258386@main">https://commits.webkit.org/258386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b3e5a2bdc2cc361677e1efe9aaf7019e5386652

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111081 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171286 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1809 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108843 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36755 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78632 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1690 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44731 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5744 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6324 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->