### PR TITLE
[CSS-Typed-OM] Fix WPT tests to stop expecting negative computed values for CSS properties that only allow positive values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'animation-duration' to CSS-wide keywords: unset
 PASS Can set 'animation-duration' to CSS-wide keywords: revert
 PASS Can set 'animation-duration' to var() references:  var(--A)
 PASS Can set 'animation-duration' to a time: 0s
-FAIL Can set 'animation-duration' to a time: -3.14ms assert_approx_equals: expected -0.00314 +/- 0.000001 but got 0
+PASS Can set 'animation-duration' to a time: -3.14ms
 PASS Can set 'animation-duration' to a time: 3.14s
 PASS Can set 'animation-duration' to a time: calc(0s + 0ms)
 PASS Setting 'animation-duration' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html
@@ -12,10 +12,20 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_time(input, result) {
+  const time = input.to('s');
+
+  if (time.value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 's'));
+  else
+    assert_style_value_equals(result, time);
+}
+
 runListValuedPropertyTests('animation-duration', [
   {
     syntax: '<time>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_time
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'animation-iteration-count' to CSS-wide keywords: revert
 PASS Can set 'animation-iteration-count' to var() references:  var(--A)
 PASS Can set 'animation-iteration-count' to the 'infinite' keyword: infinite
 PASS Can set 'animation-iteration-count' to a number: 0
-FAIL Can set 'animation-iteration-count' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'animation-iteration-count' to a number: -3.14
 PASS Can set 'animation-iteration-count' to a number: 3.14
 PASS Can set 'animation-iteration-count' to a number: calc(2 + 3)
 PASS Setting 'animation-iteration-count' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_number(input, result) {
+  const number = input.to('number');
+
+  if (number.value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else
+    assert_style_value_equals(result, number);
+}
+
 runListValuedPropertyTests('animation-iteration-count', [
   { syntax: 'infinite' },
   {
     syntax: '<number>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_number
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'block-size' to CSS-wide keywords: revert
 PASS Can set 'block-size' to var() references:  var(--A)
 PASS Can set 'block-size' to the 'auto' keyword: auto
 PASS Can set 'block-size' to a percent: 0%
-FAIL Can set 'block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'block-size' to a percent: -3.14%
 PASS Can set 'block-size' to a percent: 3.14%
 PASS Can set 'block-size' to a percent: calc(0% + 0%)
 PASS Can set 'block-size' to a length: 0px
@@ -37,7 +37,7 @@ PASS Can set 'min-block-size' to CSS-wide keywords: unset
 PASS Can set 'min-block-size' to CSS-wide keywords: revert
 PASS Can set 'min-block-size' to var() references:  var(--A)
 PASS Can set 'min-block-size' to a percent: 0%
-FAIL Can set 'min-block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-block-size' to a percent: -3.14%
 PASS Can set 'min-block-size' to a percent: 3.14%
 PASS Can set 'min-block-size' to a percent: calc(0% + 0%)
 PASS Can set 'min-block-size' to a length: 0px
@@ -69,7 +69,7 @@ PASS Can set 'max-block-size' to CSS-wide keywords: revert
 PASS Can set 'max-block-size' to var() references:  var(--A)
 PASS Can set 'max-block-size' to the 'none' keyword: none
 PASS Can set 'max-block-size' to a percent: 0%
-FAIL Can set 'max-block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-block-size' to a percent: -3.14%
 PASS Can set 'max-block-size' to a percent: 3.14%
 PASS Can set 'max-block-size' to a percent: calc(0% + 0%)
 PASS Can set 'max-block-size' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('block-size', [
   { syntax: 'auto' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -28,7 +38,8 @@ runPropertyTests('block-size', [
 runPropertyTests('min-block-size', [
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -40,7 +51,8 @@ runPropertyTests('max-block-size', [
   { syntax: 'none' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'font-size-adjust' to CSS-wide keywords: revert
 PASS Can set 'font-size-adjust' to var() references:  var(--A)
 PASS Can set 'font-size-adjust' to the 'none' keyword: none
 PASS Can set 'font-size-adjust' to a number: 0
-FAIL Can set 'font-size-adjust' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'font-size-adjust' to a number: -3.14
 PASS Can set 'font-size-adjust' to a number: 3.14
 PASS Can set 'font-size-adjust' to a number: calc(2 + 3)
 PASS Setting 'font-size-adjust' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_number(input, result) {
+  const number = input.to('number');
+
+  if (number.value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else
+    assert_style_value_equals(result, number);
+}
+
 runPropertyTests('font-size-adjust', [
   { syntax: 'none' },
   {
     syntax: '<number>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_number
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
@@ -14,7 +14,7 @@ FAIL Can set 'font-stretch' to the 'expanded' keyword: expanded assert_equals: e
 FAIL Can set 'font-stretch' to the 'extra-expanded' keyword: extra-expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'font-stretch' to the 'ultra-expanded' keyword: ultra-expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'font-stretch' to a percent: 0%
-FAIL Can set 'font-stretch' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'font-stretch' to a percent: -3.14%
 FAIL Can set 'font-stretch' to a percent: 3.14% assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
 PASS Can set 'font-stretch' to a percent: calc(0% + 0%)
 PASS Setting 'font-stretch' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('font-stretch', [
   { syntax: 'normal' },
   { syntax: 'ultra-condensed' },
@@ -25,7 +34,8 @@ runPropertyTests('font-stretch', [
   { syntax: 'ultra-expanded' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
@@ -10,7 +10,7 @@ PASS Can set 'column-gap' to a length: -3.14em
 PASS Can set 'column-gap' to a length: 3.14cm
 PASS Can set 'column-gap' to a length: calc(0px + 0em)
 PASS Can set 'column-gap' to a percent: 0%
-FAIL Can set 'column-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'column-gap' to a percent: -3.14%
 PASS Can set 'column-gap' to a percent: 3.14%
 PASS Can set 'column-gap' to a percent: calc(0% + 0%)
 PASS Setting 'column-gap' to a time: 0s throws TypeError
@@ -42,7 +42,7 @@ PASS Can set 'row-gap' to a length: -3.14em
 PASS Can set 'row-gap' to a length: 3.14cm
 PASS Can set 'row-gap' to a length: calc(0px + 0em)
 PASS Can set 'row-gap' to a percent: 0%
-FAIL Can set 'row-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'row-gap' to a percent: -3.14%
 PASS Can set 'row-gap' to a percent: 3.14%
 PASS Can set 'row-gap' to a percent: calc(0% + 0%)
 PASS Setting 'row-gap' to a time: 0s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 for (const prefix of ['column', 'row']) {
   runPropertyTests(`${prefix}-gap`, [
     { syntax: 'normal' },
@@ -22,7 +31,8 @@ for (const prefix of ['column', 'row']) {
     },
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage 
     },
   ]);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -191,7 +191,7 @@ PASS Can set 'padding-block-start' to CSS-wide keywords: unset
 PASS Can set 'padding-block-start' to CSS-wide keywords: revert
 PASS Can set 'padding-block-start' to var() references:  var(--A)
 PASS Can set 'padding-block-start' to a percent: 0%
-FAIL Can set 'padding-block-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-block-start' to a percent: -3.14%
 PASS Can set 'padding-block-start' to a percent: 3.14%
 PASS Can set 'padding-block-start' to a percent: calc(0% + 0%)
 PASS Can set 'padding-block-start' to a length: 0px
@@ -222,7 +222,7 @@ PASS Can set 'padding-block-end' to CSS-wide keywords: unset
 PASS Can set 'padding-block-end' to CSS-wide keywords: revert
 PASS Can set 'padding-block-end' to var() references:  var(--A)
 PASS Can set 'padding-block-end' to a percent: 0%
-FAIL Can set 'padding-block-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-block-end' to a percent: -3.14%
 PASS Can set 'padding-block-end' to a percent: 3.14%
 PASS Can set 'padding-block-end' to a percent: calc(0% + 0%)
 PASS Can set 'padding-block-end' to a length: 0px
@@ -253,7 +253,7 @@ PASS Can set 'padding-inline-start' to CSS-wide keywords: unset
 PASS Can set 'padding-inline-start' to CSS-wide keywords: revert
 PASS Can set 'padding-inline-start' to var() references:  var(--A)
 PASS Can set 'padding-inline-start' to a percent: 0%
-FAIL Can set 'padding-inline-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-inline-start' to a percent: -3.14%
 PASS Can set 'padding-inline-start' to a percent: 3.14%
 PASS Can set 'padding-inline-start' to a percent: calc(0% + 0%)
 PASS Can set 'padding-inline-start' to a length: 0px
@@ -284,7 +284,7 @@ PASS Can set 'padding-inline-end' to CSS-wide keywords: unset
 PASS Can set 'padding-inline-end' to CSS-wide keywords: revert
 PASS Can set 'padding-inline-end' to var() references:  var(--A)
 PASS Can set 'padding-inline-end' to a percent: 0%
-FAIL Can set 'padding-inline-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-inline-end' to a percent: -3.14%
 PASS Can set 'padding-inline-end' to a percent: 3.14%
 PASS Can set 'padding-inline-end' to a percent: calc(0% + 0%)
 PASS Can set 'padding-inline-end' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 const logical = {
   axes: ['block', 'inline'],
   sides: ['block-start', 'block-end', 'inline-start', 'inline-end'],
@@ -32,7 +41,8 @@ for (const side of [...logical.sides, ...logical.axes]) {
     // TODO: Test 'auto'
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage
     },
     {
       syntax: '<length>',

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
@@ -9,7 +9,7 @@ PASS Can set 'shape-margin' to a length: -3.14em
 PASS Can set 'shape-margin' to a length: 3.14cm
 PASS Can set 'shape-margin' to a length: calc(0px + 0em)
 PASS Can set 'shape-margin' to a percent: 0%
-FAIL Can set 'shape-margin' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'shape-margin' to a percent: -3.14%
 PASS Can set 'shape-margin' to a percent: 3.14%
 PASS Can set 'shape-margin' to a percent: calc(0% + 0%)
 PASS Setting 'shape-margin' to a time: 0s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('shape-margin', [
   {
     syntax: '<length>',
@@ -20,7 +29,8 @@ runPropertyTests('shape-margin', [
   },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
 ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -10,7 +10,7 @@ PASS Can set 'stroke-dasharray' to a length: -3.14em
 PASS Can set 'stroke-dasharray' to a length: 3.14cm
 PASS Can set 'stroke-dasharray' to a length: calc(0px + 0em)
 PASS Can set 'stroke-dasharray' to a percent: 0%
-FAIL Can set 'stroke-dasharray' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'stroke-dasharray' to a percent: -3.14%
 PASS Can set 'stroke-dasharray' to a percent: 3.14%
 PASS Can set 'stroke-dasharray' to a percent: calc(0% + 0%)
 PASS Can set 'stroke-dasharray' to a number: 0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('stroke-dasharray', [
   { syntax: 'none' },
   {
@@ -22,6 +31,7 @@ runPropertyTests('stroke-dasharray', [
   {
     syntax: '<percentage>',
     specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<number>',

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'width' to CSS-wide keywords: revert
 PASS Can set 'width' to var() references:  var(--A)
 PASS Can set 'width' to the 'auto' keyword: auto
 PASS Can set 'width' to a percent: 0%
-FAIL Can set 'width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'width' to a percent: -3.14%
 PASS Can set 'width' to a percent: 3.14%
 PASS Can set 'width' to a percent: calc(0% + 0%)
 PASS Can set 'width' to a length: 0px
@@ -37,7 +37,7 @@ PASS Can set 'min-width' to CSS-wide keywords: unset
 PASS Can set 'min-width' to CSS-wide keywords: revert
 PASS Can set 'min-width' to var() references:  var(--A)
 PASS Can set 'min-width' to a percent: 0%
-FAIL Can set 'min-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-width' to a percent: -3.14%
 PASS Can set 'min-width' to a percent: 3.14%
 PASS Can set 'min-width' to a percent: calc(0% + 0%)
 PASS Can set 'min-width' to a length: 0px
@@ -69,7 +69,7 @@ PASS Can set 'max-width' to CSS-wide keywords: revert
 PASS Can set 'max-width' to var() references:  var(--A)
 PASS Can set 'max-width' to the 'none' keyword: none
 PASS Can set 'max-width' to a percent: 0%
-FAIL Can set 'max-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-width' to a percent: -3.14%
 PASS Can set 'max-width' to a percent: 3.14%
 PASS Can set 'max-width' to a percent: calc(0% + 0%)
 PASS Can set 'max-width' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('width', [
   { syntax: 'auto' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -28,7 +38,8 @@ runPropertyTests('width', [
 runPropertyTests('min-width', [
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -40,7 +51,8 @@ runPropertyTests('max-width', [
   { syntax: 'none' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',


### PR DESCRIPTION
#### 43fd1b396d360bd56165c0e62a45af47d29a67e5
<pre>
[CSS-Typed-OM] Fix WPT tests to stop expecting negative computed values for CSS properties that only allow positive values
<a href="https://bugs.webkit.org/show_bug.cgi?id=250041">https://bugs.webkit.org/show_bug.cgi?id=250041</a>

Reviewed by Tim Nguyen.

Fix CSS Typed OM WPT tests to stop expecting negative computed values for CSS
properties that only allow positive values:
- animation-duration:
<a href="https://w3c.github.io/csswg-drafts/css-animations/#animation-duration">https://w3c.github.io/csswg-drafts/css-animations/#animation-duration</a>

- animation-iteration-count:
<a href="https://w3c.github.io/csswg-drafts/css-animations/#animation-iteration-count">https://w3c.github.io/csswg-drafts/css-animations/#animation-iteration-count</a>
<a href="https://w3c.github.io/csswg-drafts/css-animations/#typedef-single-animation-iteration-count">https://w3c.github.io/csswg-drafts/css-animations/#typedef-single-animation-iteration-count</a>

- block-size:
<a href="https://w3c.github.io/csswg-drafts/css-logical/#propdef-block-size">https://w3c.github.io/csswg-drafts/css-logical/#propdef-block-size</a>
<a href="https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width">https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width</a>

- min-block-size:
<a href="https://w3c.github.io/csswg-drafts/css-logical/#propdef-min-block-size">https://w3c.github.io/csswg-drafts/css-logical/#propdef-min-block-size</a>
<a href="https://w3c.github.io/csswg-drafts/css2/#propdef-min-width">https://w3c.github.io/csswg-drafts/css2/#propdef-min-width</a>

- max-block-size:
<a href="https://w3c.github.io/csswg-drafts/css-logical/#propdef-max-block-size">https://w3c.github.io/csswg-drafts/css-logical/#propdef-max-block-size</a>
<a href="https://w3c.github.io/csswg-drafts/css2/#propdef-max-width">https://w3c.github.io/csswg-drafts/css2/#propdef-max-width</a>

- font-size-adjust:
<a href="https://w3c.github.io/csswg-drafts/css-fonts-5/#font-size-adjust-prop">https://w3c.github.io/csswg-drafts/css-fonts-5/#font-size-adjust-prop</a>

- font-stretch:
<a href="https://w3c.github.io/csswg-drafts/css-fonts/#font-stretch-prop">https://w3c.github.io/csswg-drafts/css-fonts/#font-stretch-prop</a>

- column-gap:
- row-gap:
<a href="https://w3c.github.io/csswg-drafts/css-align/#column-row-gap">https://w3c.github.io/csswg-drafts/css-align/#column-row-gap</a>

- padding-block-start:
- padding-block-end:
- padding-inline-start:
- padding-inline-end:
<a href="https://w3c.github.io/csswg-drafts/css-logical/#padding-properties">https://w3c.github.io/csswg-drafts/css-logical/#padding-properties</a>
<a href="https://w3c.github.io/csswg-drafts/css-box-4/#propdef-padding-top">https://w3c.github.io/csswg-drafts/css-box-4/#propdef-padding-top</a>

- shape-margin:
<a href="https://w3c.github.io/csswg-drafts/css-shapes/#shape-margin-property">https://w3c.github.io/csswg-drafts/css-shapes/#shape-margin-property</a>

- stroke-dasharray:
<a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashing">https://svgwg.org/svg2-draft/painting.html#StrokeDashing</a>
<a href="https://svgwg.org/svg2-draft/painting.html#DataTypeDasharray">https://svgwg.org/svg2-draft/painting.html#DataTypeDasharray</a>

- width:
<a href="https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width">https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width</a>

- min-width:
<a href="https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-min-width">https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-min-width</a>

- max-width:
<a href="https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-max-width">https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-max-width</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width.html:

Canonical link: <a href="https://commits.webkit.org/258406@main">https://commits.webkit.org/258406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/614f735a7643b499e1d0c42b181d8a376314b3d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111189 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1917 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108947 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92416 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23843 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25330 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1773 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5762 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6427 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->