### PR TITLE
[GStreamer] Additional video rotation handling changes

### DIFF
--- a/LayoutTests/fast/mediastream/resources/getUserMedia-to-canvas.js
+++ b/LayoutTests/fast/mediastream/resources/getUserMedia-to-canvas.js
@@ -140,8 +140,16 @@ async function testUserMediaToCanvas(t, subcase) {
         }
         setMockCameraImageOrientation(0);
         await waitForVideoSize(video, realVideoSize[0], realVideoSize[1]);
-        debuge.removeChild(video);
+
+        // FIXME: Workaround for GStreamer ports, in some cases media tracks of the mock source are
+        // not correctly propagated to the media element, so we need explicit clean-up of the
+        // MediaStream here. This is temporary, hopefully.
+        video.srcObject.getVideoTracks().forEach(track => {
+            track.stop();
+            video.srcObject.removeTrack(track);
+        });
         video.srcObject = null;
+        debuge.removeChild(video);
     });
 
     if (subcase.angle == 180) {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2905,9 +2905,8 @@ webkit.org/b/223830 inspector/debugger/csp-exceptions.html [ Timeout ]
 # This test not only fails but may end up leaving the setShowPaintRects setting enabled and affect other tests.
 webkit.org/b/233047 inspector/page/setShowPaintRects.html [ Skip ]
 
-# setMockCameraOrientation seems to fail.
+# WebGL test fails when video rotation is 180.
 webkit.org/b/235396 fast/mediastream/getUserMedia-to-canvas-1.html [ Failure ]
-webkit.org/b/235396 fast/mediastream/getUserMedia-to-canvas-2.html [ Failure ]
 
 # Timing out since their import.
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -437,7 +437,7 @@ private:
 
     bool isPlayerShuttingDown() const { return m_isPlayerShuttingDown.load(); }
     MediaTime maxTimeLoaded() const;
-    bool setVideoSourceOrientation(ImageOrientation);
+
     MediaTime platformDuration() const;
     bool isMuted() const;
     void commitLoad();
@@ -496,7 +496,8 @@ private:
 
     void updateTracks(const GRefPtr<GstObject>& collectionOwner);
     void videoSinkCapsChanged(GstPad*);
-    void updateVideoSizeAndOrientationFromCaps(const GstCaps*);
+    void updateVideoSizeAndOrientationFromCapsAndTagList(const GRefPtr<GstCaps>&);
+    FloatSize applyVideoOrientationToCaps(const ImageOrientation&, const GRefPtr<GstCaps>&);
     bool hasFirstVideoSampleReachedSink() const;
 
 #if ENABLE(ENCRYPTED_MEDIA)


### PR DESCRIPTION
#### 74a42e2bf2a8d3e7107e91efb7de291408b4fa4e
<pre>
[GStreamer] Additional video rotation handling changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250005">https://bugs.webkit.org/show_bug.cgi?id=250005</a>

Reviewed by NOBODY (OOPS!).

The video orientation and size are updated only if an orientation tag was detected, the
`getVideoOrientation()` return type was changed to `optional&lt;ImageOrientation&gt;` to improve the
semantics.

The `sizeChanged` event is now emitted only if the actual video size changed, independently from the
orientation. The previous code had flows, spotted by Alicia Boya Garcia, quoting
<a href="https://github.com/WebKit/WebKit/pull/7148">https://github.com/WebKit/WebKit/pull/7148</a>:

Case 1:

1. &quot;rotate-90&quot; is received, m_videoSize is transposed, getting vertical video (correct).
2. Default rotation is received, m_videoSize is left unaltered, resulting in playing horizontal
video with vertical video dimensions.

Case 2:

1. &quot;rotate-90&quot; is received, m_videoSize is transposed, getting vertical video (correct).
2. &quot;rotate-270&quot; is received, m_videoSize is wrongly transposed again, resulting in playing vertical video as horizontal video.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::getVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSizeAndOrientationFromCaps):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a42e2bf2a8d3e7107e91efb7de291408b4fa4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112464 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172661 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3246 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110665 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37899 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79628 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26369 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2861 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45870 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7664 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->