### PR TITLE
_WKContextMenuElementInfo should expose a _WKHitTestResult property

### DIFF
--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -109,6 +109,9 @@ public:
 #if PLATFORM(IOS_FAMILY)
         ContextMenuElementInfo,
 #endif
+#if PLATFORM(MAC)
+        ContextMenuElementInfoMac,
+#endif
         ContextMenuListener,
         CustomHeaderFields,
         InternalDebugFeature,
@@ -363,6 +366,9 @@ template<> struct EnumTraits<API::Object::Type> {
         API::Object::Type::ContentWorld,
 #if PLATFORM(IOS_FAMILY)
         API::Object::Type::ContextMenuElementInfo,
+#endif
+#if PLATFORM(MAC)
+        API::Object::Type::ContextMenuElementInfoMac,
 #endif
         API::Object::Type::ContextMenuListener,
         API::Object::Type::CustomHeaderFields,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -73,6 +73,7 @@
 #import "_WKAttachmentInternal.h"
 #import "_WKAutomationSessionInternal.h"
 #import "_WKContentRuleListActionInternal.h"
+#import "_WKContextMenuElementInfoInternal.h"
 #import "_WKCustomHeaderFieldsInternal.h"
 #import "_WKDataTaskInternal.h"
 #import "_WKExperimentalFeatureInternal.h"
@@ -360,6 +361,12 @@ void* Object::newObject(size_t size, Type type)
 #if PLATFORM(IOS_FAMILY)
     case Type::ContextMenuElementInfo:
         wrapper = [WKContextMenuElementInfo alloc];
+        break;
+#endif
+
+#if PLATFORM(MAC)
+    case Type::ContextMenuElementInfoMac:
+        wrapper = [_WKContextMenuElementInfo alloc];
         break;
 #endif
 

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,46 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "_WKContextMenuElementInfo.h"
+#pragma once
 
-#import "APIHitTestResult.h"
-#import "_WKContextMenuElementInfoInternal.h"
-#import "_WKHitTestResultInternal.h"
-#import <WebCore/WebCoreObjCExtras.h>
-#import <wtf/RetainPtr.h>
+#if PLATFORM(MAC)
 
-#if !PLATFORM(IOS_FAMILY)
+#include "APIObject.h"
+#include "WebHitTestResultData.h"
 
-@implementation _WKContextMenuElementInfo
+namespace API {
 
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
-}
+class ContextMenuElementInfoMac final : public ObjectImpl<Object::Type::ContextMenuElementInfoMac> {
+public:
+    template<typename... Args> static Ref<ContextMenuElementInfoMac> create(Args&&... args)
+    {
+        return adoptRef(*new ContextMenuElementInfoMac(std::forward<Args>(args)...));
+    }
 
-- (void)dealloc
-{
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKContextMenuElementInfo.class, self))
-        return;
-    _contextMenuElementInfoMac->API::ContextMenuElementInfoMac::~ContextMenuElementInfoMac();
-    [super dealloc];
-}
+    const WebKit::WebHitTestResultData& hitTestResultData() const { return m_hitTestResultData; }
 
-- (_WKHitTestResult *)hitTestResult
-{
-    auto& hitTestResultData = _contextMenuElementInfoMac->hitTestResultData();
-    auto apiHitTestResult = API::HitTestResult::create(hitTestResultData);
-    return retainPtr(wrapper(apiHitTestResult)).autorelease();
-}
+private:
+    ContextMenuElementInfoMac(const WebKit::WebHitTestResultData& hitTestResultData)
+        : m_hitTestResultData(hitTestResultData) { }
 
-// MARK: WKObject protocol implementation
+    WebKit::WebHitTestResultData m_hitTestResultData;
+};
 
-- (API::Object&)_apiObject
-{
-    return *_contextMenuElementInfoMac;
-}
+} // namespace API
 
-@end
-
-#endif // !PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
@@ -29,8 +29,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class _WKHitTestResult;
+
 WK_CLASS_AVAILABLE(macos(10.12))
 @interface _WKContextMenuElementInfo : NSObject <NSCopying>
+
+@property (nonatomic, readonly, copy) _WKHitTestResult *hitTestResult WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfoInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,46 +23,25 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
 #import "_WKContextMenuElementInfo.h"
 
-#import "APIHitTestResult.h"
-#import "_WKContextMenuElementInfoInternal.h"
-#import "_WKHitTestResultInternal.h"
-#import <WebCore/WebCoreObjCExtras.h>
-#import <wtf/RetainPtr.h>
+#if !TARGET_OS_IPHONE
 
-#if !PLATFORM(IOS_FAMILY)
+#import "APIContextMenuElementInfoMac.h"
+#import "WKObject.h"
 
-@implementation _WKContextMenuElementInfo
+namespace WebKit {
 
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
+template<> struct WrapperTraits<API::ContextMenuElementInfoMac> {
+    using WrapperClass = _WKContextMenuElementInfo;
+};
+
 }
 
-- (void)dealloc
-{
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKContextMenuElementInfo.class, self))
-        return;
-    _contextMenuElementInfoMac->API::ContextMenuElementInfoMac::~ContextMenuElementInfoMac();
-    [super dealloc];
+@interface _WKContextMenuElementInfo () <WKObject> {
+@package
+    API::ObjectStorage<API::ContextMenuElementInfoMac> _contextMenuElementInfoMac;
 }
-
-- (_WKHitTestResult *)hitTestResult
-{
-    auto& hitTestResultData = _contextMenuElementInfoMac->hitTestResultData();
-    auto apiHitTestResult = API::HitTestResult::create(hitTestResultData);
-    return retainPtr(wrapper(apiHitTestResult)).autorelease();
-}
-
-// MARK: WKObject protocol implementation
-
-- (API::Object&)_apiObject
-{
-    return *_contextMenuElementInfoMac;
-}
-
 @end
 
-#endif // !PLATFORM(IOS_FAMILY)
+#endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2354,6 +2354,7 @@
 		DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DF7A231C291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = DF7A231B291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */; };
+		DFEAFFC629664BB200038490 /* _WKContextMenuElementInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */; };
 		E105FE5418D7B9DE008F57A8 /* EditingRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E105FE5318D7B9DE008F57A8 /* EditingRange.h */; };
 		E11D35AE16B63D1B006D23D7 /* com.apple.WebProcess.sb in Resources */ = {isa = PBXBuildFile; fileRef = E1967E37150AB5E200C73169 /* com.apple.WebProcess.sb */; };
 		E14A954A16E016A40068DE82 /* NetworkProcessPlatformStrategies.h in Headers */ = {isa = PBXBuildFile; fileRef = E14A954816E016A40068DE82 /* NetworkProcessPlatformStrategies.h */; };
@@ -7452,8 +7453,10 @@
 		DF58C6351371ACA000F9A37C /* NativeWebWheelEventMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeWebWheelEventMac.mm; sourceTree = "<group>"; };
 		DF74275C24F4955000F8ABE9 /* PDFPluginIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFPluginIdentifier.h; sourceTree = "<group>"; };
 		DF7A231B291B088D00B98DF3 /* WKSnapshotConfigurationPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSnapshotConfigurationPrivate.h; sourceTree = "<group>"; };
+		DF7B8A232968A41000647721 /* APIContextMenuElementInfoMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuElementInfoMac.h; sourceTree = "<group>"; };
 		DF84CEE2249AA21F009096F6 /* WKPDFHUDView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKPDFHUDView.mm; path = PDF/WKPDFHUDView.mm; sourceTree = "<group>"; };
 		DF84CEE3249AA21F009096F6 /* WKPDFHUDView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKPDFHUDView.h; path = PDF/WKPDFHUDView.h; sourceTree = "<group>"; };
+		DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKContextMenuElementInfoInternal.h; sourceTree = "<group>"; };
 		E105FE5318D7B9DE008F57A8 /* EditingRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditingRange.h; sourceTree = "<group>"; };
 		E133FD891423DD7F00FC7BFB /* WebKit.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = WebKit.icns; path = Resources/WebKit.icns; sourceTree = "<group>"; };
 		E14A954716E016A40068DE82 /* NetworkProcessPlatformStrategies.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkProcessPlatformStrategies.cpp; sourceTree = "<group>"; };
@@ -10201,6 +10204,7 @@
 				5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */,
 				1A5704F61BE01FF400874AF1 /* _WKContextMenuElementInfo.h */,
 				1A5704F51BE01FF400874AF1 /* _WKContextMenuElementInfo.mm */,
+				DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */,
 				5C5D2389227A1892000B9BDA /* _WKCustomHeaderFields.h */,
 				5C5D2388227A1892000B9BDA /* _WKCustomHeaderFields.mm */,
 				5C5D2387227A1891000B9BDA /* _WKCustomHeaderFieldsInternal.h */,
@@ -12666,6 +12670,7 @@
 				076E884D1A13CADF005E90FC /* APIContextMenuClient.h */,
 				5CE0C366229F2D3D003695F0 /* APIContextMenuElementInfo.cpp */,
 				5CE0C367229F2D3E003695F0 /* APIContextMenuElementInfo.h */,
+				DF7B8A232968A41000647721 /* APIContextMenuElementInfoMac.h */,
 				5C5D238A227A1D9B000B9BDA /* APICustomHeaderFields.h */,
 				7A821F4F1E2F7A5C00604577 /* APICustomProtocolManagerClient.h */,
 				5C2C6F9F27C9523500CCDA9E /* APIDataTask.cpp */,
@@ -14561,6 +14566,7 @@
 				5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */,
 				5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */,
 				1A5704F81BE01FF400874AF1 /* _WKContextMenuElementInfo.h in Headers */,
+				DFEAFFC629664BB200038490 /* _WKContextMenuElementInfoInternal.h in Headers */,
 				5C5D238C227A2CDA000B9BDA /* _WKCustomHeaderFields.h in Headers */,
 				5C2C6FA927C9E5E200CCDA9E /* _WKDataTask.h in Headers */,
 				5C2C6FAA27C9E5EB00CCDA9E /* _WKDataTaskDelegate.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKMenuItemIdentifiersPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKContextMenuElementInfo.h>
 #import <wtf/BlockPtr.h>
 
 @interface PopoverNotificationListener : NSObject
@@ -245,6 +246,26 @@ TEST(ContextMenuTests, SharePopoverDoesNotClearSelection)
 }
 
 #endif // HAVE(SHARING_SERVICE_PICKER_POPOVER_SPI)
+
+TEST(ContextMenuTests, ContextMenuElementInfoContainsHitTestResult)
+{
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        EXPECT_NOT_NULL(elementInfo.hitTestResult);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 194503237785a3e8e926acfb1dbadb179700cd56
<pre>
_WKContextMenuElementInfo should expose a _WKHitTestResult property
<a href="https://bugs.webkit.org/show_bug.cgi?id=250115">https://bugs.webkit.org/show_bug.cgi?id=250115</a>
&lt;rdar://103895210&gt;

Reviewed by Alex Christensen.

* Source/WebKit/Shared/API/APIObject.h:
Added ContextMenuElementInfoMac.

* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
Added support for _WKContextMenuElementInfo.

* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:
Added. Unfortunately, there is already an iOS-only APIContextMenuElementInfo class and a
corresponding WKContextMenuElementInfo Objective-C class, so I had to use the Mac suffix here.

* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h:
Declare a new hitTestResult property.

* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm:
This now wraps API::ContextMenuElementInfoMac.
(-[_WKContextMenuElementInfo dealloc]):
(-[_WKContextMenuElementInfo hitTestResult]):
Create a _WKHitTestResult from WebHitTestResultData.
(-[_WKContextMenuElementInfo _apiObject]):

* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfoInternal.h:
Added, wraps the API:APIContextMenuElementInfoMac class.

* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ContextMenuClient::menuFromProposedMenu):
Use the hit test result when creating the _WKContextMenuElementInfo.
Clean up some style checker errors.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Added APIContextMenuElementInfoMac.h and _WKContextMenuElementInfoInternal.h.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):
Added a test that just verifies the _WKContextMenuElementInfo hitTestResult property is set.

Canonical link: <a href="https://commits.webkit.org/258624@main">https://commits.webkit.org/258624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4d3015554ef6fa9a48daec522290ab8d9c23f97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111796 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172013 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2563 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109506 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108308 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24428 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25847 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5926 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7011 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->