### PR TITLE
Implement margin-trim for grid containers.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-block-end-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="block-end should trim block-end margins of items on last row">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item style="grid-row: span 2; height: auto;"></item>
+<item style="margin-block-end: 10px;"></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-block-end-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="grid-block-end-001-ref.html">
+<meta name="assert" content="block-end should trim block-end margins of items on last row">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: block-end;
+}
+
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item style="grid-row: span 2; height: auto;"></item>
+<item></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-block-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="block should trim block-start margin of items on first row and block-end margins of items on last row">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-start-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-block-start-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="block-start should trim block-start margins of items on first row">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.block-start-margin {
+    margin-block-start: 10px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item></item>
+<item></item>
+<item class="block-start-margin"></item>
+<item class="block-start-margin"></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-start.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-block-start-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="grid-block-start-001-ref.html">
+<meta name="assert" content="block-start should trim block-start margins of items on first row">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: block-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-start: 10px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-block-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="block should trim block-start margin of items on first row and block-end margins of items on last row">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: auto auto;
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.block-start-margin {
+    margin-block-start: 10px;
+}
+.block-end-margin {
+    margin-block-end: 20px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<grid>
+<item class="block-start-margin"></item>
+<item class="block-start-margin"></item>
+<item class="block-end-margin"></item>
+<item class="block-end-margin"></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-end-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-end-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="">
+<meta name="assert" content="inline-end should trim inline-end margins of items on last column">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: inline-end;
+}
+
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item style="grid-column: span 2; width: auto;"></item>
+<item style="margin-inline-end: 10px;"></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-end.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-end-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="grid-inline-end-001-ref.html">
+<meta name="assert" content="inline-end should trim inline-end margins of items on last column">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: inline-end;
+}
+
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 10px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item style="grid-column: span 2; width: auto;"></item>
+<item></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="inline should trim inline-start margin of items on first column and inline-end margins of items on last column">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-start-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-start-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="inline-start should trim inline-start margins of items on first column">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: inline-start;
+}
+
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.inline-start-margin {
+    margin-inline-start: 10px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item></item>
+<item class="inline-start-margin"></item>
+<item></item>
+<item class="inline-start-margin"></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-start.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-start-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="grid-inline-start-001-ref.html">
+<meta name="assert" content="inline-start should trim inline-start margins of items on first column">
+<style>
+grid {
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: inline-start;
+}
+
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-start: 10px;
+}
+</style>
+</head>
+<body>
+<grid>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="inline should trim inline-start margin of items on first column and inline-end margins of items on last column">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: auto auto;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(odd) {
+    margin-inline-start: 10px;
+}
+item:nth-child(even) {
+    margin-inline-end: 20px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<grid>
+<item></item>
+<item></item>
+<item></item>
+<item></item>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-trim-ignores-collapsed-tracks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-trim-ignores-collapsed-tracks-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-inline-001</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="should ignore collapsed margins when determining if an edge should be trimmed">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-trim-ignores-collapsed-tracks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-trim-ignores-collapsed-tracks.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: grid-trim-ignores-collapsed-tracks</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="should ignore collapsed margins when determining if an edge should be trimmed">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: repeat(auto-fit, 250px);
+    grid-template-columns: repeat(auto-fit, 250px);
+    margin-trim: block-start inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    grid-column: 2;
+    grid-row: 2;
+    margin-inline-start: 30px;
+    margin-block-start: 50px;
+    width: 100px;
+    height: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<grid>
+<item></item>
+</grid>
+</body>
+</html>

--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -186,6 +186,22 @@ GridSpan Grid::gridItemSpan(const RenderBox& gridItem, GridTrackSizingDirection 
     return direction == ForColumns ? area.columns : area.rows;
 }
 
+GridSpan Grid::gridItemSpanIgnoringCollapsedTracks(const RenderBox& gridItem, GridTrackSizingDirection direction) const
+{
+    auto span = gridItemSpan(gridItem, direction);
+    if (!span.startLine() || !hasAutoRepeatEmptyTracks(direction))
+        return span;
+    unsigned currentLine = span.startLine() - 1;
+
+    while (currentLine && isEmptyAutoRepeatTrack(direction, currentLine))
+        currentLine--; 
+    if (currentLine)
+        return GridSpan::translatedDefiniteGridSpan(currentLine + 1, span.integerSpan());
+
+    // Still need to check if the first track is empty
+    return isEmptyAutoRepeatTrack(direction, currentLine) ? GridSpan::translatedDefiniteGridSpan(currentLine, span.integerSpan()) : GridSpan::translatedDefiniteGridSpan(currentLine + 1, span.integerSpan());
+}
+
 void Grid::setupGridForMasonryLayout()
 {
     // FIXME(248472): See if we can resize grid instead of clearing it here: https://bugs.webkit.org/show_bug.cgi?id=248472

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -58,6 +58,7 @@ public:
     void setGridItemArea(const RenderBox& item, GridArea);
 
     GridSpan gridItemSpan(const RenderBox&, GridTrackSizingDirection) const;
+    GridSpan gridItemSpanIgnoringCollapsedTracks(const RenderBox&, GridTrackSizingDirection) const;
 
     const GridCell& cell(unsigned row, unsigned column) const;
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1507,6 +1507,25 @@ void RenderGrid::updateAutoMarginsInColumnAxisIfNeeded(RenderBox& child)
     }
 }
 
+bool RenderGrid::shouldTrimChildMargin(MarginTrimType marginTrimType, const RenderBox& child) const
+{
+    if (!style().marginTrim().contains(marginTrimType))
+        return false;
+    auto isTrimmingBlockDirection = marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::BlockEnd;
+    auto itemGridSpan = isTrimmingBlockDirection ? currentGrid().gridItemSpanIgnoringCollapsedTracks(child, ForRows) : currentGrid().gridItemSpanIgnoringCollapsedTracks(child, ForColumns);
+    switch (marginTrimType) {
+    case MarginTrimType::BlockStart:
+    case MarginTrimType::InlineStart:
+        return !itemGridSpan.startLine();
+    case MarginTrimType::BlockEnd:
+        return itemGridSpan.endLine() == currentGrid().numTracks(ForRows);
+    case MarginTrimType::InlineEnd:
+        return itemGridSpan.endLine() == currentGrid().numTracks(ForColumns);
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 bool RenderGrid::isBaselineAlignmentForChild(const RenderBox& child) const
 {
     return isBaselineAlignmentForChild(child, GridRowAxis) || isBaselineAlignmentForChild(child, GridColumnAxis);

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -214,6 +214,7 @@ private:
     void resetAutoMarginsAndLogicalTopInColumnAxis(RenderBox& child);
     void updateAutoMarginsInColumnAxisIfNeeded(RenderBox&);
     void updateAutoMarginsInRowAxisIfNeeded(RenderBox&);
+    bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const final;
 
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const final;
     std::optional<LayoutUnit> firstLineBaseline() const final;


### PR DESCRIPTION
#### e8f3117677da09237aee608c42a4741985dacb50
<pre>
Implement margin-trim for grid containers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249210">https://bugs.webkit.org/show_bug.cgi?id=249210</a>
rdar://103285873

Reviewed by Alan Baradlay.

Adds support for the margin-trim property on grids. This will trim the
margin of items that are adjacent to the edges of the container
specified by the property values. This can be done by checking the
placement of the grid items on the track. After
RenderGrid::placeItemsOnGrid is finished, each grid item should have a
position in the grid that we can look at.

Since we are supposed to ignore collapsed tracks, gridItemSpan may not
return the correct values to compare. gridItemSpanIgnoringCollapsedTracks
was added to try and address this. It will get the value returned by
gridItemSpan, but it will also try to adjust the position in the grid so
that it ignores the collapsed tracks.

Spec reference: <a href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">https://drafts.csswg.org/css-box-4/#margin-trim-grid</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-expected.html: Added.
* LayoutTests/imported/w3c/web-iplatform-tests/css/css-box/margin-trim/grid-block-start-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-end-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-start-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-trim-ignores-collapsed-tracks-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-trim-ignores-collapsed-tracks.html: Added.
* Source/WebCore/rendering/Grid.cpp:
(WebCore::Grid::gridItemSpanIgnoringCollapsedTracks const):
* Source/WebCore/rendering/Grid.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::shouldTrimChildMargin const):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/258587@main">https://commits.webkit.org/258587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac3d41106b662852821ad514faa3afdd3fe18da2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111700 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2457 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108189 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24343 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25766 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5180 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5892 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->