### PR TITLE
[Live Range Selection] LayoutTests/fast/events/ios/autocorrect-with-range-selection.html fails

### DIFF
--- a/LayoutTests/fast/events/ios/autocorrect-with-range-selection.html
+++ b/LayoutTests/fast/events/ios/autocorrect-with-range-selection.html
@@ -14,9 +14,9 @@
             if (!window.testRunner || !testRunner.runUIScript)
                 return;
 
-            var inputEl = document.getElementById("editable");
-            await UIHelper.activateElementAndWaitForInputSession(inputEl);
-            window.getSelection().setBaseAndExtent(inputEl, 0, inputEl, 2);
+            const editable = document.getElementById("editable");
+            await UIHelper.activateElementAndWaitForInputSession(editable);
+            window.getSelection().setBaseAndExtent(editable, 0, editable, 1);
             await UIHelper.applyAutocorrection("To", "Ti");
             testRunner.notifyDone();
         }


### PR DESCRIPTION
#### d0a82d3bd607a2f115de3084725749bc75015955
<pre>
[Live Range Selection] LayoutTests/fast/events/ios/autocorrect-with-range-selection.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=250095">https://bugs.webkit.org/show_bug.cgi?id=250095</a>

Reviewed by Wenson Hsieh.

The failure was caused by the use of an invalid offset. Use a valid offset instead.

* LayoutTests/fast/events/ios/autocorrect-with-range-selection.html:

Canonical link: <a href="https://commits.webkit.org/258466@main">https://commits.webkit.org/258466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3fc6b4624f3971cc5542b47ce71c9aa83fb202f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111336 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171538 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2066 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109090 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37119 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24025 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1904 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44941 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6571 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3061 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->