### PR TITLE
Interaction regions should take aria visibility into account

### DIFF
--- a/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
+++ b/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
@@ -15,7 +15,7 @@ button
 
       (interaction regions [
         (region
-            (rect (1,4) width=57 height=28)
+            (rect (0,3) width=59 height=30)
 )
         (borderRadius 14.00)])
       )

--- a/LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree-expected.txt
@@ -1,4 +1,5 @@
-Hi
+This is a link, outside the frame.
+This is a link, inside an aria-hidden div
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -13,9 +14,9 @@ Hi
 
       (interaction regions [
         (region
-            (rect (29,21) width=50 height=50)
+            (rect (-3,-3) width=35 height=25)
 )
-        (borderRadius 8.75)])
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree.html
+++ b/LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    #page {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<body>
+<a href="#">This</a> is a link, outside the frame.<br/>
+<div id="frame" aria-hidden="true"><a href="#">This</a> is a link, inside an aria-hidden div</div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -14,11 +14,11 @@ This is a link, outside the frame.
 
       (interaction regions [
         (region
-            (rect (-3,-3) width=35 height=25)
+            (rect (7,27) width=35 height=25)
 )
         (borderRadius 0.00),
         (region
-            (rect (7,27) width=35 height=25)
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
       )

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -120,6 +120,9 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (!element)
         return std::nullopt;
 
+    if (!isNodeAriaVisible(element))
+        return std::nullopt;
+
     if (auto* linkElement = element->enclosingLinkEventParentOrSelf())
         element = linkElement;
     if (auto* buttonElement = ancestorsOfType<HTMLButtonElement>(*element).first())


### PR DESCRIPTION
#### 64ad5fc43e2e730b5cba0d9a4810ec5d4e4a4cdc
<pre>
Interaction regions should take aria visibility into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=250029">https://bugs.webkit.org/show_bug.cgi?id=250029</a>
&lt;rdar://103453184&gt;

Reviewed by Tim Horton.

Check for aria visibility before adding an interaction region for an
element.

* LayoutTests/interaction-region/event-region-overflow-expected.txt:
* LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
Update existing test expectations.

* LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree-expected.txt: Added.
* LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree.html: Added.
Add a test case.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Ignore elements that are part of an aria-hidden subtree.

Canonical link: <a href="https://commits.webkit.org/258396@main">https://commits.webkit.org/258396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23b8fa3d3854fb2ab24264a01e084fb7ef48daa7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111165 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1891 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108924 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92399 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23825 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4571 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25313 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1756 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5753 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6402 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->