### PR TITLE
Implement margin-trim for flexbox.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-end-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-end-trimmed-only-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-block-end-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-end should only trim margin block end of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block-start: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-end-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-end-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-block-end-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-block-end-trimmed-only-ref.html">
+<meta name="assert" content="block-end should trim only margin block end of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-start-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-start-trimmed-only-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-block-start-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-start should trim only margin block start of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block-end: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-start-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-start-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-block-start-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-block-start-trimmed-only-ref.html">
+<meta name="assert" content="block-start should trim only margin block start of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    margin-trim: block-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-trimmed-only-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-block-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block should trim only block margins of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-block-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-block-trimmed-only-ref.html">
+<meta name="assert" content="block should trim only block margins of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-block-multiline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-block-multiline-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-column-block-multiline</title>
+<meta name="assert" content="block-start should be trimmed for items at the start of the flex line and block-end should be trimmed for items at the end of the flex line">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-block-multiline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-block-multiline.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-column-block-multiline</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="block-start should be trimmed for items at the start of the flex line and block-end should be trimmed for items at the end of the flex line">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    height: 100px;
+    flex-wrap: wrap;
+    flex-direction: column;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(odd) {
+    margin-block-start: 25px;
+}
+item:nth-child(even) {
+    margin-block-end: 25px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-grow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-grow-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-grow-002</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="items should grow to take up the space made available by trimming margins">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-grow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-grow.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-grow-002</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="items should grow to take up the space made available by trimming margins">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    height: 100px;
+    flex-direction: column;
+    margin-trim: block;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    margin-block: 25px;
+    flex: 1 0 auto;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-column-inline-multiline</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="inline-start should be trimmed for all items on the first flex line and inline-end should be trimmed for all items on the last flex line">
+<style>
+flexbox {
+    display: flex;
+    width: 60px;
+    height: 100px;
+    flex-direction: column;
+    flex-wrap: wrap;
+    gap: 0px 30px;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-column-inline-multiline</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-column-inline-multiline-ref.html">
+<meta name="assert" content="inline-start should be trimmed for all items on the first flex line and inline-end should be trimmed for all items on the last flex line">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    height: 100px;
+    flex-direction: column;
+    flex-wrap: wrap;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-start: 10px;
+    margin-inline-end: 20px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-orthogonal-item-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-orthogonal-item-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-orthogonal-item-002</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="orthogonal items have correct margins trimmed according to the flexbox's writing mode">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-orthogonal-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-orthogonal-item.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-orthogonal-item-002</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="orthogonal items have correct margins trimmed according to the flexbox's writing mode">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 100px;
+    height: 50px;
+}
+.orthogonal {
+    writing-mode: vertical-rl;
+}
+item:first-child {
+    margin-inline-start: 10px;
+}
+item:last-child {
+    margin-block-end: 10px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item class="orthogonal"></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-shrink-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-shrink-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-shrink-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="content should fill all available space when flex item is larger than the container and the margins are trimmed">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-shrink.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-shrink.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-shrink-001</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="content should fill all available space when flex item is larger than the container and the margins are trimmed">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: 100px;
+    height: 100px;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    margin-block: 25px;
+    flex: 0 1 auto;
+    width: 100px;
+    height: 150px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-end-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-end-trimmed-only-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-inline-end-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="inline-end should trim only inline-end margins of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    gap: 20px;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+item:first-child {
+    margin-inline-start: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-end-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-end-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-inline-end-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-inline-end-trimmed-only-ref.html">
+<meta name="assert" content="inline-end should trim only inline-end margins of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-start-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-start-trimmed-only-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-inline-start-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="inline-start trims only inline-start margin of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    gap: 20px;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+item:last-child {
+    margin-inline-end: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-start-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-start-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-inline-start-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-inline-start-trimmed-only-ref.html">
+<meta name="assert" content="inline-start trims only inline-start margin of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-trimmed-only-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-trimmed-only-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-inline-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="inline will trim only the inline margins of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    gap: 20px;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-trimmed-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-trimmed-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-inline-trimmed-only</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-inline-trimmed-only-ref.html">
+<meta name="assert" content="inline will trim only the inline margins of flex items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    border: 1px black solid;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-block-multiline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-block-multiline-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-row-block-multiline</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="block-start margins are trimmed for items on first flex line and block-end margins and trimmed for items on last flex line">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    flex-wrap: wrap;
+    gap: 20px 0px;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-block-multiline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-block-multiline.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-row-block-multiline</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-row-block-multiline-ref.html">
+<meta name="assert" content="block-start margins are trimmed for items on first flex line and block-end margins and trimmed for items on last flex line">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    flex-wrap: wrap;
+    margin-trim: block;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-grow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-grow-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="items should grow to take up the space made available by trimming margins">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-grow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-grow.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-grow-001.html</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="items should grow to take up the space made available by trimming margins">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 100px;
+    margin-inline: 25px;
+    flex: 1 0 auto;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-inline-multiline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-inline-multiline-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-row-inline-multiline</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="inline-start margins are trimmed for items at start of flex line and inline-end margins are trimmed for items at end of flex line">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-inline-multiline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-inline-multiline.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-row-inline-multiline</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="inline-start margins are trimmed for items at start of flex line and inline-end margins are trimmed for items at end of flex line">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    flex-wrap: wrap;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(odd) {
+    margin-inline-start: 25px;
+}
+item:nth-child(even) {
+    margin-inline-end: 25px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-orthogonal-item-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-orthogonal-item-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>flex-orthogonal-item-002</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="orthogonal items have correct margins trimmed according to the flexbox's writing mode">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-orthogonal-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-orthogonal-item.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>flex-orthogonal-item-002</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="orthogonal items have correct margins trimmed according to the flexbox's writing mode">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    margin-trim: inline
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 100px;
+}
+.orthogonal {
+    writing-mode: vertical-rl;
+}
+item:first-child {
+    margin-block-end: 10px;
+}
+item:last-child {
+    margin-inline-end: 10px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item class="orthogonal"></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-shrink-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-shrink-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-shrink-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="content should fill all available space when flex item is larger than the container and the margins are trimmed">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-shrink.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-shrink.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-shrink-001</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="content should fill all available space when flex item is larger than the container and the margins are trimmed">
+<style>
+flexbox {
+    display: flex;
+    width: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    background-color: green;
+    margin-inline: 25px;
+    flex: 0 1 auto;
+    width: 150px;
+    height: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<flexbox>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-trim-all-margins-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-trim-all-margins-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-trim-all-margins-001</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="specifying all margin edges should trim all of them correctly for the appropriate items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    gap: 20px;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-trim-all-margins.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-trim-all-margins.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: flex-trim-all-margins-001</title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-trim-all-margins-001-ref.html">
+<meta name="assert" content="specifying all margin edges should trim all of them correctly for the appropriate items">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    margin-trim: block-start block-end inline-start inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+<flexbox>
+<item></item>
+<item></item>
+<item></item>
+</flexbox>
+</body>
+</html>

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-template-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-template-expected.txt
@@ -1,0 +1,7 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x66
+  RenderBlock {HTML} at (0,0) size 800x66
+    RenderBody {BODY} at (8,8) size 784x50
+      RenderFlexibleBox {FLEXBOX} at (0,0) size 50x50 [bgcolor=#808080]
+        RenderBlock {ITEM} at (0,0) size 50x0 [bgcolor=#008000]

--- a/Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp
+++ b/Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp
@@ -48,14 +48,33 @@ FlexItem::FlexItem(RenderBox& box, LayoutUnit flexBaseContentSize, LayoutUnit ma
     ASSERT(!box.isOutOfFlowPositioned());
 }
 
-FlexLayoutAlgorithm::FlexLayoutAlgorithm(const RenderStyle& style, LayoutUnit lineBreakLength, const Vector<FlexItem>& allItems, LayoutUnit gapBetweenItems, LayoutUnit gapBetweenLines)
-    : m_style(style)
+FlexLayoutAlgorithm::FlexLayoutAlgorithm(RenderFlexibleBox& flexbox, LayoutUnit lineBreakLength, const Vector<FlexItem>& allItems, LayoutUnit gapBetweenItems, LayoutUnit gapBetweenLines)
+    : m_flexbox(flexbox)
     , m_lineBreakLength(lineBreakLength)
     , m_allItems(allItems)
     , m_gapBetweenItems(gapBetweenItems)
     , m_gapBetweenLines(gapBetweenLines)
 {
 }
+
+bool FlexLayoutAlgorithm::canFitItemWithTrimmedMarginEnd(const FlexItem& item, LayoutUnit sumHypotheticalMainSize) const
+{
+    auto marginTrim = m_flexbox.style().marginTrim();
+    if ((m_flexbox.isHorizontalFlow() && marginTrim.contains(MarginTrimType::InlineEnd)) || (m_flexbox.isColumnFlow() && marginTrim.contains(MarginTrimType::BlockEnd)))
+        return sumHypotheticalMainSize + item.hypotheticalMainAxisMarginBoxSize() - m_flexbox.flowAwareMarginEndForChild(item.box) <= m_lineBreakLength;
+    return false;
+}
+
+void FlexLayoutAlgorithm::removeMarginEndFromFlexSizes(FlexItem& flexItem, LayoutUnit& sumFlexBaseSize, LayoutUnit& sumHypotheticalMainSize) const
+{
+    LayoutUnit margin;
+    if (m_flexbox.isHorizontalFlow())
+        margin = flexItem.box.marginEnd(&m_flexbox.style());
+    else
+        margin = flexItem.box.marginAfter(&m_flexbox.style());
+    sumFlexBaseSize -= margin;
+    sumHypotheticalMainSize -= margin;
+} 
 
 bool FlexLayoutAlgorithm::computeNextFlexLine(size_t& nextIndex, Vector<FlexItem>& lineItems, LayoutUnit& sumFlexBaseSize, double& totalFlexGrow, double& totalFlexShrink, double& totalWeightedFlexShrink, LayoutUnit& sumHypotheticalMainSize)
 {
@@ -64,10 +83,13 @@ bool FlexLayoutAlgorithm::computeNextFlexLine(size_t& nextIndex, Vector<FlexItem
     totalFlexGrow = totalFlexShrink = totalWeightedFlexShrink = 0;
     sumHypotheticalMainSize = 0_lu;
 
+    // Trim main axis margin for item at the start of the flex line
+    if (nextIndex < m_allItems.size() && m_flexbox.shouldTrimMainAxisMarginStart())
+        m_flexbox.trimMainAxisMarginStart(m_allItems[nextIndex]);
     for (; nextIndex < m_allItems.size(); ++nextIndex) {
         const auto& flexItem = m_allItems[nextIndex];
         ASSERT(!flexItem.box.isOutOfFlowPositioned());
-        if (isMultiline() && sumHypotheticalMainSize + flexItem.hypotheticalMainAxisMarginBoxSize() > m_lineBreakLength && !lineItems.isEmpty())
+        if (isMultiline() && (sumHypotheticalMainSize + flexItem.hypotheticalMainAxisMarginBoxSize() > m_lineBreakLength && !canFitItemWithTrimmedMarginEnd(flexItem, sumHypotheticalMainSize)) && !lineItems.isEmpty())
             break;
         lineItems.append(flexItem);
         sumFlexBaseSize += flexItem.flexBaseMarginBoxSize() + m_gapBetweenItems;
@@ -85,6 +107,12 @@ bool FlexLayoutAlgorithm::computeNextFlexLine(size_t& nextIndex, Vector<FlexItem
     }
 
     ASSERT(lineItems.size() > 0 || nextIndex == m_allItems.size());
+    // Trim main axis margin for item at the end of the flex line
+    if (lineItems.size() && m_flexbox.shouldTrimMainAxisMarginEnd()) {
+        auto lastItem = lineItems.last();
+        removeMarginEndFromFlexSizes(lastItem, sumFlexBaseSize, sumHypotheticalMainSize);
+        m_flexbox.trimMainAxisMarginEnd(lastItem);
+    }
     return lineItems.size() > 0;
 }
 

--- a/Source/WebCore/rendering/FlexibleBoxAlgorithm.h
+++ b/Source/WebCore/rendering/FlexibleBoxAlgorithm.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "LayoutUnit.h"
-#include "RenderStyle.h"
+#include "RenderFlexibleBox.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 
@@ -61,9 +61,9 @@ public:
     LayoutUnit constrainSizeByMinMax(const LayoutUnit) const;
 
     RenderBox& box;
-    const LayoutUnit flexBaseContentSize;
+    LayoutUnit flexBaseContentSize;
     const LayoutUnit mainAxisBorderAndPadding;
-    const LayoutUnit mainAxisMargin;
+    mutable LayoutUnit mainAxisMargin;
     const std::pair<LayoutUnit, LayoutUnit> minMaxSizes;
     const LayoutUnit hypotheticalMainContentSize;
     LayoutUnit flexedContentSize;
@@ -75,16 +75,18 @@ class FlexLayoutAlgorithm {
     WTF_MAKE_NONCOPYABLE(FlexLayoutAlgorithm);
 
 public:
-    FlexLayoutAlgorithm(const RenderStyle&, LayoutUnit lineBreakLength, const Vector<FlexItem>& allItems, LayoutUnit gapBetweenItems, LayoutUnit gapBetweenLines);
+    FlexLayoutAlgorithm(RenderFlexibleBox&, LayoutUnit lineBreakLength, const Vector<FlexItem>& allItems, LayoutUnit gapBetweenItems, LayoutUnit gapBetweenLines);
 
     // The hypothetical main size of an item is the flex base size clamped
     // according to its min and max main size properties
     bool computeNextFlexLine(size_t& nextIndex, Vector<FlexItem>& lineItems, LayoutUnit& sumFlexBaseSize, double& totalFlexGrow, double& totalFlexShrink, double& totalWeightedFlexShrink, LayoutUnit& sumHypotheticalMainSize);
 
 private:
-    bool isMultiline() const { return m_style.flexWrap() != FlexWrap::NoWrap; }
+    bool isMultiline() const { return m_flexbox.style().flexWrap() != FlexWrap::NoWrap; }
+    bool canFitItemWithTrimmedMarginEnd(const FlexItem&, LayoutUnit sumHypotheticalMainSize) const;
+    void removeMarginEndFromFlexSizes(FlexItem&, LayoutUnit& sumFlexBaseSize, LayoutUnit& sumHypotheticalMainSize) const; 
 
-    const RenderStyle& m_style;
+    RenderFlexibleBox& m_flexbox;
     LayoutUnit m_lineBreakLength;
     const Vector<FlexItem>& m_allItems;
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -983,9 +983,9 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
     Length marginLeft = child.style().marginStartUsing(&style());
     Length marginRight = child.style().marginEndUsing(&style());
     LayoutUnit margin;
-    if (marginLeft.isFixed())
+    if (marginLeft.isFixed() && !shouldTrimChildMargin(MarginTrimType::InlineStart, child))
         margin += marginLeft.value();
-    if (marginRight.isFixed())
+    if (marginRight.isFixed() && !shouldTrimChildMargin(MarginTrimType::InlineEnd, child))
         margin += marginRight.value();
     return margin;
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -393,6 +393,7 @@ public:
     // Resolve auto margins in the inline direction of the containing block so that objects can be pushed to the start, middle or end
     // of the containing block.
     void computeInlineDirectionMargins(const RenderBlock& containingBlock, LayoutUnit containerWidth, LayoutUnit childWidth, LayoutUnit& marginStart, LayoutUnit& marginEnd) const;
+    LayoutUnit computeOrTrimInlineMargin(const RenderBlock& containingBlock, MarginTrimType marginSide, std::function<LayoutUnit()> computeInlineMargin) const;
 
     // Used to resolve margins in the containing block's block-flow direction.
     void computeBlockDirectionMargins(const RenderBlock& containingBlock, LayoutUnit& marginBefore, LayoutUnit& marginAfter) const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -413,7 +413,10 @@ void RenderFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
     
     bool oldInLayout = m_inLayout;
     m_inLayout = true;
-    
+
+    if (!style().marginTrim().isEmpty())
+        initializeMarginTrimState();
+
     if (recomputeLogicalWidth())
         relayoutChildren = true;
 
@@ -885,6 +888,20 @@ LayoutUnit RenderFlexibleBox::flowAwareMarginBeforeForChild(const RenderBox& chi
     return marginTop();
 }
 
+void RenderFlexibleBox::initializeMarginTrimState()
+{
+    // When computeIntrinsicLogicalWidth goes through each of the children, it
+    // will include the margins when computing the flexbox's min and max widths.
+    // We need to trim the margins of the first and last child early so that
+    // these margins do not incorrectly constribute to the box's min/max width
+    auto marginTrim = style().marginTrim();
+    auto isRowsFlexbox = isHorizontalFlow();
+    if (auto child = firstInFlowChildBox(); child && marginTrim.contains(MarginTrimType::InlineStart))
+        isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineStart.add(child) : m_marginTrimItems.m_itemsOnFirstFlexLine.add(child);
+    if (auto child = lastInFlowChildBox(); child && marginTrim.contains(MarginTrimType::InlineEnd))
+        isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineEnd.add(child) : m_marginTrimItems.m_itemsOnLastFlexLine.add(child);
+}
+
 LayoutUnit RenderFlexibleBox::mainAxisMarginExtentForChild(const RenderBox& child) const
 {
     if (!child.needsLayout())
@@ -911,6 +928,88 @@ LayoutUnit RenderFlexibleBox::crossAxisMarginExtentForChild(const RenderBox& chi
     else
         child.computeInlineDirectionMargins(*this, child.containingBlockLogicalWidthForContentInFragment(nullptr), child.logicalWidth(), marginStart, marginEnd);
     return marginStart + marginEnd;
+}
+
+bool RenderFlexibleBox::shouldTrimChildMargin(MarginTrimType marginTrimType, const RenderBox& child) const
+{
+    auto isMarginParallelWithMainAxis = [this](MarginTrimType marginTrimType) {
+        if (isHorizontalFlow())
+            return marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::BlockEnd;
+        return marginTrimType == MarginTrimType::InlineStart || marginTrimType == MarginTrimType::InlineEnd;
+    };
+    if (!style().marginTrim().contains(marginTrimType))
+        return false;
+    if (isMarginParallelWithMainAxis(marginTrimType))
+        return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsOnFirstFlexLine.contains(&child) : m_marginTrimItems.m_itemsOnLastFlexLine.contains(&child);
+    return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsAtFlexLineStart.contains(&child) : m_marginTrimItems.m_itemsAtFlexLineEnd.contains(&child);
+}
+
+bool RenderFlexibleBox::shouldTrimMainAxisMarginStart() const
+{
+    if (isHorizontalFlow())
+        return style().marginTrim().contains(MarginTrimType::InlineStart);
+    return style().marginTrim().contains(MarginTrimType::BlockStart);
+}
+
+bool RenderFlexibleBox::shouldTrimMainAxisMarginEnd() const
+{
+    if (isHorizontalFlow())
+        return style().marginTrim().contains(MarginTrimType::InlineEnd);
+    return style().marginTrim().contains(MarginTrimType::BlockEnd);
+}
+
+bool RenderFlexibleBox::shouldTrimCrossAxisMarginStart() const
+{
+    if (isHorizontalFlow())
+        return style().marginTrim().contains(MarginTrimType::BlockStart);
+    return style().marginTrim().contains(MarginTrimType::InlineStart);
+}
+
+bool RenderFlexibleBox::shouldTrimCrossAxisMarginEnd() const
+{
+    if (isHorizontalFlow())
+        return style().marginTrim().contains(MarginTrimType::BlockEnd);
+    return style().marginTrim().contains(MarginTrimType::InlineEnd);
+}
+
+void RenderFlexibleBox::trimMainAxisMarginStart(const FlexItem& flexItem)
+{
+    auto horizontalFlow = isHorizontalFlow();
+    flexItem.mainAxisMargin -= horizontalFlow ? flexItem.box.marginStart(&style()) : flexItem.box.marginBefore(&style());
+    if (horizontalFlow) 
+        flexItem.box.setMarginStart(0_lu, &style());
+    else
+        flexItem.box.setMarginBefore(0_lu, &style());
+    m_marginTrimItems.m_itemsAtFlexLineStart.add(&flexItem.box);
+}
+
+void RenderFlexibleBox::trimMainAxisMarginEnd(const FlexItem& flexItem)
+{
+    auto horizontalFlow = isHorizontalFlow();
+    flexItem.mainAxisMargin -= horizontalFlow ? flexItem.box.marginEnd(&style()) : flexItem.box.marginAfter(&style());
+    if (horizontalFlow)
+        flexItem.box.setMarginEnd(0_lu, &style());
+    else
+        flexItem.box.setMarginAfter(0_lu, &style());
+    m_marginTrimItems.m_itemsAtFlexLineEnd.add(&flexItem.box);
+}
+
+void RenderFlexibleBox::trimCrossAxisMarginStart(const FlexItem& flexItem)
+{
+    if (isHorizontalFlow())
+        flexItem.box.setMarginBefore(0_lu, &style());
+    else
+        flexItem.box.setMarginStart(0_lu, &style());
+    m_marginTrimItems.m_itemsOnFirstFlexLine.add(&flexItem.box);
+}
+
+void RenderFlexibleBox::trimCrossAxisMarginEnd(const FlexItem& flexItem)
+{
+    if (isHorizontalFlow())
+        flexItem.box.setMarginAfter(0_lu, &style());
+    else
+        flexItem.box.setMarginEnd(0_lu, &style());
+    m_marginTrimItems.m_itemsOnLastFlexLine.add(&flexItem.box);
 }
 
 LayoutUnit RenderFlexibleBox::crossAxisScrollbarExtent() const
@@ -1210,7 +1309,7 @@ void RenderFlexibleBox::layoutFlexItems(bool relayoutChildren)
     const LayoutUnit lineBreakLength = mainAxisContentExtent(LayoutUnit::max());
     LayoutUnit gapBetweenItems = computeGap(GapType::BetweenItems);
     LayoutUnit gapBetweenLines = computeGap(GapType::BetweenLines);
-    FlexLayoutAlgorithm flexAlgorithm(style(), lineBreakLength, allItems, gapBetweenItems, gapBetweenLines);
+    FlexLayoutAlgorithm flexAlgorithm(*this, lineBreakLength, allItems, gapBetweenItems, gapBetweenLines);
     LayoutUnit crossAxisOffset = flowAwareBorderBefore() + flowAwarePaddingBefore();
     Vector<FlexItem> lineItems;
     size_t nextIndex = 0;
@@ -1219,7 +1318,17 @@ void RenderFlexibleBox::layoutFlexItems(bool relayoutChildren)
     while (flexAlgorithm.computeNextFlexLine(nextIndex, lineItems, sumFlexBaseSize, totalFlexGrow, totalFlexShrink, totalWeightedFlexShrink, sumHypotheticalMainSize)) {
         ++numLines;
         InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine(*this, nextIndex);
-
+        // Cross axis margins should only be trimmed if they are on the first/last flex line
+        auto shouldTrimCrossAxisStart = shouldTrimCrossAxisMarginStart() && !lineContexts.size();
+        auto shouldTrimCrossAxisEnd = shouldTrimCrossAxisMarginEnd() && &allItems.last().box == &lineItems.last().box;
+        if (shouldTrimCrossAxisStart || shouldTrimCrossAxisEnd) {
+            for (auto& flexItem : lineItems) {
+                if (shouldTrimCrossAxisStart)
+                    trimCrossAxisMarginStart(flexItem);
+                if (shouldTrimCrossAxisEnd)
+                    trimCrossAxisMarginEnd(flexItem);
+            }
+        }
         LayoutUnit containerMainInnerSize = mainAxisContentExtent(sumHypotheticalMainSize);
         // availableFreeSpace is the initial amount of free space in this flexbox.
         // remainingFreeSpace starts out at the same value but as we place and lay

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -102,6 +102,7 @@ protected:
     bool shouldResetChildLogicalHeightBeforeLayout(const RenderBox&) const override { return m_shouldResetChildLogicalHeightBeforeLayout; }
 
 private:
+    friend class FlexLayoutAlgorithm;
     enum FlexSign {
         PositiveFlexibility,
         NegativeFlexibility,
@@ -179,6 +180,19 @@ private:
     void layoutFlexItems(bool relayoutChildren);
     LayoutUnit autoMarginOffsetInMainAxis(const Vector<FlexItem>&, LayoutUnit& availableFreeSpace);
     void updateAutoMarginsInMainAxis(RenderBox& child, LayoutUnit autoMarginOffset);
+    void initializeMarginTrimState(); 
+    // Start margin parallel with the cross axis
+    bool shouldTrimMainAxisMarginStart() const;
+    // End margin parallel with the cross axis
+    bool shouldTrimMainAxisMarginEnd() const;
+    // Margins parallel with the main axis
+    bool shouldTrimCrossAxisMarginStart() const;
+    bool shouldTrimCrossAxisMarginEnd() const;
+    void trimMainAxisMarginStart(const FlexItem&);
+    void trimMainAxisMarginEnd(const FlexItem&);
+    void trimCrossAxisMarginStart(const FlexItem&);
+    void trimCrossAxisMarginEnd(const FlexItem&);
+    bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const final;
     bool hasAutoMarginsInCrossAxis(const RenderBox& child) const;
     bool updateAutoMarginsInCrossAxis(RenderBox& child, LayoutUnit availableAlignmentSpace);
     void repositionLogicalHeightDependentFlexItems(Vector<LineContext>&, LayoutUnit gapBetweenLines);
@@ -234,6 +248,13 @@ private:
     mutable OrderIterator m_orderIterator { *this };
     std::optional<size_t> m_numberOfInFlowChildrenOnFirstLine { };
     std::optional<size_t> m_numberOfInFlowChildrenOnLastLine { };
+
+    struct MarginTrimItems {
+        HashSet<const RenderBox*> m_itemsAtFlexLineStart;
+        HashSet<const RenderBox*> m_itemsAtFlexLineEnd;
+        HashSet<const RenderBox*> m_itemsOnFirstFlexLine;
+        HashSet<const RenderBox*> m_itemsOnLastFlexLine;
+    } m_marginTrimItems;
 
     // This is SizeIsUnknown outside of layoutBlock()
     SizeDefiniteness m_hasDefiniteHeight { SizeDefiniteness::Unknown };


### PR DESCRIPTION
#### 0efe67f528eb93f229bb52b4d8a5ade70209c961
<pre>
Implement margin-trim for flexbox.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249208">https://bugs.webkit.org/show_bug.cgi?id=249208</a>
rdar://103285847

Reviewed by Alan Baradlay.

Adds support for the margin-trim property on flexbox containers.
Depending on the values that are set for this property, it will trim
the corresponding edges of the flex items that are adjacent to those
edges of the container.

In order to achieve this, a new data structure, m_marginTrimItems, was
added to RenderFlexibleBox. This structure simply holds the items that
are trimmed according to their location in the flexbox.

The first step of this algorithm is to trim the edges of the first and
last child of the flexbox. This is done so that
RenderFlexibleBox::computeIntrinsicLogicalWidths does not incorrectly
take these margins into consideration when computing the width of the
flexbox under a min/max content constraint.

In order to figure out which items are actually being trimmed, we cannot
perform any trimming until the flex lines are created. As the lines
get created in FlexLayoutAlgorithm::computeNextFlexLine, we can trim the
main axis margins of the first and last items. This will require not
only updating the object&apos;s MarginBox but also the main axis sizing
information of the flex item itself. In order to do this, we need to
make FlexItem&apos;s mainAxisMargin mutable.

After the line has been constructed, we can trim the cross axis margins
of the items if the line is either the first line or last line of the
flexbox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-end-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-end-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-start-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-start-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-block-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-block-multiline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-block-multiline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-grow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-grow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-inline-multiline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-orthogonal-item-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-orthogonal-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-shrink-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-shrink.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-end-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-end-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-start-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-start-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-trimmed-only-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-inline-trimmed-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-block-multiline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-block-multiline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-grow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-grow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-inline-multiline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-inline-multiline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-orthogonal-item-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-orthogonal-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-shrink-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-shrink.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-trim-all-margins-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-trim-all-margins.html: Added.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-template-expected.txt: Added.
* Source/WebCore/rendering/FlexibleBoxAlgorithm.cpp:
(WebCore::FlexLayoutAlgorithm::FlexLayoutAlgorithm):
(WebCore::FlexLayoutAlgorithm::canFitItemWithTrimmedMarginEnd const):
(WebCore::FlexLayoutAlgorithm::removeMarginEndFromFlexSizes const):
(WebCore::FlexLayoutAlgorithm::computeNextFlexLine):
* Source/WebCore/rendering/FlexibleBoxAlgorithm.h:
(WebCore::FlexLayoutAlgorithm::isMultiline const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::marginIntrinsicLogicalWidthForChild const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeLogicalWidthInFragment const):
(WebCore::RenderBox::fillAvailableMeasure const):
(WebCore::RenderBox::computeOrTrimInlineMargin const):
(WebCore::RenderBox::computeInlineDirectionMargins const):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::layoutBlock):
(WebCore::RenderFlexibleBox::initializeMarginTrimState):
(WebCore::RenderFlexibleBox::shouldTrimChildMargin const):
(WebCore::RenderFlexibleBox::shouldTrimMainAxisMarginStart const):
(WebCore::RenderFlexibleBox::shouldTrimMainAxisMarginEnd const):
(WebCore::RenderFlexibleBox::shouldTrimCrossAxisMarginStart const):
(WebCore::RenderFlexibleBox::shouldTrimCrossAxisMarginEnd const):
(WebCore::RenderFlexibleBox::trimMainAxisMarginStart):
(WebCore::RenderFlexibleBox::trimMainAxisMarginEnd):
(WebCore::RenderFlexibleBox::trimCrossAxisMarginStart):
(WebCore::RenderFlexibleBox::trimCrossAxisMarginEnd):
(WebCore::RenderFlexibleBox::layoutFlexItems):
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/258563@main">https://commits.webkit.org/258563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a9552cebe3d1d78ca41be76861cfcc612466170

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111673 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2424 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108149 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5152 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5883 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->