### PR TITLE
[EWS] Adjust Big Sur bot allocation

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -187,14 +187,14 @@
       "factory": "macOSWK1Factory", "platform": "mac-bigsur",
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["macos-bigsur-release-build-ews"],
-      "workernames": ["ews100", "ews101", "ews103", "ews112", "ews117", "ews129"]
+      "workernames": ["ews101", "ews103", "ews105", "ews116", "ews112", "ews117"]
     },
     {
       "name": "macOS-BigSur-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",
       "factory": "macOSWK2Factory", "platform": "mac-bigsur",
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["macos-bigsur-release-build-ews"],
-      "workernames": ["ews104", "ews106", "ews107", "ews113", "ews115", "ews153"]
+      "workernames": ["ews104", "ews106", "ews107", "ews113", "ews115", "ews169"]
     },
     {
       "name": "macOS-Release-WK2-Stress-Tests-EWS", "shortname": "mac-wk2-stress", "icon": "testOnly",
@@ -317,7 +317,7 @@
       "name": "API-Tests-macOS-EWS", "shortname": "api-mac", "icon": "testOnly",
       "factory": "APITestsFactory", "platform": "*",
       "triggered_by": ["macos-bigsur-release-build-ews"],
-      "workernames": ["ews105", "ews116", "ews150", "ews155", "ews169"]
+      "workernames": ["ews100", "ews129", "ews150", "ews153", "ews155"]
     },
     {
       "name": "API-Tests-GTK-EWS", "shortname": "api-gtk", "icon": "testOnly",


### PR DESCRIPTION
#### e581d875e971d99940aca8b214ba9e80259816c9
<pre>
[EWS] Adjust Big Sur bot allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=250087">https://bugs.webkit.org/show_bug.cgi?id=250087</a>
rdar://problem/103880039

Reviewed by Alexey Proskuryakov.

Adjust Big Sur bot allocation to ensure that 12-core machines are used for layout tests,
and those with fewer cores are allocated to API tests.

ews100: 6 core machine -&gt; API tests, replaced by ews105
ews129: 8 core machine -&gt; API tests, replaced by ews116
ews153: 4 core machine -&gt; API tests, replaced by ews169

* Tools/CISupport/ews-build/config.json:

Canonical link: <a href="https://commits.webkit.org/258440@main">https://commits.webkit.org/258440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d855e8437e38cb6df6c823aad6b1db44bee6dda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101994 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11138 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35064 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/111325 "The change is no longer eligible for processing.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105975 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/12109 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2055 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109080 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107775 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/12109 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35064 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/12109 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35064 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35064 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/4812 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2055 "The change is no longer eligible for processing.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/100904 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35064 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6560 "The change is no longer eligible for processing.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3047 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->