### PR TITLE
eventSender.monitorWheelEvents({ }) is interpreted as eventSender.monitorWheelEvents({ resetLatching: false })

### DIFF
--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -1288,11 +1288,15 @@ static NSUInteger swizzledEventPressedMouseButtons()
 
     bool resetLatching = true;
 
-    if (![options isKindOfClass:[WebUndefined class]]) {
-        if (id resetLatchingValue = [options valueForKey:@"resetLatching"]) {
-            if ([resetLatchingValue isKindOfClass:[NSNumber class]])
-                resetLatching = [resetLatchingValue boolValue];
+    @try {
+        if (![options isKindOfClass:[WebUndefined class]]) {
+            if (id resetLatchingValue = [options valueForKey:@"resetLatching"]) {
+                if ([resetLatchingValue isKindOfClass:[NSNumber class]])
+                    resetLatching = [resetLatchingValue boolValue];
+            }
         }
+    }
+    @catch(NSException *) {
     }
 
     WebCoreTestSupport::monitorWheelEvents(*frame, resetLatching);

--- a/Tools/TestRunnerShared/Bindings/JSBasics.cpp
+++ b/Tools/TestRunnerShared/Bindings/JSBasics.cpp
@@ -38,6 +38,11 @@ std::optional<double> toOptionalDouble(JSContextRef context, JSValueRef value)
     return JSValueIsUndefined(context, value) || JSValueIsNull(context, value) ? std::nullopt : std::make_optional(JSValueToNumber(context, value, nullptr));
 }
 
+bool isValidValue(JSContextRef context, JSValueRef value)
+{
+    return value && !JSValueIsUndefined(context, value) && !JSValueIsNull(context, value);
+}
+
 JSValueRef makeValue(JSContextRef context, std::optional<bool> value)
 {
     return value ? JSValueMakeBoolean(context, value.value()) : JSValueMakeNull(context);
@@ -77,19 +82,19 @@ JSRetainPtr<JSStringRef> stringProperty(JSContextRef context, JSObjectRef object
 bool booleanProperty(JSContextRef context, JSObjectRef object, const char* name, bool defaultValue)
 {
     auto value = property(context, object, name);
-    return value ? JSValueToBoolean(context, value) : defaultValue;
+    return isValidValue(context, value) ? JSValueToBoolean(context, value) : defaultValue;
 }
 
 double numericProperty(JSContextRef context, JSObjectRef object, const char* name)
 {
     auto value = property(context, object, name);
-    return value ? JSValueToNumber(context, value, nullptr) : 0;
+    return isValidValue(context, value) ? JSValueToNumber(context, value, nullptr) : 0;
 }
 
 JSObjectRef objectProperty(JSContextRef context, JSObjectRef object, const char* name)
 {
     auto value = property(context, object, name);
-    return value && JSValueIsObject(context, value) ? const_cast<JSObjectRef>(value) : nullptr;
+    return isValidValue(context, value) && JSValueIsObject(context, value) ? const_cast<JSObjectRef>(value) : nullptr;
 }
 
 JSObjectRef objectProperty(JSContextRef context, JSObjectRef object, std::initializer_list<const char*> names)

--- a/Tools/TestRunnerShared/Bindings/JSBasics.h
+++ b/Tools/TestRunnerShared/Bindings/JSBasics.h
@@ -35,6 +35,8 @@ namespace WTR {
 std::optional<bool> toOptionalBool(JSContextRef, JSValueRef);
 std::optional<double> toOptionalDouble(JSContextRef, JSValueRef);
 
+bool isValidValue(JSContextRef, JSValueRef);
+
 JSRetainPtr<JSStringRef> createJSString(const char* = "");
 JSRetainPtr<JSStringRef> createJSString(JSContextRef, JSValueRef);
 


### PR DESCRIPTION
#### cce6984b0a67352ec38c934715f0ec306f5a0cd6
<pre>
eventSender.monitorWheelEvents({ }) is interpreted as eventSender.monitorWheelEvents({ resetLatching: false })
<a href="https://bugs.webkit.org/show_bug.cgi?id=250110">https://bugs.webkit.org/show_bug.cgi?id=250110</a>
rdar://103891736

Reviewed by Wenson Hsieh and Brent Fulgham.

booleanProperty(), numericProperty() and objectProperty() would fetch the named property from the given
object, but fail to test whether it was the undefined value. `booleanProperty()` would then coerce it to
boolean, returning `false` when in fact it should have returned the default value. `numericProperty()`
and `objectProperty()` had a similar issue.

In DumpRenderTree, this issue occurs in a related way in `-monitorWheelEventsWithOptions:`; for some
reason, `-[WebScriptOject valueForKey:]` deliberately triggers an exception when accessing a non-existent
key, so catch that exception.

* Tools/DumpRenderTree/mac/EventSendingController.mm:
(-[EventSendingController monitorWheelEventsWithOptions:]):
* Tools/TestRunnerShared/Bindings/JSBasics.cpp:
(WTR::isValidValue):
(WTR::booleanProperty):
(WTR::numericProperty):
(WTR::objectProperty):
* Tools/TestRunnerShared/Bindings/JSBasics.h:

Canonical link: <a href="https://commits.webkit.org/258474@main">https://commits.webkit.org/258474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/886b9a75be2463eadeda5dfec15becbc7b36be5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102049 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111373 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171562 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2103 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109116 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37133 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24062 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25490 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4861 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44981 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5813 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6610 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->