### PR TITLE
Remove HTMLPreElement.wrap IDL attribute

### DIFF
--- a/LayoutTests/fast/dom/boolean-attribute-reflection-expected.txt
+++ b/LayoutTests/fast/dom/boolean-attribute-reflection-expected.txt
@@ -79,10 +79,6 @@ PASS e = make('option'); e.removeAttribute('selected'); e.defaultSelected is fal
 PASS e = make('option'); e.setAttribute('selected', ''); e.defaultSelected is true
 PASS e = make('option'); e.setAttribute('selected', 'x'); e.defaultSelected = false; e.getAttribute('selected') is null
 PASS e = make('option'); e.setAttribute('selected', 'x'); e.defaultSelected = true; e.getAttribute('selected') is ''
-PASS e = make('pre'); e.removeAttribute('wrap'); e.wrap is false
-PASS e = make('pre'); e.setAttribute('wrap', ''); e.wrap is true
-PASS e = make('pre'); e.setAttribute('wrap', 'x'); e.wrap = false; e.getAttribute('wrap') is null
-PASS e = make('pre'); e.setAttribute('wrap', 'x'); e.wrap = true; e.getAttribute('wrap') is ''
 PASS e = make('script'); e.removeAttribute('defer'); e.defer is false
 PASS e = make('script'); e.setAttribute('defer', ''); e.defer is true
 PASS e = make('script'); e.setAttribute('defer', 'x'); e.defer = false; e.getAttribute('defer') is null

--- a/LayoutTests/fast/dom/boolean-attribute-reflection.html
+++ b/LayoutTests/fast/dom/boolean-attribute-reflection.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -27,7 +27,6 @@ var attributes = [
     [ "object", "declare" ],
     [ "ol", "compact" ],
     [ "option", "defaultSelected", "selected" ],
-    [ "pre", "wrap" ],
     [ "script", "defer" ],
     [ "select", "multiple" ],
     [ "td", "noWrap" ],
@@ -66,6 +65,5 @@ for (var i = 0; i < attributes.length; ++i) {
         "''");
 }
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/HTMLPreElement.idl
+++ b/Source/WebCore/html/HTMLPreElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2010 Apple Inc. All right reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All right reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -18,14 +18,14 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://html.spec.whatwg.org/#other-elements,-attributes-and-apis
+// https://html.spec.whatwg.org/#the-pre-element
+
 [
     Exposed=Window
 ] interface HTMLPreElement : HTMLElement {
     // FIXME: DOM spec says that width should be of type DOMString
     // see http://bugs.webkit.org/show_bug.cgi?id=8992
     [CEReactions=NotNeeded, Reflect] attribute long width;
-    
-    // Extensions
-    [CEReactions=NotNeeded, Reflect] attribute boolean wrap;
 };
 


### PR DESCRIPTION
#### e05300060c5ebc3284080412f900403d9be5075a
<pre>
Remove HTMLPreElement.wrap IDL attribute

Remove HTMLPreElement.wrap IDL attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=249965">https://bugs.webkit.org/show_bug.cgi?id=249965</a>

Reviewed by Alexey Shvayka.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and web-specification.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=rev&amp">https://src.chromium.org/viewvc/blink?view=rev&amp</a>;revision=179131

This patch remove &quot;wrap&quot; from IDL file of the &quot;Pre&quot; element and align WebKit with web
standards. It was removed from Blink in 2014.

* Source/WebCore/html/HTMLPreElement.idl: Remove &apos;wrap&apos;
* LayoutTests/fast/dom/boolean-attribute-reflection.html: Rebaselined
* LayoutTests/fast/dom/boolean-attribute-reflection-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/258445@main">https://commits.webkit.org/258445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ce1515cac35073685aff9c319058acb715b14d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111269 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171472 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1998 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94342 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109023 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37042 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23934 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78783 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25397 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1839 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44885 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5793 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6505 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->