### PR TITLE
REGRESSION(257823@main): named-groups/lookbehind.js Test262-test is failing

### DIFF
--- a/JSTests/stress/regexp-lookaround-captures.js
+++ b/JSTests/stress/regexp-lookaround-captures.js
@@ -1,0 +1,108 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+  let str = '';
+  arr.forEach(function(v, index) {
+    if (typeof v == "string")
+        str += "\"" + v + "\"";
+    else
+        str += v;
+
+    if (index != (arr.length - 1)) {
+      str += ',';
+    };
+  });
+  return "[" + str + "]";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    if (v.length)
+        return arrayToString(v);
+
+    return v;
+}
+
+function compareArray(a, b)
+{
+    if (a === null && b === null)
+        return true;
+
+    if (a === null) {
+        print("### a is null, b is not null");
+        return false;
+    }
+
+    if (b === null) {
+        print("### a is not null, b is null");
+        return false;
+    }
+
+    if (a.length !== b.length) {
+        print("### a.length: " + a.length + ", b.length: " + b.length);
+        return false;
+    }
+
+    for (var i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+            print("### a[" + i + "]: \"" + a[i] + "\" !== b[" + i + "]: \"" + b[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp)
+{
+    testNumber++;
+
+    let actual = str.match(re);
+
+    if (compareArray(exp, actual)) {
+        if (verbose)
+            print(dumpValue(str) +".match(" + re.toString() + "), passed ", dumpValue(exp));
+    } else
+        print(dumpValue(str) +".match(" + re.toString() + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+// Test 1
+testRegExp(/c(?!(\D))|c/u, "abcdef", ["c", undefined]);
+testRegExp(/c(?!(\D){3})|c/u, "abcdef", ["c", undefined]);
+testRegExp(/c(?=(de)x)|c/u, "abcdef", ["c", undefined]);
+testRegExp(/c(?=(def))x|c/u, "abcdef", ["c", undefined]);
+testRegExp(/c(?=(def))x|c(?!(def))|c/, "abcdef", ["c", undefined, undefined]);
+
+// Test 6
+testRegExp(/(?<!(\D{3}))f|f/u, "abcdef", ["f", undefined]);
+testRegExp(/(?<!(\D{3}))f/, "abcdef", null);
+testRegExp(/(?<!(\D))f/u, "abcdef", null);
+testRegExp(/(?<!(\D){3})f/u, "abcdef", null);
+testRegExp(/(?<!(\D){3})f|f/u, "abcdef", ["f", undefined]);
+
+// Test 11
+testRegExp(/(?<=(\w){6})f/, "abcdef", null);
+testRegExp(/f(?=(\w{6})})/, "abcdef", null);
+testRegExp(/((?<!\D{3}))f|f/u, "abcdef", ["f", undefined]);
+testRegExp(/(?<!(\D){3})f/, "abcdef", null);
+testRegExp(/(?<!(\d){3})f/, "abcdef", ["f", undefined]);
+
+// Test 16
+testRegExp(/(?<!(\D){3})f/, "abcdef", null);
+testRegExp(/(?<!(\D){3})f|f/, "abcdef", ["f", undefined]);
+testRegExp(/((?<!\D{3}))f|f/, "abcdef", ["f", undefined]);
+testRegExp(/(?<!(\w{3}))f(?=(\w{3}))|(?<=(\w+?))c(?=(\w{2}))|(?<=(\w{4}))c(?=(\w{3})$)/, "abcdef", ["c",undefined,undefined,"b","de",undefined,undefined]);
+testRegExp(/abc|(efg).*\!|xyz/, "efg xyz", ["xyz", undefined]);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -134,7 +134,7 @@ public:
     {
         ParenthesesDisjunctionContext(unsigned* output, ByteTerm& term)
         {
-            unsigned firstSubpatternId = term.atom.subpatternId;
+            unsigned firstSubpatternId = term.subpatternId();
             unsigned numNestedSubpatterns = term.atom.parenthesesDisjunction->m_numSubpatterns;
 
             for (unsigned i = 0; i < (numNestedSubpatterns << 1); ++i) {
@@ -893,8 +893,8 @@ public:
         ASSERT(term.type == ByteTerm::Type::BackReference);
         BackTrackInfoBackReference* backTrack = reinterpret_cast<BackTrackInfoBackReference*>(context->frame + term.frameLocation);
 
-        unsigned matchBegin = output[(term.atom.subpatternId << 1)];
-        unsigned matchEnd = output[(term.atom.subpatternId << 1) + 1];
+        unsigned matchBegin = output[(term.subpatternId() << 1)];
+        unsigned matchEnd = output[(term.subpatternId() << 1) + 1];
 
         // If the end position of the referenced match hasn't set yet then the backreference in the same parentheses where it references to that.
         // In this case the result of match is empty string like when it references to a parentheses with zero-width match.
@@ -945,8 +945,8 @@ public:
         ASSERT(term.type == ByteTerm::Type::BackReference);
         BackTrackInfoBackReference* backTrack = reinterpret_cast<BackTrackInfoBackReference*>(context->frame + term.frameLocation);
 
-        unsigned matchBegin = output[(term.atom.subpatternId << 1)];
-        unsigned matchEnd = output[(term.atom.subpatternId << 1) + 1];
+        unsigned matchBegin = output[(term.subpatternId() << 1)];
+        unsigned matchEnd = output[(term.subpatternId() << 1) + 1];
 
         if (matchBegin == offsetNoMatch)
             return false;
@@ -985,7 +985,7 @@ public:
     void recordParenthesesMatch(ByteTerm& term, ParenthesesDisjunctionContext* context)
     {
         if (term.capture()) {
-            unsigned subpatternId = term.atom.subpatternId;
+            unsigned subpatternId = term.subpatternId();
             // For Backward matches, the captured indexes where recorded end then start.
             output[(subpatternId << 1) + term.matchDirection()] = context->getDisjunctionContext(term)->matchBegin - term.inputPosition;
             output[(subpatternId << 1) + 1 - term.matchDirection()] = context->getDisjunctionContext(term)->matchEnd - term.inputPosition;
@@ -993,7 +993,7 @@ public:
     }
     void resetMatches(ByteTerm& term, ParenthesesDisjunctionContext* context)
     {
-        unsigned firstSubpatternId = term.atom.subpatternId;
+        unsigned firstSubpatternId = term.subpatternId();
         unsigned count = term.atom.parenthesesDisjunction->m_numSubpatterns;
         context->restoreOutput(output, firstSubpatternId, count);
     }
@@ -1040,7 +1040,7 @@ public:
         }
 
         if (term.capture()) {
-            unsigned subpatternId = term.atom.subpatternId;
+            unsigned subpatternId = term.subpatternId();
             // For Backward matches, the captured indexes where recorded end then start.
             output[(subpatternId << 1) + term.matchDirection()] = input.getPos() - term.inputPosition;
         }
@@ -1054,7 +1054,7 @@ public:
         ASSERT(term.atom.quantityMaxCount == 1);
 
         if (term.capture()) {
-            unsigned subpatternId = term.atom.subpatternId;
+            unsigned subpatternId = term.subpatternId();
             // For Backward matches, the captured indexes where recorded end then start.
             output[(subpatternId << 1) + 1 - term.matchDirection()] = input.getPos() - term.inputPosition;
         }
@@ -1074,7 +1074,7 @@ public:
         BackTrackInfoParenthesesOnce* backTrack = reinterpret_cast<BackTrackInfoParenthesesOnce*>(context->frame + term.frameLocation);
 
         if (term.capture()) {
-            unsigned subpatternId = term.atom.subpatternId;
+            unsigned subpatternId = term.subpatternId();
             output[(subpatternId << 1)] = offsetNoMatch;
             output[(subpatternId << 1) + 1] = offsetNoMatch;
         }
@@ -1119,7 +1119,7 @@ public:
                     // the same anyway! (We don't pre-check for greedy or non-greedy matches.)
                     ASSERT((&term - term.atom.parenthesesWidth)->type == ByteTerm::Type::ParenthesesSubpatternOnceBegin);
                     ASSERT((&term - term.atom.parenthesesWidth)->inputPosition == term.inputPosition);
-                    unsigned subpatternId = term.atom.subpatternId;
+                    unsigned subpatternId = term.subpatternId();
                     // For Backward matches, the captured indexes where recorded end then start.
                     output[(subpatternId << 1) + term.matchDirection()] = input.getPos() - term.inputPosition;
                 }
@@ -1204,6 +1204,10 @@ public:
 
         // We've reached the end of the parens; if they are inverted, this is failure.
         if (term.invert()) {
+            if (term.containsAnyCaptures()) {
+                for (unsigned subpattern = term.subpatternId(); subpattern <= term.lastSubpatternId(); subpattern++)
+                    output[subpattern << 1] = offsetNoMatch;
+            }
             context->term -= term.atom.parenthesesWidth;
             return false;
         }
@@ -1238,6 +1242,11 @@ public:
         BackTrackInfoParentheticalAssertion* backTrack = reinterpret_cast<BackTrackInfoParentheticalAssertion*>(context->frame + term.frameLocation);
 
         input.setPos(backTrack->begin);
+
+        if (term.containsAnyCaptures()) {
+            for (unsigned subpattern = term.subpatternId(); subpattern <= term.lastSubpatternId(); subpattern++)
+                output[subpattern << 1] = offsetNoMatch;
+        }
 
         context->term -= term.atom.parenthesesWidth;
         return false;
@@ -1581,10 +1590,10 @@ public:
 
         switch (currentTerm().type) {
         case ByteTerm::Type::SubpatternBegin:
-            DUMP_EXTRA_IF(currentTerm().capture(), "id:", currentTerm().atom.subpatternId);
+            DUMP_EXTRA_IF(currentTerm().capture(), "id:", currentTerm().subpatternId());
             MATCH_NEXT();
         case ByteTerm::Type::SubpatternEnd:
-            DUMP_EXTRA_IF(currentTerm().capture(), "id:", currentTerm().atom.subpatternId, " - Return Match\n");
+            DUMP_EXTRA_IF(currentTerm().capture(), "id:", currentTerm().subpatternId(), " - Return Match\n");
             context->matchEnd = input.getPos();
             return JSRegExpResult::Match;
 
@@ -1884,7 +1893,7 @@ public:
 
         switch (currentTerm().type) {
         case ByteTerm::Type::SubpatternBegin:
-            DUMP_EXTRA("id:", currentTerm().atom.subpatternId, " - Return NoMatch\n");
+            DUMP_EXTRA("id:", currentTerm().subpatternId(), " - Return NoMatch\n");
             return JSRegExpResult::NoMatch;
         case ByteTerm::Type::SubpatternEnd:
             RELEASE_ASSERT_NOT_REACHED();
@@ -2256,7 +2265,7 @@ public:
         m_currentAlternativeIndex = beginTerm + 1;
     }
 
-    void atomParentheticalAssertionEnd(unsigned inputPosition, unsigned frameLocation, Checked<unsigned> quantityMaxCount, QuantifierType quantityType)
+    void atomParentheticalAssertionEnd(unsigned inputPosition, unsigned lastSubpatternId, unsigned frameLocation, Checked<unsigned> quantityMaxCount, QuantifierType quantityType)
     {
         unsigned beginTerm = popParenthesesStack();
         closeAlternative(beginTerm + 1);
@@ -2266,11 +2275,13 @@ public:
 
         bool invert = m_bodyDisjunction->terms[beginTerm].invert();
         MatchDirection matchDirection = m_bodyDisjunction->terms[beginTerm].matchDirection();
-        unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].atom.subpatternId;
+        unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].subpatternId();
 
         m_bodyDisjunction->terms.append(ByteTerm(ByteTerm::Type::ParentheticalAssertionEnd, subpatternId, false, invert, matchDirection, inputPosition));
         m_bodyDisjunction->terms[beginTerm].atom.parenthesesWidth = endTerm - beginTerm;
         m_bodyDisjunction->terms[endTerm].atom.parenthesesWidth = endTerm - beginTerm;
+        m_bodyDisjunction->terms[beginTerm].atom.ids.lastSubpatternId = lastSubpatternId;
+        m_bodyDisjunction->terms[endTerm].atom.ids.lastSubpatternId = lastSubpatternId;
         m_bodyDisjunction->terms[endTerm].frameLocation = frameLocation;
 
         m_bodyDisjunction->terms[beginTerm].atom.quantityMaxCount = quantityMaxCount;
@@ -2356,7 +2367,7 @@ public:
 
         auto parenthesesMatchDirection = parenthesesBegin.matchDirection();
         bool capture = parenthesesBegin.capture();
-        unsigned subpatternId = parenthesesBegin.atom.subpatternId;
+        unsigned subpatternId = parenthesesBegin.subpatternId();
 
         unsigned numSubpatterns = lastSubpatternId - subpatternId + 1;
         auto parenthesesDisjunction = makeUnique<ByteDisjunction>(numSubpatterns, callFrameSize);
@@ -2390,7 +2401,7 @@ public:
         ASSERT(m_bodyDisjunction->terms[beginTerm].type == ByteTerm::Type::ParenthesesSubpatternOnceBegin);
 
         bool capture = m_bodyDisjunction->terms[beginTerm].capture();
-        unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].atom.subpatternId;
+        unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].subpatternId();
 
         m_bodyDisjunction->terms.append(ByteTerm(ByteTerm::Type::ParenthesesSubpatternOnceEnd, subpatternId, capture, false, inputPosition));
         if (m_bodyDisjunction->terms[beginTerm].matchDirection() == Backward) {
@@ -2422,7 +2433,7 @@ public:
         if (m_bodyDisjunction->terms[beginTerm].matchDirection() == Backward)
             inputPosition = 0;
         bool capture = m_bodyDisjunction->terms[beginTerm].capture();
-        unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].atom.subpatternId;
+        unsigned subpatternId = m_bodyDisjunction->terms[beginTerm].subpatternId();
 
         m_bodyDisjunction->terms.append(ByteTerm(ByteTerm::Type::ParenthesesSubpatternTerminalEnd, subpatternId, capture, false, inputPosition));
         m_bodyDisjunction->terms[beginTerm].atom.parenthesesWidth = endTerm - beginTerm;
@@ -2592,7 +2603,7 @@ public:
                         atomParentheticalAssertionBegin(term.parentheses.subpatternId, 0, term.invert(), term.matchDirection(), term.frameLocation, alternativeFrameLocation);
                         if (auto error = emitDisjunction(term.parentheses.disjunction, currentCountAlreadyChecked, positiveInputOffset - uncheckAmount, term.matchDirection()))
                             return error;
-                        atomParentheticalAssertionEnd(0, term.frameLocation, term.quantityMaxCount, term.quantityType);
+                        atomParentheticalAssertionEnd(0, term.parentheses.lastSubpatternId, term.frameLocation, term.quantityMaxCount, term.quantityType);
                         if (uncheckAmount) {
                             checkInput(uncheckAmount);
                             currentCountAlreadyChecked += uncheckAmount;
@@ -2620,7 +2631,7 @@ public:
 
                         if (auto error = emitDisjunction(term.parentheses.disjunction, checkedCountForLookbehind, positiveInputOffset + minimumSize, term.matchDirection()))
                             return error;
-                        atomParentheticalAssertionEnd(0, term.frameLocation, term.quantityMaxCount, term.quantityType);
+                        atomParentheticalAssertionEnd(0, term.parentheses.lastSubpatternId, term.frameLocation, term.quantityMaxCount, term.quantityType);
 
                         if (uncheckAmount) {
                             checkInput(uncheckAmount);
@@ -2692,7 +2703,7 @@ void ByteTermDumper::dumpTerm(size_t idx, ByteTerm term)
 
     auto dumpCaptured = [&](ByteTerm& term) {
         if (term.capture())
-            out.print(" captured (#", term.atom.subpatternId, ")");
+            out.print(" captured (#", term.subpatternId(), ")");
     };
 
     auto dumpInverted = [&](ByteTerm& term) {
@@ -2854,7 +2865,7 @@ void ByteTermDumper::dumpTerm(size_t idx, ByteTerm term)
         break;
     case ByteTerm::Type::BackReference:
         outputTermIndexAndNest(idx, m_nesting);
-        out.print("BackReference #", term.atom.subpatternId);
+        out.print("BackReference #", term.subpatternId());
         dumpInputPosition(term);
         dumpQuantity(term);
         break;

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -49,7 +49,10 @@ struct ByteTerm {
                     UChar32 hi;
                 } casedCharacter;
                 CharacterClass* characterClass;
-                unsigned subpatternId;
+                struct {
+                    unsigned subpatternId;
+                    unsigned lastSubpatternId;
+                } ids;
             };
             union {
                 ByteDisjunction* parenthesesDisjunction;
@@ -188,7 +191,7 @@ struct ByteTerm {
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
-        atom.subpatternId = subpatternId;
+        atom.ids.subpatternId = subpatternId;
         atom.parenthesesDisjunction = parenthesesInfo;
         atom.quantityType = QuantifierType::FixedCount;
         atom.quantityMinCount = 1;
@@ -213,7 +216,7 @@ struct ByteTerm {
         , m_matchDirection(Forward)
         , inputPosition(inputPos)
     {
-        atom.subpatternId = subpatternId;
+        atom.ids.subpatternId = subpatternId;
         atom.quantityType = QuantifierType::FixedCount;
         atom.quantityMinCount = 1;
         atom.quantityMaxCount = 1;
@@ -226,7 +229,7 @@ struct ByteTerm {
         , m_matchDirection(matchDirection)
         , inputPosition(inputPos)
     {
-        atom.subpatternId = subpatternId;
+        atom.ids.subpatternId = subpatternId;
         atom.quantityType = QuantifierType::FixedCount;
         atom.quantityMinCount = 1;
         atom.quantityMaxCount = 1;
@@ -367,6 +370,22 @@ struct ByteTerm {
         return type == Type::CharacterClass;
     }
 
+    bool containsAnyCaptures()
+    {
+        ASSERT(this->type == Type::ParentheticalAssertionBegin
+            || this->type == Type::ParentheticalAssertionEnd);
+        return lastSubpatternId() >= subpatternId();
+    }
+
+    unsigned subpatternId()
+    {
+        return atom.ids.subpatternId;
+    }
+
+    unsigned lastSubpatternId()
+    {
+        return atom.ids.lastSubpatternId;
+    }
     bool invert()
     {
         return m_invert;

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -36,6 +36,8 @@
 
 namespace JSC { namespace Yarr {
 
+enum class CreateDisjunctionPurpose : uint8_t { NotForNextAlternative, ForNextAlternative };
+
 // The Parser class should not be used directly - only via the Yarr::parse() method.
 template<class Delegate, typename CharType>
 class Parser {
@@ -763,7 +765,7 @@ private:
             switch (peek()) {
             case '|':
                 consume();
-                m_delegate.disjunction();
+                m_delegate.disjunction(CreateDisjunctionPurpose::ForNextAlternative);
                 lastTokenType = TokenType::NotAtom;
                 break;
 
@@ -1279,7 +1281,7 @@ private:
  *
  *    void quantifyAtom(unsigned min, unsigned max, bool greedy);
  *
- *    void disjunction();
+ *    void disjunction(CreateDisjunctionPurpose purpose);
  *
  *    void resetForReparsing();
  *

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -50,7 +50,7 @@ public:
     void atomNamedBackReference(const String&) { }
     void atomNamedForwardReference(const String&) { }
     void quantifyAtom(unsigned, unsigned, bool) { }
-    void disjunction() { }
+    void disjunction(CreateDisjunctionPurpose) { }
     void resetForReparsing() { }
 };
 

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -239,7 +239,7 @@ public:
         m_floatingTerm = m_openGroups.takeLast();
     }
 
-    void disjunction()
+    void disjunction(JSC::Yarr::CreateDisjunctionPurpose)
     {
         fail(URLFilterParser::Disjunction);
     }


### PR DESCRIPTION
#### cbde560aa655d9f1759f23336aa506ccaaef8ee2
<pre>
REGRESSION(257823@main): named-groups/lookbehind.js Test262-test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=249330">https://bugs.webkit.org/show_bug.cgi?id=249330</a>
rdar://103367993

Reviewed by Mark Lam.

Relanding 258310@main with a fix for the issue found in <a href="https://bugs.webkit.org/show_bug.cgi?id=249855.">https://bugs.webkit.org/show_bug.cgi?id=249855.</a>
That issue was that we were hitting an ASSERT in clearSubpatternStart() where the subpatternId passed in was 0,
which is the whole match start index and not a subpattern.  The fix is to make sure that we always start with
a subpatternId of no less than 1.  This is handled in the new method PatternAlternative::firstCleanupSubpatternId().

Fixed the case where a nested capturing group within a lookahead / lookbehind doesn&apos;t get its capture cleared if
the lookaround fails.  This has been a long standing issue for lookaheads.

The fix is slightly different in the Yarr interpreter than in the Yarr JIT.  For the interpreter, the Parenthetical
Assertion processing will clear the nested captures within the assertion for the case where an inverted assertion
succeeds or a normal assertion fails.  For the JIT, the clearing is done at the end of a failed top level alternative
for all the contained captures for that alternative.

Updated the test accordingly.

* JSTests/stress/regexp-lookaround-captures.js: Added.
(arrayToString):
(dumpValue):
(compareArray):
(testRegExp):
(testRegExp.c):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::ParenthesesDisjunctionContext):
(JSC::Yarr::Interpreter::matchBackReference):
(JSC::Yarr::Interpreter::backtrackBackReference):
(JSC::Yarr::Interpreter::recordParenthesesMatch):
(JSC::Yarr::Interpreter::resetMatches):
(JSC::Yarr::Interpreter::matchParenthesesOnceBegin):
(JSC::Yarr::Interpreter::matchParenthesesOnceEnd):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceBegin):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceEnd):
(JSC::Yarr::Interpreter::matchParentheticalAssertionEnd):
(JSC::Yarr::Interpreter::backtrackParentheticalAssertionEnd):
(JSC::Yarr::Interpreter::matchDisjunction):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesSubpatternEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesOnceEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesTerminalEnd):
(JSC::Yarr::ByteCompiler::emitDisjunction):
(JSC::Yarr::ByteTermDumper::dumpTerm):
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
(JSC::Yarr::ByteTerm::ByteTerm):
(JSC::Yarr::ByteTerm::containsAnyCaptures):
(JSC::Yarr::ByteTerm::subpatternId):
(JSC::Yarr::ByteTerm::lastSubpatternId):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseTokens):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::atomParentheticalAssertionBegin):
(JSC::Yarr::YarrPatternConstructor::copyDisjunction):
(JSC::Yarr::YarrPatternConstructor::disjunction):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::containsAnyCaptures):
(JSC::Yarr::PatternAlternative::PatternAlternative):
(JSC::Yarr::PatternAlternative::needToCleanupCaptures const):
(JSC::Yarr::PatternAlternative::firstCleanupSubpatternId):
(JSC::Yarr::PatternDisjunction::addNewAlternative):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::disjunction):
* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::PatternParser::disjunction):

Canonical link: <a href="https://commits.webkit.org/258441@main">https://commits.webkit.org/258441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93142ab554c2bd4baaf5d4633a58de6539ca2a5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111314 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2043 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109069 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107763 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25442 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88545 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2317 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1882 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29450 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44930 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91459 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5790 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6549 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20444 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->