### PR TITLE
[Live Range Selection] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html fails

### DIFF
--- a/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html
+++ b/LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html
@@ -23,9 +23,9 @@ test(function() {
     colorprofile.appendChild(li);
     document.implementation.createDocument('' ,'' ,null).adoptNode(colorprofile)
 
-    input=document.createElement('input');
+    input = document.createElement('input');
     textPath.parentNode.insertBefore(input, textPath);
-    window.getSelection().setBaseAndExtent(input, 0, null, 0);
+    window.getSelection().setBaseAndExtent(input, 0, input, 0);
 
     document.designMode='on';
     document.execCommand('Transpose');


### PR DESCRIPTION
#### 91d6b05b3aafd86d011f5b02cdb8386aff076a8c
<pre>
[Live Range Selection] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=250089">https://bugs.webkit.org/show_bug.cgi?id=250089</a>

Reviewed by Wenson Hsieh.

The failure was caused by an invalid call to setBaseAndExtent with null as end container.
Fixed the test by specifying input element for both start &amp; end.

* LayoutTests/editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html:

Canonical link: <a href="https://commits.webkit.org/258454@main">https://commits.webkit.org/258454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f7c92f7a1643d32ede9d6ae8a12e55abd2b23a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111326 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171529 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2056 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109081 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92541 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24024 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4721 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25452 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1897 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44940 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6561 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3054 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->