### PR TITLE
Remove flightaware Quirk

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -52,8 +52,6 @@
 
 namespace WebCore {
 
-bool CSSPrimitiveValue::s_useLegacyPrecision;
-
 static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
 {
     switch (unitType) {
@@ -1220,8 +1218,6 @@ NEVER_INLINE String CSSPrimitiveValue::formatInfiniteOrNanValue(ASCIILiteral suf
 
 NEVER_INLINE String CSSPrimitiveValue::formatNumberValue(ASCIILiteral suffix) const
 {
-    if (m_cachedCSSTextUsesLegacyPrecision)
-        return formatIntegerValue(suffix);
     if (std::isnan(m_value.num) || std::isinf(m_value.num))
         return formatInfiniteOrNanValue(suffix);
     return makeString(FormattedCSSNumber::create(m_value.num), suffix);
@@ -1518,11 +1514,10 @@ String CSSPrimitiveValue::customCSSText() const
 
     CSSTextCache& cssTextCache = WebCore::cssTextCache();
 
-    if (m_hasCachedCSSText && m_cachedCSSTextUsesLegacyPrecision == s_useLegacyPrecision) {
+    if (m_hasCachedCSSText) {
         ASSERT(cssTextCache.contains(this));
         return cssTextCache.get(this);
     }
-    m_cachedCSSTextUsesLegacyPrecision = s_useLegacyPrecision;
 
     String text = formatNumberForCustomCSSText();
 

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -208,8 +208,6 @@ public:
     void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const;
     void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const;
 
-    static void setUseLegacyPrecision(bool useLegacyPrecision) { s_useLegacyPrecision = useLegacyPrecision; }
-
 private:
     friend class CSSValuePool;
     friend class StaticCSSValuePool;
@@ -263,8 +261,6 @@ private:
     static constexpr bool isFontRelativeLength(CSSUnitType);
     static constexpr bool isResolution(CSSUnitType);
     static constexpr bool isViewportPercentageLength(CSSUnitType);
-
-    static bool s_useLegacyPrecision;
 
     union {
         CSSPropertyID propertyID;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -257,7 +257,6 @@ protected:
     // CSSPrimitiveValue:
     unsigned m_primitiveUnitType : 7 { 0 }; // CSSUnitType
     mutable unsigned m_hasCachedCSSText : 1 { false };
-    mutable unsigned m_cachedCSSTextUsesLegacyPrecision : 1 { false };
     unsigned m_isImplicit : 1 { false };
 
     // CSSValueList and CSSValuePair:

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -308,16 +308,7 @@ String PropertySetCSSStyleDeclaration::getPropertyValueInternal(CSSPropertyID pr
     if (!isExposed(propertyID))
         return { };
 
-    if (auto* wrapper = this->wrapper()) {
-        if (auto* globalObject = wrapper->globalObject()) {
-            if (auto* document = activeDOMWindow(*globalObject).document())
-                CSSPrimitiveValue::setUseLegacyPrecision(document->quirks().needsFlightAwareSerializationQuirk());
-        }
-    }
-
     auto value = m_propertySet->getPropertyValue(propertyID);
-
-    CSSPrimitiveValue::setUseLegacyPrecision(false);
 
     if (!value.isEmpty())
         return value;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1282,18 +1282,6 @@ bool Quirks::needsHDRPixelDepthQuirk() const
     return *m_needsHDRPixelDepthQuirk;
 }
 
-// FIXME: remove this once rdar://92531240 has been fixed.
-bool Quirks::needsFlightAwareSerializationQuirk() const
-{
-    if (!needsQuirks())
-        return false;
-
-    if (!m_needsFlightAwareSerializationQuirk)
-        m_needsFlightAwareSerializationQuirk = equalLettersIgnoringASCIICase(m_document->url().host(), "flightaware.com"_s);
-
-    return *m_needsFlightAwareSerializationQuirk;
-}
-
 bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -134,8 +134,6 @@ public:
     bool needsVP9FullRangeFlagQuirk() const;
     bool needsHDRPixelDepthQuirk() const;
     
-    bool needsFlightAwareSerializationQuirk() const;
-
     bool requiresUserGestureToPauseInPictureInPicture() const;
     bool requiresUserGestureToLoadInPictureInPicture() const;
 
@@ -201,7 +199,6 @@ private:
     mutable std::optional<bool> m_shouldBypassAsyncScriptDeferring;
     mutable std::optional<bool> m_needsVP9FullRangeFlagQuirk;
     mutable std::optional<bool> m_needsHDRPixelDepthQuirk;
-    mutable std::optional<bool> m_needsFlightAwareSerializationQuirk;
     mutable std::optional<bool> m_needsBlackFullscreenBackgroundQuirk;
     mutable std::optional<bool> m_requiresUserGestureToPauseInPictureInPicture;
     mutable std::optional<bool> m_requiresUserGestureToLoadInPictureInPicture;


### PR DESCRIPTION
#### 1e23db52156ff945e5bb3fa036fd74dc178510a2
<pre>
Remove flightaware Quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=249376">https://bugs.webkit.org/show_bug.cgi?id=249376</a>
rdar://103391012

Reviewed by Darin Adler.

<a href="https://bugs.webkit.org/show_bug.cgi?id=240320">https://bugs.webkit.org/show_bug.cgi?id=240320</a> implemented a Quirk
for FlightAware app. It was necessary because of
<a href="https://bugs.webkit.org/show_bug.cgi?id=218880">https://bugs.webkit.org/show_bug.cgi?id=218880</a>
which implemented the specification, but created a webcompat issue.

They changed their JavaScript so the number in the matrix are now
per spec. See <a href="https://bugs.webkit.org/show_bug.cgi?id=240320#c8">https://bugs.webkit.org/show_bug.cgi?id=240320#c8</a>

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::formatNumberValue const):
(WebCore::CSSPrimitiveValue::customCSSText const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::PropertySetCSSStyleDeclaration::getPropertyValueInternal):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsFlightAwareSerializationQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/258527@main">https://commits.webkit.org/258527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3da682626cc659054e9d220ddcab656e1d03f1e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111557 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2294 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108022 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92742 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24224 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4915 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25646 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5040 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45144 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5845 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6791 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->