### PR TITLE
WebKit::LegacyCustomProtocolManager::didReceiveResponse() should take a specific type for cacheStoragePolicy

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -159,6 +159,7 @@ $(PROJECT_DIR)/Shared/ApplePay/PaymentSetupConfiguration.serialization.in
 $(PROJECT_DIR)/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
 $(PROJECT_DIR)/Shared/Authentication/AuthenticationManager.messages.in
 $(PROJECT_DIR)/Shared/AuxiliaryProcess.messages.in
+$(PROJECT_DIR)/Shared/Cocoa/CacheStoragePolicy.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2010-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -481,6 +481,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/API/APIURL.serialization.in \
 	Shared/API/APIURLRequest.serialization.in \
 	Shared/API/APIURLResponse.serialization.in \
+	Shared/Cocoa/CacheStoragePolicy.serialization.in \
 	Shared/Cocoa/DataDetectionResult.serialization.in \
 	Shared/Cocoa/RevealItem.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \

--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "LegacyCustomProtocolManager.h"
 
+#import "CacheStoragePolicy.h"
 #import "LegacyCustomProtocolManagerMessages.h"
 #import "NetworkProcess.h"
 #import <Foundation/NSURLSession.h>
@@ -190,7 +191,7 @@ void LegacyCustomProtocolManager::didLoadData(LegacyCustomProtocolID customProto
     });
 }
 
-void LegacyCustomProtocolManager::didReceiveResponse(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceResponse& response, uint32_t cacheStoragePolicy)
+void LegacyCustomProtocolManager::didReceiveResponse(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceResponse& response, CacheStoragePolicy cacheStoragePolicy)
 {
     RetainPtr<WKCustomProtocol> protocol = protocolForID(customProtocolID);
     if (!protocol)
@@ -199,7 +200,7 @@ void LegacyCustomProtocolManager::didReceiveResponse(LegacyCustomProtocolID cust
     RetainPtr<NSURLResponse> nsResponse = response.nsURLResponse();
 
     dispatchOnInitializationRunLoop(protocol.get(), ^ {
-        [[protocol client] URLProtocol:protocol.get() didReceiveResponse:nsResponse.get() cacheStoragePolicy:static_cast<NSURLCacheStoragePolicy>(cacheStoragePolicy)];
+        [[protocol client] URLProtocol:protocol.get() didReceiveResponse:nsResponse.get() cacheStoragePolicy:toNSURLCacheStoragePolicy(cacheStoragePolicy)];
     });
 }
 

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@ class ResourceResponse;
 
 namespace WebKit {
 
+enum class CacheStoragePolicy : uint8_t;
 class NetworkProcess;
 struct NetworkProcessCreationParameters;
 
@@ -87,7 +88,7 @@ private:
 
     void didFailWithError(LegacyCustomProtocolID, const WebCore::ResourceError&);
     void didLoadData(LegacyCustomProtocolID, const IPC::DataReference&);
-    void didReceiveResponse(LegacyCustomProtocolID, const WebCore::ResourceResponse&, uint32_t cacheStoragePolicy);
+    void didReceiveResponse(LegacyCustomProtocolID, const WebCore::ResourceResponse&, CacheStoragePolicy);
     void didFinishLoading(LegacyCustomProtocolID);
     void wasRedirectedToRequest(LegacyCustomProtocolID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse);
 

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -259,6 +259,7 @@ list(APPEND WebKit_MESSAGES_IN_FILES
 )
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/Cocoa/CacheStoragePolicy.serialization.in
     Shared/Cocoa/DataDetectionResult.serialization.in
     Shared/Cocoa/RevealItem.serialization.in
     Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in

--- a/Source/WebKit/Shared/Cocoa/CacheStoragePolicy.h
+++ b/Source/WebKit/Shared/Cocoa/CacheStoragePolicy.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if defined(__OBJC__)
+#import <Foundation/NSURLCache.h>
+#endif
+
+namespace WebKit {
+
+enum class CacheStoragePolicy : uint8_t {
+    Allowed = 0,
+    AllowedInMemoryOnly,
+    NotAllowed
+};
+
+#if defined(__OBJC__)
+
+inline NSURLCacheStoragePolicy toNSURLCacheStoragePolicy(CacheStoragePolicy policy)
+{
+    switch (policy) {
+    case CacheStoragePolicy::Allowed:
+        return NSURLCacheStorageAllowed;
+    case CacheStoragePolicy::AllowedInMemoryOnly:
+        return NSURLCacheStorageAllowedInMemoryOnly;
+    case CacheStoragePolicy::NotAllowed:
+        return NSURLCacheStorageNotAllowed;
+    }
+    ASSERT_NOT_REACHED();
+    return NSURLCacheStorageNotAllowed;
+}
+
+inline CacheStoragePolicy toCacheStoragePolicy(NSURLCacheStoragePolicy policy)
+{
+    switch (policy) {
+    case NSURLCacheStorageAllowed:
+        return CacheStoragePolicy::Allowed;
+    case NSURLCacheStorageAllowedInMemoryOnly:
+        return CacheStoragePolicy::AllowedInMemoryOnly;
+    case NSURLCacheStorageNotAllowed:
+        return CacheStoragePolicy::NotAllowed;
+    }
+    ASSERT_NOT_REACHED();
+    return CacheStoragePolicy::NotAllowed;
+}
+
+#endif // defined(__OBJC__)
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/CacheStoragePolicy.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CacheStoragePolicy.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,13 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> LegacyCustomProtocolManager NotRefCounted {
-    DidFailWithError(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceError error)
-    DidLoadData(WebKit::LegacyCustomProtocolID customProtocolID, IPC::DataReference data)
-    DidReceiveResponse(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceResponse response, enum:uint8_t WebKit::CacheStoragePolicy cacheStoragePolicy)
-    DidFinishLoading(WebKit::LegacyCustomProtocolID customProtocolID)
-    WasRedirectedToRequest(WebKit::LegacyCustomProtocolID customProtocolID, WebCore::ResourceRequest request, WebCore::ResourceResponse redirectResponse);
-
-    RegisterScheme(String name)
-    UnregisterScheme(String name)
-}
+header: "CacheStoragePolicy.h"
+enum class WebKit::CacheStoragePolicy : uint8_t {
+    Allowed,
+    AllowedInMemoryOnly,
+    NotAllowed
+};

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "LegacyCustomProtocolManagerClient.h"
 
+#import "CacheStoragePolicy.h"
 #import "DataReference.h"
 #import "LegacyCustomProtocolManagerProxy.h"
 #import <WebCore/ResourceError.h>
@@ -100,7 +101,7 @@
         return;
 
     WebCore::ResourceResponse coreResponse(response);
-    _customProtocolManagerProxy->didReceiveResponse(_customProtocolID, coreResponse, _storagePolicy);
+    _customProtocolManagerProxy->didReceiveResponse(_customProtocolID, coreResponse, WebKit::toCacheStoragePolicy(_storagePolicy));
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
@@ -62,7 +62,7 @@ void LegacyCustomProtocolManagerProxy::wasRedirectedToRequest(LegacyCustomProtoc
     m_networkProcessProxy.send(Messages::LegacyCustomProtocolManager::WasRedirectedToRequest(customProtocolID, request, redirectResponse), 0);
 }
 
-void LegacyCustomProtocolManagerProxy::didReceiveResponse(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceResponse& response, uint32_t cacheStoragePolicy)
+void LegacyCustomProtocolManagerProxy::didReceiveResponse(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceResponse& response, CacheStoragePolicy cacheStoragePolicy)
 {
     m_networkProcessProxy.send(Messages::LegacyCustomProtocolManager::DidReceiveResponse(customProtocolID, response, cacheStoragePolicy), 0);
 }

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@ class ResourceResponse;
 
 namespace WebKit {
 
+enum class CacheStoragePolicy : uint8_t;
 class NetworkProcessProxy;
 
 class LegacyCustomProtocolManagerProxy : public IPC::MessageReceiver {
@@ -57,7 +58,7 @@ public:
     void invalidate();
 
     void wasRedirectedToRequest(LegacyCustomProtocolID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
-    void didReceiveResponse(LegacyCustomProtocolID, const WebCore::ResourceResponse&, uint32_t cacheStoragePolicy);
+    void didReceiveResponse(LegacyCustomProtocolID, const WebCore::ResourceResponse&, CacheStoragePolicy);
     void didLoadData(LegacyCustomProtocolID, const IPC::DataReference&);
     void didFailWithError(LegacyCustomProtocolID, const WebCore::ResourceError&);
     void didFinishLoading(LegacyCustomProtocolID);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -925,6 +925,7 @@
 		41FABD2A1F4DE001006A6C97 /* CacheStorageEngineCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FABD281F4DDFDC006A6C97 /* CacheStorageEngineCache.h */; };
 		41FAF5F51E3C0649001AE678 /* WebRTCResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FAF5F41E3C0641001AE678 /* WebRTCResolver.h */; };
 		41FAF5F81E3C1021001AE678 /* LibWebRTCResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 41FAF5F61E3C0B47001AE678 /* LibWebRTCResolver.h */; };
+		441379612964F10A003C34C6 /* CacheStoragePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */; };
 		442E7BEB27B4586900C69AC1 /* RevealItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 442E7BEA27B4581300C69AC1 /* RevealItem.h */; };
 		4459984222833E8700E61373 /* SyntheticEditingCommandType.h in Headers */ = {isa = PBXBuildFile; fileRef = 4459984122833E6000E61373 /* SyntheticEditingCommandType.h */; };
 		4476EF0925BFC8B7004A0587 /* _WKAppHighlightDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4476EF0825BFC8B7004A0587 /* _WKAppHighlightDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4840,6 +4841,8 @@
 		41FFD2DA275A560B00501BBF /* ServiceWorkerDownloadTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDownloadTask.cpp; sourceTree = "<group>"; };
 		41FFD2DB275A560C00501BBF /* ServiceWorkerDownloadTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDownloadTask.h; sourceTree = "<group>"; };
 		41FFD2DC275A6A9400501BBF /* ServiceWorkerDownloadTask.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ServiceWorkerDownloadTask.messages.in; sourceTree = "<group>"; };
+		4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CacheStoragePolicy.h; sourceTree = "<group>"; };
+		441379602964F0C2003C34C6 /* CacheStoragePolicy.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CacheStoragePolicy.serialization.in; sourceTree = "<group>"; };
 		442E7BE827B4572B00C69AC1 /* RevealItem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RevealItem.mm; sourceTree = "<group>"; };
 		442E7BEA27B4581300C69AC1 /* RevealItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevealItem.h; sourceTree = "<group>"; };
 		4450AEBF1DC3FAE5009943F2 /* SharedMemoryCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedMemoryCocoa.cpp; sourceTree = "<group>"; };
@@ -10524,6 +10527,8 @@
 				52EB68CB279E2145005C98D9 /* ARKitSoftLink.h */,
 				52EB68CC279E2145005C98D9 /* ARKitSoftLink.mm */,
 				1A698F171E4910220064E881 /* AuxiliaryProcessCocoa.mm */,
+				4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */,
+				441379602964F0C2003C34C6 /* CacheStoragePolicy.serialization.in */,
 				CE11AD511CBC482F00681EE5 /* CodeSigning.h */,
 				CE11AD4F1CBC47F800681EE5 /* CodeSigning.mm */,
 				37BEC4DF19491486008B4286 /* CompletionHandlerCallChecker.h */,
@@ -14813,6 +14818,7 @@
 				41897EDA1F415D8A0016FA42 /* CacheStorageEngineConnection.h in Headers */,
 				935BF8002936BF1A00B41326 /* CacheStorageManager.h in Headers */,
 				934CF815294B884C00304F7D /* CacheStorageMemoryStore.h in Headers */,
+				441379612964F10A003C34C6 /* CacheStoragePolicy.h in Headers */,
 				935BF8042936BF1A00B41326 /* CacheStorageRecord.h in Headers */,
 				935BF8072936C9FD00B41326 /* CacheStorageRegistry.h in Headers */,
 				935BF7FF2936BF1A00B41326 /* CacheStorageStore.h in Headers */,


### PR DESCRIPTION
#### 07e9312ccba7cc1c280a7638c4e03030db0aba06
<pre>
WebKit::LegacyCustomProtocolManager::didReceiveResponse() should take a specific type for cacheStoragePolicy
<a href="https://bugs.webkit.org/show_bug.cgi?id=250006">https://bugs.webkit.org/show_bug.cgi?id=250006</a>
&lt;rdar://63360220&gt;

Reviewed by Alex Christensen.

Update LegacyCustomProtocolManager::didReceiveResponse() to use
new WebKit::CacheStoragePolicy enum class instead of uint32_t.
Helper methods are used to convert between CacheStoragePolicy
and NSURLCacheStoragePolicy enum values.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/PlatformMac.cmake:
- Add CacheStoragePolicy.serialization.in to build files.

* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(WebKit::LegacyCustomProtocolManager::didReceiveResponse):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
(WebKit::LegacyCustomProtocolManager::didReceiveResponse):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.messages.in:
- Switch to use WebKit::CacheStoragePolicy.

* Source/WebKit/Shared/Cocoa/CacheStoragePolicy.h: Add.
(WebKit::CacheStoragePolicy):
(WebKit::toNSURLCacheStoragePolicy):
(WebKit::toCacheStoragePolicy):
- Add enum class and conversion functions.

* Source/WebKit/Shared/Cocoa/CacheStoragePolicy.serialization.in: Add.
- Add for IPC.

* Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm:
(-[WKCustomProtocolLoader connection:didReceiveResponse:]):
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp:
(WebKit::LegacyCustomProtocolManagerProxy::didReceiveResponse):
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h:
(WebKit::LegacyCustomProtocolManagerProxy::didReceiveResponse):
- Switch to use WebKit::CacheStoragePolicy.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
- Add CacheStoragePolicy.h and
  CacheStoragePolicy.serialization.in to Xcode project.

Canonical link: <a href="https://commits.webkit.org/258433@main">https://commits.webkit.org/258433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e0b1f35d3afb65563cb5fdf9f9b85e4dd78afeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111291 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2019 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109045 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107739 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92506 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25417 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1857 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44905 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6525 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3041 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->