### PR TITLE
Painting an in-process VideoFrame in a remotely-backed canvas does not work

### DIFF
--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -55,7 +55,7 @@ namespace WebCore {
 SharedVideoFrameInfo SharedVideoFrameInfo::fromCVPixelBuffer(CVPixelBufferRef pixelBuffer)
 {
     auto type = CVPixelBufferGetPixelFormatType(pixelBuffer);
-    if (type == kCVPixelFormatType_32BGRA)
+    if (type == kCVPixelFormatType_32BGRA || type == kCVPixelFormatType_32ARGB)
         return { type, static_cast<uint32_t>(CVPixelBufferGetWidth(pixelBuffer)), static_cast<uint32_t>(CVPixelBufferGetHeight(pixelBuffer)), static_cast<uint32_t>(CVPixelBufferGetBytesPerRow(pixelBuffer)) };
     return { type, static_cast<uint32_t>(CVPixelBufferGetWidthOfPlane(pixelBuffer, 0)), static_cast<uint32_t>(CVPixelBufferGetHeightOfPlane(pixelBuffer, 0)), static_cast<uint32_t>(CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0)), static_cast<uint32_t>(CVPixelBufferGetWidthOfPlane(pixelBuffer, 1)), static_cast<uint32_t>(CVPixelBufferGetHeightOfPlane(pixelBuffer, 1)), static_cast<uint32_t>(CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1)) };
 }
@@ -63,6 +63,7 @@ SharedVideoFrameInfo SharedVideoFrameInfo::fromCVPixelBuffer(CVPixelBufferRef pi
 bool SharedVideoFrameInfo::isReadWriteSupported() const
 {
     return m_bufferType == kCVPixelFormatType_32BGRA
+        || m_bufferType == kCVPixelFormatType_32ARGB
         || m_bufferType == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
         || m_bufferType == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
         || m_bufferType == kCVPixelFormatType_420YpCbCr10BiPlanarFullRange

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -610,9 +610,7 @@ void GraphicsContext::paintFrameForMedia(MediaPlayer& player, const FloatRect& d
 {
     player.playerPrivate()->paintCurrentFrameInContext(*this, destination);
 }
-#endif
 
-#if ENABLE(WEB_CODECS)
 void GraphicsContext::paintVideoFrame(VideoFrame& frame, const FloatRect& destination, bool shouldDiscardAlpha)
 {
     frame.paintInContext(*this, destination, ImageOrientation::None, shouldDiscardAlpha);

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -274,8 +274,6 @@ public:
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT virtual void paintFrameForMedia(MediaPlayer&, const FloatRect& destination);
-#endif
-#if ENABLE(WEB_CODECS)
     WEBCORE_EXPORT virtual void paintVideoFrame(VideoFrame&, const FloatRect& destination, bool shouldDiscardAlpha);
 #endif
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -582,16 +582,10 @@ void Recorder::paintFrameForMedia(MediaPlayer& player, const FloatRect& destinat
     ASSERT(player.identifier());
     recordPaintFrameForMedia(player, destination);
 }
-#endif
 
-#if ENABLE(WEB_CODECS)
 void Recorder::paintVideoFrame(VideoFrame& frame, const FloatRect& destination, bool shouldDiscardAlpha)
 {
-    if (!frame.isRemoteProxy()) {
-        GraphicsContext::paintVideoFrame(frame, destination, shouldDiscardAlpha);
-        return;
-    }
-    // FIXME: Implement recording.
+    recordPaintVideoFrame(frame, destination, shouldDiscardAlpha);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -119,6 +119,7 @@ protected:
     virtual void recordFillEllipse(const FloatRect&) = 0;
 #if ENABLE(VIDEO)
     virtual void recordPaintFrameForMedia(MediaPlayer&, const FloatRect& destination) = 0;
+    virtual void recordPaintVideoFrame(VideoFrame&, const FloatRect& destination, bool shouldDiscardAlpha) = 0;
 #endif
     virtual void recordStrokeRect(const FloatRect&, float) = 0;
 #if ENABLE(INLINE_PATH_DATA)
@@ -273,8 +274,6 @@ private:
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT void paintFrameForMedia(MediaPlayer&, const FloatRect& destination) final;
-#endif
-#if ENABLE(WEB_CODECS)
     WEBCORE_EXPORT void paintVideoFrame(VideoFrame&, const FloatRect&, bool shouldDiscardAlpha) final;
 #endif
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -316,6 +316,11 @@ void RecorderImpl::recordPaintFrameForMedia(MediaPlayer& player, const FloatRect
 {
     append<PaintFrameForMedia>(player, destination);
 }
+
+void RecorderImpl::recordPaintVideoFrame(VideoFrame&, const FloatRect&, bool /* shouldDiscardAlpha */)
+{
+    // FIXME: TODO
+}
 #endif // ENABLE(VIDEO)
 
 void RecorderImpl::recordStrokeRect(const FloatRect& rect, float width)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -98,6 +98,7 @@ private:
     void recordFillEllipse(const FloatRect&) final;
 #if ENABLE(VIDEO)
     void recordPaintFrameForMedia(MediaPlayer&, const FloatRect& destination) final;
+    void recordPaintVideoFrame(VideoFrame&, const FloatRect& destination, bool shouldDiscardAlpha) final;
 #endif
     void recordStrokeRect(const FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -31,6 +31,7 @@
 #include "DisplayListRecorderFlushIdentifier.h"
 #include "QualifiedRenderingResourceIdentifier.h"
 #include "RemoteRenderingBackend.h"
+#include "SharedVideoFrame.h"
 #include "StreamMessageReceiver.h"
 #include "StreamServerConnection.h"
 #include <WebCore/ControlFactory.h>
@@ -160,11 +161,20 @@ private:
     void startListeningForIPC();
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    void paintVideoFrame(SharedVideoFrame&&, const WebCore::FloatRect&, bool shouldDiscardAlpha);
+    void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
+    void setSharedVideoFrameMemory(const SharedMemory::Handle&);
+#endif
+
     WeakPtr<WebCore::ImageBuffer> m_imageBuffer;
     QualifiedRenderingResourceIdentifier m_imageBufferIdentifier;
     WebCore::ProcessIdentifier m_webProcessIdentifier;
     RefPtr<RemoteRenderingBackend> m_renderingBackend;
     std::unique_ptr<WebCore::ControlFactory> m_controlFactory;
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    SharedVideoFrameReader m_sharedVideoFrameReader;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -96,6 +96,12 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
 #endif
     ApplyDeviceScaleFactor(float scaleFactor)
     FlushContext(WebKit::DisplayListRecorderFlushIdentifier identifier)
+
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    PaintVideoFrame(struct WebKit::SharedVideoFrame frame, WebCore::FloatRect rect, bool shouldDiscardAlpha) NotStreamEncodable
+    SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
+    SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle) NotStreamEncodable
+#endif
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -103,6 +103,9 @@ public:
     const WebCore::ProcessIdentity& resourceOwner() const { return m_resourceOwner; }
 
     void releaseResource(WebCore::RenderingResourceIdentifier);
+
+    GPUConnectionToWebProcess& gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
+
 private:
     RemoteRenderingBackend(GPUConnectionToWebProcess&, RemoteRenderingBackendCreationParameters&&, IPC::StreamServerConnection::Handle&&);
     void startListeningForIPC();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "DisplayListRecorderFlushIdentifier.h"
+#include "SharedVideoFrame.h"
 #include <WebCore/DisplayListRecorder.h>
 #include <WebCore/DrawGlyphsRecorder.h>
 #include <WebCore/GraphicsContext.h>
@@ -111,7 +112,10 @@ private:
 #endif
     void recordFillPath(const WebCore::Path&) final;
     void recordFillEllipse(const WebCore::FloatRect&) final;
+#if ENABLE(VIDEO)
     void recordPaintFrameForMedia(WebCore::MediaPlayer&, const WebCore::FloatRect& destination) final;
+    void recordPaintVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect&, bool shouldDiscardAlpha) final;
+#endif
     void recordStrokeRect(const WebCore::FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const WebCore::LineData&) final;
@@ -144,6 +148,9 @@ private:
     WebCore::RenderingResourceIdentifier m_destinationBufferIdentifier;
     WeakPtr<RemoteImageBufferProxy> m_imageBuffer;
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+    SharedVideoFrameWriter m_sharedVideoFrameWriter;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -201,6 +201,8 @@ SharedVideoFrameReader::SharedVideoFrameReader(RefPtr<RemoteVideoFrameObjectHeap
 
 SharedVideoFrameReader::SharedVideoFrameReader() = default;
 
+SharedVideoFrameReader::~SharedVideoFrameReader() = default;
+
 RetainPtr<CVPixelBufferRef> SharedVideoFrameReader::readBufferFromSharedMemory()
 {
     if (!m_storage) {

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -100,6 +100,8 @@ private:
 class SharedVideoFrameReader {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    ~SharedVideoFrameReader();
+
     enum class UseIOSurfaceBufferPool { No, Yes };
     explicit SharedVideoFrameReader(RefPtr<RemoteVideoFrameObjectHeap>&&, const WebCore::ProcessIdentity& = { }, UseIOSurfaceBufferPool = UseIOSurfaceBufferPool::Yes);
     SharedVideoFrameReader();


### PR DESCRIPTION
#### 2818008f7934a4e77dea44d03713df75892c7bd3
<pre>
Painting an in-process VideoFrame in a remotely-backed canvas does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=250002">https://bugs.webkit.org/show_bug.cgi?id=250002</a>
rdar://problem/103812253

Reviewed by Eric Carlson.

In-process rendering of a VideoFrame in a canvas is based on VideoFrame::paintInContext using a PixelBufferConformerCV.
This does not work in WebProcess once sandbox is tigthened/using remote rendering tree.
To fix this, we reuse the existing RemoteDisplayListRecorder infrastructure.
We use a SharedVideoFrameWriter/SharedVideoFrameReader in RemoteDisplayListRecorderProxy/RemoteDisplayListRecorder.
We enable ARGB since VideoFrameCV uses this type.

Covered by WPT webcodecs tests with remote rendering tree enabled.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::drawNativeImage):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImage):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawNativeImage):
(WebCore::DisplayList::Recorder::paintVideoFrame):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordPaintFrameForMedia):
(WebCore::DisplayList::RecorderImpl::recordPaintVideoFrame):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawNativeImage):
(WebKit::RemoteDisplayListRecorder::paintVideoFrame):
(WebKit::RemoteDisplayListRecorder::setSharedVideoFrameSemaphore):
(WebKit::RemoteDisplayListRecorder::setSharedVideoFrameMemory):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordPaintVideoFrame):
(WebKit::RemoteDisplayListRecorderProxy::disconnect):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:

Canonical link: <a href="https://commits.webkit.org/258479@main">https://commits.webkit.org/258479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1bd2eaa08eb0f7ad047ae772ea95526f151d45c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111267 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171470 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1996 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109021 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37041 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78785 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25399 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1838 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5815 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6503 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->