### PR TITLE
AccessibilityObjectAtspi::textAttributes() should move attributes HashMap into the returning struct

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -827,37 +827,37 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
 
     auto defaultAttributes = accessibilityTextAttributes(m_coreObject, { });
     if (!utf16Offset)
-        return { defaultAttributes, -1, -1 };
+        return { WTFMove(defaultAttributes), -1, -1 };
 
     if (is<RenderListMarker>(*m_coreObject->renderer()))
-        return { defaultAttributes, 0, static_cast<int>(m_coreObject->stringValue().length()) };
+        return { WTFMove(defaultAttributes), 0, static_cast<int>(m_coreObject->stringValue().length()) };
 
     if (!m_coreObject->node())
-        return { defaultAttributes, -1, -1 };
+        return { WTFMove(defaultAttributes), -1, -1 };
 
     if (!*utf16Offset && m_hasListMarkerAtStart) {
         // Always consider list marker an independent run.
         auto attributes = accessibilityTextAttributes(m_coreObject->children()[0].get(), defaultAttributes);
         if (!includeDefault)
-            return { attributes, 0, 1 };
+            return { WTFMove(attributes), 0, 1 };
 
         for (const auto& it : attributes)
             defaultAttributes.set(it.key, it.value);
-        return { defaultAttributes, 0, 1 };
+        return { WTFMove(defaultAttributes), 0, 1 };
     }
 
     VisiblePosition offsetPosition = m_coreObject->visiblePositionForIndex(adjustInputOffset(*utf16Offset, m_hasListMarkerAtStart));
     auto* childNode = offsetPosition.deepEquivalent().deprecatedNode();
     if (!childNode)
-        return { defaultAttributes, -1, -1 };
+        return { WTFMove(defaultAttributes), -1, -1 };
 
     auto* childRenderer = childNode->renderer();
     if (!childRenderer)
-        return { defaultAttributes, -1, -1 };
+        return { WTFMove(defaultAttributes), -1, -1 };
 
     auto* childAxObject = childRenderer->document().axObjectCache()->get(childRenderer);
     if (!childAxObject || childAxObject == m_coreObject)
-        return { defaultAttributes, -1, -1 };
+        return { WTFMove(defaultAttributes), -1, -1 };
 
     auto attributes = accessibilityTextAttributes(childAxObject, defaultAttributes);
     auto firstValidPosition = firstPositionInOrBeforeNode(m_coreObject->node()->firstDescendant());
@@ -894,12 +894,12 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
     auto startOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(startPosition), m_hasListMarkerAtStart);
     auto endOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(endPosition), m_hasListMarkerAtStart);
     if (!includeDefault)
-        return { attributes, startOffset, endOffset };
+        return { WTFMove(attributes), startOffset, endOffset };
 
     for (const auto& it : attributes)
         defaultAttributes.set(it.key, it.value);
 
-    return { defaultAttributes, startOffset, endOffset };
+    return { WTFMove(defaultAttributes), startOffset, endOffset };
 }
 
 AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttributesWithUTF8Offset(std::optional<int> offset, bool includeDefault) const


### PR DESCRIPTION
#### a910306f1de52119a900d570b630b03e609ab031
<pre>
AccessibilityObjectAtspi::textAttributes() should move attributes HashMap into the returning struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=250019">https://bugs.webkit.org/show_bug.cgi?id=250019</a>

Reviewed by Carlos Garcia Campos.

In AccessibilityObjectAtspi::textAttributes(), the HashMap can be moved into the
returning TextAttributes struct, removing the nuisance of copying the object otherwise.

* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):

Canonical link: <a href="https://commits.webkit.org/258384@main">https://commits.webkit.org/258384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8579003b78aa044dba4f0b006d228cc39c6b308c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111132 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1858 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108893 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92363 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1728 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44766 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5743 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6371 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->