### PR TITLE
<button> and <select> elements with "readonly" attribute shouldn't be barred from constraint validation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute-expected.txt
@@ -1,0 +1,4 @@
+1 2
+
+PASS Button element with "readonly" attribute shouldn't be barred from constraint validation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>Button element with "readonly" attribute shouldn't be barred from constraint validation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="implicitSubmitButton" readonly>1</button>
+<button id="explicitSubmitButton" readonly type="submit">2</button>
+<script>
+  test(() => {
+    assert_true(implicitSubmitButton.willValidate);
+    assert_true(explicitSubmitButton.willValidate);
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Select element with "readonly" attribute shouldn't be barred from constraint validation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>Select element with "readonly" attribute shouldn't be barred from constraint validation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<select id="singleSelect" readonly>
+  <option>1
+  <option>2
+</select>
+
+<select id="multiSelect" readonly multiple>
+  <option>a
+  <option>b
+  <option>c
+  <option>d
+</select>
+
+<script>
+  test(() => {
+    assert_true(singleSelect.willValidate);
+    assert_true(multiSelect.willValidate);
+  });
+</script>

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -401,8 +401,9 @@ bool HTMLFormControlElement::computeWillValidate() const
         m_dataListAncestorState = NotInsideDataList;
 #endif
     }
-    // readonly bars constraint validation for *all* <input> elements, regardless of the <input> type, for compat reasons.
-    return m_dataListAncestorState == NotInsideDataList && !isDisabledFormControl() && !m_hasReadOnlyAttribute;
+    // readonly attribute bars *all* <input> elements from constraint validation, regardless of the <input> type, for compat reasons:
+    // https://html.spec.whatwg.org/multipage/input.html#the-readonly-attribute:barred-from-constraint-validation
+    return m_dataListAncestorState == NotInsideDataList && !isDisabledFormControl() && !(m_hasReadOnlyAttribute && readOnlyBarsFromConstraintValidation());
 }
 
 bool HTMLFormControlElement::willValidate() const

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -163,6 +163,7 @@ protected:
     // This must be called any time the result of willValidate() has changed.
     void updateWillValidateAndValidity();
     virtual bool computeWillValidate() const;
+    virtual bool readOnlyBarsFromConstraintValidation() const { return false; }
 
     bool validationMessageShadowTreeContains(const Node&) const;
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -117,6 +117,7 @@ protected:
 
     void disabledStateChanged() override;
     void readOnlyStateChanged() override;
+    bool readOnlyBarsFromConstraintValidation() const final { return true; }
 
     void updateInnerTextElementEditability();
 


### PR DESCRIPTION
#### a4eb84de0c697f529d942d00816cab7a703788ea
<pre>
&lt;button&gt; and &lt;select&gt; elements with &quot;readonly&quot; attribute shouldn&apos;t be barred from constraint validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=250037">https://bugs.webkit.org/show_bug.cgi?id=250037</a>

Reviewed by Aditya Keerthi.

Per spec, only &lt;input&gt; [1], &lt;textarea&gt; [2], and form-associated custom elements [3] are barred from
constraint validation if &quot;readonly&quot; attribute is present.

This change makes &quot;readonly&quot; attribute check conditional based on readOnlyBarsFromConstraintValidation().
We can&apos;t use supportsReadonly() instead as it reports `false` for certain &lt;input&gt; types, violating the spec [1].

Aligns WebKit with Gecko and the spec.

Tests: imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute.html

[1] <a href="https://html.spec.whatwg.org/multipage/input.html#the-readonly-attribute">https://html.spec.whatwg.org/multipage/input.html#the-readonly-attribute</a>:barred-from-constraint-validation
[2] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a>:barred-from-constraint-validation
[3] <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts</a>:barred-from-constraint-validation

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-willvalidate-readonly-attribute.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-willvalidate-readonly-attribute.html: Added.
* Source/WebCore/html/HTMLFormControlElement.h
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::computeWillValidate const):
* Source/WebCore/html/HTMLTextFormControlElement.h:

Canonical link: <a href="https://commits.webkit.org/258485@main">https://commits.webkit.org/258485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ac1ca2e055a67b08682bd9964d2115651d6a99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111438 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171613 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2170 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109175 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37174 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78896 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25547 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1986 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45043 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6670 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3070 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->