### PR TITLE
Wrap calls to eventSender.monitorWheelEvents() in a UIHelper function

### DIFF
--- a/LayoutTests/compositing/fixed-with-main-thread-scrolling.html
+++ b/LayoutTests/compositing/fixed-with-main-thread-scrolling.html
@@ -21,15 +21,16 @@
             background-attachment: fixed;
         }
     </style>
+    <script src="../resources/ui-helper.js"></script>
     <script>
         if (window.testRunner) {
             testRunner.waitUntilDone();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             eventSender.mouseMoveTo(20, 20);
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -100, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -100, "changed", "none");
@@ -41,11 +42,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -100, "none", "continue");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -100, "none", "continue");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-            eventSender.callAfterScrollingCompletes(() => {
-                setTimeout(() => {
-                    testRunner.notifyDone()                
-                }, 0);
-            });
+            await UIHelper.waitForScrollCompletion();
+            testRunner.notifyDone()                
         }
 
         window.addEventListener('load', () => {

--- a/LayoutTests/fast/events/wheel/platform-wheelevent-in-scrolling-div.html
+++ b/LayoutTests/fast/events/wheel/platform-wheelevent-in-scrolling-div.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <script src="../../../resources/js-test-pre.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
             var expectedScrollTop = 5;
             var expectedScrollLeft = 3;
@@ -10,7 +11,7 @@
 
             jsTestIsAsync = true;
 
-            function dispatchWheelEvent()
+            async function dispatchWheelEvent()
             {
                 if (!window.eventSender) {
                     finishJSTest();
@@ -22,9 +23,10 @@
                     overflowElement.addEventListener("mousewheel", mousewheelHandler, false);
 
                 eventSender.mouseMoveTo(100, 110);
-                eventSender.monitorWheelEvents();
+                await UIHelper.startMonitoringWheelEvents();
                 eventSender.mouseScrollBy(-expectedScrollLeft, -expectedScrollTop);
-                eventSender.callAfterScrollingCompletes(checkOffsets);
+                await UIHelper.waitForScrollCompletion();
+                checkOffsets();
             }
 
             function checkOffsets()

--- a/LayoutTests/fast/events/wheel/wheel-events-become-non-cancelable.html
+++ b/LayoutTests/fast/events/wheel/wheel-events-become-non-cancelable.html
@@ -29,7 +29,7 @@
                 finishJSTest();
                 return;
             }
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
             await UIHelper.renderingUpdate();

--- a/LayoutTests/fast/repaint/resources/fixed-move-after-keyboard-scroll-iframe.html
+++ b/LayoutTests/fast/repaint/resources/fixed-move-after-keyboard-scroll-iframe.html
@@ -1,6 +1,7 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <script src="../../../resources/ui-helper.js"></script>
   <script type="text/javascript">
       function scrollAndRepaint()
       {
@@ -12,6 +13,7 @@
               setTimeout(repaintTest, 15);
           }
       }
+
       function repaintTest()
       {
           document.getElementById('toMove').style.left = "150px";
@@ -19,14 +21,15 @@
           if (window.testRunner)
               window.testRunner.notifyDone();
       }
+
       if (window.testRunner)
           window.testRunner.waitUntilDone();
-
-      eventSender.monitorWheelEvents();
-
-      setTimeout(function() {
-          eventSender.callAfterScrollingCompletes(scrollAndRepaint);
-      }, 0);
+      
+      window.addEventListener('load', async () => {
+          await UIHelper.startMonitoringWheelEvents();
+          await UIHelper.waitForScrollCompletion();
+          scrollAndRepaint();
+      }, false);
   </script>
 </head>
   <body style="height: 820;">

--- a/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
+++ b/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
@@ -17,6 +17,7 @@
             background-color: blue;
         }
     </style>
+    <script src="../../resources/ui-helper.js"></script>
     <script>
         if (window.testRunner) {
             testRunner.dumpAsText();
@@ -39,16 +40,15 @@
                 testRunner.notifyDone();
         }
 
-        function doTest()
+        async function doTest()
         {
             if (window.eventSender) {
-                eventSender.monitorWheelEvents();
+                await UIHelper.startMonitoringWheelEvents();
                 eventSender.keyDown("leftArrow");
                 eventSender.keyDown("leftArrow");
                 eventSender.keyDown("leftArrow");
-                setTimeout(function() {
-                    eventSender.callAfterScrollingCompletes(checkForScroll);
-                }, 0);
+                await UIHelper.waitForScrollCompletion();
+                checkForScroll();
             }
         }
         

--- a/LayoutTests/fast/scrolling/latching/iframe-latch-small-deltas.html
+++ b/LayoutTests/fast/scrolling/latching/iframe-latch-small-deltas.html
@@ -27,7 +27,7 @@
             }
 
             eventSender.mouseMoveTo(50, 250); // Inside the iframe.
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
@@ -47,7 +47,7 @@
             shouldBe('iframeTarget.contentWindow.pageYOffset', '410');
             shouldBe('window.pageYOffset', '200');
 
-            eventSender.monitorWheelEvents({ resetLatching: false });
+            await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 1, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 1, 'changed', 'none');

--- a/LayoutTests/fast/scrolling/latching/iframe_in_iframe.html
+++ b/LayoutTests/fast/scrolling/latching/iframe_in_iframe.html
@@ -17,6 +17,7 @@
         width:50%;
     }
     </style>
+    <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test-pre.js"></script>
     <script>
         jsTestIsAsync = true;
@@ -51,7 +52,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -67,7 +68,7 @@
             var startPosX = Math.round(iframeTarget.offsetLeft) + 20;
             var startPosY = Math.round(iframeTarget.offsetTop) + 80;
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
@@ -76,7 +77,9 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/latched-scroll-in-passive-region.html
+++ b/LayoutTests/fast/scrolling/latching/latched-scroll-in-passive-region.html
@@ -22,7 +22,7 @@
         await UIHelper.renderingUpdate();
 
         eventSender.mouseMoveTo(100, 10);
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');

--- a/LayoutTests/fast/scrolling/latching/latched-scroll-into-nonfast-region.html
+++ b/LayoutTests/fast/scrolling/latching/latched-scroll-into-nonfast-region.html
@@ -28,7 +28,8 @@
         
         debug('Scrolling the main frame with latching');
         eventSender.mouseMoveTo(100, 10); // Above the slow region.
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
+
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         // 100ms has to elapse between the start of the gesture and some momentum event to trigger the bug.
         await UIHelper.delayFor(25);

--- a/LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html
+++ b/LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html
@@ -59,7 +59,7 @@
             }
 
             eventSender.mouseMoveTo(200, 350); // Over the overflow inside the iframe.
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, 'changed', 'none');

--- a/LayoutTests/fast/scrolling/latching/latching-stuck-to-main-page.html
+++ b/LayoutTests/fast/scrolling/latching/latching-stuck-to-main-page.html
@@ -45,7 +45,7 @@
         debug('Triggering main page latch; scrolling up');
 
         eventSender.mouseMoveTo(400, 200);
-        eventSender.monitorWheelEvents({ resetLatching: false });
+        await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 2, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 11, 'changed', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
@@ -67,7 +67,7 @@
 
         debug('Checking wheel event over the select again');
         eventSender.mouseMoveTo(50, 200);
-        eventSender.monitorWheelEvents({ resetLatching: false });
+        await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -5, 'changed', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');

--- a/LayoutTests/fast/scrolling/latching/nested-cross-axis-latch-expiration.html
+++ b/LayoutTests/fast/scrolling/latching/nested-cross-axis-latch-expiration.html
@@ -54,7 +54,7 @@
 
             eventSender.mouseMoveTo(150, 150);
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             // Latch to the inner vertical scroller.
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
             await UIHelper.renderingUpdate();
@@ -70,7 +70,7 @@
             await UIHelper.waitForScrollCompletion();
         
             // Now try to scroll on the other axis while still latched.
-            eventSender.monitorWheelEvents({ resetLatching: false });
+            await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
             await UIHelper.renderingUpdate();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'began', 'none');
             await UIHelper.renderingUpdate();

--- a/LayoutTests/fast/scrolling/latching/overflow-hidden-on-one-axis.html
+++ b/LayoutTests/fast/scrolling/latching/overflow-hidden-on-one-axis.html
@@ -37,7 +37,7 @@
     {
         eventSender.mouseMoveTo(100, 100);
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         // Latch to the scroller.
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, 'changed', 'none');
@@ -48,7 +48,7 @@
         await UIHelper.waitForScrollCompletion();
         
         // Now scroll on the other axis.
-        eventSender.monitorWheelEvents({ resetLatching: false });
+        await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
         eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(-10, 0, 'changed', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');

--- a/LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html
+++ b/LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html
@@ -39,7 +39,7 @@
             }
 
             eventSender.mouseMoveTo(200, 350); // Over the overflow.
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, 'changed', 'none');

--- a/LayoutTests/fast/scrolling/latching/scroll-div-latched-div.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-div-latched-div.html
@@ -12,6 +12,7 @@
     background-image: repeating-linear-gradient(silver, white 200px);
 }
 </style>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -34,7 +35,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -47,7 +48,7 @@
         var startPosX = Math.round(divTarget.offsetLeft) + 20;
         var startPosY = Math.round(divTarget.offsetTop) + 100; // One wheel turn before end.
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
@@ -56,7 +57,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-div-latched-mainframe.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-div-latched-mainframe.html
@@ -12,6 +12,7 @@
     background-image: repeating-linear-gradient(silver, white 200px);
 }
 </style>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -34,7 +35,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -46,7 +47,7 @@
         var startPosX = Math.round(divTarget.offsetLeft) + 20;
         var startPosY = Math.round(divTarget.offsetTop) - 42; // Slightly more than one wheel scroll away from the iframe
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iframe
         debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
@@ -56,7 +57,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html
@@ -67,6 +67,7 @@ body {
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
 
+        // FIXME: Use await UIHelper.waitForScrollCompletion();
         setTimeout(checkForScroll, 100);
     }
 

--- a/LayoutTests/fast/scrolling/latching/scroll-div-with-nested-nonscrollable-iframe.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-div-with-nested-nonscrollable-iframe.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -45,7 +46,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -58,7 +59,7 @@
 
         divScrollPositionBefore = divTarget.scrollTop;
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
@@ -67,7 +68,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-iframe-fragment.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-iframe-fragment.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test-pre.js"></script>
     <script>
         jsTestIsAsync = true;
@@ -23,7 +24,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -39,7 +40,7 @@
             debug("IFrame display height = " + iframeTarget.clientHeight);
             var startPosY = iframeTarget.offsetTop + iframeTarget.clientHeight - 42; // One wheel turn before end.
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
 
@@ -50,7 +51,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-iframe-in-overflow.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-iframe-in-overflow.html
@@ -1,6 +1,5 @@
 <html>
 <head>
-    <script src="../../../resources/js-test-pre.js"></script>
     <style type="text/css">
     #wrapper {
         height: 400px;
@@ -20,6 +19,8 @@
         margin: 0;
     }
     </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
     <script>
     jsTestIsAsync = true;
 
@@ -34,9 +35,9 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(200, 50);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "changed", "none");
@@ -52,7 +53,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setup() {

--- a/LayoutTests/fast/scrolling/latching/scroll-iframe-latched-iframe.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-iframe-latched-iframe.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
         jsTestIsAsync = true;
 
@@ -23,7 +24,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -39,7 +40,7 @@
             debug("IFrame display height = " + iframeTarget.clientHeight);
             var startPosY = iframeTarget.offsetTop + iframeTarget.clientHeight - 42; // One wheel turn before end.
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
 
             debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
@@ -50,7 +51,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         function setupTopLevel() 

--- a/LayoutTests/fast/scrolling/latching/scroll-iframe-latched-mainframe.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-iframe-latched-mainframe.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test-pre.js"></script>
     <script>
         jsTestIsAsync = true;
@@ -23,7 +24,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             pageScrollPositionBefore = document.scrollingElement.scrollTop;
             iframeScrollPositionBefore = window.frames['target'].document.scrollingElement.scrollTop;
@@ -34,7 +35,7 @@
             var startPosX = iframeTarget.offsetLeft + 20;
             var startPosY = iframeTarget.offsetTop - 42; // Slightly more than one wheel scroll away from the iframe
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
 
@@ -45,7 +46,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-iframe-webkit1-latching-bug.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-iframe-webkit1-latching-bug.html
@@ -3,6 +3,7 @@
 <head>
     <link rel="help" href="http://www.w3.org/TR/DOM-Level-3-Events/#events-WheelEvent">
     <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
         jsTestIsAsync = true;
         var iframeTarget;
@@ -23,7 +24,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -39,7 +40,7 @@
             debug("iframe display height = " + iframeTarget.clientHeight);
             var startPosY = iframeTarget.offsetTop + iframeTarget.clientHeight - 42; // One wheel turn before end.
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iframe
             debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
@@ -49,7 +50,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-latched-nested-div.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-latched-nested-div.html
@@ -72,7 +72,7 @@
 
         wrapperScrollPositionBefore = wrapperTarget.scrollTop;
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
@@ -101,7 +101,7 @@
         var startPosX = divTarget.offsetLeft + divTarget.clientWidth + 50;
         var startPosY = Math.round(divTarget.offsetTop) - 42; // One wheel turn before end.
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');

--- a/LayoutTests/fast/scrolling/latching/scroll-nested-iframe.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-nested-iframe.html
@@ -7,6 +7,7 @@
         height: 1000px;
     }
     </style>
+    <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test-pre.js"></script>
     <script>
         jsTestIsAsync = true;
@@ -29,7 +30,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -47,7 +48,7 @@
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none', true);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
@@ -55,7 +56,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin', true);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue', true);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end', true);
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-select-bottom-test.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-bottom-test.html
@@ -9,6 +9,7 @@
     background: #f3f3f3;
 }
 </style>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -32,7 +33,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -48,7 +49,7 @@
         eventSender.mouseMoveTo(startPosX, startPosY);
         debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
@@ -56,7 +57,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end', true);
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setupTopLevel() 

--- a/LayoutTests/fast/scrolling/latching/scroll-select-latched-mainframe.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-latched-mainframe.html
@@ -11,6 +11,7 @@
 }
 
 </style>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -33,7 +34,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -47,7 +48,7 @@
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
         debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
@@ -55,7 +56,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end', true);
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setupTopLevel()

--- a/LayoutTests/fast/scrolling/latching/scroll-select-latched-select.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-latched-select.html
@@ -24,6 +24,7 @@
     background: #f3f3f3;
 }
 </style>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -46,7 +47,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -62,7 +63,7 @@
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
         debug("Mouse moved to (" + startPosX + ", " + startPosY + ")");
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none', true);
@@ -70,7 +71,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue', true);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end', true);
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
 
     function setupTopLevel() {

--- a/LayoutTests/fast/scrolling/latching/scroll-snap-latching.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-snap-latching.html
@@ -48,7 +48,7 @@
 
     async function sendWheelEvents()
     {
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(100, 100);
         // This sequence needs to be long enough (> resetLatchedStateTimeout or 100ms) to allow latching to time out.
 

--- a/LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html
+++ b/LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html
@@ -46,7 +46,7 @@
                 return;
             }
             
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(20, 20);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "changed", "none");

--- a/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-element.html
+++ b/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-element.html
@@ -2,6 +2,7 @@
 <script src="../../../resources/testharness.js"></script>
 <script src="../../../resources/testharnessreport.js"></script>
 <script src="../resources/overscroll-behavior-support.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-iframe.html
+++ b/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-iframe.html
@@ -2,6 +2,7 @@
 <script src="../../../resources/testharness.js"></script>
 <script src="../../../resources/testharnessreport.js"></script>
 <script src="../resources/overscroll-behavior-support.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-unscrollable-element.html
+++ b/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-unscrollable-element.html
@@ -3,6 +3,7 @@
 <script src="../../../resources/testharness.js"></script>
 <script src="../../../resources/testharnessreport.js"></script>
 <script src="../resources/overscroll-behavior-support.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-unscrollable-iframe.html
+++ b/LayoutTests/fast/scrolling/mac/async-overscroll-behavior-unscrollable-iframe.html
@@ -3,6 +3,7 @@
 <script src="../../../resources/testharness.js"></script>
 <script src="../../../resources/testharnessreport.js"></script>
 <script src="../resources/overscroll-behavior-support.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/mac/horizontal-overflow-trapping-small-deltas.html
+++ b/LayoutTests/fast/scrolling/mac/horizontal-overflow-trapping-small-deltas.html
@@ -46,7 +46,7 @@
         
         async function doMouseWheelScroll()
         {
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, -5, "changed", "none");

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html
@@ -15,14 +15,11 @@
         async function runTest()
         {
             if (window.eventSender) {
-                eventSender.monitorWheelEvents();
+                await UIHelper.startMonitoringWheelEvents();
                 eventSender.keyDown("downArrow");
 
-                setTimeout(function() {
-                    eventSender.callAfterScrollingCompletes(() => {
-                        testRunner.notifyDone();
-                    });
-                }, 0);
+                UIHelper.waitForScrollCompletion();
+                testRunner.notifyDone();
             }
         }
     </script>

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
@@ -14,7 +14,7 @@
         
         async function runTest()
         {
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             if (!window.testRunner || !testRunner.runUIScript)
                 return;
 

--- a/LayoutTests/fast/scrolling/mac/rubberband-axis-locking.html
+++ b/LayoutTests/fast/scrolling/mac/rubberband-axis-locking.html
@@ -34,7 +34,7 @@
 
             window.addEventListener('scroll', scrollListener);
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             // Pull down and slightly sideways
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 2, "began", "none");
@@ -58,7 +58,7 @@
 
             window.addEventListener('scroll', scrollListener);
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             // Pull left and slightly sideways
             eventSender.mouseScrollByWithWheelAndMomentumPhases(2, 0, "began", "none");

--- a/LayoutTests/fast/scrolling/mac/scroll-container-horizontally.html
+++ b/LayoutTests/fast/scrolling/mac/scroll-container-horizontally.html
@@ -21,32 +21,31 @@
 <div class=slider id=secondcontainer>
   <div class=scrollable></div>
 </div>
+<script src="../../../resources/ui-helper.js"></script>
 <script>
-  function runTest() {
-    eventSender.monitorWheelEvents();
+  async function runTest() {
+    await UIHelper.startMonitoringWheelEvents();
     // Scroll vertically to reach the bottom scrollable container.
     eventSender.mouseMoveTo(10, 499);
     eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
     eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
     eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
     eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
+    await UIHelper.waitForScrollCompletion();
 
-    eventSender.callAfterScrollingCompletes(function() {
-      // Scroll horizontally to check if we scroll the bottom scrollable container.
-      eventSender.monitorWheelEvents();
-      eventSender.mouseMoveTo(10, 510);
-      eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'began', 'none');
-      eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'changed', 'none');
-      eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'changed', 'none');
-      eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none'); 
+    // Scroll horizontally to check if we scroll the bottom scrollable container.
+    await UIHelper.startMonitoringWheelEvents();
+    eventSender.mouseMoveTo(10, 510);
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'began', 'none');
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'changed', 'none');
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, 'changed', 'none');
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none'); 
+    await UIHelper.waitForScrollCompletion();
       
-      eventSender.callAfterScrollingCompletes(function() {
-        var firstOffset = document.getElementById("firstcontainer").scrollLeft;
-        var secondOffset = document.getElementById("secondcontainer").scrollLeft;
-        document.body.innerText = !firstOffset && secondOffset ? "PASS" : "FAIL";  
-        testRunner.notifyDone();
-        }); 
-    });
+    var firstOffset = document.getElementById("firstcontainer").scrollLeft;
+    var secondOffset = document.getElementById("secondcontainer").scrollLeft;
+    document.body.innerText = !firstOffset && secondOffset ? "PASS" : "FAIL";  
+    testRunner.notifyDone();
   }
 
   if (window.eventSender && window.testRunner) {

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element.html
@@ -31,7 +31,7 @@
          async function runTest()
          {
             document.querySelector('.fixed').scrollTop = 0;            
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             await UIHelper.mouseWheelScrollAt(50, 50, 0, -10);
             await UIHelper.waitForScrollCompletion();
             shouldBe('window.pageYOffset', '200');

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-iframe.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-iframe.html
@@ -29,7 +29,7 @@
          async function runTest()
          {
             document.querySelector('.iframe').scrollTop = 0;            
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             await UIHelper.mouseWheelScrollAt(50, 50, 0, -10);
             await UIHelper.waitForScrollCompletion();
             shouldBe('window.pageYOffset', '200');

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout.html
@@ -29,8 +29,8 @@
             scrollContainer = document.querySelector('.scroll-container');
 
             if (window.eventSender)
-                eventSender.monitorWheelEvents();
-            
+                await UIHelper.startMonitoringWheelEvents();
+
             scrollContainer.scrollTo({
                 top: 0,
                 left: 500,

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden.html
@@ -25,8 +25,8 @@
             scrollContainer = document.querySelector('.scroll-container');
 
             if (window.eventSender)
-                eventSender.monitorWheelEvents();
-            
+                await UIHelper.startMonitoringWheelEvents();
+
             scrollContainer.scrollTo({
                 top: 0,
                 left: 500,

--- a/LayoutTests/fast/scrolling/mac/vertical-scroll-in-horizontal-scroller.html
+++ b/LayoutTests/fast/scrolling/mac/vertical-scroll-in-horizontal-scroller.html
@@ -29,7 +29,7 @@
 
         async function mouseWheelScrollAt(x, y, deltaX, deltaY)
         {
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(x, y);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(deltaX, deltaY, "none", "none");
             return new Promise(resolve => {

--- a/LayoutTests/fast/scrolling/overflow-scroll-past-max.html
+++ b/LayoutTests/fast/scrolling/overflow-scroll-past-max.html
@@ -100,14 +100,14 @@
             checkForScroll();
         }
 
-        function startTest()
+        async function startTest()
         {
             if (window.eventSender) {
                 testRunner.dumpAsText();
                 testRunner.waitUntilDone();
 
-                eventSender.monitorWheelEvents();
-                setTimeout(scrollTest, 0);
+                await UIHelper.startMonitoringWheelEvents();
+                await scrollTest();
             }
         }
         

--- a/LayoutTests/fast/scrolling/programmatic-scroll-to-zero-zero.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-to-zero-zero.html
@@ -14,27 +14,26 @@
             background-color: green;
         }
     </style>
+    <script src="../../resources/ui-helper.js"></script>
     <script>
 		if (window.testRunner)
             testRunner.waitUntilDone();
 
-		function doTest()
+		async function doTest()
         {
             document.scrollingElement.scrollTop = 20;
             document.scrollingElement.scrollTop = 0;
-            
-            eventSender.monitorWheelEvents();
 
-            setTimeout(() => {
-                eventSender.mouseMoveTo(20, 20);
-                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
-                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
-                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
-                eventSender.callAfterScrollingCompletes(() => {
-                    document.scrollingElement.scrollTop = 0;
-                    testRunner.notifyDone();
-                });
-            }, 0);
+            await UIHelper.startMonitoringWheelEvents();
+            eventSender.mouseMoveTo(20, 20);
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+            
+            await UIHelper.waitForScrollCompletion();
+
+            document.scrollingElement.scrollTop = 0;
+            testRunner.notifyDone();
         }
 
         window.addEventListener('load', doTest, false);

--- a/LayoutTests/fast/scrolling/programmatic-smooth-scroll-after-focus.html
+++ b/LayoutTests/fast/scrolling/programmatic-smooth-scroll-after-focus.html
@@ -24,7 +24,7 @@
         {
             scrollContainer = document.querySelector('.scroll-container');
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             
             scrollContainer.focus();
             scrollContainer.scrollTo({

--- a/LayoutTests/fast/scrolling/resources/overscroll-behavior-support.js
+++ b/LayoutTests/fast/scrolling/resources/overscroll-behavior-support.js
@@ -26,11 +26,13 @@ async function mouseWheelScrollAndWait(x, y, beginX, beginY, deltaX, deltaY)
     if (deltaY === undefined)
         deltaY = -10;
 
-    eventSender.monitorWheelEvents();
+    await UIHelper.startMonitoringWheelEvents();
     eventSender.mouseMoveTo(x, y);
     eventSender.mouseScrollByWithWheelAndMomentumPhases(beginX, beginY, "began", "none");
     eventSender.mouseScrollByWithWheelAndMomentumPhases(deltaX, deltaY, "changed", "none");
     eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+
+    // FIXME: Use UIHelper.waitForScrollCompletion() (but doing so causes timeouts).
     return new Promise(resolve => {
         setTimeout(() => {
             requestAnimationFrame(resolve);

--- a/LayoutTests/fast/scrolling/rtl-point-in-iframe.html
+++ b/LayoutTests/fast/scrolling/rtl-point-in-iframe.html
@@ -2,7 +2,6 @@
 <html dir="rtl">
 <head>
     <link rel="stylesheet" href="resources/scrollable-style.css">
-    <script src="../../resources/js-test-pre.js"></script>
     <style>
     .origin {
         position: absolute;
@@ -22,6 +21,8 @@
         position: absolute;
     }
     </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test-pre.js"></script>
     <script>
     var pageScrollPositionBefore;
     var iframeScrollPositionBefore;
@@ -39,7 +40,7 @@
         testRunner.notifyDone();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -49,7 +50,7 @@
         var startPosX = iframeTarget.offsetLeft + 20;
         var startPosY = iframeTarget.offsetTop + 20;
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'changed', 'none');
@@ -58,7 +59,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'begin');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'continue');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-        eventSender.callAfterScrollingCompletes(checkForScroll);
+        await UIHelper.waitForScrollCompletion();
+        checkForScroll();
     }
     
     function startTest()

--- a/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-element.html
+++ b/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-element.html
@@ -2,6 +2,7 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script src="resources/overscroll-behavior-support.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-iframe.html
+++ b/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-iframe.html
@@ -2,6 +2,7 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script src="resources/overscroll-behavior-support.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-element.html
+++ b/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-element.html
@@ -2,6 +2,7 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script src="resources/overscroll-behavior-support.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html
+++ b/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html
@@ -2,6 +2,7 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script src="resources/overscroll-behavior-support.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior">
 <style>
     .scrolling {

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -70,6 +70,12 @@ window.UIHelper = class UIHelper {
         await UIHelper.animationFrame();
     }
 
+    static async startMonitoringWheelEvents(...args)
+    {
+        eventSender.monitorWheelEvents(args);
+        await UIHelper.renderingUpdate();
+    }
+
     static async mouseWheelScrollAt(x, y, beginX, beginY, deltaX, deltaY)
     {
         if (beginX === undefined)
@@ -82,28 +88,20 @@ window.UIHelper = class UIHelper {
         if (deltaY === undefined)
             deltaY = -10;
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(x, y);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(beginX, beginY, "began", "none");
         eventSender.mouseScrollByWithWheelAndMomentumPhases(deltaX, deltaY, "changed", "none");
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
-        return new Promise(resolve => {
-            eventSender.callAfterScrollingCompletes(() => {
-                requestAnimationFrame(resolve);
-            });
-        });
+        await UIHelper.waitForScrollCompletion();
     }
 
     static async statelessMouseWheelScrollAt(x, y, deltaX, deltaY)
     {
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(x, y);
         eventSender.mouseScrollBy(deltaX, deltaY);
-        return new Promise(resolve => {
-            eventSender.callAfterScrollingCompletes(() => {
-                requestAnimationFrame(resolve);
-            });
-        });
+        await UIHelper.waitForScrollCompletion();
     }
 
     static async mouseWheelMayBeginAt(x, y)
@@ -123,7 +121,8 @@ window.UIHelper = class UIHelper {
     static async mouseWheelSequence(eventStream, { waitForCompletion = true } = {})
     {
         if (waitForCompletion)
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
+
         const eventStreamAsString = JSON.stringify(eventStream);
         await new Promise(resolve => {
             testRunner.runUIScript(`

--- a/LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe-overscroll-behavior.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe-overscroll-behavior.html
@@ -45,7 +45,7 @@
         
         async function onScrollCompletion(x, y)
         {
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(x, y);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, 0, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");

--- a/LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html
@@ -44,7 +44,7 @@
         
         async function onScrollCompletion(x, y)
         {
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(x, y);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, 0, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");

--- a/LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-in-vertical-overflow.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-in-vertical-overflow.html
@@ -35,6 +35,7 @@
         }
     </style>
     <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
         jsTestIsAsync = true;
         var outerScroller;
@@ -49,7 +50,7 @@
             finishJSTest();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             outerScroller = document.getElementById('outer');
             innerScroller = document.getElementById('inner');
@@ -63,13 +64,14 @@
                 return;
             }
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(150, 300); // Over the horizontally scrollable overflow.
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-            eventSender.callAfterScrollingCompletes(checkForScroll);
+            await UIHelper.waitForScrollCompletion();
+            checkForScroll();
         }
 
         window.addEventListener('load', () => {

--- a/LayoutTests/scrollingcoordinator/mac/latching/scrolling-select-should-not-latch-mainframe.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/scrolling-select-should-not-latch-mainframe.html
@@ -35,7 +35,7 @@
             const x = selectBounds.left + 10;
             const y = selectBounds.top + 10;
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(x, y);
 
             debug('Scrolling up then down in the select');
@@ -47,7 +47,7 @@
             await UIHelper.waitForScrollCompletion();
 
             // Scroll up again to trigger a document bounce.
-            eventSender.monitorWheelEvents({ resetLatching: false });
+            await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 1, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 20, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
@@ -55,7 +55,7 @@
             await UIHelper.waitForScrollCompletion();
 
             // Scroll down. This should scroll the select, not the document.
-            eventSender.monitorWheelEvents({ resetLatching: false });
+            await UIHelper.startMonitoringWheelEvents({ resetLatching: false });
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -2, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -20, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -20, "changed", "none");

--- a/LayoutTests/scrollingcoordinator/mac/nested-sticky-with-nonsticking-sticky-parent.html
+++ b/LayoutTests/scrollingcoordinator/mac/nested-sticky-with-nonsticking-sticky-parent.html
@@ -29,9 +29,7 @@
                 }
 
                 try {
-                    await UIHelper.delayFor(0);
-
-                    eventSender.monitorWheelEvents();
+                    await UIHelper.startMonitoringWheelEvents();
                     eventSender.mouseMoveTo(10, 10);
 
                     // `direction` is a two-element array with a one in the appropriate direction.

--- a/LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-mainframe.html
+++ b/LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-mainframe.html
@@ -127,13 +127,13 @@ async function scrollTest()
     // We should finish via the scroll event; this will fire in the case of failure when the page doesn't scroll.
 }
 
-function setupTopLevel()
+async function setupTopLevel()
 {
     if (window.eventSender) {
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         setTimeout(scrollTest, 0);
     } else {
         var messageLocation = document.getElementById('parent');

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/resources/mainframe-scroll-snap-test.js
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/resources/mainframe-scroll-snap-test.js
@@ -54,7 +54,7 @@ async function doScrollTest(targetElement, direction, scrollMotions)
     startPosX += 5;
     startPosY += 5;
 
-    eventSender.monitorWheelEvents();
+    await UIHelper.startMonitoringWheelEvents();
     eventSender.mouseMoveTo(startPosX, startPosY);
 
     // `direction` is a two-element array with a one in the appropriate direction.

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-async-iframe.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-async-iframe.html
@@ -76,7 +76,7 @@
 
         var startPosX = windowPosition.x + 0.5 * iframeTarget.clientWidth;
         var startPosY = windowPosition.y + 0.5 * iframeTarget.clientHeight;
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -129,7 +129,7 @@
 
         var startPosX = windowPosition.x + 0.5 * iframeTarget.clientWidth;
         var startPosY = windowPosition.y + 0.5 * iframeTarget.clientHeight;
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-iframe.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-iframe.html
@@ -19,6 +19,7 @@
             }
         </style>
         <script src="../../../resources/js-test-pre.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -63,7 +64,7 @@
                 finishJSTest();
         }
 
-        function scrollSnapTest(targetLabel)
+        async function scrollSnapTest(targetLabel)
         {
             debug("Testing scroll-snap snap for " + targetLabel + ":");
             var iframeTarget = document.getElementById(targetLabel);
@@ -82,13 +83,14 @@
 
             var startPosX = windowPosition.x + 0.5 * iframeTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * iframeTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
-            eventSender.callAfterScrollingCompletes(() => { return checkForScrollSnap(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap(targetLabel);
         }
 
         function checkForScrollGlide(targetLabel)
@@ -112,7 +114,7 @@
             setTimeout(() => { scrollSnapTest(targetLabel) }, 0);
         }
 
-        function scrollGlideTest(targetLabel)
+        async function scrollGlideTest(targetLabel)
         {
             debug("Testing scroll-snap glide for " + targetLabel + ":");
             var iframeTarget = document.getElementById(targetLabel);
@@ -132,7 +134,7 @@
 
             var startPosX = windowPosition.x + 0.5 * iframeTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * iframeTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -142,7 +144,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(() => { return checkForScrollGlide(targetLabel) });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide(targetLabel);
         }
 
         function onLoad()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-2d-overflow.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-2d-overflow.html
@@ -35,6 +35,7 @@
             }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -43,7 +44,8 @@
         var divScrollPositionBeforeSnap;
         var divScrollPositionBeforeSingleAxisGlide;
 
-        function checkForSingleAxisGlide() {
+        function checkForSingleAxisGlide()
+        {
             if (divTarget.scrollTop == divScrollPositionBeforeSingleAxisGlide.y + 400 && divTarget.scrollLeft == divScrollPositionBeforeSingleAxisGlide.x)
                 testPassed("div successfully snapped after dragging along one axis and then scrolling in the other.");
             else
@@ -51,13 +53,14 @@
             finishJSTest();
         }
 
-        function scrollAndGlideInSingleAxisTest() {
+        async function scrollAndGlideInSingleAxisTest()
+        {
             divScrollPositionBeforeSingleAxisGlide = {
                 x: divTarget.scrollLeft,
                 y: divTarget.scrollTop
             };
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, "changed", "none");
@@ -69,10 +72,12 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "none", "begin");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "none", "continue");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-            eventSender.callAfterScrollingCompletes(checkForSingleAxisGlide);
+            await UIHelper.waitForScrollCompletion();
+            checkForSingleAxisGlide();
         }
 
-        function checkForScrollSnap() {
+        function checkForScrollSnap()
+        {
             if (divTarget.scrollTop == divScrollPositionBeforeSnap.y && divTarget.scrollLeft == divScrollPositionBeforeSnap.x)
                 testPassed("div successfully snapped diagonally.");
             else
@@ -80,22 +85,25 @@
             setTimeout(scrollAndGlideInSingleAxisTest, 0);
         }
 
-        function scrollSnapTest() {
+        async function scrollSnapTest()
+        {
             divScrollPositionBeforeSnap = {
                 x: divTarget.scrollLeft,
                 y: divTarget.scrollTop
             };
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, 1, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, 1, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, 1, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
-            eventSender.callAfterScrollingCompletes(checkForScrollSnap);
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap();
         }
 
-        function checkForScrollGlide() {
+        function checkForScrollGlide()
+        {
             // The div should have scrolled (glided) to the next snap point.
             if (divTarget.scrollTop == divScrollPositionBeforeGlide.y + 400 && divTarget.scrollLeft == divScrollPositionBeforeGlide.x + 400)
                 testPassed("div successfully scrolled diagonally.");
@@ -104,14 +112,15 @@
             setTimeout(scrollSnapTest, 0);
         }
 
-        function scrollGlideTest() {
+        async function scrollGlideTest()
+        {
             divTarget = document.getElementById("grid-container");
             divScrollPositionBeforeGlide = {
                 x: divTarget.scrollLeft,
                 y: divTarget.scrollTop
             };
 
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(100, 100);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, -1, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, -1, "changed", "none");
@@ -121,10 +130,12 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, -1, "none", "begin");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, -1, "none", "continue");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-            eventSender.callAfterScrollingCompletes(checkForScrollGlide);
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide();
         }
 
-        function onLoad() {
+        function onLoad()
+        {
             if (window.eventSender) {
                 internals.setPlatformMomentumScrollingPredictionEnabled(false);
                 setTimeout(scrollGlideTest, 0);

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow-stateless.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow-stateless.html
@@ -19,6 +19,7 @@
             #item1 { background-color: green; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -53,6 +54,7 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "none");
             // Wait for the snapping to finish.
+            // FIXME: Use await UIHelper.waitForScrollCompletion();
             setTimeout(function() {
                 if (divTarget.scrollTop != 400)
                     testFailed("div did not snap to the green region. Expected 400, but got " + divTarget.scrollTop + ".");
@@ -63,12 +65,11 @@
             }, 2000);
         }
 
-
-        function onLoad()
+        async function onLoad()
         {
             if (window.eventSender) {
-                eventSender.monitorWheelEvents();
                 internals.setPlatformMomentumScrollingPredictionEnabled(false);
+                await UIHelper.startMonitoringWheelEvents();
                 setTimeout(scrollSnapTest, 0);
             } else {
                 var messageLocationH = document.getElementById("item0");

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow.html
@@ -41,6 +41,7 @@
             #itemH5, #itemV5 { background-color: fuchsia; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -85,7 +86,7 @@
                 finishJSTest();
         }
 
-        function scrollSnapTest(targetLabel)
+        async function scrollSnapTest(targetLabel)
         {
             debug("Testing scroll-snap snap for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -104,13 +105,14 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollSnap(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap(targetLabel);
         }
 
         function checkForScrollGlide(targetLabel)
@@ -133,7 +135,7 @@
             setTimeout(function() { scrollSnapTest(targetLabel) }, 0);
         }
 
-        function scrollGlideTest(targetLabel)
+        async function scrollGlideTest(targetLabel)
         {
             debug("Testing scroll-snap glide for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -152,7 +154,7 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -162,7 +164,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollGlide(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide(targetLabel);
         }
 
         function onLoad()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-borders.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-borders.html
@@ -51,6 +51,7 @@
             #itemH5, #itemV5 { background-color: fuchsia; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -95,7 +96,7 @@
                 finishJSTest();
         }
 
-        function scrollSnapTest(targetLabel)
+        async function scrollSnapTest(targetLabel)
         {
             debug("Testing scroll-snap snap for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -114,13 +115,14 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollSnap(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap(targetLabel);
         }
 
         function checkForScrollGlide(targetLabel)
@@ -143,7 +145,7 @@
             setTimeout(function() { scrollSnapTest(targetLabel) }, 0);
         }
 
-        function scrollGlideTest(targetLabel)
+        async function scrollGlideTest(targetLabel)
         {
             debug("Testing scroll-snap glide for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -162,7 +164,7 @@
 
             var startPosX = windowPosition.x + divTarget.clientWidth - 10;
             var startPosY = windowPosition.y + 50;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -172,7 +174,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollGlide(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide(targetLabel);
         }
 
         function onLoad()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-hidden-scrollbars.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-hidden-scrollbars.html
@@ -30,6 +30,7 @@
                 scroll-snap-align: center;
             }
         </style>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         let write = s => output.innerHTML += s + "<br>";
 
@@ -38,14 +39,14 @@
             testRunner.waitUntilDone();
         }
 
-        function run() {
+        async function run() {
             if (!window.testRunner || !window.eventSender) {
                 write("To manually test, verify that scrolling in the overflow container snaps to each of the children.");
                 return;
             }
 
             internals.setPlatformMomentumScrollingPredictionEnabled(false);
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(250, 250);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "began", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "changed", "none");
@@ -54,10 +55,10 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "none", "begin");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, "none", "continue");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-            eventSender.callAfterScrollingCompletes(() => {
-                write(`After swiping, the container's scrollTop is now: ${port.scrollTop}`);
-                testRunner.notifyDone();
-            });
+
+            await UIHelper.waitForScrollCompletion();
+            write(`After swiping, the container's scrollTop is now: ${port.scrollTop}`);
+            testRunner.notifyDone();
         }
         </script>
     </head>

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-overflow-stateless.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-overflow-stateless.html
@@ -19,6 +19,7 @@
             #item1 { background-color: green; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -53,6 +54,7 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "none");
             // Wait for the snapping to finish.
+            // FIXME: Use await UIHelper.waitForScrollCompletion();
             setTimeout(function() {
                 if (divTarget.scrollTop != 400)
                     testFailed("div did not snap to the green region. Expected 400, but got " + divTarget.scrollTop + ".");
@@ -63,12 +65,11 @@
             }, 2000);
         }
 
-
-        function onLoad()
+        async function onLoad()
         {
             if (window.eventSender) {
-                eventSender.monitorWheelEvents();
                 internals.setPlatformMomentumScrollingPredictionEnabled(false);
+                await UIHelper.startMonitoringWheelEvents();
                 setTimeout(scrollSnapTest, 0);
             } else {
                 var messageLocationH = document.getElementById("item0");

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-overflow.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-overflow.html
@@ -41,6 +41,7 @@
             #itemH5, #itemV5 { background-color: fuchsia; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -85,7 +86,7 @@
                 finishJSTest();
         }
 
-        function scrollSnapTest(targetLabel)
+        async function scrollSnapTest(targetLabel)
         {
             debug("Testing scroll-snap snap for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -104,13 +105,14 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollSnap(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap(targetLabel);
         }
 
         function checkForScrollGlide(targetLabel)
@@ -133,7 +135,7 @@
             setTimeout(function() { scrollSnapTest(targetLabel) }, 0);
         }
 
-        function scrollGlideTest(targetLabel)
+        async function scrollGlideTest(targetLabel)
         {
             debug("Testing scroll-snap glide for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -152,7 +154,7 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -162,7 +164,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollGlide(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide(targetLabel);
         }
 
         function onLoad()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-padding.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-padding.html
@@ -49,6 +49,7 @@
             #itemH5, #itemV5 { background-color: fuchsia; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -93,7 +94,7 @@
                 finishJSTest();
         }
 
-        function scrollSnapTest(targetLabel)
+        async function scrollSnapTest(targetLabel)
         {
             debug("Testing scroll-snap snap for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -112,13 +113,14 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollSnap(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap(targetLabel);
         }
 
         function checkForScrollGlide(targetLabel)
@@ -143,7 +145,7 @@
             setTimeout(function() { scrollSnapTest(targetLabel) }, 0);
         }
 
-        function scrollGlideTest(targetLabel)
+        async function scrollGlideTest(targetLabel)
         {
             debug("Testing scroll-snap glide for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -162,7 +164,7 @@
 
             var startPosX = windowPosition.x + divTarget.clientWidth - 10;
             var startPosY = windowPosition.y + 50;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -172,7 +174,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollGlide(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide(targetLabel);
         }
 
         function onLoad()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-rotated.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-rotated.html
@@ -43,6 +43,7 @@
             #itemH5, #itemV5 { background-color: fuchsia; }
         </style>
         <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         window.jsTestIsAsync = true;
 
@@ -87,7 +88,7 @@
                 finishJSTest();
         }
 
-        function scrollSnapTest(targetLabel)
+        async function scrollSnapTest(targetLabel)
         {
             debug("Testing scroll-snap snap for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -106,13 +107,14 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'ended', 'none');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollSnap(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollSnap(targetLabel);
         }
 
         function checkForScrollGlide(targetLabel)
@@ -135,7 +137,7 @@
             setTimeout(function() { scrollSnapTest(targetLabel) }, 0);
         }
 
-        function scrollGlideTest(targetLabel)
+        async function scrollGlideTest(targetLabel)
         {
             debug("Testing scroll-snap glide for " + targetLabel + ":");
             var divTarget = document.getElementById(targetLabel);
@@ -154,7 +156,7 @@
 
             var startPosX = windowPosition.x + 0.5 * divTarget.clientWidth;
             var startPosY = windowPosition.y + 0.5 * divTarget.clientHeight;
-            eventSender.monitorWheelEvents();
+            await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(startPosX, startPosY);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -164,7 +166,8 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-            eventSender.callAfterScrollingCompletes(function() { return checkForScrollGlide(targetLabel); });
+            await UIHelper.waitForScrollCompletion();
+            checkForScrollGlide(targetLabel);
         }
 
         function onLoad()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-then-proximity.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-then-proximity.html
@@ -26,6 +26,7 @@
                 scroll-snap-align: start;
             }
         </style>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         let write = s => output.innerHTML += s + "<br>";
         if (window.testRunner) {
@@ -33,38 +34,39 @@
             testRunner.waitUntilDone();
         }
 
-        function verticalScrollInContainer(dragDeltas, momentumDeltas)
+        async function verticalScrollInContainer(dragDeltas, momentumDeltas)
         {
-            return new Promise(resolve => {
-                write(`Scrolling in ${container.id} with scroll-snap-type: ${getComputedStyle(container).scrollSnapType}`);
-                eventSender.monitorWheelEvents();
-                internals.setPlatformMomentumScrollingPredictionEnabled(false);
-                eventSender.mouseMoveTo(300, 300);
-                dragDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, i == 0 ? "began" : "changed", "none"));
-                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
-                if (momentumDeltas && momentumDeltas.length) {
-                    momentumDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, "none", i == 0 ? "begin" : "continue"));
-                    eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
-                }
-                eventSender.callAfterScrollingCompletes(() => {
-                    write(`- Did the scrolling snap to the top? ${container.scrollTop == 0 ? "YES" : "NO"}`);
-                    write(`- Did scrolling snap to the second box? ${container.scrollTop == 600 ? "YES" : "NO"}`);
-                    container.style.scrollSnapType = "y proximity"
-                    container.scrollTop = 0;
-                    setTimeout(resolve, 0);
-                });
-            });
+            write(`Scrolling in ${container.id} with scroll-snap-type: ${getComputedStyle(container).scrollSnapType}`);
+            await UIHelper.startMonitoringWheelEvents();
+            internals.setPlatformMomentumScrollingPredictionEnabled(false);
+            eventSender.mouseMoveTo(300, 300);
+            dragDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, i == 0 ? "began" : "changed", "none"));
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+            if (momentumDeltas && momentumDeltas.length) {
+                momentumDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, "none", i == 0 ? "begin" : "continue"));
+                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
+            }
+            
+            await UIHelper.waitForScrollCompletion();
+            
+            write(`- Did the scrolling snap to the top? ${container.scrollTop == 0 ? "YES" : "NO"}`);
+            write(`- Did scrolling snap to the second box? ${container.scrollTop == 600 ? "YES" : "NO"}`);
+            container.style.scrollSnapType = "y proximity"
+            container.scrollTop = 0;
+
+            await UIHelper.delayFor(0);
         }
 
-        function run() {
+        async function run()
+        {
             if (!window.testRunner || !window.eventSender) {
                 write("This test requires EventSender support.");
                 return;
             }
 
-            verticalScrollInContainer(new Array(16).fill(-1), new Array(3).fill(-1))
-                .then(() => verticalScrollInContainer(new Array(16).fill(-1), new Array(3).fill(-1)))
-                .then(() => testRunner.notifyDone());
+            await verticalScrollInContainer(new Array(16).fill(-1), new Array(3).fill(-1));
+            await verticalScrollInContainer(new Array(16).fill(-1), new Array(3).fill(-1));
+            testRunner.notifyDone();
         }
         </script>
     </head>

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-phase-change-relatching.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-phase-change-relatching.html
@@ -20,6 +20,7 @@
         }
     </style>
     <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
     jsTestIsAsync = true;
 
@@ -32,7 +33,7 @@
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         targetScroller = document.getElementById('scroller');
 
@@ -42,7 +43,7 @@
         var dy = -1;
         var startPosX = targetRect.left + 50;
         var startPosY = targetRect.top + 50;
-        eventSender.monitorWheelEvents();
+        await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(startPosX, startPosY);
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'began', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'changed', 'none');
@@ -52,7 +53,8 @@
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'begin');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(dx, dy, 'none', 'continue');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, 'none', 'end');
-        eventSender.callAfterScrollingCompletes(checkEndState);
+        await UIHelper.waitForScrollCompletion();
+        checkEndState();
     }
 
     function startTest()

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe.html
@@ -26,6 +26,7 @@
                 position: fixed;
             }
         </style>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         let write = s => output.innerHTML += s + "<br>";
         if (window.testRunner) {
@@ -33,26 +34,27 @@
             testRunner.waitUntilDone();
         }
 
-        function verticalScrollInBody(dragDeltas)
+        async function verticalScrollInBody(dragDeltas)
         {
-            return new Promise(resolve => {
-                write(`Scrolling body with ${dragDeltas.length} drag ticks`);
-                eventSender.monitorWheelEvents();
-                internals.setPlatformMomentumScrollingPredictionEnabled(false);
-                eventSender.mouseMoveTo(window.innerWidth / 2, window.innerHeight / 2);
-                dragDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, i == 0 ? "began" : "changed", "none"));
-                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
-                eventSender.callAfterScrollingCompletes(() => {
-                    let areaHeight = document.querySelector(".area").clientHeight;
-                    write(`- Did the scrolling snap to the top? ${document.scrollingElement.scrollTop == 0 ? "YES" : "NO"}`);
-                    write(`- Did scrolling snap to the second box? ${document.scrollingElement.scrollTop == areaHeight ? "YES" : "NO"}`);
-                    document.scrollingElement.scrollTop = 0;
-                    setTimeout(resolve, 0);
-                });
-            });
+            write(`Scrolling body with ${dragDeltas.length} drag ticks`);
+            internals.setPlatformMomentumScrollingPredictionEnabled(false);
+            await UIHelper.startMonitoringWheelEvents();
+            eventSender.mouseMoveTo(window.innerWidth / 2, window.innerHeight / 2);
+            dragDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, i == 0 ? "began" : "changed", "none"));
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+
+            await UIHelper.waitForScrollCompletion();
+
+            let areaHeight = document.querySelector(".area").clientHeight;
+            write(`- Did the scrolling snap to the top? ${document.scrollingElement.scrollTop == 0 ? "YES" : "NO"}`);
+            write(`- Did scrolling snap to the second box? ${document.scrollingElement.scrollTop == areaHeight ? "YES" : "NO"}`);
+            document.scrollingElement.scrollTop = 0;
+
+            await UIHelper.delayFor(0);
         }
 
-        function run() {
+        async function run()
+        {
             if (!window.testRunner || !window.eventSender) {
                 write("To manually test, verify that scrolling near one of the boundaries between the colored boxes");
                 write("snaps to the edge of the nearest colored box, but scrolling somewhere near the middle of two");
@@ -61,10 +63,11 @@
             }
 
             let areaHeight = document.querySelector(".area").clientHeight;
-            verticalScrollInBody(new Array(2).fill(-1))
-                .then(() => verticalScrollInBody(new Array(Math.round(areaHeight / 20)).fill(-1)))
-                .then(() => verticalScrollInBody(new Array(Math.round(areaHeight / 10)).fill(-1)))
-                .then(() => testRunner.notifyDone());
+            
+            await verticalScrollInBody(new Array(2).fill(-1));
+            await verticalScrollInBody(new Array(Math.round(areaHeight / 20)).fill(-1));
+            await verticalScrollInBody(new Array(Math.round(areaHeight / 10)).fill(-1));
+            testRunner.notifyDone();
         }
         </script>
     </head>

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow.html
@@ -25,6 +25,7 @@
                 scroll-snap-align: start;
             }
         </style>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         let write = s => output.innerHTML += s + "<br>";
         if (window.testRunner) {
@@ -32,25 +33,25 @@
             testRunner.waitUntilDone();
         }
 
-        function verticalScrollInContainer(dragDeltas)
+        async function verticalScrollInContainer(dragDeltas)
         {
-            return new Promise(resolve => {
-                write(`Scrolling in ${container.id} with ${dragDeltas.length} drag ticks`);
-                eventSender.monitorWheelEvents();
-                internals.setPlatformMomentumScrollingPredictionEnabled(false);
-                eventSender.mouseMoveTo(300, 300);
-                dragDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, i == 0 ? "began" : "changed", "none"));
-                eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
-                eventSender.callAfterScrollingCompletes(() => {
-                    write(`- Did the scrolling snap to the top? ${container.scrollTop == 0 ? "YES" : "NO"}`);
-                    write(`- Did scrolling snap to the second box? ${container.scrollTop == 600 ? "YES" : "NO"}`);
-                    container.scrollTop = 0;
-                    setTimeout(resolve, 0);
-                });
-            });
+            write(`Scrolling in ${container.id} with ${dragDeltas.length} drag ticks`);
+            internals.setPlatformMomentumScrollingPredictionEnabled(false);
+            await UIHelper.startMonitoringWheelEvents();
+            eventSender.mouseMoveTo(300, 300);
+            dragDeltas.forEach((delta, i) => eventSender.mouseScrollByWithWheelAndMomentumPhases(0, delta, i == 0 ? "began" : "changed", "none"));
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+            await UIHelper.waitForScrollCompletion();
+            
+            write(`- Did the scrolling snap to the top? ${container.scrollTop == 0 ? "YES" : "NO"}`);
+            write(`- Did scrolling snap to the second box? ${container.scrollTop == 600 ? "YES" : "NO"}`);
+            container.scrollTop = 0;
+
+            await UIHelper.delayFor(0);
         }
 
-        function run() {
+        async function run()
+        {
             if (!window.testRunner || !window.eventSender) {
                 write("To manually test, verify that scrolling near one of the boundaries between the colored boxes");
                 write("snaps to the edge of the nearest colored box, but scrolling somewhere near the middle of two");
@@ -58,10 +59,10 @@
                 return;
             }
 
-            verticalScrollInContainer(new Array(2).fill(-1))
-                .then(() => verticalScrollInContainer(new Array(31).fill(-1)))
-                .then(() => verticalScrollInContainer(new Array(59).fill(-1)))
-                .then(() => testRunner.notifyDone());
+            await verticalScrollInContainer(new Array(2).fill(-1));
+            await verticalScrollInContainer(new Array(31).fill(-1));
+            await verticalScrollInContainer(new Array(59).fill(-1));
+            testRunner.notifyDone();
         }
         </script>
     </head>

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-scrolling-jumps-to-top.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-scrolling-jumps-to-top.html
@@ -23,9 +23,11 @@
                 scroll-snap-align: start;
             }
         </style>
+        <script src="../../../resources/ui-helper.js"></script>
         <script>
         let write = s => output.innerHTML += s + "<br>";
-        function run() {
+        async function run()
+        {
             container.scrollTop = 300;
             write(`The scroll position is: ${container.scrollTop}`);
             if (!window.eventSender || !window.testRunner)
@@ -33,8 +35,10 @@
 
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
-            eventSender.monitorWheelEvents();
+
             internals.setPlatformMomentumScrollingPredictionEnabled(false);
+            await UIHelper.startMonitoringWheelEvents();
+
             eventSender.mouseMoveTo(container.offsetLeft + container.clientWidth / 2, container.offsetTop + container.clientHeight / 2);
 
             write("Scrolling without momentum to the same position several times")
@@ -46,12 +50,11 @@
                 eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
             }
 
-            setTimeout(() => {
-                eventSender.callAfterScrollingCompletes(() => {
-                    write(`The scroll position is now: ${container.scrollTop}`);
-                    testRunner.notifyDone();
-                });
-            }, 0);
+            await UIHelper.delayFor(0); // Unclear if this is needed.
+            await UIHelper.waitForScrollCompletion();
+
+            write(`The scroll position is now: ${container.scrollTop}`);
+            testRunner.notifyDone();
         }
         </script>
     </head>

--- a/LayoutTests/tiled-drawing/scrolling/stateless-scrolling-no-rubber-band.html
+++ b/LayoutTests/tiled-drawing/scrolling/stateless-scrolling-no-rubber-band.html
@@ -20,6 +20,7 @@
             #cell5 { background-color: #6666FF; }
         </style>
         <script src="../../resources/js-test-pre.js"></script>
+        <script src="../../resources/ui-helper.js"></script>
         <script>
 
         function checkScrollOffsets()
@@ -38,13 +39,13 @@
             setTimeout(checkScrollOffsets, 0);
         }
 
-        function setup()
+        async function setup()
         {
             if (window.eventSender) {
                 window.jsTestIsAsync = true;
                 testRunner.dumpAsText();
                 testRunner.waitUntilDone();
-                eventSender.monitorWheelEvents();
+                await UIHelper.startMonitoringWheelEvents();
                 setTimeout(testStatelessScrollingAgainstEdge, 0);
             }
         }


### PR DESCRIPTION
#### 117ebe14e9c273e6be15f47cd04a7867d7145e74
<pre>
Wrap calls to eventSender.monitorWheelEvents() in a UIHelper function
<a href="https://bugs.webkit.org/show_bug.cgi?id=250058">https://bugs.webkit.org/show_bug.cgi?id=250058</a>
rdar://103857097

Reviewed by Ryosuke Niwa.

`eventSender.monitorWheelEvents()` will need to become async, so in preparation (and also to fix
scrolling tests with UI-side compositing), hide calls to `eventSender.monitorWheelEvents()` inside a
UIHelper function, which also waits for a rendering update.

Do other minor cleanup, like using `await UIHelper.waitForScrollCompletion()` where possible.

* LayoutTests/compositing/fixed-with-main-thread-scrolling.html:
* LayoutTests/fast/events/wheel/platform-wheelevent-in-scrolling-div.html:
* LayoutTests/fast/events/wheel/wheel-events-become-non-cancelable.html:
* LayoutTests/fast/repaint/resources/fixed-move-after-keyboard-scroll-iframe.html:
* LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html:
* LayoutTests/fast/scrolling/latching/iframe-latch-small-deltas.html:
* LayoutTests/fast/scrolling/latching/iframe_in_iframe.html:
* LayoutTests/fast/scrolling/latching/latched-scroll-in-passive-region.html:
* LayoutTests/fast/scrolling/latching/latched-scroll-into-nonfast-region.html:
* LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html:
* LayoutTests/fast/scrolling/latching/latching-stuck-to-main-page.html:
* LayoutTests/fast/scrolling/latching/nested-cross-axis-latch-expiration.html:
* LayoutTests/fast/scrolling/latching/overflow-hidden-on-one-axis.html:
* LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html:
* LayoutTests/fast/scrolling/latching/scroll-div-latched-div.html:
* LayoutTests/fast/scrolling/latching/scroll-div-latched-mainframe.html:
* LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html:
* LayoutTests/fast/scrolling/latching/scroll-div-with-nested-nonscrollable-iframe.html:
* LayoutTests/fast/scrolling/latching/scroll-iframe-fragment.html:
* LayoutTests/fast/scrolling/latching/scroll-iframe-in-overflow.html:
* LayoutTests/fast/scrolling/latching/scroll-iframe-latched-iframe.html:
* LayoutTests/fast/scrolling/latching/scroll-iframe-latched-mainframe.html:
* LayoutTests/fast/scrolling/latching/scroll-iframe-webkit1-latching-bug.html:
* LayoutTests/fast/scrolling/latching/scroll-latched-nested-div.html:
* LayoutTests/fast/scrolling/latching/scroll-nested-iframe.html:
* LayoutTests/fast/scrolling/latching/scroll-select-bottom-test.html:
* LayoutTests/fast/scrolling/latching/scroll-select-latched-mainframe.html:
* LayoutTests/fast/scrolling/latching/scroll-select-latched-select.html:
* LayoutTests/fast/scrolling/latching/scroll-snap-latching.html:
* LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html:
* LayoutTests/fast/scrolling/mac/async-overscroll-behavior-element.html:
* LayoutTests/fast/scrolling/mac/async-overscroll-behavior-iframe.html:
* LayoutTests/fast/scrolling/mac/async-overscroll-behavior-unscrollable-element.html:
* LayoutTests/fast/scrolling/mac/async-overscroll-behavior-unscrollable-iframe.html:
* LayoutTests/fast/scrolling/mac/horizontal-overflow-trapping-small-deltas.html:
* LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html:
* LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html:
* LayoutTests/fast/scrolling/mac/rubberband-axis-locking.html:
* LayoutTests/fast/scrolling/mac/scroll-container-horizontally.html:
* LayoutTests/fast/scrolling/mac/smooth-scroll-fixed-element.html:
* LayoutTests/fast/scrolling/mac/smooth-scroll-iframe.html:
* LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden-and-layout.html:
* LayoutTests/fast/scrolling/mac/smooth-scroll-with-overflow-hidden.html:
* LayoutTests/fast/scrolling/mac/vertical-scroll-in-horizontal-scroller.html:
* LayoutTests/fast/scrolling/overflow-scroll-past-max.html:
* LayoutTests/fast/scrolling/programmatic-scroll-to-zero-zero.html:
* LayoutTests/fast/scrolling/programmatic-smooth-scroll-after-focus.html:
* LayoutTests/fast/scrolling/resources/overscroll-behavior-support.js:
(async mouseWheelScrollAndWait):
* LayoutTests/fast/scrolling/rtl-point-in-iframe.html:
* LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-element.html:
* LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-iframe.html:
* LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-element.html:
* LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async startMonitoringWheelEvents):
(window.UIHelper.async mouseWheelScrollAt):
(window.UIHelper.async statelessMouseWheelScrollAt):
* LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe-overscroll-behavior.html:
* LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html:
* LayoutTests/scrollingcoordinator/mac/latching/horizontal-overflow-in-vertical-overflow.html:
* LayoutTests/scrollingcoordinator/mac/latching/scrolling-select-should-not-latch-mainframe.html:
* LayoutTests/scrollingcoordinator/mac/nested-sticky-with-nonsticking-sticky-parent.html:
* LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-mainframe.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/resources/mainframe-scroll-snap-test.js:
(async doScrollTest):
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-async-iframe.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-iframe.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-2d-overflow.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow-stateless.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-borders.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-hidden-scrollbars.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-overflow-stateless.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-overflow.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-padding.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-rotated.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-then-proximity.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-phase-change-relatching.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-scrolling-jumps-to-top.html:
* LayoutTests/tiled-drawing/scrolling/stateless-scrolling-no-rubber-band.html:

Canonical link: <a href="https://commits.webkit.org/258483@main">https://commits.webkit.org/258483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1287ebe2f95e85bbc971f543cefc0e662f7672ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111412 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171588 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2143 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109148 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37155 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91219 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4789 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25519 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1963 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45015 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5818 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6646 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->