### PR TITLE
[CMake] Fix version detection of libwpe

### DIFF
--- a/Source/cmake/FindWPE.cmake
+++ b/Source/cmake/FindWPE.cmake
@@ -69,16 +69,16 @@ find_library(WPE_LIBRARY
 )
 
 if (WPE_INCLUDE_DIR AND NOT WPE_VERSION)
-    if (EXISTS "${WPE_INCLUDE_DIR}/wpe/version.h")
-        file(READ "${WPE_INCLUDE_DIR}/wpe/version.h" WPE_VERSION_CONTENT)
+    if (EXISTS "${WPE_INCLUDE_DIR}/wpe/libwpe-version.h")
+        file(READ "${WPE_INCLUDE_DIR}/wpe/libwpe-version.h" WPE_VERSION_CONTENT)
 
-        string(REGEX MATCH "#define +WPE_MAJOR_VERSION +\\(([0-9]+)\\)" _dummy "${WPE_VERSION_CONTENT}")
+        string(REGEX MATCH "#define +WPE_MAJOR_VERSION +([0-9]+)" _dummy "${WPE_VERSION_CONTENT}")
         set(WPE_VERSION_MAJOR "${CMAKE_MATCH_1}")
 
-        string(REGEX MATCH "#define +WPE_MINOR_VERSION +\\(([0-9]+)\\)" _dummy "${WPE_VERSION_CONTENT}")
+        string(REGEX MATCH "#define +WPE_MINOR_VERSION +([0-9]+)" _dummy "${WPE_VERSION_CONTENT}")
         set(WPE_VERSION_MINOR "${CMAKE_MATCH_1}")
 
-        string(REGEX MATCH "#define +WPE_MICRO_VERSION +\\(([0-9]+)\\)" _dummy "${WPE_VERSION_CONTENT}")
+        string(REGEX MATCH "#define +WPE_MICRO_VERSION +([0-9]+)" _dummy "${WPE_VERSION_CONTENT}")
         set(WPE_VERSION_PATCH "${CMAKE_MATCH_1}")
 
         set(WPE_VERSION "${WPE_VERSION_MAJOR}.${WPE_VERSION_MINOR}.${WPE_VERSION_PATCH}")

--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -59,7 +59,7 @@ if (ENABLE_WEBCORE)
     if (WPEBackendPlayStation_FOUND)
         # WPE::libwpe is compiled into the PlayStation backend
         set(WPE_NAMES SceWPE)
-        find_package(WPE REQUIRED)
+        find_package(WPE 1.14.0 REQUIRED)
 
         SET_AND_EXPOSE_TO_BUILD(USE_WPE_BACKEND_PLAYSTATION ON)
 


### PR DESCRIPTION
#### d2477fc765e231521b33da5342255e0520bde404
<pre>
[CMake] Fix version detection of libwpe
<a href="https://bugs.webkit.org/show_bug.cgi?id=250054">https://bugs.webkit.org/show_bug.cgi?id=250054</a>

Reviewed by Michael Catanzaro.

The wrong header was being searched for the version number. Also the
regex wasn&apos;t correct.

Bump the version required by PlayStation to be 1.14.

* Source/cmake/FindWPE.cmake:
* Source/cmake/OptionsPlayStation.cmake:

Canonical link: <a href="https://commits.webkit.org/258421@main">https://commits.webkit.org/258421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/632ec288ecc8409c4532d9dc63fab9a561f1fc0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111227 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1956 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108982 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107675 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92449 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4626 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25363 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88460 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2232 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1804 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29435 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44850 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91370 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5778 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6465 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20429 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->