### PR TITLE
[Live Range Selection] editing/selection/ios/clear-selection-after-tapping-on-element-with-no-click-handler.html fails

### DIFF
--- a/LayoutTests/editing/selection/ios/clear-selection-after-tapping-on-element-with-no-click-handler.html
+++ b/LayoutTests/editing/selection/ios/clear-selection-after-tapping-on-element-with-no-click-handler.html
@@ -39,7 +39,7 @@
         var clickTarget = document.getElementById("clickTarget");
 
         var target = document.getElementById("target");        
-        window.getSelection().setBaseAndExtent(target, 0, target, 6);
+        window.getSelection().setBaseAndExtent(target, 0, target, 1);
 
         await UIHelper.activateElement(clickTarget);
         setTimeout(() => testRunner.notifyDone(), 0);


### PR DESCRIPTION
#### 6bb0f971c893cecfc0c6722f0f444501d88cd8de
<pre>
[Live Range Selection] editing/selection/ios/clear-selection-after-tapping-on-element-with-no-click-handler.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=250092">https://bugs.webkit.org/show_bug.cgi?id=250092</a>

Reviewed by Wenson Hsieh.

The failure was caused by the test using an invalid offset to setBaseAndExtent. Use a valid offset instead.

* LayoutTests/editing/selection/ios/clear-selection-after-tapping-on-element-with-no-click-handler.html:

Canonical link: <a href="https://commits.webkit.org/258461@main">https://commits.webkit.org/258461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9384efa8e1acd58cd9c2412a08ebf00cc00a9e0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111331 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171533 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2061 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109086 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37114 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24016 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25448 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4818 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44936 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6566 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3059 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->