### PR TITLE
Potential Assertion Fix - Fix loop condition in BidiRunList::replaceRunWithRuns

### DIFF
--- a/LayoutTests/fast/text/bidi-replace-runs-crash-expected.txt
+++ b/LayoutTests/fast/text/bidi-replace-runs-crash-expected.txt
@@ -1,0 +1,2 @@
+>> >>
+Test passes if it does not crash or assert.

--- a/LayoutTests/fast/text/bidi-replace-runs-crash.html
+++ b/LayoutTests/fast/text/bidi-replace-runs-crash.html
@@ -1,0 +1,9 @@
+>><output></output>
+<small dir="ltr"><output>>>
+<p>
+    Test passes if it does not crash or assert.
+</p>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/platform/text/BidiRunList.h
+++ b/Source/WebCore/platform/text/BidiRunList.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003, 2004, 2006, 2007, 2008 Apple Inc.  All right reserved.
- * Copyright (C) 2011 Google, Inc.  All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc.  All right reserved.
+ * Copyright (C) 2011-2014 Google, Inc.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -166,7 +166,7 @@ void BidiRunList<Run>::replaceRunWithRuns(Run* toReplace, BidiRunList<Run>& newR
     } else {
         // Find the run just before "toReplace" in the list of runs.
         Run* previousRun = m_firstRun.get();
-        while (previousRun->next() != toReplace)
+        while (previousRun->next() && previousRun->next() != toReplace)
             previousRun = previousRun->next();
         ASSERT(previousRun);
 


### PR DESCRIPTION
#### f1fd9e9795a69fedff6f67401a3f77d93b81959e
<pre>
Potential Assertion Fix - Fix loop condition in BidiRunList::replaceRunWithRuns

Potential Assertion Fix - Fix loop condition in BidiRunList::replaceRunWithRuns
<a href="https://bugs.webkit.org/show_bug.cgi?id=249968">https://bugs.webkit.org/show_bug.cgi?id=249968</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=179068

This patch is to potentially fix an assertion on debug builds by fixing a loop condition in
BidiRunList::replaceRunWithRuns to check if next run exists before accessing it.

* Source/WebCore/platform/text/BidiRunList.h:
(BidiRunList&lt;Run&gt;::replaceRunwithRuns): update &apos;while&apos; loop
* LayoutTests/fast/text/bidi-replace-runs-crash.html: Add Test Case
* LayoutTests/fast/text/bidi-replace-runs-crash-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258465@main">https://commits.webkit.org/258465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d0a7fd553dd182a461f7ef7a755e92158aba235

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111299 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171500 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2027 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109053 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92516 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37084 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4694 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25427 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1866 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44915 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5808 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6533 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->