### PR TITLE
Land stubs for Gamepad.vibrationActuator API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/gamepad/idlharness-extensions.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gamepad/idlharness-extensions.https.window-expected.txt
@@ -3,17 +3,17 @@ PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface Gamepad: original interface defined
 PASS Partial interface Gamepad: member names are unique
-FAIL GamepadHapticActuator interface: existence and properties of interface object assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface object length assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface object name assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: existence and properties of interface prototype object assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: attribute type assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: operation canPlayEffectType(GamepadHapticEffectType) assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: operation playEffect(GamepadHapticEffectType, optional GamepadEffectParameters) assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: operation pulse(double, double) assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
-FAIL GamepadHapticActuator interface: operation reset() assert_own_property: self does not have own property "GamepadHapticActuator" expected property "GamepadHapticActuator" missing
+PASS GamepadHapticActuator interface: existence and properties of interface object
+PASS GamepadHapticActuator interface object length
+PASS GamepadHapticActuator interface object name
+PASS GamepadHapticActuator interface: existence and properties of interface prototype object
+PASS GamepadHapticActuator interface: existence and properties of interface prototype object's "constructor" property
+PASS GamepadHapticActuator interface: existence and properties of interface prototype object's @@unscopables property
+PASS GamepadHapticActuator interface: attribute type
+PASS GamepadHapticActuator interface: operation canPlayEffectType(GamepadHapticEffectType)
+PASS GamepadHapticActuator interface: operation playEffect(GamepadHapticEffectType, optional GamepadEffectParameters)
+FAIL GamepadHapticActuator interface: operation pulse(double, double) assert_own_property: interface prototype object missing non-static operation expected property "pulse" missing
+PASS GamepadHapticActuator interface: operation reset()
 FAIL GamepadPose interface: existence and properties of interface object assert_own_property: self does not have own property "GamepadPose" expected property "GamepadPose" missing
 FAIL GamepadPose interface object length assert_own_property: self does not have own property "GamepadPose" expected property "GamepadPose" missing
 FAIL GamepadPose interface object name assert_own_property: self does not have own property "GamepadPose" expected property "GamepadPose" missing
@@ -42,5 +42,5 @@ FAIL Gamepad interface: attribute hand assert_true: The prototype object must ha
 FAIL Gamepad interface: attribute hapticActuators assert_true: The prototype object must have a property "hapticActuators" expected true got false
 FAIL Gamepad interface: attribute pose assert_true: The prototype object must have a property "pose" expected true got false
 FAIL Gamepad interface: attribute touchEvents assert_true: The prototype object must have a property "touchEvents" expected true got false
-FAIL Gamepad interface: attribute vibrationActuator assert_true: The prototype object must have a property "vibrationActuator" expected true got false
+PASS Gamepad interface: attribute vibrationActuator
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2322,6 +2322,19 @@ GStreamerEnabled:
     WebKit:
       default: true
 
+GamepadVibrationActuatorEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "Gamepad.vibrationActuator support"
+  humanReadableDescription: "Support for Gamepad.vibrationActuator"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GamepadsEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1516,7 +1516,9 @@ list(APPEND WebCore_IDL_INCLUDES
 list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/gamepad/Gamepad.idl
     Modules/gamepad/GamepadButton.idl
+    Modules/gamepad/GamepadEffectParameters.idl
     Modules/gamepad/GamepadEvent.idl
+    Modules/gamepad/GamepadHapticActuator.idl
     Modules/gamepad/Navigator+Gamepad.idl
     Modules/gamepad/WindowEventHandlers+Gamepad.idl
 )
@@ -1526,6 +1528,7 @@ if (ENABLE_GAMEPAD)
         Modules/gamepad/Gamepad.cpp
         Modules/gamepad/GamepadButton.cpp
         Modules/gamepad/GamepadEvent.cpp
+        Modules/gamepad/GamepadHapticActuator.cpp
         Modules/gamepad/GamepadManager.cpp
         Modules/gamepad/NavigatorGamepad.cpp
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -300,7 +300,9 @@ $(PROJECT_DIR)/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
 $(PROJECT_DIR)/Modules/filesystemaccess/StorageManager+FileSystemAccess.idl
 $(PROJECT_DIR)/Modules/gamepad/Gamepad.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadButton.idl
+$(PROJECT_DIR)/Modules/gamepad/GamepadEffectParameters.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadEvent.idl
+$(PROJECT_DIR)/Modules/gamepad/GamepadHapticActuator.idl
 $(PROJECT_DIR)/Modules/gamepad/Navigator+Gamepad.idl
 $(PROJECT_DIR)/Modules/gamepad/WindowEventHandlers+Gamepad.idl
 $(PROJECT_DIR)/Modules/geolocation/Coordinates.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1255,8 +1255,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepad.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepad.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadButton.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadButton.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEffectParameters.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEffectParameters.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadHapticActuator.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadHapticActuator.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGenericTransformStream.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGenericTransformStream.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGeolocation.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -322,7 +322,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/filesystemaccess/StorageManager+FileSystemAccess.idl \
     $(WebCore)/Modules/gamepad/Gamepad.idl \
     $(WebCore)/Modules/gamepad/GamepadButton.idl \
+    $(WebCore)/Modules/gamepad/GamepadEffectParameters.idl \
     $(WebCore)/Modules/gamepad/GamepadEvent.idl \
+    $(WebCore)/Modules/gamepad/GamepadHapticActuator.idl \
     $(WebCore)/Modules/gamepad/Navigator+Gamepad.idl \
     $(WebCore)/Modules/gamepad/WindowEventHandlers+Gamepad.idl \
     $(WebCore)/Modules/geolocation/Geolocation.idl \

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GAMEPAD)
 
 #include "GamepadButton.h"
+#include "GamepadHapticActuator.h"
 #include "PlatformGamepad.h"
 #include <wtf/text/WTFString.h>
 
@@ -41,6 +42,7 @@ Gamepad::Gamepad(const PlatformGamepad& platformGamepad)
     , m_timestamp(platformGamepad.lastUpdateTime())
     , m_mapping(platformGamepad.mapping())
     , m_axes(platformGamepad.axisValues().size(), 0.0)
+    , m_vibrationActuator(GamepadHapticActuator::create())
 {
     unsigned buttonCount = platformGamepad.buttonValues().size();
     m_buttons.reserveInitialCapacity(buttonCount);
@@ -68,6 +70,11 @@ void Gamepad::updateFromPlatformGamepad(const PlatformGamepad& platformGamepad)
         m_buttons[i]->setValue(platformGamepad.buttonValues()[i].value());
 
     m_timestamp = platformGamepad.lastUpdateTime();
+}
+
+GamepadHapticActuator& Gamepad::vibrationActuator()
+{
+    return m_vibrationActuator.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/Gamepad.h
+++ b/Source/WebCore/Modules/gamepad/Gamepad.h
@@ -35,6 +35,7 @@
 namespace WebCore {
 
 class GamepadButton;
+class GamepadHapticActuator;
 class PlatformGamepad;
 
 class Gamepad: public RefCounted<Gamepad> {
@@ -57,6 +58,8 @@ public:
     void updateFromPlatformGamepad(const PlatformGamepad&);
     void setConnected(bool connected) { m_connected = connected; }
 
+    GamepadHapticActuator& vibrationActuator();
+
 private:
     explicit Gamepad(const PlatformGamepad&);
     String m_id;
@@ -67,6 +70,8 @@ private:
 
     Vector<double> m_axes;
     Vector<Ref<GamepadButton>> m_buttons;
+
+    Ref<GamepadHapticActuator> m_vibrationActuator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/Gamepad.idl
+++ b/Source/WebCore/Modules/gamepad/Gamepad.idl
@@ -35,5 +35,8 @@
     readonly attribute DOMString mapping;
     readonly attribute sequence<double> axes;
     readonly attribute sequence<GamepadButton> buttons;
+
+    // Extension: https://w3c.github.io/gamepad/extensions.html#partial-gamepad-interface
+    [EnabledBySetting=GamepadVibrationActuatorEnabled] readonly attribute GamepadHapticActuator vibrationActuator;
 };
 

--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD)
+
+namespace WebCore {
+
+struct GamepadEffectParameters {
+    double duration = 0.0;
+    double startDelay = 0.0;
+    double strongMagnitude = 0.0;
+    double weakMagnitude = 0.0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=GAMEPAD,
+    EnabledBySetting=GamepadVibrationActuatorEnabled
+] dictionary GamepadEffectParameters {
+    double duration = 0.0;
+    double startDelay = 0.0;
+    double strongMagnitude = 0.0;
+    double weakMagnitude = 0.0;
+};

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(GAMEPAD)
+#include "GamepadHapticActuator.h"
+
+#include "GamepadEffectParameters.h"
+#include "JSDOMPromiseDeferred.h"
+
+namespace WebCore {
+
+Ref<GamepadHapticActuator> GamepadHapticActuator::create()
+{
+    return adoptRef(*new GamepadHapticActuator);
+}
+
+GamepadHapticActuator::GamepadHapticActuator()
+    : m_type { Type::Vibration }
+{
+}
+
+bool GamepadHapticActuator::canPlayEffectType(EffectType) const
+{
+    return false;
+}
+
+void GamepadHapticActuator::playEffect(EffectType, GamepadEffectParameters&&, Ref<DeferredPromise>&& promise)
+{
+    promise->reject(Exception { NotSupportedError });
+}
+
+void GamepadHapticActuator::reset(Ref<DeferredPromise>&& promise)
+{
+    promise->reject(Exception { NotSupportedError });
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD)
+
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+struct GamepadEffectParameters;
+
+class GamepadHapticActuator : public RefCounted<GamepadHapticActuator> {
+public:
+    static Ref<GamepadHapticActuator> create();
+
+    enum class Type : uint8_t { Vibration, DualRumble };
+    enum class EffectType : uint8_t { DualRumble };
+    enum class Result : uint8_t { Complete, Preempted };
+
+    Type type() const { return m_type; }
+    bool canPlayEffectType(EffectType) const;
+    void playEffect(EffectType, GamepadEffectParameters&&, Ref<DeferredPromise>&&);
+    void reset(Ref<DeferredPromise>&&);
+
+private:
+    GamepadHapticActuator();
+
+    Type m_type;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+enum GamepadHapticActuatorType {
+  "vibration",
+  "dual-rumble"
+};
+
+enum GamepadHapticEffectType {
+  "dual-rumble"
+};
+
+enum GamepadHapticResult {
+  "complete",
+  "preempted"
+};
+
+[
+    Conditional=GAMEPAD,
+    EnabledBySetting=GamepadVibrationActuatorEnabled,
+    Exposed=Window
+] interface GamepadHapticActuator {
+    readonly attribute GamepadHapticActuatorType type;
+    boolean canPlayEffectType(GamepadHapticEffectType type);
+    Promise<GamepadHapticResult> playEffect(GamepadHapticEffectType type, optional GamepadEffectParameters params = {});
+    Promise<GamepadHapticResult> reset();
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3453,6 +3453,8 @@ JSGPUVertexStepMode.cpp
 JSGainNode.cpp
 JSGainOptions.cpp
 JSGamepad.cpp
+JSGamepadEffectParameters.cpp
+JSGamepadHapticActuator.cpp
 JSGamepadButton.cpp
 JSGamepadEvent.cpp
 JSGeolocation.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -221,6 +221,7 @@ namespace WebCore {
     macro(Gamepad) \
     macro(GamepadButton) \
     macro(GamepadEvent) \
+    macro(GamepadHapticActuator) \
     macro(HighlightRegister) \
     macro(Highlight) \
     macro(HTMLAttachmentElement) \


### PR DESCRIPTION
#### 60f4fa76729bafa5b2594c42d3eb0996ebe2838e
<pre>
Land stubs for Gamepad.vibrationActuator API
<a href="https://bugs.webkit.org/show_bug.cgi?id=250079">https://bugs.webkit.org/show_bug.cgi?id=250079</a>

Reviewed by Brady Eidson.

Land stubs for Gamepad.vibrationActuator API:
- <a href="https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface">https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface</a>

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
(WebCore::Gamepad::Gamepad):
(WebCore::Gamepad::vibrationActuator):
* Source/WebCore/Modules/gamepad/Gamepad.h:
* Source/WebCore/Modules/gamepad/Gamepad.idl:
* Source/WebCore/Modules/gamepad/GamepadEffectParameters.h: Copied from Source/WebCore/Modules/gamepad/Gamepad.idl.
* Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl: Copied from Source/WebCore/Modules/gamepad/Gamepad.idl.
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp: Copied from Source/WebCore/Modules/gamepad/Gamepad.idl.
(WebCore::GamepadHapticActuator::create):
(WebCore::GamepadHapticActuator::GamepadHapticActuator):
(WebCore::GamepadHapticActuator::canPlayEffectType const):
(WebCore::GamepadHapticActuator::playEffect):
(WebCore::GamepadHapticActuator::reset):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h: Copied from Source/WebCore/Modules/gamepad/Gamepad.idl.
(WebCore::GamepadHapticActuator::type const):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl: Copied from Source/WebCore/Modules/gamepad/Gamepad.idl.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/258482@main">https://commits.webkit.org/258482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/177fa8f46610b667ec66478d7f88eb1d992f2a7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111398 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171582 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2130 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109136 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37153 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78878 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92433 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25513 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88638 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2403 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1957 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29472 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45007 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91556 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6634 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20466 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3067 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->