### PR TITLE
CSS Nesting: nesting at-rule inside style rule

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6174,7 +6174,3 @@ fast/text/text-edge-no-half-leading-with-line-height-simple.html [ Skip ]
 webkit.org/b/249010 [ Debug ] fast/text/line-clamp-truncation-assert.html [ Skip ]
 
 webkit.org/b/245905 imported/w3c/web-platform-tests/css/css-text/line-breaking/line-breaking-019.html [ ImageOnlyFailure ]
-
-# CSS Nesting
-imported/w3c/web-platform-tests/css/css-nesting/conditional-properties.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Simple CSSOM manipulation of subrules assert_equals: expected "div {\n  @media screen {\n  &.a { color: red; }\n}\n}" but got "div { }"
+FAIL Simple CSSOM manipulation of subrules assert_equals: expected "div {\n  @media screen {\n  &.a { color: red; }\n}\n}" but got "div {\n  @layer {\n  &.a { font-size: 10px; }\n}\n}@media screen {\n  &.a { color: red; }\n  @layer {\n  &.a { font-size: 10px; }\n}\n}\n}"
 FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@layer {}', 0); }" threw object "TypeError: undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')" that is not a DOMException HierarchyRequestError: property "code" is equal to undefined, expected 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt
@@ -1,4 +1,4 @@
 Test passes if color is green.
 
-FAIL CSS Selectors nested invalidation through @media by selectorText assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL CSS Selectors nested invalidation through @media by selectorText undefined is not an object (evaluating 'document.styleSheets[0].rules[1].selectorText = '.a'')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
@@ -13,6 +13,10 @@
   body * + * {
     margin-top: 8px;
   }
+
+  .fail {
+    background-color: red;
+  }
 </style>
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
@@ -26,4 +30,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test fail"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -80,6 +80,12 @@
     background-color: green !important;
   }
 
+  & {
+    :not(&).test-12 {
+      background-color: green;
+    }
+  }
+
   body * + * {
     margin-top: 8px;
   }
@@ -100,4 +106,5 @@
   <div class="test test-9 t9-- t9-"><div></div></div>
   <div class="test test-10"><div></div></div>
   <div class="test test-11"><div></div></div>
+  <div class="test test-12"><div></div></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -40,10 +40,10 @@ FAIL .foo {
   @media (min-width: 50px) {
   & { color: green; }
 }
-} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo { }"
+} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo {\n  @media (min-width: 50px) {\n  & { color: green; }\n}\n}"
 FAIL .foo {
   @media (min-width: 50px) { color: green; }
-} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo { }"
+} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo {\n  @media (min-width: 50px) {\n  & { color: green; }\n}\n}"
 PASS main {
   & > section, & > article {
   & > header { color: green; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Serialization of declarations in group rules assert_equals: expected "div {\n  @media screen { color: red; background-color: green; }\n}" but got "div { }"
-FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div { }"
-FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen { color: red; }\n}" but got "div { }"
+FAIL Serialization of declarations in group rules assert_equals: expected "div {\n  @media screen { color: red; background-color: green; }\n}" but got "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}"
+FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n  &:hover { color: navy; }\n}\n}"
+FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen { color: red; }\n}" but got "div {\n  @media screen {\n  & { color: red; }\n}\n}"
 FAIL Serialization of declarations in group rules 3 assert_equals: expected "div {\n & { color: red; }\n}" but got "div {\n  & { color: red; }\n}"
-FAIL Serialization of declarations in group rules 4 assert_equals: expected "div {\n  @media screen {\n}\n}" but got "div { }"
+PASS Serialization of declarations in group rules 4
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -67,6 +67,7 @@ struct PossiblyQuotedIdentifier {
 
         bool hasExplicitNestingParent() const;
         void resolveNestingParentSelectors(const CSSSelectorList& parent);
+        void replaceNestingParentByNotAll();
 
         // How the attribute value has to match. Default is Exact.
         enum Match {
@@ -343,6 +344,7 @@ struct PossiblyQuotedIdentifier {
         CSSSelector* tagHistory() { return m_isLastInTagHistory ? nullptr : this + 1; }
 
         CSSSelector& operator=(const CSSSelector&) = delete;
+        CSSSelector(CSSSelector&&) = delete;
 
         struct RareData : public RefCounted<RareData> {
             WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSelectorRareData);

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -214,7 +214,7 @@ unsigned StyleRule::averageSizeInBytes()
     return sizeof(StyleRule) + sizeof(CSSSelector) + StyleProperties::averageSizeInBytes() + sizeof(Vector<Ref<StyleRuleBase>>);
 }
 
-StyleRule::StyleRule(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRule>>&& nestedRules)
+StyleRule::StyleRule(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
     : StyleRuleBase(StyleRuleType::Style, hasDocumentSecurityOrigin)
     , m_properties(WTFMove(properties))
     , m_selectorList(WTFMove(selectors))
@@ -242,7 +242,7 @@ StyleRule::StyleRule(const StyleRule& o)
 
 StyleRule::~StyleRule() = default;
 
-Ref<StyleRule> StyleRule::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRule>>&& nestedRules)
+Ref<StyleRule> StyleRule::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
 {
     return adoptRef(*new StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors), WTFMove(nestedRules)));
 }

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -107,7 +107,7 @@ class StyleRule final : public StyleRuleBase {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRule);
 public:
     static Ref<StyleRule> create(bool hasDocumentSecurityOrigin, CSSSelectorList&&);
-    static Ref<StyleRule> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRule>>&& nestedRules);
+    static Ref<StyleRule> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
     Ref<StyleRule> copy() const;
     ~StyleRule();
 
@@ -140,13 +140,13 @@ public:
 
     static unsigned averageSizeInBytes();
     void setProperties(Ref<StyleProperties> properties) { m_properties = properties; }
-    void setNestedRules(Vector<Ref<StyleRule>> nestedRules) { m_nestedRules = nestedRules; }
+    void setNestedRules(Vector<Ref<StyleRuleBase>> nestedRules) { m_nestedRules = nestedRules; }
     void setResolvedSelectorList(CSSSelectorList&& resolvedSelectorList) const { m_resolvedSelectorList = WTFMove(resolvedSelectorList); }
-    const Vector<Ref<StyleRule>>& nestedRules() const { return m_nestedRules; }
-    void appendNestedRule(Ref<StyleRule> rule) { m_nestedRules.append(rule); }
+    const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
+    void appendNestedRule(Ref<StyleRuleBase> rule) { m_nestedRules.append(rule); }
 
 private:
-    StyleRule(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRule>>&&);
+    StyleRule(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&&);
     StyleRule(bool hasDocumentSecurityOrigin, CSSSelectorList&&);
     StyleRule(const StyleRule&);
 
@@ -154,8 +154,8 @@ private:
 
     mutable Ref<StyleProperties> m_properties;
     CSSSelectorList m_selectorList;
-    mutable CSSSelectorList m_resolvedSelectorList { };
-    Vector<Ref<StyleRule>> m_nestedRules;
+    mutable CSSSelectorList m_resolvedSelectorList;
+    Vector<Ref<StyleRuleBase>> m_nestedRules;
 
 #if ENABLE(CSS_SELECTOR_JIT)
     mutable UniqueArray<CompiledSelector> m_compiledSelectors;
@@ -273,7 +273,7 @@ public:
 
     void wrapperInsertRule(unsigned, Ref<StyleRuleBase>&&);
     void wrapperRemoveRule(unsigned);
-    
+
 protected:
     StyleRuleGroup(StyleRuleType, Vector<RefPtr<StyleRuleBase>>&&);
     StyleRuleGroup(const StyleRuleGroup&);

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -83,18 +83,18 @@ CSSParser::ParseResult CSSParserImpl::parseValue(MutableStyleProperties* declara
     CSSParserImpl parser(context, string);
     auto ruleType = context.enclosingRuleType.value_or(StyleRuleType::Style);
     parser.consumeDeclarationValue(parser.tokenizer()->tokenRange(), propertyID, important, ruleType);
-    if (parser.m_parsedProperties.isEmpty())
+    if (parser.topContext().m_parsedProperties.isEmpty())
         return CSSParser::ParseResult::Error;
-    return declaration->addParsedProperties(parser.m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
+    return declaration->addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
 }
 
 CSSParser::ParseResult CSSParserImpl::parseCustomPropertyValue(MutableStyleProperties* declaration, const AtomString& propertyName, const String& string, bool important, const CSSParserContext& context)
 {
     CSSParserImpl parser(context, string);
     parser.consumeCustomPropertyValue(parser.tokenizer()->tokenRange(), propertyName, important);
-    if (parser.m_parsedProperties.isEmpty())
+    if (parser.topContext().m_parsedProperties.isEmpty())
         return CSSParser::ParseResult::Error;
-    return declaration->addParsedProperties(parser.m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
+    return declaration->addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
 }
 
 static inline void filterProperties(bool important, const ParsedPropertyVector& input, ParsedPropertyVector& output, size_t& unusedEntries, std::bitset<numCSSProperties>& seenProperties, HashSet<AtomString>& seenCustomProperties)
@@ -145,7 +145,7 @@ Ref<ImmutableStyleProperties> CSSParserImpl::parseInlineStyleDeclaration(const S
 
     CSSParserImpl parser(context, string);
     parser.consumeDeclarationList(parser.tokenizer()->tokenRange(), StyleRuleType::Style);
-    return createStyleProperties(parser.m_parsedProperties, context.mode);
+    return createStyleProperties(parser.topContext().m_parsedProperties, context.mode);
 }
 
 bool CSSParserImpl::parseDeclarationList(MutableStyleProperties* declaration, const String& string, const CSSParserContext& context)
@@ -153,15 +153,15 @@ bool CSSParserImpl::parseDeclarationList(MutableStyleProperties* declaration, co
     CSSParserImpl parser(context, string);
     auto ruleType = context.enclosingRuleType.value_or(StyleRuleType::Style);
     parser.consumeDeclarationList(parser.tokenizer()->tokenRange(), ruleType);
-    if (parser.m_parsedProperties.isEmpty())
+    if (parser.topContext().m_parsedProperties.isEmpty())
         return false;
 
     std::bitset<numCSSProperties> seenProperties;
-    size_t unusedEntries = parser.m_parsedProperties.size();
+    size_t unusedEntries = parser.topContext().m_parsedProperties.size();
     ParsedPropertyVector results(unusedEntries);
     HashSet<AtomString> seenCustomProperties;
-    filterProperties(true, parser.m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
-    filterProperties(false, parser.m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
+    filterProperties(true, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
+    filterProperties(false, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     if (unusedEntries)
         results.remove(0, unusedEntries);
     return declaration->addParsedProperties(results);
@@ -246,10 +246,10 @@ Vector<double> CSSParserImpl::parseKeyframeKeyList(const String& keyList)
 
 bool CSSParserImpl::supportsDeclaration(CSSParserTokenRange& range)
 {
-    ASSERT(m_parsedProperties.isEmpty());
+    ASSERT(topContext().m_parsedProperties.isEmpty());
     consumeDeclaration(range, StyleRuleType::Style);
-    bool result = !m_parsedProperties.isEmpty();
-    m_parsedProperties.clear();
+    bool result = !topContext().m_parsedProperties.isEmpty();
+    topContext().m_parsedProperties.clear();
     return result;
 }
 
@@ -414,12 +414,8 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeAtRule(CSSParserTokenRange& range, A
 }
 
 // https://drafts.csswg.org/css-syntax/#consume-a-qualified-rule
-RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& range, AllowedRulesType allowedRules, RefPtr<StyleRule> parentRule)
+RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& range, AllowedRulesType allowedRules)
 {
-    auto isNestedContext = [&]() {
-        return parentRule && context().cssNestingEnabled;
-    };
-
     const CSSParserToken* preludeStart = &range.peek();
 
     // Parsing a selector (aka a component value) should stop at the first semicolon (and goes to error recovery)
@@ -441,7 +437,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& r
     CSSParserTokenRange block = range.consumeBlockCheckingForEditability(m_styleSheet.get());
 
     if (allowedRules <= RegularRules)
-        return consumeStyleRule(prelude, block, parentRule);
+        return consumeStyleRule(prelude, block);
     
     if (allowedRules == KeyframeRules)
         return consumeKeyframeStyleRule(prelude, block);
@@ -558,20 +554,58 @@ RefPtr<StyleRuleNamespace> CSSParserImpl::consumeNamespaceRule(CSSParserTokenRan
     return StyleRuleNamespace::create(namespacePrefix, uri);
 }
 
-RefPtr<StyleRuleMedia> CSSParserImpl::consumeMediaRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
+void CSSParserImpl::runInNewNestingContext(auto&& run)
+{
+    m_nestingContextStack.append(NestingContext { });
+    run();
+    m_nestingContextStack.removeLast();
+}
+
+RefPtr<StyleRuleBase> CSSParserImpl::createNestingParentRule()
+{
+    CSSSelector nestingParentSelector;
+    nestingParentSelector.setMatch(CSSSelector::Match::PseudoClass);
+    nestingParentSelector.setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassNestingParent);
+    auto parserSelector = makeUnique<CSSParserSelector>(nestingParentSelector);
+    Vector<std::unique_ptr<CSSParserSelector>> selectorList;
+    selectorList.append(WTFMove(parserSelector));
+    auto styleRule = StyleRule::create(m_context.hasDocumentSecurityOrigin, CSSSelectorList { WTFMove(selectorList) });
+    styleRule->setProperties(createStyleProperties(topContext().m_parsedProperties, m_context.mode));
+    return styleRule;
+}
+
+Vector<RefPtr<StyleRuleBase>> CSSParserImpl::consumeRegularRuleList(CSSParserTokenRange block)
 {
     Vector<RefPtr<StyleRuleBase>> rules;
+    if (isNestedContext()) {
+        runInNewNestingContext([&]() {
+            consumeStyleBlock(block, StyleRuleType::Style);
+            if (!topContext().m_parsedProperties.isEmpty()) {
+                // This at-rule contains orphan declarations, we attach them to an implicit parent nesting rule
+                rules.append(createNestingParentRule());
+            }
+            for (auto& rule : topContext().m_parsedRules)
+                rules.append(rule.ptr());
+        });
 
+    } else {
+        consumeRuleList(block, RegularRuleList, [&rules](RefPtr<StyleRuleBase> rule) {
+            rules.append(rule);
+        });
+    }
+    rules.shrinkToFit();
+    return rules;
+}
+
+RefPtr<StyleRuleMedia> CSSParserImpl::consumeMediaRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
+{
     if (m_observerWrapper) {
         m_observerWrapper->observer().startRuleHeader(StyleRuleType::Media, m_observerWrapper->startOffset(prelude));
         m_observerWrapper->observer().endRuleHeader(m_observerWrapper->endOffset(prelude));
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 
-    consumeRuleList(block, RegularRuleList, [&rules](RefPtr<StyleRuleBase> rule) {
-        rules.append(rule);
-    });
-    rules.shrinkToFit();
+    auto rules = consumeRegularRuleList(block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
@@ -591,11 +625,7 @@ RefPtr<StyleRuleSupports> CSSParserImpl::consumeSupportsRule(CSSParserTokenRange
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 
-    Vector<RefPtr<StyleRuleBase>> rules;
-    consumeRuleList(block, RegularRuleList, [&rules](RefPtr<StyleRuleBase> rule) {
-        rules.append(rule);
-    });
-    rules.shrinkToFit();
+    auto rules = consumeRegularRuleList(block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
@@ -617,7 +647,7 @@ RefPtr<StyleRuleFontFace> CSSParserImpl::consumeFontFaceRule(CSSParserTokenRange
     }
 
     consumeDeclarationList(block, StyleRuleType::FontFace);
-    return StyleRuleFontFace::create(createStyleProperties(m_parsedProperties, m_context.mode));
+    return StyleRuleFontFace::create(createStyleProperties(topContext().m_parsedProperties, m_context.mode));
 }
 
 // The associated number represents the maximum number of allowed values for this font-feature-values type.
@@ -765,7 +795,7 @@ RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(C
     }
 
     consumeDeclarationList(block, StyleRuleType::FontPaletteValues);
-    auto properties = createStyleProperties(m_parsedProperties, m_context.mode);
+    auto properties = createStyleProperties(topContext().m_parsedProperties, m_context.mode);
 
     AtomString fontFamily;
     if (auto fontFamilyValue = properties->getPropertyCSSValue(CSSPropertyFontFamily))
@@ -849,7 +879,7 @@ RefPtr<StyleRulePage> CSSParserImpl::consumePageRule(CSSParserTokenRange prelude
 
     consumeDeclarationList(block, StyleRuleType::Style);
     
-    return StyleRulePage::create(createStyleProperties(m_parsedProperties, m_context.mode), WTFMove(selectorList));
+    return StyleRulePage::create(createStyleProperties(topContext().m_parsedProperties, m_context.mode), WTFMove(selectorList));
 }
 
 RefPtr<StyleRuleCounterStyle> CSSParserImpl::consumeCounterStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
@@ -870,7 +900,7 @@ RefPtr<StyleRuleCounterStyle> CSSParserImpl::consumeCounterStyleRule(CSSParserTo
     }
 
     consumeDeclarationList(block, StyleRuleType::CounterStyle);
-    return StyleRuleCounterStyle::create(name, createStyleProperties(m_parsedProperties, m_context.mode));
+    return StyleRuleCounterStyle::create(name, createStyleProperties(topContext().m_parsedProperties, m_context.mode));
 }
 
 RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)
@@ -922,11 +952,7 @@ RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelu
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(*block));
     }
 
-    Vector<RefPtr<StyleRuleBase>> rules;
-    consumeRuleList(*block, RegularRuleList, [&](RefPtr<StyleRuleBase> rule) {
-        rules.append(rule);
-    });
-    rules.shrinkToFit();
+    auto rules = consumeRegularRuleList(*block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(*block));
@@ -952,18 +978,13 @@ RefPtr<StyleRuleContainer> CSSParserImpl::consumeContainerRule(CSSParserTokenRan
     if (!prelude.atEnd())
         return nullptr;
 
-    Vector<RefPtr<StyleRuleBase>> rules;
-
     if (m_observerWrapper) {
         m_observerWrapper->observer().startRuleHeader(StyleRuleType::Container, m_observerWrapper->startOffset(originalPreludeRange));
         m_observerWrapper->observer().endRuleHeader(m_observerWrapper->endOffset(originalPreludeRange));
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 
-    consumeRuleList(block, RegularRuleList, [&rules](RefPtr<StyleRuleBase> rule) {
-        rules.append(rule);
-    });
-    rules.shrinkToFit();
+    auto rules = consumeRegularRuleList(block);
 
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
@@ -988,7 +1009,7 @@ RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange
 
     auto propertyDescriptor = StyleRuleProperty::Descriptor { name };
 
-    for (auto& property : m_parsedProperties) {
+    for (auto& property : topContext().m_parsedProperties) {
         switch (property.id()) {
         case CSSPropertySyntax:
             propertyDescriptor.syntax = downcast<CSSPrimitiveValue>(*property.value()).stringValue();
@@ -1004,7 +1025,7 @@ RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange
         };
     };
 
-    m_parsedProperties.clear();
+    topContext().m_parsedProperties.clear();
 
     return StyleRuleProperty::create(WTFMove(propertyDescriptor));
 }
@@ -1021,7 +1042,7 @@ RefPtr<StyleRuleKeyframe> CSSParserImpl::consumeKeyframeStyleRule(CSSParserToken
     }
 
     consumeDeclarationList(block, StyleRuleType::Keyframe);
-    return StyleRuleKeyframe::create(WTFMove(keyList), createStyleProperties(m_parsedProperties, m_context.mode));
+    return StyleRuleKeyframe::create(WTFMove(keyList), createStyleProperties(topContext().m_parsedProperties, m_context.mode));
 }
 
 static void observeSelectors(CSSParserObserverWrapper& wrapper, CSSParserTokenRange selectors)
@@ -1044,35 +1065,33 @@ static void observeSelectors(CSSParserObserverWrapper& wrapper, CSSParserTokenRa
     wrapper.observer().endRuleHeader(wrapper.endOffset(originalRange));
 }
 
-RefPtr<StyleRule> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block, RefPtr<StyleRule> parentRule)
+RefPtr<StyleRule> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    auto selectorList = parseCSSSelector(prelude, m_context, m_styleSheet.get(), parentRule ? CSSSelectorParser::IsNestedContext::Yes : CSSSelectorParser::IsNestedContext::No);
+    auto selectorList = parseCSSSelector(prelude, m_context, m_styleSheet.get(), isNestedContext() ? CSSSelectorParser::IsNestedContext::Yes : CSSSelectorParser::IsNestedContext::No);
     if (!selectorList)
         return nullptr; // Parse error, invalid selector list
 
     if (m_observerWrapper)
         observeSelectors(*m_observerWrapper, prelude);
     
-    // Save the already parsed properties to avoid mixing them with the nested ones.
-    ParsedPropertyVector previouslyParsedProperties;
-    std::swap(m_parsedProperties, previouslyParsedProperties);
-    
     auto styleRule = StyleRule::create(m_context.hasDocumentSecurityOrigin, WTFMove(*selectorList));
 
-    consumeStyleBlock(block, StyleRuleType::Style, styleRule.ptr());
-    
-    styleRule->setProperties(createStyleProperties(m_parsedProperties, m_context.mode));
-    
-    // Restore the old (= caller) state
-    m_parsedProperties = WTFMove(previouslyParsedProperties);
+    runInNewNestingContext([&]() {
+        m_styleRuleNestingDepth += 1;
+        consumeStyleBlock(block, StyleRuleType::Style);  
+        styleRule->setNestedRules(WTFMove(topContext().m_parsedRules));
+        styleRule->setProperties(createStyleProperties(topContext().m_parsedProperties, m_context.mode));
+        m_styleRuleNestingDepth -= 1;
+    });
     
     return styleRule;
 }
 
 // parentRule determines if we are in a declaration list or in a style block
-void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange range, StyleRuleType ruleType, RefPtr<StyleRule> parentRule)
+void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange range, StyleRuleType ruleType)
 {
-    ASSERT(m_parsedProperties.isEmpty());
+    ASSERT(topContext().m_parsedProperties.isEmpty());
+    ASSERT(topContext().m_parsedRules.isEmpty());
 
     bool useObserver = m_observerWrapper && (ruleType == StyleRuleType::Style || ruleType == StyleRuleType::Keyframe || ruleType == StyleRuleType::CounterStyle);
     if (useObserver) {
@@ -1106,20 +1125,28 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
             break;
         }
         case AtKeywordToken: {
-            // FIXME: Add support for nested rules
-            auto rule = consumeAtRule(range, NoRules);
-            ASSERT_UNUSED(rule, !rule);
+            if (m_styleRuleNestingDepth && context().cssNestingEnabled) {
+                auto rule = consumeAtRule(range, RegularRules);
+                if (!rule)
+                    break;
+                // FIXME: add @scope
+                if (!rule->isMediaRule() && !rule->isSupportsRule() && !rule->isLayerRule() && !rule->isContainerRule())
+                    break;
+                topContext().m_parsedRules.append(*rule);
+            } else {
+                auto rule = consumeAtRule(range, NoRules);
+                ASSERT_UNUSED(rule, !rule);    
+            }
             break;
         }
         default: 
-            if (parentRule && context().cssNestingEnabled) {
-                auto rule = consumeQualifiedRule(range, AllowedRulesType::RegularRules, parentRule);
+            if (m_styleRuleNestingDepth && context().cssNestingEnabled) {
+                auto rule = consumeQualifiedRule(range, AllowedRulesType::RegularRules);
                 if (!rule)
                     break;
-                // FIXME: Add support for valid at-rules (@media, ...)
                 if (!rule->isStyleRule())
                     break;
-                parentRule->appendNestedRule(downcast<StyleRule>(*rule));
+                topContext().m_parsedRules.append(*rule);
                 break;
             }
         FALLTHROUGH;
@@ -1139,12 +1166,12 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
 
 void CSSParserImpl::consumeDeclarationList(CSSParserTokenRange range, StyleRuleType ruleType)
 {
-    consumeDeclarationListOrStyleBlockHelper(range, ruleType, nullptr);
+    consumeDeclarationListOrStyleBlockHelper(range, ruleType);
 }
 
-void CSSParserImpl::consumeStyleBlock(CSSParserTokenRange range, StyleRuleType ruleType, RefPtr<StyleRule> parentRule)
+void CSSParserImpl::consumeStyleBlock(CSSParserTokenRange range, StyleRuleType ruleType)
 {
-    consumeDeclarationListOrStyleBlockHelper(range, ruleType, parentRule);
+    consumeDeclarationListOrStyleBlockHelper(range, ruleType);
 }
 
 static void removeTrailingWhitespace(const CSSParserTokenRange& range, const CSSParserToken*& position)
@@ -1184,7 +1211,7 @@ void CSSParserImpl::consumeDeclaration(CSSParserTokenRange range, StyleRuleType 
         }
     }
 
-    size_t propertiesCount = m_parsedProperties.size();
+    size_t propertiesCount = topContext().m_parsedProperties.size();
 
     if (!isExposed(propertyID, &m_context.propertySettings))
         propertyID = CSSPropertyInvalid;
@@ -1203,21 +1230,21 @@ void CSSParserImpl::consumeDeclaration(CSSParserTokenRange range, StyleRuleType 
     if (m_observerWrapper && (ruleType == StyleRuleType::Style || ruleType == StyleRuleType::Keyframe)) {
         m_observerWrapper->observer().observeProperty(
             m_observerWrapper->startOffset(rangeCopy), m_observerWrapper->endOffset(rangeCopy),
-            important, m_parsedProperties.size() != propertiesCount);
+            important, topContext().m_parsedProperties.size() != propertiesCount);
     }
 }
 
 void CSSParserImpl::consumeCustomPropertyValue(CSSParserTokenRange range, const AtomString& variableName, bool important)
 {
     if (range.atEnd())
-        m_parsedProperties.append(CSSProperty(CSSPropertyCustom, CSSCustomPropertyValue::createEmpty(variableName), important));
+        topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, CSSCustomPropertyValue::createEmpty(variableName), important));
     else if (auto value = CSSVariableParser::parseDeclarationValue(variableName, range, m_context))
-        m_parsedProperties.append(CSSProperty(CSSPropertyCustom, WTFMove(value), important));
+        topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, WTFMove(value), important));
 }
 
 void CSSParserImpl::consumeDeclarationValue(CSSParserTokenRange range, CSSPropertyID propertyID, bool important, StyleRuleType ruleType)
 {
-    CSSPropertyParser::parseValue(propertyID, important, range, m_context, m_parsedProperties, ruleType);
+    CSSPropertyParser::parseValue(propertyID, important, range, m_context, topContext().m_parsedProperties, ruleType);
 }
 
 Vector<double> CSSParserImpl::consumeKeyframeKeyList(CSSParserTokenRange range)

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -97,7 +97,6 @@ public:
     void prependTagSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
     std::unique_ptr<CSSParserSelector> releaseTagHistory();
 
-
 private:
     std::unique_ptr<CSSSelector> m_selector;
     std::unique_ptr<CSSParserSelector> m_tagHistory;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -509,7 +509,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeSimpleSelector(CSSP
         selector = consumeId(range);
     else if (token.type() == DelimiterToken && token.delimiter() == '.')
         selector = consumeClass(range);
-    else if (token.type() == DelimiterToken && token.delimiter() == '&' && m_context.cssNestingEnabled)
+    else if (token.type() == DelimiterToken && token.delimiter() == '&' && m_context.cssNestingEnabled && m_isNestedContext == IsNestedContext::Yes) // FIXME: handle top-level nesting selector
         selector = consumeNesting(range);
     else if (token.type() == LeftBracketToken)
         selector = consumeAttribute(range);
@@ -1166,43 +1166,52 @@ bool CSSSelectorParser::containsUnknownWebKitPseudoElements(const CSSSelector& c
     return false;
 }
 
-CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList& parentResolvedSelectorList)
+CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList)
 {
     Vector<std::unique_ptr<CSSParserSelector>> result;
     CSSSelectorList copiedSelectorList { nestedSelectorList };
     auto selector = copiedSelectorList.first();
     while (selector) {
         if (selector->hasExplicitNestingParent()) {
-            // FIXME: We should build a new CSSParserSelector from this selector and resolve it
-            const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(parentResolvedSelectorList);
-            auto uniqueSelector = makeUnique<CSSParserSelector>(*selector);
-            result.append(WTFMove(uniqueSelector));
-        } else {
-            // We add the implicit parent selector at the beginning of the selector
+            if (parentResolvedSelectorList) {
+                // FIXME: We should build a new CSSParserSelector from this selector and resolve it
+                const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(*parentResolvedSelectorList);
+            } else {
+                // It's top-level, the nesting parent selector should be replace by not(*)
+                const_cast<CSSSelector*>(selector)->replaceNestingParentByNotAll();
+            }
             auto parserSelector = makeUnique<CSSParserSelector>(*selector);
-            auto lastSelector = parserSelector->leftmostSimpleSelector()->selector();
-            ASSERT(lastSelector);
-            bool isLastInSelectorList = lastSelector->isLastInSelectorList();
-            lastSelector->setNotLastInTagHistory();
-            lastSelector->setNotLastInSelectorList();
-            CSSSelector parentIsSelector;
-            parentIsSelector.setMatch(CSSSelector::Match::PseudoClass);
-            parentIsSelector.setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassIs);
-            parentIsSelector.setSelectorList(makeUnique<CSSSelectorList>(parentResolvedSelectorList));
-            parentIsSelector.setLastInTagHistory();
-            if (isLastInSelectorList)
-                parentIsSelector.setLastInSelectorList();
-            else
-                parentIsSelector.setNotLastInSelectorList();
+            result.append(WTFMove(parserSelector));
+        } else {
+            auto parserSelector = makeUnique<CSSParserSelector>(*selector);
+            if (parentResolvedSelectorList) {
+                // We add the implicit parent selector at the beginning of the selector
+                auto lastSelector = parserSelector->leftmostSimpleSelector()->selector();
+                ASSERT(lastSelector);
+                bool isLastInSelectorList = lastSelector->isLastInSelectorList();
+                lastSelector->setNotLastInTagHistory();
+                lastSelector->setNotLastInSelectorList();
+                CSSSelector parentIsSelector;
+                parentIsSelector.setMatch(CSSSelector::Match::PseudoClass);
+                parentIsSelector.setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassIs);
+                parentIsSelector.setSelectorList(makeUnique<CSSSelectorList>(*parentResolvedSelectorList));
+                parentIsSelector.setLastInTagHistory();
+                if (isLastInSelectorList)
+                    parentIsSelector.setLastInSelectorList();
+                else
+                    parentIsSelector.setNotLastInSelectorList();
 
-            auto uniqueParentIsSelector = makeUnique<CSSParserSelector>(parentIsSelector);
-            parserSelector->appendTagHistory(CSSSelector::RelationType::DescendantSpace, WTFMove(uniqueParentIsSelector));
+                auto uniqueParentIsSelector = makeUnique<CSSParserSelector>(parentIsSelector);
+                parserSelector->appendTagHistory(CSSSelector::RelationType::DescendantSpace, WTFMove(uniqueParentIsSelector));
+            }
+            // Otherwise, no nesting parent selector and top-level, do nothing to this selector
             result.append(WTFMove(parserSelector));
         }
         selector = copiedSelectorList.next(selector);
     }
 
-    return CSSSelectorList { WTFMove(result) };
+    auto final = CSSSelectorList { WTFMove(result) };
+    return final;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -57,7 +57,7 @@ public:
     CSSSelectorList consumeNestedSelectorList(CSSParserTokenRange&);
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSParserContext&);
-    static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList& parentResolvedSelectorList);
+    static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList);
 
 private:
     template<typename ConsumeSelector> CSSSelectorList consumeSelectorList(CSSParserTokenRange&, ConsumeSelector&&);

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -34,13 +34,14 @@ public:
     ~RuleSetBuilder();
 
     void addRulesFromSheet(const StyleSheetContents&, const MQ::MediaQueryList& sheetQuery = { });
-    void addStyleRule(const StyleRule&, const CSSSelectorList* parentResolvedSelectorList = nullptr);
+    void addStyleRule(const StyleRule&);
 
 private:
     RuleSetBuilder(const MQ::MediaQueryEvaluator&);
 
     void addRulesFromSheetContents(const StyleSheetContents&);
     void addChildRules(const Vector<RefPtr<StyleRuleBase>>&);
+    void addChildRule(RefPtr<StyleRuleBase>);
     void disallowDynamicMediaQueryEvaluationIfNeeded();
 
     void registerLayers(const Vector<CascadeLayerName>&);
@@ -50,6 +51,7 @@ private:
     
     void addMutatingRulesToResolver();
     void updateDynamicMediaQueries();
+    void populateStyleRuleResolvedSelectorList(const StyleRule&);
 
     struct MediaQueryCollector {
         ~MediaQueryCollector();
@@ -80,6 +82,7 @@ private:
     CascadeLayerName m_resolvedCascadeLayerName;
     HashMap<CascadeLayerName, RuleSet::CascadeLayerIdentifier> m_cascadeLayerIdentifierMap;
     RuleSet::CascadeLayerIdentifier m_currentCascadeLayerIdentifier { 0 };
+    Vector<const CSSSelectorList*> m_styleRuleStack;
 
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
 


### PR DESCRIPTION
#### fb1992149cc152d60241cfe53faae4986c6499c7
<pre>
CSS Nesting: nesting at-rule inside style rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=250042">https://bugs.webkit.org/show_bug.cgi?id=250042</a>
rdar://103147312

Reviewed by Antti Koivisto.

In both RuleSetBuilder and CSSParserImpl, we use
a member object to maintain the state of the
style rule stack.

ParserImpl methods should always work with the top of the stack context
via the topContext() method.

Some WPT are failing because:
- exact serialization is still in flux
- we don&apos;t handle top-level nesting selector

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::replaceNestingParentByNotAll):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::StyleRule):
(WebCore::StyleRule::create):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseValue):
(WebCore::CSSParserImpl::parseCustomPropertyValue):
(WebCore::CSSParserImpl::parseInlineStyleDeclaration):
(WebCore::CSSParserImpl::parseDeclarationList):
(WebCore::CSSParserImpl::supportsDeclaration):
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::CSSParserImpl::runInNewNestingContext):
(WebCore::CSSParserImpl::createNestingParentRule):
(WebCore::CSSParserImpl::consumeRegularRuleList):
(WebCore::CSSParserImpl::consumeMediaRule):
(WebCore::CSSParserImpl::consumeSupportsRule):
(WebCore::CSSParserImpl::consumeFontFaceRule):
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):
(WebCore::CSSParserImpl::consumePageRule):
(WebCore::CSSParserImpl::consumeCounterStyleRule):
(WebCore::CSSParserImpl::consumeLayerRule):
(WebCore::CSSParserImpl::consumeContainerRule):
(WebCore::CSSParserImpl::consumePropertyRule):
(WebCore::CSSParserImpl::consumeKeyframeStyleRule):
(WebCore::CSSParserImpl::consumeStyleRule):
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):
(WebCore::CSSParserImpl::consumeDeclarationList):
(WebCore::CSSParserImpl::consumeStyleBlock):
(WebCore::CSSParserImpl::consumeDeclaration):
(WebCore::CSSParserImpl::consumeCustomPropertyValue):
(WebCore::CSSParserImpl::consumeDeclarationValue):
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::topContext):
(WebCore::CSSParserImpl::isNestedContext):
(WebCore::CSSParserImpl::consumeQualifiedRule): Deleted.
(WebCore::CSSParserImpl::consumeStyleRule): Deleted.
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper): Deleted.
(WebCore::CSSParserImpl::consumeStyleBlock): Deleted.
* Source/WebCore/css/parser/CSSParserSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeSimpleSelector):
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRules):
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::populateStyleRuleResolvedSelectorList):
(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/258560@main">https://commits.webkit.org/258560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c21f07160169f13bc656ebcf0aa54bc7b81de9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111608 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171796 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2357 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109317 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37271 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24267 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4954 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25686 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5093 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2143 "Found 1 new test failure: fast/css-generated-content/noscript-pseudo-anim-crash.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45188 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6845 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3107 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->