### PR TITLE
[ANGLE] Combine eglGetPlatformDisplayEXT, EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE to target the desired EGL platform

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/DisplayEGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/DisplayEGL.cpp
@@ -255,7 +255,10 @@ egl::Error DisplayEGL::initialize(egl::Display *display)
 
     void *eglHandle =
         reinterpret_cast<void *>(mDisplayAttributes.get(EGL_PLATFORM_ANGLE_EGL_HANDLE_ANGLE, 0));
-    ANGLE_TRY(mEGL->initialize(display->getNativeDisplayId(), getEGLPath(), eglHandle));
+    EGLAttrib platformType =
+        mDisplayAttributes.get(EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE, 0);
+    ANGLE_TRY(
+        mEGL->initialize(platformType, display->getNativeDisplayId(), getEGLPath(), eglHandle));
 
     gl::Version eglVersion(mEGL->majorVersion, mEGL->minorVersion);
     if (eglVersion < gl::Version(1, 4))

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp
@@ -175,7 +175,7 @@ FunctionsEGL::~FunctionsEGL()
     SafeDelete(mFnPtrs);
 }
 
-egl::Error FunctionsEGL::initialize(EGLNativeDisplayType nativeDisplay)
+egl::Error FunctionsEGL::initialize(EGLAttrib platformType, EGLNativeDisplayType nativeDisplay)
 {
 #define ANGLE_GET_PROC_OR_ERROR(MEMBER, NAME)                                           \
     do                                                                                  \
@@ -210,7 +210,15 @@ egl::Error FunctionsEGL::initialize(EGLNativeDisplayType nativeDisplay)
     ANGLE_GET_PROC_OR_ERROR(&mFnPtrs->surfaceAttribPtr, eglSurfaceAttrib);
     ANGLE_GET_PROC_OR_ERROR(&mFnPtrs->swapIntervalPtr, eglSwapInterval);
 
-    mEGLDisplay = mFnPtrs->getDisplayPtr(nativeDisplay);
+    if (platformType != 0)
+    {
+        mEGLDisplay = getPlatformDisplay(platformType, nativeDisplay);
+    }
+    else
+    {
+        mEGLDisplay = mFnPtrs->getDisplayPtr(nativeDisplay);
+    }
+
     if (mEGLDisplay != EGL_NO_DISPLAY)
     {
         if (mFnPtrs->initializePtr(mEGLDisplay, &majorVersion, &minorVersion) != EGL_TRUE)
@@ -370,6 +378,32 @@ egl::Error FunctionsEGL::terminate()
         return egl::NoError();
     }
     return egl::Error(mFnPtrs->getErrorPtr());
+}
+
+EGLDisplay FunctionsEGL::getPlatformDisplay(EGLAttrib platformType,
+                                            EGLNativeDisplayType nativeDisplay)
+{
+    // As in getNativeDisplay(), querying EGL_EXTENSIONS string and loading it into the mExtensions
+    // vector will at this point retrieve the client extensions since mEGLDisplay is still
+    // EGL_NO_DISPLAY. This is desired, and mExtensions will later be reinitialized with the display
+    // extensions once the display is created and initialized.
+    const char *extensions = queryString(EGL_EXTENSIONS);
+    if (!extensions)
+    {
+        return EGL_NO_DISPLAY;
+    }
+    angle::SplitStringAlongWhitespace(extensions, &mExtensions);
+
+    bool hasPlatformBaseEXT = hasExtension("EGL_EXT_platform_base");
+    PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplayEXTPtr;
+    if (!hasPlatformBaseEXT ||
+        !SetPtr(&getPlatformDisplayEXTPtr, getProcAddress("eglGetPlatformDisplayEXT")))
+    {
+        return EGL_NO_DISPLAY;
+    }
+
+    return getPlatformDisplayEXTPtr(static_cast<EGLenum>(platformType),
+                                    reinterpret_cast<void *>(nativeDisplay), nullptr);
 }
 
 EGLDisplay FunctionsEGL::getNativeDisplay(int *major, int *minor)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.h
@@ -31,7 +31,7 @@ class FunctionsEGL
     int majorVersion;
     int minorVersion;
 
-    egl::Error initialize(EGLNativeDisplayType nativeDisplay);
+    egl::Error initialize(EGLAttrib platformType, EGLNativeDisplayType nativeDisplay);
     egl::Error terminate();
 
     virtual void *getProcAddress(const char *name) const = 0;
@@ -122,6 +122,9 @@ class FunctionsEGL
     // use angle::NonCopyable so we replicated it here instead.
     FunctionsEGL(const FunctionsEGL &)   = delete;
     void operator=(const FunctionsEGL &) = delete;
+
+    // Helper mechanism for creating a display for the desired platform type.
+    EGLDisplay getPlatformDisplay(EGLAttrib platformType, EGLNativeDisplayType nativeDisplay);
 
     // Fallback mechanism for creating a display from a native device object.
     EGLDisplay getNativeDisplay(int *major, int *minor);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGLDL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGLDL.cpp
@@ -28,7 +28,8 @@ FunctionsEGLDL::FunctionsEGLDL() : mGetProcAddressPtr(nullptr) {}
 
 FunctionsEGLDL::~FunctionsEGLDL() {}
 
-egl::Error FunctionsEGLDL::initialize(EGLNativeDisplayType nativeDisplay,
+egl::Error FunctionsEGLDL::initialize(EGLAttrib platformType,
+                                      EGLNativeDisplayType nativeDisplay,
                                       const char *libName,
                                       void *eglHandle)
 {
@@ -56,7 +57,7 @@ egl::Error FunctionsEGLDL::initialize(EGLNativeDisplayType nativeDisplay,
         return egl::EglNotInitialized() << "Could not find eglGetProcAddress";
     }
 
-    return FunctionsEGL::initialize(nativeDisplay);
+    return FunctionsEGL::initialize(platformType, nativeDisplay);
 }
 
 void *FunctionsEGLDL::getProcAddress(const char *name) const

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGLDL.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGLDL.h
@@ -20,7 +20,10 @@ class FunctionsEGLDL : public FunctionsEGL
     FunctionsEGLDL();
     ~FunctionsEGLDL() override;
 
-    egl::Error initialize(EGLNativeDisplayType nativeDisplay, const char *libName, void *eglHandle);
+    egl::Error initialize(EGLAttrib platformType,
+                          EGLNativeDisplayType nativeDisplay,
+                          const char *libName,
+                          void *eglHandle);
     void *getProcAddress(const char *name) const override;
 
   private:

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp
@@ -112,6 +112,7 @@ bool GraphicsContextGLFallback::platformInitializeContext()
 
     EGLint configAttributes[] = {
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
         EGL_BLUE_SIZE, 8,

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -146,6 +146,7 @@ bool GraphicsContextGLGBM::platformInitializeContext()
 
     EGLint configAttributes[] = {
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
         EGL_BLUE_SIZE, 8,


### PR DESCRIPTION
#### 0d1736acdd5b498cb5b6b10d603943a4a998f227
<pre>
[ANGLE] Combine eglGetPlatformDisplayEXT, EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE to target the desired EGL platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=250073">https://bugs.webkit.org/show_bug.cgi?id=250073</a>

Reviewed by Carlos Garcia Campos.

This change applies upstream ANGLE revision 01c641d5 into the third-party source
checkout. The revision enhances DisplayEGL functionality so that the platform
type, when specified via EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE, is
used in combination with EGL_EXT_platform_base to retrieve a display object for
the desired EGL platform.

On Linux ports using ANGLE, this avoids getting stuck with the EGL platform that
is set as default by the underlying EGL runtime through build-time configuration
or environment processing.

In GraphicsContextGLFallback and GraphicsContextGLGBM, the EGL_SURFACE_TYPE
value in the config is explicitly stated to be EGL_PBUFFER_BIT. This works
around ANGLE which defaults the EGL_SURFACE_TYPE config attribute to
EGL_WINDOW_BIT, which can get rejected by implementations of the surfaceless
EGL platform.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/DisplayEGL.cpp:
(rx::DisplayEGL::initialize):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp:
(rx::FunctionsEGL::initialize):
(rx::FunctionsEGL::getPlatformDisplay):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGLDL.cpp:
(rx::FunctionsEGLDL::initialize):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGLDL.h:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp:
(WebCore::GraphicsContextGLFallback::platformInitializeContext):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::platformInitializeContext):

Canonical link: <a href="https://commits.webkit.org/258932@main">https://commits.webkit.org/258932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c234bd1b5805c811e015dd37827aa6225c8a54a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112442 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172640 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3223 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95415 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110648 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37870 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79605 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26361 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2838 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45862 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6138 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7643 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->