### PR TITLE
'parser-grammar-unused-reason' used for a few properties with used parser-grammars

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8374,7 +8374,7 @@
             "codegen-properties": {
                 "converter": "TextUnderlineOffset",
                 "parser-grammar": "auto | <length>",
-                "parser-grammar-unused-reason": "The current specification has a <length-percentage>, not just <length>"
+                "parser-grammar-comment": "The current specification has a <length-percentage>, not just <length>"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -8385,7 +8385,7 @@
             "codegen-properties": {
                 "converter": "TextDecorationThickness",
                 "parser-grammar": "auto | from-font | <length>",
-                "parser-grammar-unused-reason": "The current specification has a <length-percentage>, not just <length>"
+                "parser-grammar-comment": "The current specification has a <length-percentage>, not just <length>"
             },
             "specification": {
                 "category": "css-text-decor",

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -593,6 +593,10 @@ class StylePropertyCodeGenProperties:
             grammar.perform_fixups(parsing_context.parsed_shared_grammar_rules)
             json_value["parser-grammar-unused"] = grammar
 
+        if json_value.get("parser-grammar-unused-reason"):
+            if "parser-grammar-unused" not in json_value:
+                raise Exception(f"{key_path} must have 'parser-grammar-unused' specified when using 'parser-grammar-unused-reason'.")
+
         if json_value.get("parser-function"):
             if "parser-grammar-unused" not in json_value:
                 raise Exception(f"{key_path} must have 'parser-grammar-unused' specified when using 'parser-function'.")
@@ -1055,6 +1059,10 @@ class DescriptorCodeGenProperties:
             grammar = Grammar.from_string(parsing_context, f"{key_path}", name, json_value["parser-grammar-unused"])
             grammar.perform_fixups(parsing_context.parsed_shared_grammar_rules)
             json_value["parser-grammar-unused"] = grammar
+
+        if json_value.get("parser-grammar-unused-reason"):
+            if "parser-grammar-unused" not in json_value:
+                raise Exception(f"{key_path} must have 'parser-grammar-unused' specified when using 'parser-grammar-unused-reason'.")
 
         if json_value.get("parser-function"):
             if "parser-grammar-unused" not in json_value:


### PR DESCRIPTION
#### ebc41da45e849b096eed7c0c7be3c1210cdf96f4
<pre>
&apos;parser-grammar-unused-reason&apos; used for a few properties with used parser-grammars
<a href="https://bugs.webkit.org/show_bug.cgi?id=250026">https://bugs.webkit.org/show_bug.cgi?id=250026</a>
rdar://103835748

Reviewed by Tim Nguyen.

Enforce that &apos;parser-grammar-unused-reason&apos; is only used when &apos;parser-grammar-unused&apos;
is also set.

* Source/WebCore/css/CSSProperties.json:
Replace use of &apos;parser-grammar-unused-reason&apos; with &apos;parser-grammar-comment&apos; for
properties with valid &apos;parser-grammar&apos;s.

* Source/WebCore/css/process-css-properties.py:
(StylePropertyCodeGenProperties.from_json):
(DescriptorCodeGenProperties.from_json):
Add check that &apos;parser-grammar-unused-reason&apos; is only set when &apos;parser-grammar-unused&apos;
is also set.

Canonical link: <a href="https://commits.webkit.org/258405@main">https://commits.webkit.org/258405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51e9f89a6efaac9b09e2645eeed65cc905ce63d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111149 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171354 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1875 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108909 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36879 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78690 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4556 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1741 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5760 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6387 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->