### PR TITLE
[Live Range Selection] text recognition tests fail

### DIFF
--- a/LayoutTests/fast/images/text-recognition/mac/context-menu-for-image-in-link-contains-copy.html
+++ b/LayoutTests/fast/images/text-recognition/mac/context-menu-for-image-in-link-contains-copy.html
@@ -58,7 +58,8 @@ addEventListener("load", () => {
     eventSender.mouseMoveTo(50, 150);
 
     shouldBeNull("getCopyContextMenuItem()");
-    getSelection().selectAllChildren(internals.shadowRoot(image).getElementById("image-overlay"));
+    const overlay = internals.shadowRoot(image).getElementById("image-overlay");
+    internals.setSelectionWithoutValidation(overlay, 0, overlay, overlay.childNodes.length);
     testPassed("Selected text in image");
     shouldBeNonNull("getCopyContextMenuItem()");
 });

--- a/LayoutTests/fast/images/text-recognition/mac/select-image-overlay-with-mouse-drag-2-expected.html
+++ b/LayoutTests/fast/images/text-recognition/mac/select-image-overlay-with-mouse-drag-2-expected.html
@@ -54,7 +54,8 @@ addEventListener("load", () => {
         }
     ]);
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).querySelector("div#image-overlay"));
+    const overlay = internals.shadowRoot(image).querySelector("div#image-overlay");
+    internals.setSelectionWithoutValidation(overlay, 0, overlay, overlay.childNodes.length);
 });
 </script>
 </body>

--- a/LayoutTests/fast/images/text-recognition/mac/select-word-in-draggable-image-overlay.html
+++ b/LayoutTests/fast/images/text-recognition/mac/select-word-in-draggable-image-overlay.html
@@ -32,7 +32,8 @@ addEventListener("load", () => {
         }
     ]);
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).querySelector(".image-overlay-text"));
+    const overlay = internals.shadowRoot(image).querySelector(".image-overlay-text");
+    internals.setSelectionWithoutValidation(overlay, 0, overlay, overlay.childNodes.length);
 });
 </script>
 </body>

--- a/LayoutTests/fast/images/text-recognition/mac/select-word-in-transparent-image-overlay.html
+++ b/LayoutTests/fast/images/text-recognition/mac/select-word-in-transparent-image-overlay.html
@@ -48,7 +48,8 @@ addEventListener("load", () => {
         }
     ]);
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).querySelector(".image-overlay-text"));
+    const overlay = internals.shadowRoot(image).querySelector(".image-overlay-text");
+    internals.setSelectionWithoutValidation(overlay, 0, overlay, overlay.childNodes.length);
 });
 </script>
 </body>


### PR DESCRIPTION
#### b011a6f10fc0dfcb20bff7cf7bc2b1e53f21d5a7
<pre>
[Live Range Selection] text recognition tests fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=250114">https://bugs.webkit.org/show_bug.cgi?id=250114</a>

Reviewed by Wenson Hsieh.

These tests rely on setBaseAndExtent being able to select contents inside a UA shadow tree,
which is no longer true once live range selection is enabled.

Use internals.setSelectionWithoutValidation instead.

* LayoutTests/fast/images/text-recognition/mac/context-menu-for-image-in-link-contains-copy.html:
* LayoutTests/fast/images/text-recognition/mac/select-image-overlay-with-mouse-drag-2-expected.html:
* LayoutTests/fast/images/text-recognition/mac/select-word-in-draggable-image-overlay.html:
* LayoutTests/fast/images/text-recognition/mac/select-word-in-transparent-image-overlay.html:

Canonical link: <a href="https://commits.webkit.org/258476@main">https://commits.webkit.org/258476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b82006e97551fb38eceff58ce7a3447b1b589e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111383 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171570 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2113 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109124 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37140 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24071 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25499 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1944 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44990 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6620 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3065 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->