### PR TITLE
_WKAuthenticatorAttestationResponse and _WKAuthenticatorResponse should retain/copy their instance variables

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticatorAttestationResponse : _WKAuthenticatorResponse
 
-@property (nonatomic, readonly) NSData *attestationObject;
+@property (nonatomic, strong, readonly) NSData *attestationObject;
 @property (nonatomic, copy) NSArray<NSNumber *> *transports;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm
@@ -37,8 +37,8 @@
     if (!(self = [super initWithClientDataJSON:clientDataJSON rawId:rawId extensions:WTFMove(extensions) attachment:attachment]))
         return nil;
 
-    _attestationObject = attestationObject;
-    _transports = transports;
+    _attestationObject = [attestationObject retain];
+    _transports = [transports copy];
     return self;
 }
 
@@ -47,9 +47,16 @@
     if (!(self = [super initWithClientDataJSON:clientDataJSON rawId:rawId extensionOutputsCBOR:WTFMove(extensionOutputsCBOR) attachment:attachment]))
         return nil;
 
-    _attestationObject = attestationObject;
-    _transports = transports;
+    _attestationObject = [attestationObject retain];
+    _transports = [transports copy];
     return self;
+}
+
+- (void)dealloc
+{
+    [_attestationObject release];
+    [_transports release];
+    [super dealloc];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.h
@@ -38,9 +38,9 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticatorResponse : NSObject
 
 @property (nonatomic, readonly) _WKAuthenticatorAttachment attachment;
-@property (nullable, nonatomic, readonly) NSData *clientDataJSON;
-@property (nonatomic, readonly) NSData *rawId;
-@property (nullable, nonatomic, readonly, strong) _WKAuthenticationExtensionsClientOutputs *extensions;
+@property (nullable, nonatomic, strong, readonly) NSData *clientDataJSON;
+@property (nonatomic, strong, readonly) NSData *rawId;
+@property (nullable, nonatomic, strong, readonly) _WKAuthenticationExtensionsClientOutputs *extensions;
 @property (nullable, nonatomic, copy) NSData *extensionOutputsCBOR;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
@@ -38,9 +38,9 @@
     if (!(self = [super init]))
         return nil;
 
-    _clientDataJSON = clientDataJSON;
-    _rawId = rawId;
-    _extensions = extensions;
+    _clientDataJSON = [clientDataJSON retain];
+    _rawId = [rawId retain];
+    _extensions = WTFMove(extensions);
     _attachment = attachment;
 
     return self;
@@ -51,12 +51,20 @@
     if (!(self = [super init]))
         return nil;
 
-    _clientDataJSON = clientDataJSON;
-    _rawId = rawId;
-    _extensionOutputsCBOR = extensionOutputsCBOR;
+    _clientDataJSON = [clientDataJSON retain];
+    _rawId = [rawId retain];
+    _extensionOutputsCBOR = [extensionOutputsCBOR copy];
     _attachment = attachment;
 
     return self;
+}
+
+- (void)dealloc
+{
+    [_clientDataJSON release];
+    [_rawId release];
+    [_extensionOutputsCBOR release];
+    [super dealloc];
 }
 
 - (_WKAuthenticationExtensionsClientOutputs *)extensions


### PR DESCRIPTION
#### fe1655421cc54053541f73893479da9f25418daa
<pre>
_WKAuthenticatorAttestationResponse and _WKAuthenticatorResponse should retain/copy their instance variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=250080">https://bugs.webkit.org/show_bug.cgi?id=250080</a>
&lt;rdar://103876775&gt;

Reviewed by Brent Fulgham.

Update @property declarations to retain instance variables
rather than storing them as unsafe-unretained, update init
methods to properly retain/copy the instance variables, and
add -dealloc methods to release instance variables.

* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.h:
- Update @property declarations to store strong references.
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm:
(-[_WKAuthenticatorAttestationResponse initWithClientDataJSON:rawId:extensions:attestationObject:attachment:transports:]):
(-[_WKAuthenticatorAttestationResponse initWithClientDataJSON:rawId:extensionOutputsCBOR:attestationObject:attachment:transports:]):
- Retain or copy instance variables to match @property
  declarations.
(-[_WKAuthenticatorAttestationResponse dealloc]): Add.
- Release retained/copied instance variables to prevent leaks.

* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.h:
- Update @property declarations to store strong references.
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm:
(-[_WKAuthenticatorResponse initWithClientDataJSON:rawId:extensions:attachment:]):
(-[_WKAuthenticatorResponse initWithClientDataJSON:rawId:extensionOutputsCBOR:attachment:]):
- Retain or copy instance variables to match @property
  declarations.
- Use WTFMove() to avoid ref churn of rvalue parameter.
(-[_WKAuthenticatorResponse dealloc]): Add.
- Release retained/copied instance variables to prevent leaks.

Canonical link: <a href="https://commits.webkit.org/258471@main">https://commits.webkit.org/258471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cb87ffa339889095cf2f4eef5dc3aa43da99fc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111321 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2050 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109076 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37106 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78827 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25444 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1885 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44932 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5812 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6556 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->