### PR TITLE
Add support for custom annotations in the CSS BNF syntax

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -667,10 +667,7 @@
                 "custom": "Initial|Inherit",
                 "font-property": true,
                 "high-priority": true,
-                "parser-function": "consumeFontFeatureSettings",
-                "parser-function-requires-value-pool": true,
-                "parser-grammar-unused": "normal | <font-feature-tag>#",
-                "parser-grammar-unused-reason": "Needs support for applying restrictions to <string>."
+                "parser-grammar": "normal | <feature-tag-value>#@(no-single-item-opt)"
             },
             "specification": {
                 "category": "css-fonts-4",
@@ -689,9 +686,7 @@
                 "font-property": true,
                 "high-priority": true,
                 "enable-if": "ENABLE_VARIATION_FONTS",
-                "parser-function": "consumeFontVariationSettings",
-                "parser-grammar-unused": "normal | <font-variation-tag>#",
-                "parser-grammar-unused-reason": "Needs support for applying restrictions to <string>."
+                "parser-grammar": "normal | <variation-tag-value>#@(no-single-item-opt)"
             },
             "specification": {
                 "category": "css-fonts-4",
@@ -9535,10 +9530,7 @@
                     "normal"
                 ],
                 "codegen-properties": {
-                    "parser-function": "consumeFontFeatureSettings",
-                    "parser-function-requires-value-pool": true,
-                    "parser-grammar-unused": "normal | <font-feature-tag>#",
-                    "parser-grammar-unused-reason": "Needs support for applying restrictions to <string>."
+                    "parser-grammar": "normal | <feature-tag-value>#@(no-single-item-opt)"
                 },
                 "specification": {
                     "category": "css-fonts-4",

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1,5 +1,5 @@
 // Copyright 2016 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2023 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -49,9 +49,6 @@
 #include "CSSFontVariantAlternatesValue.h"
 #include "CSSFontVariantLigaturesParser.h"
 #include "CSSFontVariantNumericParser.h"
-#if ENABLE(VARIATION_FONTS)
-#include "CSSFontVariationValue.h"
-#endif
 #include "CSSFunctionValue.h"
 #include "CSSGradientValue.h"
 #include "CSSGridAutoRepeatValue.h"
@@ -5101,50 +5098,6 @@ RefPtr<CSSValue> consumeWillChange(CSSParserTokenRange& range, const CSSParserCo
 
     return values;
 }
-
-#if ENABLE(VARIATION_FONTS)
-
-static RefPtr<CSSValue> consumeFontVariationTag(CSSParserTokenRange& range)
-{
-    if (range.peek().type() != StringToken)
-        return nullptr;
-    
-    auto string = range.consumeIncludingWhitespace().value();
-    
-    FontTag tag;
-    if (string.length() != tag.size())
-        return nullptr;
-    for (unsigned i = 0; i < tag.size(); ++i) {
-        // Limits the range of characters to 0x20-0x7E, following the tag name rules defiend in the OpenType specification.
-        UChar character = string[i];
-        if (character < 0x20 || character > 0x7E)
-            return nullptr;
-        tag[i] = character;
-    }
-    
-    if (range.atEnd())
-        return nullptr;
-
-    auto tagValue = consumeNumberRaw(range);
-    if (!tagValue)
-        return nullptr;
-    
-    return CSSFontVariationValue::create(tag, tagValue->value);
-}
-
-RefPtr<CSSValue> consumeFontVariationSettings(CSSParserTokenRange& range)
-{
-    if (range.peek().id() == CSSValueNormal)
-        return consumeIdent(range);
-    
-    auto settings = consumeCommaSeparatedListWithoutSingleValueOptimization(range, consumeFontVariationTag);
-    if (!settings || !settings->length())
-        return nullptr;
-
-    return settings;
-}
-
-#endif // ENABLE(VARIATION_FONTS)
 
 RefPtr<CSSValue> consumeQuotes(CSSParserTokenRange& range)
 {

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -1,5 +1,5 @@
 // Copyright 2016 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2023 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -223,9 +223,6 @@ bool isSelfPositionOrLeftOrRightKeyword(CSSValueID);
 
 RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeWillChange(CSSParserTokenRange&, const CSSParserContext&);
-#if ENABLE(VARIATION_FONTS)
-RefPtr<CSSValue> consumeFontVariationSettings(CSSParserTokenRange&);
-#endif
 RefPtr<CSSValue> consumeQuotes(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontVariantLigatures(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontVariantEastAsian(CSSParserTokenRange&);

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2021 Metrological Group B.V.
  * Copyright (C) 2021 Igalia S.L.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,12 +62,14 @@ RefPtr<CSSPrimitiveValue> consumeFontStretchKeywordValue(CSSParserTokenRange&, C
 RefPtr<CSSPrimitiveValue> consumeFontStretch(CSSParserTokenRange&, CSSValuePool&);
 RefPtr<CSSValueList> consumeFontFaceUnicodeRange(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontFeatureSettings(CSSParserTokenRange&, CSSValuePool&);
+RefPtr<CSSValue> consumeFeatureTagValue(CSSParserTokenRange&);
 RefPtr<CSSPrimitiveValue> consumeFontFaceFontDisplay(CSSParserTokenRange&, CSSValuePool&);
 
 #if ENABLE(VARIATION_FONTS)
 RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange&, CSSParserMode, CSSValuePool&);
 RefPtr<CSSValue> consumeFontWeightAbsoluteRange(CSSParserTokenRange&, CSSValuePool&);
 RefPtr<CSSValue> consumeFontStretchRange(CSSParserTokenRange&, CSSValuePool&);
+RefPtr<CSSValue> consumeVariationTagValue(CSSParserTokenRange&);
 #endif
 
 #if !ENABLE(VARIATION_FONTS)

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1359,25 +1359,25 @@ class Term:
     @staticmethod
     def wrap_with_multiplier(multiplier, term):
         if multiplier.kind == BNFNodeMultiplier.Kind.ZERO_OR_ONE:
-            return OptionalTerm.wrapping_term(term)
+            return OptionalTerm.wrapping_term(term, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.SPACE_SEPARATED_ZERO_OR_MORE:
-            return UnboundedRepetitionTerm.wrapping_term(term, variation=' ', min=0)
+            return UnboundedRepetitionTerm.wrapping_term(term, variation=' ', min=0, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.SPACE_SEPARATED_ONE_OR_MORE:
-            return UnboundedRepetitionTerm.wrapping_term(term, variation=' ', min=1)
+            return UnboundedRepetitionTerm.wrapping_term(term, variation=' ', min=1, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.SPACE_SEPARATED_EXACT:
-            return FixedSizeRepetitionTerm.wrapping_term(term, variation=' ', size=multiplier.range.min)
+            return FixedSizeRepetitionTerm.wrapping_term(term, variation=' ', size=multiplier.range.min, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.SPACE_SEPARATED_AT_LEAST:
-            return UnboundedRepetitionTerm.wrapping_term(term, variation=' ', min=multiplier.range.min)
+            return UnboundedRepetitionTerm.wrapping_term(term, variation=' ', min=multiplier.range.min, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.SPACE_SEPARATED_BETWEEN:
-            return BoundedRepetitionTerm.wrapping_term(term, variation=' ', min=multiplier.range.min, max=multiplier.range.max)
+            return BoundedRepetitionTerm.wrapping_term(term, variation=' ', min=multiplier.range.min, max=multiplier.range.max, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.COMMA_SEPARATED_ONE_OR_MORE:
-            return UnboundedRepetitionTerm.wrapping_term(term, variation=',', min=1)
+            return UnboundedRepetitionTerm.wrapping_term(term, variation=',', min=1, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.COMMA_SEPARATED_EXACT:
-            return FixedSizeRepetitionTerm.wrapping_term(term, variation=',', size=multiplier.range.min)
+            return FixedSizeRepetitionTerm.wrapping_term(term, variation=',', size=multiplier.range.min, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.COMMA_SEPARATED_AT_LEAST:
-            return UnboundedRepetitionTerm.wrapping_term(term, variation=',', min=multiplier.range.min)
+            return UnboundedRepetitionTerm.wrapping_term(term, variation=',', min=multiplier.range.min, annotation=multiplier.annotation)
         elif multiplier.kind == BNFNodeMultiplier.Kind.COMMA_SEPARATED_BETWEEN:
-            return BoundedRepetitionTerm.wrapping_term(term, variation=' ', min=multiplier.range.min, max=multiplier.range.max)
+            return BoundedRepetitionTerm.wrapping_term(term, variation=',', min=multiplier.range.min, max=multiplier.range.max, annotation=multiplier.annotation)
 
     @staticmethod
     def from_node(node):
@@ -1548,7 +1548,8 @@ class ReferenceTerm:
         BuiltinSchema.Entry("custom-ident", "consumeCustomIdent"),
         BuiltinSchema.Entry("dashed-ident", "consumeDashedIdent"),
         BuiltinSchema.Entry("url", "consumeURL"),
-        BuiltinSchema.Entry("declaration-value", "consumeDeclarationValue")
+        BuiltinSchema.Entry("feature-tag-value", "consumeFeatureTagValue"),
+        BuiltinSchema.Entry("variation-tag-value", "consumeVariationTagValue"),
     )
 
     def __init__(self, name, is_internal, is_function_reference, parameters):
@@ -1782,28 +1783,37 @@ class MatchOneTerm:
 #   e.g. "[ <length> <length> ]" or "[ <length> && <string> && <number> ]"
 #
 class GroupTerm:
-    def __init__(self, subterms, kind):
+    def __init__(self, subterms, kind, annotation):
         self.subterms = subterms
         self.kind = kind
 
+        self._process_annotation(annotation)
+
     def __str__(self):
-        return '[ ' + self.stringify_without_brackets + ' ]'
+        return '[ ' + self.stringified_without_brackets + ' ]'
 
     def __repr__(self):
         return self.__str__()
 
     @property
-    def stringify_without_brackets(self):
+    def stringified_without_brackets(self):
         if self.kind != BNFGroupingNode.Kind.MATCH_ALL_ORDERED:
             join_string = ' ' + str(self.kind.value) + ' '
         else:
             join_string = ' '
         return join_string.join(str(subterm) for subterm in self.subterms)
 
+    def _process_annotation(self, annotation):
+        if not annotation:
+            return
+        # FIXME: Add initialization of annotation state here if/when group specific annotations are needed.
+        for directive in annotation.directives:
+            raise Exception(f"Unknown grouping annotation directive '{directive}'.")
+
     @staticmethod
     def from_node(node):
         assert(type(node) is BNFGroupingNode)
-        return GroupTerm(list(compact_map(lambda member: Term.from_node(member), node.members)), node.kind)
+        return GroupTerm(list(compact_map(lambda member: Term.from_node(member), node.members)), node.kind, node.annotation)
 
     def perform_fixups(self, all_rules):
         self.subterms = [subterm.perform_fixups(all_rules) for subterm in self.subterms]
@@ -1834,8 +1844,10 @@ class GroupTerm:
 #   e.g. "<length>?" or "[ <length> <string> ]?"
 #
 class OptionalTerm:
-    def __init__(self, subterm):
+    def __init__(self, subterm, *, annotation):
         self.subterm = subterm
+
+        self._process_annotation(annotation)
 
     def __str__(self):
         return f"{str(self.subterm)}?"
@@ -1843,9 +1855,15 @@ class OptionalTerm:
     def __repr__(self):
         return self.__str__()
 
+    def _process_annotation(self, annotation):
+        if not annotation:
+            return
+        for directive in annotation.directives:
+            raise Exception(f"Unknown optional term annotation directive '{directive}'.")
+
     @staticmethod
-    def wrapping_term(subterm):
-        return OptionalTerm(subterm)
+    def wrapping_term(subterm, *, annotation):
+        return OptionalTerm(subterm, annotation=annotation)
 
     def perform_fixups(self, all_rules):
         self.subterm = self.subterm.perform_fixups(all_rules)
@@ -1868,20 +1886,22 @@ class OptionalTerm:
 #   e.g. "<length>#" or "<length>+"
 #
 class UnboundedRepetitionTerm:
-    def __init__(self, repeated_term, *, variation, min):
+    def __init__(self, repeated_term, *, variation, min, annotation):
         self.repeated_term = repeated_term
-        self.single_value_optimization = True
         self.variation = variation
         self.min = min
 
+        self.single_value_optimization = True
+        self._process_annotation(annotation)
+
     def __str__(self):
-        return f"{str(self.repeated_term)}{self.suffix}"
+        return str(self.repeated_term) + self.stringified_suffix + self.stringified_annotation
 
     def __repr__(self):
         return self.__str__()
 
     @property
-    def suffix(self):
+    def stringified_suffix(self):
         if self.variation == ' ':
             if self.min == 0:
                 return '*'
@@ -1896,9 +1916,24 @@ class UnboundedRepetitionTerm:
                 return '#{' + str(self.min) + ',}'
         raise Exception(f"Unknown UnboundedRepetitionTerm variation '{self.variation}'")
 
+    @property
+    def stringified_annotation(self):
+        if not self.single_value_optimization:
+            return '@(no-single-item-opt)'
+        return ''
+
+    def _process_annotation(self, annotation):
+        if not annotation:
+            return
+        for directive in annotation.directives:
+            if directive == 'no-single-item-opt':
+                self.single_value_optimization = False
+            else:
+                raise Exception(f"Unknown multiplier annotation directive '{directive}'.")
+
     @staticmethod
-    def wrapping_term(term, *, variation, min):
-        return UnboundedRepetitionTerm(term, variation=variation, min=min)
+    def wrapping_term(term, *, variation, min, annotation):
+        return UnboundedRepetitionTerm(term, variation=variation, min=min, annotation=annotation)
 
     def perform_fixups(self, all_rules):
         self.repeated_term = self.repeated_term.perform_fixups(all_rules)
@@ -1922,29 +1957,37 @@ class UnboundedRepetitionTerm:
 #   e.g. "<length>{1,2}" or "<length>#{3,5}"
 #
 class BoundedRepetitionTerm:
-    def __init__(self, repeated_term, *, variation, min, max):
+    def __init__(self, repeated_term, *, variation, min, max, annotation):
         self.repeated_term = repeated_term
         self.variation = variation
         self.min = min
         self.max = max
 
+        self._process_annotation(annotation)
+
     def __str__(self):
-        return f"{str(self.repeated_term)}{self.suffix}"
+        return str(self.repeated_term) + self.stringified_suffix
 
     def __repr__(self):
         return self.__str__()
 
     @property
-    def suffix(self):
+    def stringified_suffix(self):
         if self.variation == ' ':
             return '{' + str(self.min) + ',' + str(self.max) + '}'
         if self.variation == ',':
             return '#{' + str(self.min) + ',' + str(self.max) + '}'
         raise Exception(f"Unknown BoundedRepetitionTerm variation '{self.variation}'")
 
+    def _process_annotation(self, annotation):
+        if not annotation:
+            return
+        for directive in annotation.directives:
+            raise Exception(f"Unknown bounded repetition term annotation directive '{directive}'.")
+
     @staticmethod
-    def wrapping_term(term, *, variation, min, max):
-        return BoundedRepetitionTerm(term, variation=variation, min=min, max=max)
+    def wrapping_term(term, *, variation, min, max, annotation):
+        return BoundedRepetitionTerm(term, variation=variation, min=min, max=max, annotation=annotation)
 
     def perform_fixups(self, all_rules):
         self.repeated_term = self.repeated_term.perform_fixups(all_rules)
@@ -1968,28 +2011,36 @@ class BoundedRepetitionTerm:
 #   e.g. "<length>{2}" or "<length>#{4}"
 #
 class FixedSizeRepetitionTerm:
-    def __init__(self, repeated_term, *, variation, size):
+    def __init__(self, repeated_term, *, variation, size, annotation):
         self.repeated_term = repeated_term
         self.variation = variation
         self.size = size
 
+        self._process_annotation(annotation)
+
     def __str__(self):
-        return f"{str(self.repeated_term)}{self.suffix}"
+        return str(self.repeated_term) + self.stringified_suffix
 
     def __repr__(self):
         return self.__str__()
 
     @property
-    def suffix(self):
+    def stringified_suffix(self):
         if self.variation == ' ':
             return '{' + str(self.size) + '}'
         if self.variation == ',':
             return '#{' + str(self.size) + '}'
-        raise Exception(f"Unknown BoundedRepetitionTerm variation '{self.variation}'")
+        raise Exception(f"Unknown FixedSizeRepetitionTerm variation '{self.variation}'")
+
+    def _process_annotation(self, annotation):
+        if not annotation:
+            return
+        for directive in annotation.directives:
+            raise Exception(f"Unknown fixed size repetition term annotation directive '{directive}'.")
 
     @staticmethod
-    def wrapping_term(term, *, variation, size):
-        return FixedSizeRepetitionTerm(term, variation=variation, size=size)
+    def wrapping_term(term, *, variation, size, annotation):
+        return FixedSizeRepetitionTerm(term, variation=variation, size=size, annotation=annotation)
 
     def perform_fixups(self, all_rules):
         self.repeated_term = self.repeated_term.perform_fixups(all_rules)
@@ -4355,20 +4406,9 @@ class TermGeneratorReferenceTerm(TermGenerator):
                 if builtin.quirky_colors:
                     return f"{builtin.consume_function_name}({range_string}, {context_string}, {context_string}.mode == HTMLQuirksMode)"
                 return f"{builtin.consume_function_name}({range_string}, {context_string})"
-            elif isinstance(builtin, BuiltinResolutionConsumer):
-                return f"{builtin.consume_function_name}({range_string})"
-            elif isinstance(builtin, BuiltinStringConsumer):
-                return f"{builtin.consume_function_name}({range_string})"
-            elif isinstance(builtin, BuiltinCustomIdentConsumer):
-                return f"{builtin.consume_function_name}({range_string})"
-            elif isinstance(builtin, BuiltinDashedIdentConsumer):
-                return f"{builtin.consume_function_name}({range_string})"
-            elif isinstance(builtin, BuiltinURLConsumer):
-                return f"{builtin.consume_function_name}({range_string})"
-            elif isinstance(builtin, BuiltinDeclarationValueConsumer):
-                return f"{builtin.consume_function_name}({range_string}, {context_string})"
             else:
-                raise Exception(f"Unknown builtin type used: {builtin.name.name}")
+                assert(not self.requires_context)
+                return f"{builtin.consume_function_name}({range_string})"
         else:
             return f"consume{self.term.name.id_without_prefix}({range_string}, {context_string})"
 
@@ -4404,8 +4444,10 @@ class TermGeneratorReferenceTerm(TermGenerator):
                 return False
             elif isinstance(builtin, BuiltinURLConsumer):
                 return False
-            elif isinstance(builtin, BuiltinDeclarationValueConsumer):
-                return True
+            elif isinstance(builtin, BuiltinFeatureTagValueConsumer):
+                return False
+            elif isinstance(builtin, BuiltinVariationTagValueConsumer):
+                return False
             else:
                 raise Exception(f"Unknown builtin type used: {builtin.name.name}")
         else:
@@ -5032,6 +5074,7 @@ class BNFToken(StringEqualingEnum):
     LT      = re.compile(r'<')
     GT      = re.compile(r'>')
     SQUOTE  = re.compile(r'\'')
+    ATPAREN = re.compile(r'@\(')
 
     # Multipliers.
     HASH    = re.compile(r'#')
@@ -5105,6 +5148,20 @@ class BNFRepetitionModifier:
         raise Exception("Unknown repetition kind: {self.kind}")
 
 
+# BNFAnnotations are introduced by trailing '@(foo-bar baz)' and are an
+# extension to the syntax used by CSS, added to allow passing additional
+# metadata to the generators for parser creation.
+class BNFAnnotation:
+    def __init__(self):
+        self.directives = []
+
+    def __str__(self):
+        return '@(' + ' '.join(self.directives) + ')'
+
+    def add_directive(self, directive):
+        self.directives.append(directive)
+
+
 # Node multipliers are introduced by trailing symbols like '#', '+', '*', and '{1,4}'.
 # https://drafts.csswg.org/css-values-4/#component-multipliers
 class BNFNodeMultiplier:
@@ -5123,8 +5180,15 @@ class BNFNodeMultiplier:
     def __init__(self):
         self.kind = None
         self.range = None
+        self.annotation = None
 
     def __str__(self):
+        if self.annotation:
+            return self.stringified_without_annotation + str(self.annotation)
+        return self.stringified_without_annotation
+
+    @property
+    def stringified_without_annotation(self):
         if self.kind == BNFNodeMultiplier.Kind.ZERO_OR_ONE:
             return '?'
         elif self.kind == BNFNodeMultiplier.Kind.SPACE_SEPARATED_ZERO_OR_MORE:
@@ -5148,6 +5212,9 @@ class BNFNodeMultiplier:
         return ''
 
     def add(self, multiplier):
+        if self.annotation:
+            raise Exception("Invalid to stack another multiplier on top of a multiplier that has already received an annotation.")
+
         if self.kind is None:
             if isinstance(multiplier, BNFRepetitionModifier):
                 if multiplier.kind == BNFRepetitionModifier.Kind.EXACT:
@@ -5193,6 +5260,28 @@ class BNFNodeMultiplier:
         elif self.kind == BNFNodeMultiplier.Kind.COMMA_SEPARATED_BETWEEN:
             raise Exception("Invalid to stack another multiplier on top of a comma modifier range multiplier.")
 
+    def add_annotation(self, annotation):
+        if self.annotation:
+            raise Exception("Invalid to add an annotation to a multiplier node that already has an annotation.")
+
+        SUPPORTED_DIRECTIVES = {
+            'no-single-item-opt': {
+                BNFNodeMultiplier.Kind.SPACE_SEPARATED_ZERO_OR_MORE,
+                BNFNodeMultiplier.Kind.SPACE_SEPARATED_ONE_OR_MORE,
+                BNFNodeMultiplier.Kind.SPACE_SEPARATED_AT_LEAST,
+                BNFNodeMultiplier.Kind.COMMA_SEPARATED_ONE_OR_MORE,
+                BNFNodeMultiplier.Kind.COMMA_SEPARATED_AT_LEAST
+            },
+        }
+
+        for directive in annotation.directives:
+            if directive not in SUPPORTED_DIRECTIVES:
+                raise Exception(f"Unknown annotation directive '{directive}' for multiplier '{self}'.")
+            if self.kind not in SUPPORTED_DIRECTIVES[directive]:
+                raise Exception(f"Unsupported annotation directive '{directive}' for multiplier '{self}'.")
+
+        self.annotation = annotation
+
 
 # https://drafts.csswg.org/css-values-4/#component-combinators
 class BNFGroupingNode:
@@ -5207,6 +5296,7 @@ class BNFGroupingNode:
         self.members = []
         self.multiplier = BNFNodeMultiplier()
         self.is_initial = is_initial
+        self.annotation = None
 
     def __str__(self):
         return self.stringified_without_multipliers + str(self.multiplier)
@@ -5232,6 +5322,30 @@ class BNFGroupingNode:
     @property
     def last(self):
         return self.members[-1]
+
+    def add_annotation(self, annotation):
+        if self.multiplier.kind:
+            self.multiplier.add_annotation(annotation)
+            return
+
+        if self.annotation:
+            raise Exception("Invalid to add an annotation to a grouping node that already has an annotation.")
+
+        SUPPORTED_DIRECTIVES = {
+            'primitive-pair': {
+                BNFGroupingNode.Kind.MATCH_ALL_ORDERED,
+                BNFGroupingNode.Kind.MATCH_ALL_ANY_ORDER,
+                BNFGroupingNode.Kind.MATCH_ONE_OR_MORE_ANY_ORDER,
+            },
+        }
+
+        for directive in annotation.directives:
+            if directive not in SUPPORTED_DIRECTIVES:
+                raise Exception(f"Unknown annotation directive '{directive}' for grouping '{self}'.")
+            if self.kind not in SUPPORTED_DIRECTIVES[directive]:
+                raise Exception(f"Unsupported annotation directive '{directive}' for grouping '{self}'.")
+
+        self.annotation = annotation
 
 
 # https://drafts.csswg.org/css-values-4/#functional-notation
@@ -5271,7 +5385,7 @@ class BNFReferenceNode:
             self.max = None
 
         def __str__(self):
-            return f"[{self.min},{self.max}]"
+            return '[' + str(self.min) + ',' + str(self.max) + ']'
 
     def __init__(self, *, is_internal=False):
         self.name = None
@@ -5279,6 +5393,7 @@ class BNFReferenceNode:
         self.is_function_reference = False
         self.attributes = []
         self.multiplier = BNFNodeMultiplier()
+        self.annotation = None
 
     def __str__(self):
         return self.stringified_without_multipliers + str(self.multiplier)
@@ -5304,11 +5419,28 @@ class BNFReferenceNode:
     def add_attribute(self, attribute):
         self.attributes.append(attribute)
 
+    def add_annotation(self, annotation):
+        if self.multiplier.kind:
+            self.multiplier.add_annotation(annotation)
+            return
+
+        if self.annotation:
+            raise Exception("Invalid to add an annotation to a reference node that already has an annotation.")
+
+        SUPPORTED_DIRECTIVES = {}
+
+        for directive in annotation.directives:
+            if directive not in SUPPORTED_DIRECTIVES:
+                raise Exception(f"Unknown annotation directive '{directive}' for reference node '{self}'.")
+
+        self.annotation = annotation
+
 
 class BNFKeywordNode:
     def __init__(self, keyword):
         self.keyword = keyword
         self.multiplier = BNFNodeMultiplier()
+        self.annotation = None
 
     def __str__(self):
         return self.stringified_without_multipliers + str(self.multiplier)
@@ -5317,11 +5449,28 @@ class BNFKeywordNode:
     def stringified_without_multipliers(self):
         return self.keyword
 
+    def add_annotation(self, annotation):
+        if self.multiplier.kind:
+            self.multiplier.add_annotation(annotation)
+            return
+
+        if self.annotation:
+            raise Exception("Invalid to add an annotation to a keyword node that already has an annotation.")
+
+        SUPPORTED_DIRECTIVES = {}
+
+        for directive in annotation.directives:
+            if directive not in SUPPORTED_DIRECTIVES:
+                raise Exception(f"Unknown annotation directive '{directive}' for keyword '{self}'.")
+
+        self.annotation = annotation
+
 
 class BNFLiteralNode:
     def __init__(self, value=None):
         self.value = value
         self.multiplier = BNFNodeMultiplier()
+        self.annotation = None
 
     def __str__(self):
         return self.stringified_without_multipliers + str(self.multiplier)
@@ -5329,6 +5478,22 @@ class BNFLiteralNode:
     @property
     def stringified_without_multipliers(self):
         return str(self.value)
+
+    def add_annotation(self, annotation):
+        if self.multiplier.kind:
+            self.multiplier.add_annotation(annotation)
+            return
+
+        if self.annotation:
+            raise Exception("Invalid to add an annotation to a literal node that already has an annotation.")
+
+        SUPPORTED_DIRECTIVES = {}
+
+        for directive in annotation.directives:
+            if directive not in SUPPORTED_DIRECTIVES:
+                raise Exception(f"Unknown annotation directive '{directive}' for literal '{self}'.")
+
+        self.annotation = annotation
 
 
 class BNFParserState(enum.Enum):
@@ -5352,6 +5517,8 @@ class BNFParserState(enum.Enum):
     REPETITION_MODIFIER_SEEN_MAX = enum.auto()
     QUOTED_LITERAL_INITIAL = enum.auto()
     QUOTED_LITERAL_SEEN_ID = enum.auto()
+    ANNOTATION_INITIAL = enum.auto()
+    ANNOTATION_SEEN_ID = enum.auto()
     DONE = enum.auto()
 
 
@@ -5411,6 +5578,8 @@ class BNFParser:
             BNFParserState.REPETITION_MODIFIER_SEEN_MAX: BNFParser.parse_REPETITION_MODIFIER_SEEN_MAX,
             BNFParserState.QUOTED_LITERAL_INITIAL: BNFParser.parse_QUOTED_LITERAL_INITIAL,
             BNFParserState.QUOTED_LITERAL_SEEN_ID: BNFParser.parse_QUOTED_LITERAL_SEEN_ID,
+            BNFParserState.ANNOTATION_INITIAL: BNFParser.parse_ANNOTATION_INITIAL,
+            BNFParserState.ANNOTATION_SEEN_ID: BNFParser.parse_ANNOTATION_SEEN_ID,
         }
 
         for token in BNFLexer(self.data):
@@ -5513,12 +5682,21 @@ class BNFParser:
         self.pop()
         self.top.node.add_attribute(state.node)
 
+    # BNFLiteralNode. e.g. '['
     def enter_new_quoted_literal(self, token, state):
         self.push(BNFParserState.QUOTED_LITERAL_INITIAL, BNFLiteralNode())
 
     def exit_quoted_literal(self, token, state):
         self.pop()
         self.top.node.add(state.node)
+
+    # BNFAnnotation. e.g. @(foo-bar baz)
+    def enter_new_annotation(self, token, state):
+        self.push(BNFParserState.ANNOTATION_INITIAL, BNFAnnotation())
+
+    def exit_annotation(self, token, state):
+        self.pop()
+        self.top.node.last.add_annotation(state.node)
 
     # MARK: Parsing Thunks.
 
@@ -5622,6 +5800,10 @@ class BNFParser:
             state.node.last.multiplier.add(token.value)
             return
 
+        if token.name == BNFToken.ATPAREN:
+            self.enter_new_annotation(token, state)
+            return
+
         if token.name == BNFToken.LBRACE:
             self.enter_new_repetition_modifier(token, state)
             return
@@ -5671,6 +5853,10 @@ class BNFParser:
 
         if token.name in BNFParser.SIMPLE_MULTIPLIERS:
             state.node.last.multiplier.add(token.value)
+            return
+
+        if token.name == BNFToken.ATPAREN:
+            self.enter_new_annotation(token, state)
             return
 
         raise self.unexpected(token, state)
@@ -5728,6 +5914,10 @@ class BNFParser:
 
         if token.name in BNFParser.SIMPLE_MULTIPLIERS:
             state.node.last.multiplier.add(token.value)
+            return
+
+        if token.name == BNFToken.ATPAREN:
+            self.enter_new_annotation(token, state)
             return
 
         if token.name == BNFToken.LBRACE:
@@ -5880,6 +6070,25 @@ class BNFParser:
 
         # Append the value regardles of the token value.
         state.node.value = state.node.value + token.value
+
+    def parse_ANNOTATION_INITIAL(self, token, state):
+        if token.name == BNFToken.ID:
+            self.transition_top(to=BNFParserState.ANNOTATION_SEEN_ID)
+            state.node.add_directive(token.value)
+            return
+
+        raise self.unexpected(token, state)
+
+    def parse_ANNOTATION_SEEN_ID(self, token, state):
+        if token.name == BNFToken.ID:
+            state.node.add_directive(token.value)
+            return
+
+        if token.name == BNFToken.RPAREN:
+            self.exit_annotation(token, state)
+            return
+
+        raise self.unexpected(token, state)
 
 
 def main():


### PR DESCRIPTION
#### 78551d0c1acbf2e69884ad14f993d45f4ca1caed
<pre>
Add support for custom annotations in the CSS BNF syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=250010">https://bugs.webkit.org/show_bug.cgi?id=250010</a>
rdar://103817055

Reviewed by Simon Fraser.

Adds suppport for a custom syntax to annotate the CSS property grammar
BNF to allow passing additional information to the generators on a per
term basis. The syntax is of the form `@(foo-bar baz)`. That is an &apos;@&apos;
symbol followed by a space separated list of identifiers inside a pair
of parentheses.

In this initial commit, it is used to annotate a &apos;#&apos; multiplier as:

  &quot;normal | &lt;variation-tag-value&gt;#@(no-single-item-opt)&quot;

This will tell the code generators to not use the default behavior of
stashing a single item list as the item itself, but rather to always
return a list.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontVariationTag): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFontVariationSettings): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontTag):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFeatureTagValue):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFeatureSettings):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeVariationTagValue):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFeatureTag): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h:
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/258410@main">https://commits.webkit.org/258410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d89f50f34e0891b5d67cc9f5aaee18fdd8ed674

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111208 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1936 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107653 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1788 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5767 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6446 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->