### PR TITLE
Run WindowEventLoop tasks in at post-rendering update time

### DIFF
--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -117,6 +117,11 @@ MicrotaskQueue& WindowEventLoop::microtaskQueue()
 
 void WindowEventLoop::didReachTimeToRun()
 {
+    runTasks();
+}
+
+void WindowEventLoop::runTasks()
+{
     Ref protectedThis { *this }; // Executing tasks may remove the last reference to this WindowEventLoop.
     run();
 }

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -52,6 +52,8 @@ public:
     HashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
 
     CustomElementQueue& backupElementQueue();
+    
+    void runTasks();
 
     WEBCORE_EXPORT static void breakToAllowRenderingUpdate();
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -167,6 +167,7 @@
 #include "WheelEventDeltaFilter.h"
 #include "WheelEventTestMonitor.h"
 #include "Widget.h"
+#include "WindowEventLoop.h"
 #include "WorkerOrWorkletScriptController.h"
 #include <wtf/FileSystem.h>
 #include <wtf/RefCountedLeakCounter.h>
@@ -1945,8 +1946,11 @@ void Page::didCompleteRenderingFrame()
     LOG_WITH_STREAM(EventLoop, stream << "Page " << this << " didCompleteRenderingFrame()");
 
     // FIXME: This is where we'd call requestPostAnimationFrame callbacks: webkit.org/b/249798.
-    // FIXME: Run WindowEventLoop tasks from here: webkit.org/b/249684.
     // FIXME: Drive InspectorFrameEnd from here; webkit.org/b/249796.
+
+    forEachDocument([&] (Document& document) {
+        document.windowEventLoop().runTasks();
+    });
 }
 
 void Page::prioritizeVisibleResources()


### PR DESCRIPTION
#### 18cceb1efc6ed228c5c32d7e644108fc8a1b6558
<pre>
Run WindowEventLoop tasks in at post-rendering update time
<a href="https://bugs.webkit.org/show_bug.cgi?id=249684">https://bugs.webkit.org/show_bug.cgi?id=249684</a>
rdar://103575958

Reviewed by NOBODY (OOPS!).

It&apos;s impossible to write non-flakey layout tests that involve async/await and requestAnimationFrame, because
their ordering depends on exactly when the Microtask that resumes the async function runs, and that&apos;s sensitive
to when the WindowEventLoop zero-delay timer fires.

Rendering updates are scheduled (generally at a 60Hz cadence) via display refresh callbacks, but each
one is then triggered from that callback via a CFRunLoopObserver in TiledCoreAnimationDrawingArea, and
a zero-delay timer in RemoteLayerTreeDrawingArea. In addition (and, more importantly, in every layout test)
a rendering update is triggered when unfreezing the layer tree. These can differ in their ordering with the
zero-delay WindowEventLoop timer.

To create a reliable way to have a layout test `await` a rendering update, we need to be able to run the
task associated with a Promise that is resolved at the end of the renderingUpdate before zero-delay
timers fire. So run WindowEventLoop tasks in `Page::didCompleteRenderingFrame()`.

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::didReachTimeToRun):
(WebCore::WindowEventLoop::runTasks):
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCompleteRenderingFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18cceb1efc6ed228c5c32d7e644108fc8a1b6558

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111226 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171435 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1955 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108981 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107674 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9187 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html, imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html, media/audio-session-category.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36982 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91072 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23911 "Found 54 new test failures: animations/crash-on-removing-animation.html, fast/dom/Window/mozilla-focus-blur.html, fast/dom/Window/open-zero-size-as-default.html, fast/dom/lazy-image-loading-document-leak.html, fast/history/history_reload.html, fast/loader/stateobjects/popstate-fires-with-page-cache.html, fast/loader/stateobjects/replacestate-in-iframe.html, fast/text/font-face-crash.html, http/tests/security/frameNavigation/opener.html, http/tests/security/showModalDialog-sync-cross-origin-page-load2.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78745 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4625 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25386 "Found 2 new test failures: storage/indexeddb/cursor-request-cycle-private.html, storage/indexeddb/cursor-request-cycle.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1803 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44874 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6464 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->