### PR TITLE
Handle moving a UI-side composited window between displays with different properties

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -70,6 +70,7 @@ public:
     struct Parameters {
         Type type { Type::Bitmap };
         WebCore::FloatSize size;
+        WebCore::DestinationColorSpace colorSpace { WebCore::DestinationColorSpace::SRGB() };
         float scale { 1.0f };
         bool deepColor { false };
         bool isOpaque { false };
@@ -86,6 +87,7 @@ public:
         {
             return (type == other.type
                 && size == other.size
+                && colorSpace == other.colorSpace
                 && scale == other.scale
                 && deepColor == other.deepColor
                 && isOpaque == other.isOpaque
@@ -115,7 +117,7 @@ public:
     WebCore::FloatSize size() const { return m_parameters.size; }
     float scale() const { return m_parameters.scale; }
     bool usesDeepColorBackingStore() const;
-    WebCore::DestinationColorSpace colorSpace() const;
+    WebCore::DestinationColorSpace colorSpace() const { return m_parameters.colorSpace; }
     WebCore::PixelFormat pixelFormat() const;
     Type type() const { return m_parameters.type; }
     bool isOpaque() const { return m_parameters.isOpaque; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -196,22 +196,11 @@ bool RemoteLayerBackingStore::usesDeepColorBackingStore() const
     return false;
 }
 
-DestinationColorSpace RemoteLayerBackingStore::colorSpace() const
-{
-#if PLATFORM(MAC)
-    if (auto* context = m_layer->context())
-        return context->displayColorSpace().value_or(DestinationColorSpace::SRGB());
-#else
-    if (usesDeepColorBackingStore())
-        return DestinationColorSpace { extendedSRGBColorSpaceRef() };
-#endif
-    return DestinationColorSpace::SRGB();
-}
-
 PixelFormat RemoteLayerBackingStore::pixelFormat() const
 {
     if (usesDeepColorBackingStore())
         return m_parameters.isOpaque ? PixelFormat::RGB10 : PixelFormat::RGB10A8;
+
     return PixelFormat::BGRA8;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -33,6 +33,7 @@
 #import "RemoteLayerTreeContext.h"
 #import "RemoteLayerTreePropertyApplier.h"
 #import <WebCore/AnimationUtilities.h>
+#import <WebCore/ColorSpaceCG.h>
 #import <WebCore/EventRegion.h>
 #import <WebCore/GraphicsContext.h>
 #import <WebCore/GraphicsLayerCA.h>
@@ -238,6 +239,14 @@ void PlatformCALayerRemote::updateBackingStore()
     RemoteLayerBackingStore::Parameters parameters;
     parameters.type = m_acceleratesDrawing ? RemoteLayerBackingStore::Type::IOSurface : RemoteLayerBackingStore::Type::Bitmap;
     parameters.size = m_properties.bounds.size();
+
+#if PLATFORM(IOS_FAMILY)
+    parameters.colorSpace = m_wantsDeepColorBackingStore ? DestinationColorSpace { extendedSRGBColorSpaceRef() } : DestinationColorSpace::SRGB();
+#else
+    if (auto displayColorSpace = m_context->displayColorSpace())
+        parameters.colorSpace = displayColorSpace.value();
+#endif
+
     parameters.scale = m_properties.contentsScale;
     parameters.deepColor = m_wantsDeepColorBackingStore;
     parameters.isOpaque = m_properties.opaque;

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -53,6 +53,9 @@ DelegatedScrollingMode RemoteLayerTreeDrawingAreaMac::delegatedScrollingMode() c
 void RemoteLayerTreeDrawingAreaMac::setColorSpace(std::optional<WebCore::DestinationColorSpace> colorSpace)
 {
     m_displayColorSpace = colorSpace;
+
+    // We rely on the fact that the full style recalc that happens when moving a window between displays triggers repaints,
+    // which causes PlatformCALayerRemote::updateBackingStore() to re-create backing stores with the new colorspace.
 }
 
 std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeDrawingAreaMac::displayColorSpace() const


### PR DESCRIPTION
#### a516b8527e73e0a16dfd0c660ca4ebd8d9b6130c
<pre>
Handle moving a UI-side composited window between displays with different properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=247932">https://bugs.webkit.org/show_bug.cgi?id=247932</a>
rdar://102346937

Reviewed by Tim Horton

On macOS windows can be moved between displays with different colorspaces, so with
UI-side compositing we need to ensure that we update layer backing stores with the
new colorspace.

To fix this, add the colorspace to RemoteLayerBackingStore::Parameters, and initialize
it in PlatformCALayerRemote::updateBackingStore() by getting the colorspace from the
RemoteLayerTreeContext (on macOS). This allows the existing call to `ensureBackingStore()`
to do the right thing when the colorspace changes.

We rely on the fact that moving between displays triggers repaints in all layers already
to make sure that we hit PlatformCALayerRemote::updateBackingStore().

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
(WebKit::RemoteLayerBackingStore::Parameters::operator== const):
(WebKit::RemoteLayerBackingStore::colorSpace const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::pixelFormat const):
(WebKit::RemoteLayerBackingStore::colorSpace const): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::updateBackingStore):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::setColorSpace):

Canonical link: <a href="https://commits.webkit.org/258486@main">https://commits.webkit.org/258486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58c595ff3f62ed82d1b6b037d249eab328b690f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111417 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2148 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109153 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37159 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25525 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1967 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5819 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6651 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->