### PR TITLE
StringConcatenate's StringTypeAdapter<std::tuple<>> incorrectly writes into a 16-bit destination

### DIFF
--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -252,7 +252,7 @@ public:
 
 template<typename... StringTypes> class StringTypeAdapter<std::tuple<StringTypes...>, void> {
 public:
-    StringTypeAdapter(std::tuple<StringTypes...> tuple)
+    StringTypeAdapter(const std::tuple<StringTypes...>& tuple)
         : m_tuple { tuple }
         , m_length { std::apply(computeLength, tuple) }
         , m_is8Bit { std::apply(computeIs8Bit, tuple) }
@@ -263,27 +263,26 @@ public:
     bool is8Bit() const { return m_is8Bit; }
     template<typename CharacterType> void writeTo(CharacterType* destination) const
     {
-        std::apply([&](StringTypes... strings) {
+        std::apply([&](const StringTypes&... strings) {
             unsigned offset = 0;
             (..., (
-                StringTypeAdapter<StringTypes>(strings).writeTo(destination + (offset * sizeof(CharacterType))),
+                StringTypeAdapter<StringTypes>(strings).writeTo(destination + offset),
                 offset += StringTypeAdapter<StringTypes>(strings).length()
             ));
         }, m_tuple);
     }
 
 private:
-    static unsigned computeLength(StringTypes... strings)
+    static unsigned computeLength(const StringTypes&... strings)
     {
         return (... + StringTypeAdapter<StringTypes>(strings).length());
     }
 
-    static bool computeIs8Bit(StringTypes... strings)
+    static bool computeIs8Bit(const StringTypes&... strings)
     {
         return (... && StringTypeAdapter<StringTypes>(strings).is8Bit());
     }
-
-    std::tuple<StringTypes...> m_tuple;
+    const std::tuple<StringTypes...>& m_tuple;
     unsigned m_length;
     bool m_is8Bit;
 };

--- a/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
@@ -196,4 +196,24 @@ TEST(WTF, StringConcatenate_Pad)
     EXPECT_STREQ(" B32AF0071F9 id 1231232312313231 (0.000,0.000-0.000,0.000) 0.00KB", makeString(pad(' ', 12, hex(12312312312313)), " id ", 1231232312313231, " (", FormattedNumber::fixedWidth(0.f, 3), ',', FormattedNumber::fixedWidth(0.f, 3), '-', FormattedNumber::fixedWidth(0.f, 3), ',', FormattedNumber::fixedWidth(0.f, 3), ") ", FormattedNumber::fixedWidth(0.f, 2), "KB").utf8().data());
 }
 
+TEST(WTF, StringConcatenate_Tuple)
+{
+    EXPECT_STREQ("hello 42 world", makeString("hello", ' ', 42, ' ', "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString("hello", ' ', std::make_tuple(unsigned(42)), ' ', "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString("hello", ' ', std::make_tuple(unsigned(42), ' ', "world")).utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString(std::make_tuple("hello", ' ', unsigned(42), ' ', "world")).utf8().data());
+
+    UChar checkmarkCodepoint = 0x2713;
+    EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString("hello", ' ', checkmarkCodepoint, ' ', "world").utf8().data());
+    EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString("hello", ' ', std::make_tuple(checkmarkCodepoint), ' ', "world").utf8().data());
+    EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString("hello", ' ', std::make_tuple(checkmarkCodepoint, ' ', "world")).utf8().data());
+    EXPECT_STREQ("hello \xE2\x9C\x93 world", makeString(std::make_tuple("hello", ' ', checkmarkCodepoint, ' ', "world")).utf8().data());
+
+    const UChar helloCodepoints[] = { 'h', 'e', 'l', 'l', 'o', '\0' };
+    EXPECT_STREQ("hello 42 world", makeString(helloCodepoints, ' ', unsigned(42), ' ', "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints), ' ', unsigned(42), ' ', "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42)), ' ', "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42), ' ', "world")).utf8().data());
+}
+
 }


### PR DESCRIPTION
#### b41ac5266fe96d75848e7de585dc61d6b29d261c
<pre>
StringConcatenate&apos;s StringTypeAdapter&lt;std::tuple&lt;&gt;&gt; incorrectly writes into a 16-bit destination
<a href="https://bugs.webkit.org/show_bug.cgi?id=250070">https://bugs.webkit.org/show_bug.cgi?id=250070</a>

Reviewed by Sam Weinig.

When StringTypeAdapter&lt;std::tuple&lt;...&gt;&gt; writes into any destination string, the
offset value shouldn&apos;t be multiplied by the size of the string&apos;s character type.
Pointer arithmetic will take care of that on its own.

Test case in the StringConcatenate suite is provided, covering both 8-bit and
16-bit strings constructed partially or completely from a tuple object.

The StringTypeAdapter specialization is also adjusted to only keep a reference
to the tuple object, and not copy it. Passes over the tuple elements are done
with lambdas that take arguments through const lvalue references, avoiding any
copying of the contained elements.

* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::StringTypeAdapter&lt;std::tuple&lt;StringTypes::StringTypeAdapter):
(WTF::StringTypeAdapter&lt;std::tuple&lt;StringTypes::writeTo const):
(WTF::StringTypeAdapter&lt;std::tuple&lt;StringTypes::computeLength):
(WTF::StringTypeAdapter&lt;std::tuple&lt;StringTypes::computeIs8Bit):
* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/258446@main">https://commits.webkit.org/258446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1b4d820d06c551704e5c84f6125da2c62b138f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111282 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171483 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2011 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109036 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37064 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78795 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92337 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25410 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88513 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2285 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1850 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29445 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44898 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91425 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5795 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6518 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20439 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->