### PR TITLE
[Live Range Selection] Some tests in TestWebKitAPI.ImageAnalysisTests fail

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -433,7 +433,8 @@ TEST(ImageAnalysisTests, MenuControllerItems)
     [webView _setEditable:YES];
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"multiple-images"];
-    [webView objectByEvaluatingJavaScript:@"let image = document.images[0]; getSelection().setBaseAndExtent(image, 0, image, 1);"];
+    [webView objectByEvaluatingJavaScript:@"let image = document.images[0]; nodeIndex = [...image.parentNode.childNodes].indexOf(image);"
+        "getSelection().setBaseAndExtent(image.parentNode, nodeIndex, image.parentNode, nodeIndex + 1);"];
     [webView waitForNextPresentationUpdate];
     simulateCalloutBarAppearance(webView.get());
 
@@ -449,7 +450,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
     [webView buildMenuWithBuilder:menuBuilder.get()];
     EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground()]);
 
-    [webView objectByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(document.body, 0, document.images[0], 1);"];
+    [webView objectByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(document.body, 0, image.parentNode, nodeIndex + 1);"];
     [webView waitForNextPresentationUpdate];
     simulateCalloutBarAppearance(webView.get());
 
@@ -485,7 +486,7 @@ static RetainPtr<TestWKWebView> runMarkupTest(NSString *testPage, NSString *scri
 
 TEST(ImageAnalysisTests, PerformRemoveBackground)
 {
-    runMarkupTest(@"multiple-images", @"getSelection().setBaseAndExtent(document.body, 0, document.images[0], 1)", [](TestWKWebView *webView, NSString *previousSelectedText) {
+    runMarkupTest(@"multiple-images", @"image = document.images[0]; getSelection().setBaseAndExtent(document.body, 0, image.parentNode, [...image.parentNode.childNodes].indexOf(image) + 1)", [](TestWKWebView *webView, NSString *previousSelectedText) {
         EXPECT_WK_STREQ(previousSelectedText, webView.selectedText);
         Util::waitForConditionWithLogging([&] {
             return [[webView objectByEvaluatingJavaScript:@"document.images[0].getBoundingClientRect().width"] intValue] == 215;
@@ -512,7 +513,8 @@ TEST(ImageAnalysisTests, AllowRemoveBackgroundOnce)
 
     RemoveBackgroundSwizzler swizzler { iconImage().autorelease(), CGRectMake(10, 10, 215, 174) };
 
-    [webView objectByEvaluatingJavaScript:@"let image = document.images[0]; getSelection().setBaseAndExtent(image, 0, image, 1)"];
+    [webView objectByEvaluatingJavaScript:@"let image = document.images[0]; nodeIndex = [...image.parentNode.childNodes].indexOf(image);"
+        "getSelection().setBaseAndExtent(image.parentNode, nodeIndex, image.parentNode, nodeIndex + 1)"];
     [webView waitForNextPresentationUpdate];
     simulateCalloutBarAppearance(webView.get());
 


### PR DESCRIPTION
#### 62f15ab41eb01a6f102c272374587d8cacbf7f3e
<pre>
[Live Range Selection] Some tests in TestWebKitAPI.ImageAnalysisTests fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=250125">https://bugs.webkit.org/show_bug.cgi?id=250125</a>

Reviewed by Darin Adler.

The following tests fail when enabling live range selection because they were using legacy editing offsets,
which is no longer allowed. Fixed the tests by using valid offsets instead.
TestWebKitAPI.ImageAnalysisTests.AllowRemoveBackgroundOnce
TestWebKitAPI.ImageAnalysisTests.MenuControllerItems
TestWebKitAPI.ImageAnalysisTests.PerformRemoveBackground

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm:

Canonical link: <a href="https://commits.webkit.org/258494@main">https://commits.webkit.org/258494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cda924f3f7e083c8512b5256d8bb9d0e0ef2201

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111428 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171603 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2160 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109165 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37168 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4804 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25537 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1977 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45033 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6662 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3072 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->