### PR TITLE
[CSS-Typed-OM] flex-basis / flex-grow / flex-shrink computed values should be clamped

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
@@ -14,7 +14,7 @@ PASS Can set 'flex-basis' to a length: -3.14em
 PASS Can set 'flex-basis' to a length: 3.14cm
 PASS Can set 'flex-basis' to a length: calc(0px + 0em)
 PASS Can set 'flex-basis' to a percent: 0%
-FAIL Can set 'flex-basis' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-basis' to a percent: -3.14%
 PASS Can set 'flex-basis' to a percent: 3.14%
 PASS Can set 'flex-basis' to a percent: calc(0% + 0%)
 PASS Setting 'flex-basis' to a time: 0s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('flex-basis', [
   { syntax: 'auto' },
   { syntax: 'content' },
@@ -26,6 +35,7 @@ runPropertyTests('flex-basis', [
   {
     syntax: '<percentage>',
     specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'flex-grow' to CSS-wide keywords: unset
 PASS Can set 'flex-grow' to CSS-wide keywords: revert
 PASS Can set 'flex-grow' to var() references:  var(--A)
 PASS Can set 'flex-grow' to a number: 0
-FAIL Can set 'flex-grow' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-grow' to a number: -3.14
 PASS Can set 'flex-grow' to a number: 3.14
 PASS Can set 'flex-grow' to a number: calc(2 + 3)
 PASS Setting 'flex-grow' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow.html
@@ -13,10 +13,20 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_number(input, result) {
+  const number = input.to('number');
+
+  if (number.value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else
+    assert_style_value_equals(result, number);
+}
+
 runPropertyTests('flex-grow', [
   {
     syntax: '<number>',
     specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_number
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'flex-shrink' to CSS-wide keywords: unset
 PASS Can set 'flex-shrink' to CSS-wide keywords: revert
 PASS Can set 'flex-shrink' to var() references:  var(--A)
 PASS Can set 'flex-shrink' to a number: 0
-FAIL Can set 'flex-shrink' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-shrink' to a number: -3.14
 PASS Can set 'flex-shrink' to a number: 3.14
 PASS Can set 'flex-shrink' to a number: calc(2 + 3)
 PASS Setting 'flex-shrink' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink.html
@@ -13,10 +13,20 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_number(input, result) {
+  const number = input.to('number');
+
+  if (number.value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else
+    assert_style_value_equals(result, number);
+}
+
 runPropertyTests('flex-shrink', [
   {
     syntax: '<number>',
     specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_number
   },
 ]);
 


### PR DESCRIPTION
#### da48215a5f58b6125a7423b14f79cd37d8156a50
<pre>
[CSS-Typed-OM] flex-basis / flex-grow / flex-shrink computed values should be clamped
<a href="https://bugs.webkit.org/show_bug.cgi?id=250036">https://bugs.webkit.org/show_bug.cgi?id=250036</a>

Reviewed by Tim Nguyen.

flex-basis / flex-grow / flex-shrink computed values should be clamped, since
the specification indicates the values cannot be negative:
- <a href="https://w3c.github.io/csswg-drafts/css-flexbox/#flex-basis-property">https://w3c.github.io/csswg-drafts/css-flexbox/#flex-basis-property</a>
- <a href="https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width">https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width</a>
- <a href="https://w3c.github.io/csswg-drafts/css-flexbox/#flex-shrink-property">https://w3c.github.io/csswg-drafts/css-flexbox/#flex-shrink-property</a>
- <a href="https://w3c.github.io/csswg-drafts/css-flexbox/#flex-grow-property">https://w3c.github.io/csswg-drafts/css-flexbox/#flex-grow-property</a>

Update the Web-Platform-Tests accordingly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink.html:

Canonical link: <a href="https://commits.webkit.org/258403@main">https://commits.webkit.org/258403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84ad14caabf0878dbf95e6942603600a340cac67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111178 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171383 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1904 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108936 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92406 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/36919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23832 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4582 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4664 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5758 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6415 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->