### PR TITLE
[macOS] Extend GPU process sandbox to permit connection to com.apple.coremedia.shaphelper.xpc

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -855,6 +855,9 @@
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 120000
     (global-name "com.apple.coremedia.samplebufferconsumer.xpc")
 #endif
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
+    (global-name "com.apple.coremedia.shaphelper.xpc")
+#endif
     (global-name "com.apple.coremedia.volumecontroller.xpc")
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
     (global-name "com.apple.timesync.expositor")


### PR DESCRIPTION
#### b212810b234edeb5ae524beab1f0e591e7de33fe
<pre>
[macOS] Extend GPU process sandbox to permit connection to com.apple.coremedia.shaphelper.xpc
<a href="https://bugs.webkit.org/show_bug.cgi?id=250102">https://bugs.webkit.org/show_bug.cgi?id=250102</a>
&lt;rdar://problem/103602668&gt;

Reviewed by Per Arne Vollan.

Some echo mitigation features don&apos;t work in macOS Ventura because we block access to a new
CoreMedia mach service. This patch permits this access.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/259057@main">https://commits.webkit.org/259057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6657d6c14874a19f8233aa965b3c525aa25e140

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111350 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2084 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109100 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37123 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78846 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25471 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1918 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44959 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6585 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->