### PR TITLE
Improve StringTypeAdapter templates and handling

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -95,7 +95,7 @@ Ref<JSON::Value> InjectedScriptBase::makeCall(Deprecated::ScriptFunctionCall& fu
 
     auto resultJSONValue = toInspectorValue(globalObject, value);
     if (!resultJSONValue)
-        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')'));
+        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", unsigned(JSON::Value::maxDepth), ')'));
 
     return resultJSONValue.releaseNonNull();
 }
@@ -125,7 +125,7 @@ void InjectedScriptBase::makeAsyncCall(Deprecated::ScriptFunctionCall& function,
             else if (auto resultJSONValue = toInspectorValue(globalObject, callFrame->argument(0)))
                 checkAsyncCallResult(resultJSONValue, callback);
             else
-                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')')), callback);
+                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", unsigned(JSON::Value::maxDepth), ')')), callback);
             return JSC::JSValue::encode(JSC::jsUndefined());
         });
     }

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -51,8 +51,8 @@ public:
     {
     }
 
-    unsigned length() { return 1; }
-    bool is8Bit() { return true; }
+    unsigned length() const { return 1; }
+    bool is8Bit() const { return true; }
     template<typename CharacterType> void writeTo(CharacterType* destination) const { *destination = m_character; }
 
 private:
@@ -148,104 +148,26 @@ public:
     }
 };
 
-template<> class StringTypeAdapter<ASCIILiteral, void> : public StringTypeAdapter<const char*, void> {
+template<> class StringTypeAdapter<StringView, void> {
 public:
-    StringTypeAdapter(ASCIILiteral characters)
-        : StringTypeAdapter<const char*, void> { characters }
-    {
-    }
-};
-
-template<typename CharType, size_t N>
-class StringTypeAdapter<Vector<CharType, N>, void> {
-public:
-    using CharTypeForString = std::conditional_t<sizeof(CharType) == sizeof(LChar), LChar, UChar>;
-    static_assert(sizeof(CharTypeForString) == sizeof(CharType));
-
-    StringTypeAdapter(const Vector<CharType, N>& vector)
-        : m_vector { vector }
-    {
-    }
-
-    size_t length() const { return m_vector.size(); }
-    bool is8Bit() const { return sizeof(CharType) == 1; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, characters(), length()); }
-
-private:
-    const CharTypeForString* characters() const
-    {
-        return reinterpret_cast<const CharTypeForString*>(m_vector.data());
-    }
-
-    const Vector<CharType, N>& m_vector;
-};
-
-template<> class StringTypeAdapter<StringImpl*, void> {
-public:
-    StringTypeAdapter(StringImpl* string)
-        : m_string { string }
-    {
-    }
-
-    unsigned length() const { return m_string ? m_string->length() : 0; }
-    bool is8Bit() const { return !m_string || m_string->is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
-    {
-        StringView { m_string }.getCharacters(destination);
-        WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING();
-    }
-
-private:
-    StringImpl* const m_string;
-};
-
-template<> class StringTypeAdapter<AtomStringImpl*, void> : public StringTypeAdapter<StringImpl*, void> {
-public:
-    StringTypeAdapter(AtomStringImpl* string)
-        : StringTypeAdapter<StringImpl*, void> { static_cast<StringImpl*>(string) }
-    {
-    }
-};
-
-template<> class StringTypeAdapter<String, void> : public StringTypeAdapter<StringImpl*, void> {
-public:
-    StringTypeAdapter(const String& string)
-        : StringTypeAdapter<StringImpl*, void> { string.impl() }
-    {
-    }
-};
-
-template<> class StringTypeAdapter<AtomString, void> : public StringTypeAdapter<String, void> {
-public:
-    StringTypeAdapter(const AtomString& string)
-        : StringTypeAdapter<String, void> { string.string() }
-    {
-    }
-};
-
-template<> class StringTypeAdapter<StringImpl&, void> {
-public:
-    StringTypeAdapter(StringImpl& string)
+    StringTypeAdapter(const StringView& string)
         : m_string { string }
     {
     }
 
     unsigned length() const { return m_string.length(); }
     bool is8Bit() const { return m_string.is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
-    {
-        StringView { m_string }.getCharacters(destination);
-        WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING();
-    }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { m_string.getCharacters(destination); }
 
 private:
-    StringImpl& m_string;
+    StringView m_string;
 };
 
-template<> class StringTypeAdapter<AtomStringImpl&, void> : public StringTypeAdapter<StringImpl&, void> {
+template<typename T>
+class StringTypeAdapter<T, std::enable_if_t<std::is_constructible_v<StringView, const T&>>> : public StringTypeAdapter<StringView, void> {
 public:
-    StringTypeAdapter(StringImpl& string)
-        : StringTypeAdapter<StringImpl&, void> { string }
+    StringTypeAdapter(const T& string)
+        : StringTypeAdapter<StringView, void> { StringView { string } }
     {
     }
 };
@@ -358,17 +280,17 @@ public:
     {
     }
 
-    unsigned length()
+    unsigned length() const
     {
         return m_indentation.value * N;
     }
 
-    bool is8Bit()
+    bool is8Bit() const
     {
         return true;
     }
 
-    template<typename CharacterType> void writeTo(CharacterType* destination)
+    template<typename CharacterType> void writeTo(CharacterType* destination) const
     {
         std::fill_n(destination, m_indentation.value * N, ' ');
     }
@@ -410,33 +332,24 @@ private:
     const ASCIICaseConverter& m_converter;
 };
 
-template<typename Adapter>
-inline bool are8Bit(Adapter adapter)
+template<typename... Adapters>
+inline bool are8Bit(const Adapters&... adapters)
 {
-    return adapter.is8Bit();
+    return (... && adapters.is8Bit());
 }
 
-template<typename Adapter, typename... Adapters>
-inline bool are8Bit(Adapter adapter, Adapters ...adapters)
+template<typename ResultType, typename... Adapters>
+inline void stringTypeAdapterAccumulator(ResultType* result, const Adapters&... adapters)
 {
-    return adapter.is8Bit() && are8Bit(adapters...);
+    unsigned offset = 0;
+    (..., [&] {
+        adapters.writeTo(result + offset);
+        offset += adapters.length();
+    }());
 }
 
-template<typename ResultType, typename Adapter>
-inline void stringTypeAdapterAccumulator(ResultType* result, Adapter adapter)
-{
-    adapter.writeTo(result);
-}
-
-template<typename ResultType, typename Adapter, typename... Adapters>
-inline void stringTypeAdapterAccumulator(ResultType* result, Adapter adapter, Adapters ...adapters)
-{
-    adapter.writeTo(result);
-    stringTypeAdapterAccumulator(result + adapter.length(), adapters...);
-}
-
-template<typename StringTypeAdapter, typename... StringTypeAdapters>
-RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool areAllAdapters8Bit, StringTypeAdapter adapter, StringTypeAdapters ...adapters)
+template<typename... StringTypeAdapters>
+RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool areAllAdapters8Bit, const StringTypeAdapters&... adapters)
 {
     ASSERT(length <= String::MaxLength);
     if (areAllAdapters8Bit) {
@@ -446,7 +359,7 @@ RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool a
             return nullptr;
 
         if (buffer)
-            stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+            stringTypeAdapterAccumulator(buffer, adapters...);
 
         return resultImpl;
     }
@@ -457,37 +370,37 @@ RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool a
         return nullptr;
 
     if (buffer)
-        stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+        stringTypeAdapterAccumulator(buffer, adapters...);
 
     return resultImpl;
 }
 
 template<typename Func, typename... StringTypes>
-auto handleWithAdapters(Func&& func, StringTypes&& ...strings) -> decltype(auto)
+auto handleWithAdapters(Func&& func, const StringTypes&... strings) -> decltype(auto)
 {
-    return func(StringTypeAdapter<StringTypes>(std::forward<StringTypes>(strings))...);
+    return func(StringTypeAdapter<StringTypes>(strings)...);
 }
 
-template<typename StringTypeAdapter, typename... StringTypeAdapters>
-String tryMakeStringFromAdapters(StringTypeAdapter adapter, StringTypeAdapters ...adapters)
+template<typename... StringTypeAdapters>
+String tryMakeStringFromAdapters(const StringTypeAdapters&... adapters)
 {
     static_assert(String::MaxLength == std::numeric_limits<int32_t>::max());
-    auto sum = checkedSum<int32_t>(adapter.length(), adapters.length()...);
+    auto sum = checkedSum<int32_t>(adapters.length()...);
     if (sum.hasOverflowed())
         return String();
 
-    bool areAllAdapters8Bit = are8Bit(adapter, adapters...);
-    return tryMakeStringImplFromAdaptersInternal(sum, areAllAdapters8Bit, adapter, adapters...);
+    bool areAllAdapters8Bit = are8Bit(adapters...);
+    return tryMakeStringImplFromAdaptersInternal(sum, areAllAdapters8Bit, adapters...);
 }
 
 template<typename... StringTypes>
-String tryMakeString(StringTypes ...strings)
+String tryMakeString(const StringTypes&... strings)
 {
     return tryMakeStringFromAdapters(StringTypeAdapter<StringTypes>(strings)...);
 }
 
 template<typename... StringTypes>
-String makeString(StringTypes... strings)
+String makeString(const StringTypes&... strings)
 {
     String result = tryMakeString(strings...);
     if (!result)
@@ -495,40 +408,40 @@ String makeString(StringTypes... strings)
     return result;
 }
 
-template<typename StringTypeAdapter, typename... StringTypeAdapters>
-AtomString tryMakeAtomStringFromAdapters(StringTypeAdapter adapter, StringTypeAdapters ...adapters)
+template<typename... StringTypeAdapters>
+AtomString tryMakeAtomStringFromAdapters(const StringTypeAdapters&... adapters)
 {
     static_assert(String::MaxLength == std::numeric_limits<int32_t>::max());
-    auto sum = checkedSum<int32_t>(adapter.length(), adapters.length()...);
+    auto sum = checkedSum<int32_t>(adapters.length()...);
     if (sum.hasOverflowed())
         return AtomString();
 
     unsigned length = sum;
     ASSERT(length <= String::MaxLength);
 
-    bool areAllAdapters8Bit = are8Bit(adapter, adapters...);
+    bool areAllAdapters8Bit = are8Bit(adapters...);
     constexpr size_t maxLengthToUseStackVariable = 64;
     if (length < maxLengthToUseStackVariable) {
         if (areAllAdapters8Bit) {
             LChar buffer[maxLengthToUseStackVariable];
-            stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+            stringTypeAdapterAccumulator(buffer, adapters...);
             return AtomString { buffer, length };
         }
         UChar buffer[maxLengthToUseStackVariable];
-        stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+        stringTypeAdapterAccumulator(buffer, adapters...);
         return AtomString { buffer, length };
     }
-    return tryMakeStringImplFromAdaptersInternal(length, areAllAdapters8Bit, adapter, adapters...).get();
+    return tryMakeStringImplFromAdaptersInternal(length, areAllAdapters8Bit, adapters...).get();
 }
 
 template<typename... StringTypes>
-AtomString tryMakeAtomString(StringTypes ...strings)
+AtomString tryMakeAtomString(const StringTypes&... strings)
 {
     return tryMakeAtomStringFromAdapters(StringTypeAdapter<StringTypes>(strings)...);
 }
 
 template<typename... StringTypes>
-AtomString makeAtomString(StringTypes... strings)
+AtomString makeAtomString(const StringTypes&... strings)
 {
     AtomString result = tryMakeAtomString(strings...);
     if (result.isNull())

--- a/Source/WTF/wtf/text/StringOperators.h
+++ b/Source/WTF/wtf/text/StringOperators.h
@@ -46,14 +46,14 @@ public:
         return AtomString(operator String());
     }
 
-    bool is8Bit()
+    bool is8Bit() const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
         return adapter1.is8Bit() && adapter2.is8Bit();
     }
 
-    void writeTo(LChar* destination)
+    void writeTo(LChar* destination) const
     {
         ASSERT(is8Bit());
         StringTypeAdapter<StringType1> adapter1(m_string1);
@@ -62,7 +62,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    void writeTo(UChar* destination)
+    void writeTo(UChar* destination) const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -70,7 +70,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    unsigned length()
+    unsigned length() const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -85,7 +85,7 @@ private:
 template<typename StringType1, typename StringType2>
 class StringTypeAdapter<StringAppend<StringType1, StringType2>> {
 public:
-    StringTypeAdapter(StringAppend<StringType1, StringType2>& buffer)
+    StringTypeAdapter(const StringAppend<StringType1, StringType2>& buffer)
         : m_buffer { buffer }
     {
     }
@@ -95,7 +95,7 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { m_buffer.writeTo(destination); }
 
 private:
-    StringAppend<StringType1, StringType2>& m_buffer;
+    const StringAppend<StringType1, StringType2>& m_buffer;
 };
 
 inline StringAppend<const char*, String> operator+(const char* string1, const String& string2)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -67,11 +67,21 @@ public:
     StringView(const LChar*, unsigned length);
     StringView(const UChar*, unsigned length);
     StringView(const char*, unsigned length);
-    StringView(ASCIILiteral);
-    ALWAYS_INLINE StringView(Span<const LChar> characters) : StringView(characters.data(), characters.size()) { }
-    ALWAYS_INLINE StringView(Span<const UChar> characters) : StringView(characters.data(), characters.size()) { }
+    StringView(const ASCIILiteral&);
+    ALWAYS_INLINE StringView(const Span<const LChar>& characters) : StringView(characters.data(), characters.size()) { }
+    ALWAYS_INLINE StringView(const Span<const UChar>& characters) : StringView(characters.data(), characters.size()) { }
 
-    ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
+    template<typename CharType, size_t N>
+    StringView(const CharType(&characters)[N])
+        : StringView { characters, N - 1 }
+    {
+        ASSERT(!characters[N - 1]);
+    }
+
+    ALWAYS_INLINE static StringView fromLatin1(const char* characters)
+    {
+        return { characters, static_cast<unsigned>(characters ? strlen(characters) : 0) };
+    }
 
     static StringView empty();
 
@@ -196,9 +206,6 @@ public:
     struct UnderlyingString;
 
 private:
-    // Clients should use StringView(ASCIILiteral) or StringView::fromLatin1() instead.
-    explicit StringView(const char*);
-
     friend bool equal(StringView, StringView);
     friend bool equal(StringView, StringView, unsigned length);
     friend WTF_EXPORT_PRIVATE bool equalRespectingNullity(StringView, StringView);
@@ -372,17 +379,12 @@ inline StringView::StringView(const UChar* characters, unsigned length)
     initialize(characters, length);
 }
 
-inline StringView::StringView(const char* characters)
-{
-    initialize(reinterpret_cast<const LChar*>(characters), characters ? strlen(characters) : 0);
-}
-
 inline StringView::StringView(const char* characters, unsigned length)
 {
     initialize(reinterpret_cast<const LChar*>(characters), length);
 }
 
-inline StringView::StringView(ASCIILiteral string)
+inline StringView::StringView(const ASCIILiteral& string)
 {
     initialize(string.characters8(), string.length());
 }
@@ -673,21 +675,6 @@ inline void StringView::invalidate(const StringImpl&)
 }
 
 #endif
-
-template<> class StringTypeAdapter<StringView, void> {
-public:
-    StringTypeAdapter(StringView string)
-        : m_string { string }
-    {
-    }
-
-    unsigned length() { return m_string.length(); }
-    bool is8Bit() { return m_string.is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) { m_string.getCharacters(destination); }
-
-private:
-    StringView m_string;
-};
 
 template<typename CharacterType, size_t inlineCapacity> void append(Vector<CharacterType, inlineCapacity>& buffer, StringView string)
 {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -387,7 +387,7 @@ void AXIsolatedTree::updatePropertiesForSelfAndDescendants(AXCoreObject& axObjec
 void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const Vector<AXPropertyName>& properties)
 {
     AXTRACE("AXIsolatedTree::updateNodeProperties"_s);
-    AXLOG(makeString("Updating properties ", properties, " for objectID ", axObject.objectID().loggingString()));
+    AXLOG(makeString("Updating properties ", Span { reinterpret_cast<const UChar*>(properties.data()), properties.size() }, " for objectID ", axObject.objectID().loggingString()));
     ASSERT(isMainThread());
 
     AXPropertyMap propertyMap;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -108,7 +108,7 @@ public:
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
     // FIXME: When this is incremented, remove LegacyCertificateInfoType.
-    static const unsigned version = 16;
+    static constexpr unsigned version = 16;
 
     String basePathIsolatedCopy() const;
     String versionPath() const;


### PR DESCRIPTION
#### bd28677dcc291ac6b56dfbd517849f993ea6f9fa
<pre>
Improve StringTypeAdapter templates and handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=250017">https://bugs.webkit.org/show_bug.cgi?id=250017</a>

Reviewed by NOBODY (OOPS!).

StringConcatenate&apos;s makeString() and makeAtomString() are adjusted to accept
arguments as const lvalue references, propagating them down to each
StringTypeAdapter object without unnecessary copies. Similarly, the adapter
objects too are handled through const lvalue references once constructed and
passed on.

Newly-imposed constness requires additional const qualifiers on common methods
across different StringTypeAdapter specializations.

The are8Bit() and stringTypeAdapterAccumulator() helper functions are simplified
through using parameter packs and fold expressions to perform the necessary
operations across a range of adapter objects.

StringTypeAdapter specialization for StringView is moved from the StringView
header into the StringConcatenate header. A new partial specialization for the
StringTypeAdapter template is added, conditionally enabled if a const reference
of the specified type can be used to construct a StringView object. This
specialization inherits from the StringView specialization, hence a StringView
is constructed for such objects.

An exception for this partial specialization are character string literals whose
type is reduced to a fixed-length C array. These for the moment require a
separate specialization in order to avoid implicitly creating a String object
that&apos;s then used for the StringView. The fixed-length array data is instead
passed to the partial specializations handling string pointers, in order to
pass the data through string-length computation and getting the correct length.
This avoids potential problems with fixed-length arrays with inflated size that
are used as buffers for string data that&apos;s otherwise null-terminated at some
previous position.

This enables removing a bunch of other StringTypeAdapter specializations.
Different WTF string and impl types can be used to construct the StringView,
as well as ASCIILiteral. For Vectors of character values, a corresponding Span
can be implicitly constructed and is then used for StringView construction.

In StringView, constructors taking in ASCIILiteral or Span are adjusted to
handle const lvalue references of those objects.

Different static integer values can now end up generating undesired symbols when
handled through references in calls to makeString() and makeAtomString(). This
can be avoided by explicitly copying the passed-in value.

* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::makeCall):
(Inspector::InjectedScriptBase::makeAsyncCall):
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::are8Bit):
(WTF::stringTypeAdapterAccumulator):
(WTF::tryMakeStringImplFromAdaptersInternal):
(WTF::handleWithAdapters):
(WTF::tryMakeStringFromAdapters):
(WTF::tryMakeString):
(WTF::makeString):
(WTF::tryMakeAtomStringFromAdapters):
(WTF::tryMakeAtomString):
(WTF::makeAtomString):
* Source/WTF/wtf/text/StringOperators.h:
(WTF::StringAppend::is8Bit const):
(WTF::StringAppend::writeTo const):
(WTF::StringAppend::length const):
(WTF::StringAppend::is8Bit): Deleted.
(WTF::StringAppend::writeTo): Deleted.
(WTF::StringAppend::length): Deleted.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
</pre>