### PR TITLE
Implement non autofill credential type for autocomplete attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt
@@ -59,13 +59,13 @@ PASS tel-local-suffix is an allowed autocomplete field name
 PASS tel-extension is an allowed autocomplete field name
 PASS email is an allowed autocomplete field name
 PASS impp is an allowed autocomplete field name
-FAIL webauthn is an allowed autocomplete field name assert_equals: expected "webauthn" but got ""
+PASS webauthn is an allowed autocomplete field name
 PASS Test whitespace-only attribute value
 PASS Test maximum number of tokens
 PASS Unknown field
 PASS Test 'wearing the autofill anchor mantle' with off/on
 PASS Serialize combinations of section, mode, contact, and field
-FAIL Serialize combinations of section, mode, contact, field, and credential assert_equals: expected "username webauthn" but got ""
+FAIL Serialize combinations of section, mode, contact, field, and credential assert_equals: expected "section-login shipping work tel webauthn" but got ""
 
 
 

--- a/Source/WebCore/html/Autofill.h
+++ b/Source/WebCore/html/Autofill.h
@@ -36,6 +36,11 @@ enum class AutofillMantle {
     Anchor
 };
 
+enum class NonAutofillCredentialType {
+    None,
+    WebAuthn
+};
+
 enum class AutofillFieldName {
     None,
     Name,
@@ -90,10 +95,12 @@ enum class AutofillFieldName {
     TelLocalSuffix,
     TelExtension,
     Email,
-    Impp
+    Impp,
+    WebAuthn
 };
 
 WEBCORE_EXPORT AutofillFieldName toAutofillFieldName(const AtomString&);
+WEBCORE_EXPORT String nonAutofillCredentialTypeString(NonAutofillCredentialType);
 
 class HTMLFormControlElement;
 
@@ -101,9 +108,10 @@ class AutofillData {
 public:
     static AutofillData createFromHTMLFormControlElement(const HTMLFormControlElement&);
 
-    AutofillData(const AtomString& fieldName, const String& idlExposedValue)
+    AutofillData(const AtomString& fieldName, const String& idlExposedValue, NonAutofillCredentialType nonAutofillCredentialType)
         : fieldName(fieldName)
         , idlExposedValue(idlExposedValue)
+        , nonAutofillCredentialType(nonAutofillCredentialType)
     {
     }
 
@@ -111,6 +119,7 @@ public:
 
     AtomString fieldName;
     String idlExposedValue;
+    NonAutofillCredentialType nonAutofillCredentialType;
 };
 
 } // namespace WebCore
@@ -173,7 +182,16 @@ template<> struct EnumTraits<WebCore::AutofillFieldName> {
         WebCore::AutofillFieldName::TelLocalSuffix,
         WebCore::AutofillFieldName::TelExtension,
         WebCore::AutofillFieldName::Email,
-        WebCore::AutofillFieldName::Impp
+        WebCore::AutofillFieldName::Impp,
+        WebCore::AutofillFieldName::WebAuthn
+    >;
+};
+
+template<> struct EnumTraits<WebCore::NonAutofillCredentialType> {
+    using values = EnumValues<
+        WebCore::NonAutofillCredentialType,
+        WebCore::NonAutofillCredentialType::None,
+        WebCore::NonAutofillCredentialType::WebAuthn
     >;
 };
 

--- a/Source/WebKit/Shared/FocusedElementInformation.h
+++ b/Source/WebKit/Shared/FocusedElementInformation.h
@@ -32,6 +32,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/ElementContext.h>
 #include <WebCore/EnterKeyHint.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/InputMode.h>
 #include <WebCore/IntRect.h>
@@ -118,6 +119,7 @@ struct FocusedElementInformation {
     bool isAutofillableUsernameField { false };
     URL representingPageURL;
     WebCore::AutofillFieldName autofillFieldName { WebCore::AutofillFieldName::None };
+    WebCore::NonAutofillCredentialType nonAutofillCredentialType { WebCore::NonAutofillCredentialType::None };
     String placeholder;
     String label;
     String ariaLabel;
@@ -139,6 +141,8 @@ struct FocusedElementInformation {
 
     FocusedElementInformationIdentifier identifier;
     WebCore::ScrollingNodeID containerScrollingNodeID { 0 };
+
+    WebCore::FrameIdentifier frameID;
 };
 #endif
 

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -64,6 +64,7 @@ headers: "FocusedElementInformation.h" "WebCoreArgumentCoders.h"
     bool isAutofillableUsernameField;
     URL representingPageURL;
     WebCore::AutofillFieldName autofillFieldName;
+    WebCore::NonAutofillCredentialType nonAutofillCredentialType;
     String placeholder;
     String label;
     String ariaLabel;
@@ -85,5 +86,6 @@ headers: "FocusedElementInformation.h" "WebCoreArgumentCoders.h"
 
     WebKit::FocusedElementInformationIdentifier identifier;
     WebCore::ScrollingNodeID containerScrollingNodeID;
+    WebCore::FrameIdentifier frameID;
 }
 #endif

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -462,10 +462,8 @@ static inline void continueAfterRequest(RetainPtr<id <ASCCredentialProtocol>> cr
     AuthenticatorAttachment attachment;
     if ([rawAttachment isEqualToString:@"platform"])
         attachment = AuthenticatorAttachment::Platform;
-    else {
-        ASSERT([rawAttachment isEqualToString:@"cross-platform"]);
+    else
         attachment = AuthenticatorAttachment::CrossPlatform;
-    }
 
     handler(response, attachment, exceptionData);
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5979,6 +5979,7 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
     case WebCore::AutofillFieldName::URL:
         return UITextContentTypeURL;
     case WebCore::AutofillFieldName::Username:
+    case WebCore::AutofillFieldName::WebAuthn:
         return UITextContentTypeUsername;
     case WebCore::AutofillFieldName::None:
     case WebCore::AutofillFieldName::NewPassword:
@@ -9208,6 +9209,11 @@ static NSArray<NSItemProvider *> *extractItemProvidersFromDropSession(id <UIDrop
     if (platformURL)
         context.get()[@"_WebViewURL"] = platformURL;
 
+    if (_focusedElementInformation.nonAutofillCredentialType == WebCore::NonAutofillCredentialType::WebAuthn) {
+        context.get()[@"_page_id"] = [NSNumber numberWithUnsignedLong:_page->webPageID().toUInt64()];
+        context.get()[@"_frame_id"] = [NSNumber numberWithUnsignedLong:_focusedElementInformation.frameID.object().toUInt64()];
+        context.get()[@"_credential_type"] = WebCore::nonAutofillCredentialTypeString(_focusedElementInformation.nonAutofillCredentialType);
+    }
     return context.autorelease();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3491,6 +3491,8 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         information.isReadOnly = element.isReadOnly();
         information.value = element.value();
         information.autofillFieldName = WebCore::toAutofillFieldName(element.autofillData().fieldName);
+        information.nonAutofillCredentialType = element.autofillData().nonAutofillCredentialType;
+        information.frameID = CheckedRef(m_page->focusController())->focusedOrMainFrame().frameID();
         information.placeholder = element.attributeWithoutSynchronization(HTMLNames::placeholderAttr);
         information.inputMode = element.canonicalInputMode();
         information.enterKeyHint = element.canonicalEnterKeyHint();
@@ -3560,6 +3562,8 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         information.value = element.value();
         information.valueAsNumber = element.valueAsNumber();
         information.autofillFieldName = WebCore::toAutofillFieldName(element.autofillData().fieldName);
+        information.nonAutofillCredentialType = element.autofillData().nonAutofillCredentialType;
+        information.frameID = CheckedRef(m_page->focusController())->focusedOrMainFrame().frameID();
     } else if (focusedElement->hasEditableStyle()) {
         information.elementType = InputType::ContentEditable;
         if (is<HTMLElement>(*focusedElement)) {


### PR DESCRIPTION
#### aa8945d7e8f05e48e56e2a49da697d8fe0e98122
<pre>
Implement non autofill credential type for autocomplete attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=250076">https://bugs.webkit.org/show_bug.cgi?id=250076</a>
rdar://problem/103872859

Reviewed by Brent Fulgham.

This patch implements the autofill credential type for the autocompletion
attribute described here: <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#non-autofill-credential-type">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#non-autofill-credential-type</a>

This value is exposed to _autofillContext with an associated API test.

* Source/WebCore/html/Autofill.cpp:
(WebCore::maxTokensForAutofillFieldCategory):
(WebCore::AutofillData::createFromHTMLFormControlElement):
* Source/WebCore/html/Autofill.h:
(WebCore::AutofillData::AutofillData):
* Source/WebKit/Shared/FocusedElementInformation.h:
* Source/WebKit/Shared/FocusedElementInformation.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(contentTypeFromFieldName):
(-[WKContentView _autofillContext]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt:

Canonical link: <a href="https://commits.webkit.org/258582@main">https://commits.webkit.org/258582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/411d1fef4a09ced4120c830a96439c4ee97806d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/102444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/111723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/106415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/12554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/108224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/12554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/12554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3127 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->