### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/letter-spacing.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
@@ -5,10 +5,10 @@ PASS Can set 'letter-spacing' to CSS-wide keywords: unset
 PASS Can set 'letter-spacing' to CSS-wide keywords: revert
 PASS Can set 'letter-spacing' to var() references:  var(--A)
 PASS Can set 'letter-spacing' to the 'normal' keyword: normal
-FAIL Can set 'letter-spacing' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSKeywordValue"
+PASS Can set 'letter-spacing' to a length: 0px
 PASS Can set 'letter-spacing' to a length: -3.14em
 PASS Can set 'letter-spacing' to a length: 3.14cm
-FAIL Can set 'letter-spacing' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
+PASS Can set 'letter-spacing' to a length: calc(0px + 0em)
 PASS Setting 'letter-spacing' to a percent: 0% throws TypeError
 PASS Setting 'letter-spacing' to a percent: -3.14% throws TypeError
 PASS Setting 'letter-spacing' to a percent: 3.14% throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing.html
@@ -13,9 +13,28 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_zero_special_handling(input, result) {
+  let is_zero_length = true;
+  if (input instanceof CSSMathSum) {
+    for (let operand of input.values)
+      is_zero_length &&= (operand.value == 0);
+  } else
+    is_zero_length = input.value == 0;
+
+  // Per the specification, a computed letter-spacing of zero yields a resolved value (getComputedStyle()
+  // return value) of normal.
+  if (is_zero_length)
+    assert_style_value_equals(result, new CSSKeywordValue("normal"));
+  else
+    assert_is_unit('px', result); // Same check as in testsuite.js
+}
+
 runPropertyTests('letter-spacing', [
   { syntax: 'normal' },
-  { syntax: '<length>' },
+  {
+    syntax: '<length>',
+    computed: assert_is_equal_with_zero_special_handling
+  },
 ]);
 
 </script>


### PR DESCRIPTION
#### 54dd46449a7308573361679a9c5a0f37c7a771e7
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/letter-spacing.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=250049">https://bugs.webkit.org/show_bug.cgi?id=250049</a>

Reviewed by Tim Nguyen.

Fix css/css-typed-om/the-stylepropertymap/properties/letter-spacing.html WPT
test so that it expects &quot;normal&quot; as computed value when the input is a length
that is zero, as per:
- <a href="https://w3c.github.io/csswg-drafts/css-text/#letter-spacing-property">https://w3c.github.io/csswg-drafts/css-text/#letter-spacing-property</a>

&quot;&quot;&quot;
For legacy reasons, a computed letter-spacing of zero yields a resolved value
(getComputedStyle() return value) of normal.
&quot;&quot;&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing.html:

Canonical link: <a href="https://commits.webkit.org/258447@main">https://commits.webkit.org/258447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8feeff7508064c41d5d047253c684f127d8052bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111303 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171504 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2031 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109057 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37091 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23994 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4698 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1870 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44922 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5796 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6537 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->