### PR TITLE
[WebGPU] Support memoryless textures for render attachments

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.h
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.h
@@ -37,6 +37,7 @@ struct HardwareCapabilities {
     struct BaseCapabilities {
         MTLArgumentBuffersTier argumentBuffersTier { MTLArgumentBuffersTier1 };
         bool supportsNonPrivateDepthStencilTextures { false };
+        bool supportsMemorylessTextures { false };
         id<MTLCounterSet> timestampCounterSet { nil };
         id<MTLCounterSet> statisticCounterSet { nil };
     } baseCapabilities;

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -53,6 +53,7 @@ static HardwareCapabilities::BaseCapabilities baseCapabilities(id<MTLDevice> dev
     return {
         [device argumentBuffersSupport],
         false, // To be filled in by the caller.
+        false, // To be filled in by the caller.
         timestampCounterSet,
         statisticCounterSet,
     };
@@ -96,6 +97,7 @@ static HardwareCapabilities apple3(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
+    baseCapabilities.supportsMemorylessTextures = true;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -465,6 +467,7 @@ static HardwareCapabilities::BaseCapabilities mergeBaseCapabilities(const Hardwa
     return {
         previous.argumentBuffersTier,
         previous.supportsNonPrivateDepthStencilTextures || next.supportsNonPrivateDepthStencilTextures,
+        previous.supportsMemorylessTextures,
         previous.timestampCounterSet,
         previous.statisticCounterSet,
     };

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -87,6 +87,7 @@ public:
     const WGPUTextureDescriptor& descriptor() const { return m_descriptor; }
 
     Device& device() const { return m_device; }
+    void recreateBackingWithStorage() const;
 
 private:
     Texture(id<MTLTexture>, const WGPUTextureDescriptor&, Vector<WGPUTextureFormat>&& viewFormats, Device&);
@@ -96,7 +97,7 @@ private:
     uint32_t arrayLayerCount() const;
     bool validateCreateView(const WGPUTextureViewDescriptor&) const;
 
-    id<MTLTexture> m_texture { nil };
+    mutable id<MTLTexture> m_texture { nil };
 
     const WGPUTextureDescriptor m_descriptor { };
     const Vector<WGPUTextureFormat> m_viewFormats;

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -41,37 +41,39 @@ class Texture;
 class TextureView : public WGPUTextureViewImpl, public RefCounted<TextureView> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<TextureView> create(id<MTLTexture> texture, const WGPUTextureViewDescriptor& descriptor, const std::optional<WGPUExtent3D>& renderExtent, Device& device)
+    static Ref<TextureView> create(id<MTLTexture> texture, const WGPUTextureViewDescriptor& descriptor, const std::optional<WGPUExtent3D>& renderExtent, Device& device, const Ref<Texture>& textureBacking)
     {
-        return adoptRef(*new TextureView(texture, descriptor, renderExtent, device));
+        return adoptRef(*new TextureView(texture, descriptor, renderExtent, device, textureBacking));
     }
-    static Ref<TextureView> createInvalid(Device& device)
+    static Ref<TextureView> createInvalid(Device& device, const Ref<Texture>& textureBacking)
     {
-        return adoptRef(*new TextureView(device));
+        return adoptRef(*new TextureView(device, textureBacking));
     }
 
     ~TextureView();
 
     void setLabel(String&&);
 
-    bool isValid() const { return m_texture; }
+    bool isValid() const { return texture(); }
 
-    id<MTLTexture> texture() const { return m_texture; }
+    id<MTLTexture> texture() const;
     const WGPUTextureViewDescriptor& descriptor() const { return m_descriptor; }
     const std::optional<WGPUExtent3D>& renderExtent() const { return m_renderExtent; }
 
     Device& device() const { return m_device; }
+    void recreateBackingWithStorageIfNeeded() const;
 
 private:
-    TextureView(id<MTLTexture>, const WGPUTextureViewDescriptor&, const std::optional<WGPUExtent3D>&, Device&);
-    TextureView(Device&);
+    TextureView(id<MTLTexture>, const WGPUTextureViewDescriptor&, const std::optional<WGPUExtent3D>&, Device&, const Ref<Texture>&);
+    TextureView(Device&, const Ref<Texture>&);
 
-    const id<MTLTexture> m_texture { nil };
+    id<MTLTexture> m_texture { nil };
 
     const WGPUTextureViewDescriptor m_descriptor;
     const std::optional<WGPUExtent3D> m_renderExtent;
 
     const Ref<Device> m_device;
+    const Ref<Texture> m_textureBacking;
 };
 
 } // namespace WebGPU

--- a/Websites/webkit.org/demos/webgpu/two-pass-instanced-textured-cube.html
+++ b/Websites/webkit.org/demos/webgpu/two-pass-instanced-textured-cube.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Instanced Textured Cubes with Depth Buffer</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Instanced Textured Cubes with Depth Buffer</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/two-pass-instanced-textured-cube.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### 02b481e73663f84fbd02e067238a4993cd8d7a00
<pre>
[WebGPU] Support memoryless textures for render attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=250064">https://bugs.webkit.org/show_bug.cgi?id=250064</a>
&lt;radar://103862028&gt;

Reviewed by NOBODY (OOPS!).

Automatically support memoryless render target attachments, e.g., for
MSAA targets and depth buffers, when the attachment is only used
as a render target and not used in subsequent passes.

This would for example reduce the memory usage of a fullscreen
WebGPU web app on iPhone 14 Pro from ~128MB to ~14MB, assuming
4x MSAA and 32bpp render+depth targets, accounting only for the MSAA,
depth, and resolve targets.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::storeAction):
Default to don&apos;t care for memoryless textures to avoid recreating for example
a depth buffer which is specified with store but only used in one render pass.

(WebGPU::addTextureStorageIfNeeded):
(WebGPU::CommandEncoder::beginRenderPass):
Recreate textures without memoryless storage if needed.

* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::storageMode):
Extract common logic to function.

(WebGPU::createTextureDescriptor):
Extract common logic to function.

(WebGPU::Device::createTexture):
Call extracted function.

(WebGPU::Texture::recreateBackingWithStorage):
Recreate texture without memoryless storage.

(WebGPU::Texture::createView):
Don&apos;t create a view when the format is identical as this is not
compatible with memoryless textures.

* Source/WebGPU/WebGPU/TextureView.h:
(WebGPU::TextureView::create):
Cache a reference to the Texture instance.

* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::TextureView):
(WebGPU::TextureView::recreateBackingWithStorageIfNeeded):
Recreate the texture and texture view if needed.

* Websites/webkit.org/demos/webgpu/scripts/two-pass-instanced-textured-cube.js: Added.
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/two-pass-instanced-textured-cube.html: Added.
Add a sample that illustrates how memoryless textures, initially used, will no longer
be used due to inefficient construction of render passes.

* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js:
Add sample to show how to opt-in to memoryless textures.

* Source/WebGPU/WebGPU/HardwareCapabilities.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::apple3):
(WebGPU::mergeBaseCapabilities):
Add a flag for whether or not memoryless textures are supported.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02b481e73663f84fbd02e067238a4993cd8d7a00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112509 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95490 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110773 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109039 "Build is being retried. Recent messages:Running configure-build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37937 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26388 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2902 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45894 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7711 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->