### PR TITLE
Set value of m_textAsOfLastFormControlChangeEvent before triggering change event

### DIFF
--- a/LayoutTests/fast/events/onchange-js-expected.txt
+++ b/LayoutTests/fast/events/onchange-js-expected.txt
@@ -1,0 +1,14 @@
+This test verifies that the change event is fired, when value is changed in change event handler.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "foo bar baz"
+PASS changeEventCounter is 1
+PASS input.value is ""
+PASS input.value is "foo bar baz"
+PASS changeEventCounter is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/onchange-js.html
+++ b/LayoutTests/fast/events/onchange-js.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<input id="input" type="text" onchange="changeHandler()">
+<script>
+description('This test verifies that the change event is fired, when value is changed in change event handler.');
+var input = document.getElementById('input');
+var changeEventCounter = 0;
+function changeHandler()
+{
+    changeEventCounter++;
+    input.value = '';
+}
+input.focus();
+document.execCommand('InsertText', false, 'foo bar baz');
+shouldBeEqualToString('input.value', 'foo bar baz');
+input.blur();
+shouldBe('changeEventCounter', '1');
+shouldBeEqualToString('input.value', '');
+input.focus();
+document.execCommand('InsertText', false, 'foo bar baz');
+shouldBeEqualToString('input.value', 'foo bar baz');
+input.blur();
+shouldBe('changeEventCounter', '2');
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -2,8 +2,9 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -228,8 +229,8 @@ String HTMLTextFormControlElement::selectedText() const
 void HTMLTextFormControlElement::dispatchFormControlChangeEvent()
 {
     if (m_textAsOfLastFormControlChangeEvent != value()) {
-        dispatchChangeEvent();
         setTextAsOfLastFormControlChangeEvent(value());
+        dispatchChangeEvent();
     }
     setChangedSinceLastFormControlChangeEvent(false);
     setInteractedWithSinceLastFormSubmitEvent(true);


### PR DESCRIPTION
#### 1a99dd74ee9b62f22ec9030d7d89535c9affc209
<pre>
Set value of m_textAsOfLastFormControlChangeEvent before triggering change event

Set value of m_textAsOfLastFormControlChangeEvent before triggering change event
<a href="https://bugs.webkit.org/show_bug.cgi?id=250025">https://bugs.webkit.org/show_bug.cgi?id=250025</a>

Reviewed by Chris Dumez.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=175565&amp">https://src.chromium.org/viewvc/blink?revision=175565&amp</a>;view=revision

The value is updated inside change event, which gets overwritten by setTextAsOfLastFormControlChangeEvent. This patch ensure that new value if similar to previous value trigger change event.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(HTMLTextFormControl::dispatchFormControlChangeEvent): Move &quot;dispatchChangeEvent&quot; after setting the value
* LayoutTests/fast/events/onchange-js.html: Add Test Case
* LayoutTests/fast/events/onchange-js-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258395@main">https://commits.webkit.org/258395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2fa7b0e1cd4f0bd38513395bbf05764f76d778c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111145 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171350 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1871 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108905 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36869 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91005 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78688 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25296 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1739 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5750 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6383 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->