### PR TITLE
REGRESSION(255641@main): Web process crash in WebCore::isDescendantOfFullScreenLayer when when fullscreening video on reddit.com

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2674,8 +2674,11 @@ static FullScreenDescendant isDescendantOfFullScreenLayer(const RenderLayer& lay
         return FullScreenDescendant::NotApplicable;
 
     auto* fullScreenRenderer = dynamicDowncast<RenderLayerModelObject>(fullScreenElement->renderer());
+    if (!fullScreenRenderer)
+        return FullScreenDescendant::NotApplicable;
+
     auto* fullScreenLayer = fullScreenRenderer->layer();
-    if (!fullScreenRenderer || !fullScreenLayer)
+    if (!fullScreenLayer)
         return FullScreenDescendant::NotApplicable;
 
     auto backdropRenderer = fullScreenRenderer->backdropRenderer();


### PR DESCRIPTION
#### e29dfab61f35b45f262f1c25945f518f3c994aa5
<pre>
REGRESSION(255641@main): Web process crash in WebCore::isDescendantOfFullScreenLayer when when fullscreening video on reddit.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=249689">https://bugs.webkit.org/show_bug.cgi?id=249689</a>

Reviewed by Brent Fulgham and Tim Nguyen.

Currently we crash if the downcast here fails. The code inconsistently
expects it to always succeed, then checks for failure right below. Check
first. This seems to be all that&apos;s required to fix fullscreen video on
reddit.com.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::isDescendantOfFullScreenLayer):

Canonical link: <a href="https://commits.webkit.org/258593@main">https://commits.webkit.org/258593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b452f5dacbf14ca9171bbe35296d1b73f02537e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111358 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171553 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2091 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94428 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109107 "Hash 7b452f5d for PR 8213 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37128 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78852 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25479 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1923 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44967 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5804 "The change is no longer eligible for processing.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6594 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3133 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->