### PR TITLE
Fix up copy-prone uses of std::tuple structured binding

### DIFF
--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -849,7 +849,7 @@ void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelectio
             if (selection.start().deprecatedNode() != element->userAgentShadowRoot())
                 return;
 
-            auto [selectionStart, selectionEnd, selectionDirection] = selectionState;
+            auto& [selectionStart, selectionEnd, selectionDirection] = selectionState;
             element->setSelectionRange(selectionStart, selectionEnd, selectionDirection);
         });
     }

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -348,7 +348,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData)
     addToMap(classRules, selectorFeatures.classes, &classesAffectingHost);
 
     for (auto& entry : selectorFeatures.attributes) {
-        auto [selector, matchElement, isNegation] = entry;
+        auto& [selector, matchElement, isNegation] = entry;
         attributeRules.ensure(selector->attribute().localName().convertToASCIILowercase(), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
         }).iterator->value->append({ ruleData, matchElement, isNegation, selector });
@@ -358,7 +358,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData)
     }
 
     for (auto& entry : selectorFeatures.pseudoClasses) {
-        auto [selector, matchElement, isNegation] = entry;
+        auto& [selector, matchElement, isNegation] = entry;
         pseudoClassRules.ensure(makePseudoClassInvalidationKey(selector->pseudoClassType(), *selector), [] {
             return makeUnique<Vector<RuleFeature>>();
         }).iterator->value->append({ ruleData, matchElement, isNegation });
@@ -371,7 +371,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData)
     }
 
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
-        auto [selector, matchElement, isNegation] = entry;
+        auto& [selector, matchElement, isNegation] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
         hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClassHas, *selector), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -102,7 +102,7 @@ void PrefetchCache::clearExpiredEntries()
 {
     auto timeout = WallTime::now();
     while (!m_sessionExpirationList.isEmpty()) {
-        auto [requestUrl, timestamp] = m_sessionExpirationList.first();
+        auto& [requestUrl, timestamp] = m_sessionExpirationList.first();
         auto* resources = m_sessionPrefetches.get();
         ASSERT(resources);
         ASSERT(resources->contains(requestUrl));


### PR DESCRIPTION
#### d0b38ae861c77ada6620bfd3ed3642956e6f9114
<pre>
Fix up copy-prone uses of std::tuple structured binding
<a href="https://bugs.webkit.org/show_bug.cgi?id=250018">https://bugs.webkit.org/show_bug.cgi?id=250018</a>

Reviewed by Carlos Garcia Campos.

Adjust a few places where structured binding is used on std::tuple objects,
using a lvalue-reference-qualified auto specifier to reference the objects
inside the existing tuple rather than copying the whole tuple and retrieving the
objects from that.

* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createContainer):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp:
(WebKit::PrefetchCache::clearExpiredEntries):

Canonical link: <a href="https://commits.webkit.org/258385@main">https://commits.webkit.org/258385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa29efc8910535be94ed2a96097dff554a1ea52f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111127 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171333 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1853 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108888 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92360 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90988 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1725 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5742 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6366 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->