### PR TITLE
Share some adjustTransientZoom() code between TiledCoreAnimationDrawingArea and RemoteLayerTreeDrawingAreaMac

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -31,7 +31,9 @@
 #include "WebPageCreationParameters.h"
 #include "WebProcess.h"
 #include <WebCore/DisplayRefreshMonitor.h>
+#include <WebCore/FrameView.h>
 #include <WebCore/ScrollView.h>
+#include <WebCore/TiledBacking.h>
 #include <WebCore/TransformationMatrix.h>
 
 // Subclasses
@@ -153,6 +155,24 @@ bool DrawingArea::supportsGPUProcessRendering(DrawingAreaType type)
     default:
         return false;
     }
+}
+
+WebCore::TiledBacking* DrawingArea::mainFrameTiledBacking() const
+{
+    auto* frameView = m_webPage.mainFrameView();
+    return frameView ? frameView->tiledBacking() : nullptr;
+}
+
+void DrawingArea::prepopulateRectForZoom(double scale, WebCore::FloatPoint origin)
+{
+    double currentPageScale = m_webPage.totalScaleFactor();
+    auto* frameView = m_webPage.mainFrameView();
+    FloatRect tileCoverageRect = frameView->visibleContentRectIncludingScrollbars();
+    tileCoverageRect.moveBy(-origin);
+    tileCoverageRect.scale(currentPageScale / scale);
+
+    if (auto* tiledBacking = mainFrameTiledBacking())
+        tiledBacking->prepopulateRect(tileCoverageRect);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -163,6 +163,9 @@ public:
     virtual void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) { }
 
     void removeMessageReceiverIfNeeded();
+    
+    WebCore::TiledBacking* mainFrameTiledBacking() const;
+    void prepopulateRectForZoom(double scale, WebCore::FloatPoint origin);
 
 protected:
     DrawingArea(DrawingAreaType, DrawingAreaIdentifier, WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -119,8 +119,6 @@ private:
     void startRenderingUpdateTimer();
     void didCompleteRenderingUpdateDisplay() override;
 
-    WebCore::TiledBacking* mainFrameTiledBacking() const;
-
     TransactionID takeNextTransactionID() { return m_currentTransactionID.increment(); }
 
     void tryMarkLayersVolatile(CompletionHandler<void(bool succeeded)>&&) final;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -258,12 +258,6 @@ void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedC
     triggerRenderingUpdate();
 }
 
-TiledBacking* RemoteLayerTreeDrawingArea::mainFrameTiledBacking() const
-{
-    FrameView* frameView = m_webPage.mainFrameView();
-    return frameView ? frameView->tiledBacking() : nullptr;
-}
-
 void RemoteLayerTreeDrawingArea::startRenderingUpdateTimer()
 {
     if (m_updateRenderingTimer.isActive())

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -55,8 +55,6 @@ private:
     void applyTransientZoomToPage(double scale, WebCore::FloatPoint);
 
     void willCommitLayerTree(RemoteLayerTreeTransaction&) override;
-
-    WebCore::TiledBacking* mainFrameTiledBacking() const;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -130,7 +130,6 @@ private:
     void setRootCompositingLayer(CALayer *);
     void updateRootLayers();
 
-    WebCore::TiledBacking* mainFrameTiledBacking() const;
     void updateDebugInfoLayer(bool showLayer);
 
     void scaleViewToFitDocumentIfNeeded();

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -719,12 +719,6 @@ void TiledCoreAnimationDrawingArea::setRootCompositingLayer(CALayer *layer)
     [CATransaction commit];
 }
 
-TiledBacking* TiledCoreAnimationDrawingArea::mainFrameTiledBacking() const
-{
-    FrameView* frameView = m_webPage.mainFrameView();
-    return frameView ? frameView->tiledBacking() : nullptr;
-}
-
 void TiledCoreAnimationDrawingArea::updateDebugInfoLayer(bool showLayer)
 {
     if (m_debugInfoLayer) {
@@ -823,14 +817,7 @@ void TiledCoreAnimationDrawingArea::adjustTransientZoom(double scale, FloatPoint
     double currentPageScale = m_webPage.totalScaleFactor();
     if (scale > currentPageScale)
         return;
-
-    auto* frameView = m_webPage.mainFrameView();
-    FloatRect tileCoverageRect = frameView->visibleContentRectIncludingScrollbars();
-    tileCoverageRect.moveBy(-origin);
-    tileCoverageRect.scale(currentPageScale / scale);
-    
-    if (auto* tiledBacking = mainFrameTiledBacking())
-        tiledBacking->prepopulateRect(tileCoverageRect);
+    prepopulateRectForZoom(scale, origin);
 }
 
 static RetainPtr<CABasicAnimation> transientZoomSnapAnimationForKeyPath(ASCIILiteral keyPath)


### PR DESCRIPTION
#### 10939443b246921d69184ae50092f7462a2a06b9
<pre>
Share some adjustTransientZoom() code between TiledCoreAnimationDrawingArea and RemoteLayerTreeDrawingAreaMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=250050">https://bugs.webkit.org/show_bug.cgi?id=250050</a>
rdar://103851612

Reviewed by Simon Fraser.

Share code that prepopulates the zoomed area in adjustTransientZoom() by moving it to DrawingArea.

* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::mainFrameTiledBacking const):
(WebKit::DrawingArea::prepolateRectForZoom):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::mainFrameTiledBacking const): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaMac::mainFrameTiledBacking const): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::adjustTransientZoom):
(WebKit::TiledCoreAnimationDrawingArea::mainFrameTiledBacking const): Deleted.

Canonical link: <a href="https://commits.webkit.org/258417@main">https://commits.webkit.org/258417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aff3b101da79cd377197c17f55525650d793ccd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111219 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1948 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108974 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107667 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1797 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5774 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6457 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->