### PR TITLE
[WebGPU] Opening https://playground.babylonjs.com/ asserts in debug

### DIFF
--- a/Source/WebGPU/WebGPU/Adapter.h
+++ b/Source/WebGPU/WebGPU/Adapter.h
@@ -74,7 +74,7 @@ private:
     id<MTLDevice> m_device { nil };
     const Ref<Instance> m_instance;
 
-    HardwareCapabilities m_capabilities { };
+    const HardwareCapabilities m_capabilities { };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -572,10 +572,9 @@ bool anyLimitIsBetterThan(const WGPULimits& target, const WGPULimits& reference)
 
 bool includesUnsupportedFeatures(const Vector<WGPUFeatureName>& target, const Vector<WGPUFeatureName>& reference)
 {
-    ASSERT(WTF::isSortedConstExpr(target.begin(), target.end()));
     ASSERT(WTF::isSortedConstExpr(reference.begin(), reference.end()));
     for (auto feature : target) {
-        if (!std::find(reference.begin(), reference.end(), feature))
+        if (!std::binary_search(reference.begin(), reference.end(), feature))
             return true;
     }
     return false;


### PR DESCRIPTION
#### 664cd63a8a679a287e77de63b10a3ab7b4dbdddd
<pre>
[WebGPU] Opening <a href="https://playground.babylonjs.com/">https://playground.babylonjs.com/</a> asserts in debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=250057">https://bugs.webkit.org/show_bug.cgi?id=250057</a>
&lt;radar://103857030&gt;

Reviewed by Myles C. Maxfield.

This function performs a loop over all elements in t and
then a find(r.begin, r.end, item) where item is from t.

The features in descriptor.requiredFeatures are not sorted
and it does not appear they need to be for this function to
work correctly, so we can simply remove the assertions.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::includesUnsupportedFeatures):

* Source/WebGPU/WebGPU/Adapter.h:
Make m_capabilities const as it can not be modified after the adapter
is created.

Canonical link: <a href="https://commits.webkit.org/259015@main">https://commits.webkit.org/259015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39ac59cafbfca05c731b15a3b2dee4936d8fca6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112890 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3676 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95901 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109434 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25299 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6146 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6321 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6192 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8080 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->