### PR TITLE
CSS animations should participate in the cascade

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2309,9 +2309,6 @@ webkit.org/b/148026 [ Debug ] animations/restart-after-scroll.html [ Skip ]
 
 webkit.org/b/148650 fast/repaint/add-table-overpaint.html [ Pass Failure ]
 
-imported/w3c/web-platform-tests/css/css-cascade/important-prop.html [ ImageOnlyFailure ]
-webkit.org/b/192334 imported/w3c/web-platform-tests/css/css-cascade/revert-layer-011.html [ ImageOnlyFailure ]
-
 # Initial failures on the import of css-content
 
 imported/w3c/web-platform-tests/css/css-content/element-replacement-on-replaced-element.tentative.html [ ImageOnlyFailure ]
@@ -4134,7 +4131,6 @@ webkit.org/b/206579 [ Debug ] imported/w3c/web-platform-tests/css/css-background
 
 webkit.org/b/207262 imported/w3c/web-platform-tests/web-animations/timing-model/animations/sync-start-times.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/210963 imported/w3c/web-platform-tests/css/css-animations/animation-important-002.html [ ImageOnlyFailure ]
 webkit.org/b/235110 imported/w3c/web-platform-tests/css/css-animations/flip-running-animation-via-variable.html [ ImageOnlyFailure ]
 
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform-transformed-tr-percent-height-child.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL em units respond to font-size animation assert_equals: expected "15px" but got "1px"
-FAIL ex units respond to font-size animation assert_equals: expected "6.71875px" but got "0.4375px"
-FAIL var() references respond to custom property animation assert_equals: expected "20px" but got "0px"
+PASS em units respond to font-size animation
+PASS ex units respond to font-size animation
+PASS var() references respond to custom property animation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Identical elements are all responsive to font-size animation assert_equals: expected "15px" but got "1px"
+PASS Identical elements are all responsive to font-size animation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-004-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Base is responsive to font-affecting appearing via setKeyframes assert_equals: expected "15px" but got "10px"
+PASS Base is responsive to font-affecting appearing via setKeyframes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-001-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Interpolated value is observable
-FAIL Important rules override animations assert_equals: expected "rgb(0, 128, 0)" but got "rgb(15, 15, 15)"
-FAIL Non-overriden interpolations are observable assert_equals: expected "rgb(0, 128, 0)" but got "rgb(15, 15, 15)"
+PASS Important rules override animations
+PASS Non-overriden interpolations are observable
 FAIL Important rules override animations (::before) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(15, 15, 15)"
 PASS Important rules do not override animations on :visited as seen from JS
-FAIL Standard property animations appearing via setKeyframes do not override important declarations assert_equals: expected "rgb(255, 255, 255)" but got "rgb(15, 15, 15)"
-FAIL Custom property animations appearing via setKeyframes do not override important declarations assert_equals: expected "10px" but got "150px"
+PASS Standard property animations appearing via setKeyframes do not override important declarations
+PASS Custom property animations appearing via setKeyframes do not override important declarations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/keyframes-unrelated-custom-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/keyframes-unrelated-custom-property-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Unrelated custom properties do not conflict with each other assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Unrelated custom properties do not conflict with each other
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value assert_equals: expected "25px" but got "0px"
+PASS Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Running a transition a non-inherited CSS variable is reflected on a standard property using that variable as a value assert_equals: expected "150px" but got "200px"
+PASS Running a transition a non-inherited CSS variable is reflected on a standard property using that variable as a value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL em units respond to font-size transition assert_equals: expected "15px" but got "20px"
-FAIL ex units respond to font-size transition assert_equals: expected "6.71875px" but got "8.96875px"
+PASS em units respond to font-size transition
+PASS ex units respond to font-size transition
 PASS var() references respond to custom property transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Identical elements are all responsive to font-size transition assert_equals: expected "15px" but got "20px"
+PASS Identical elements are all responsive to font-size transition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-animation-from-to-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-animation-from-to-expected.txt
@@ -1,7 +1,7 @@
 This text should animate from blue to green over a period of 1 second.
 
 PASS Verify CSS variable value before animation
-FAIL Verify substituted color value before animation assert_equals: color is blue before animation runs expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS Verify substituted color value before animation
 PASS Verify CSS variable value after animation
-FAIL Verify substituted color value after animation assert_equals: color is green after animation runs expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Verify substituted color value after animation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-animation-over-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-animation-over-transition-expected.txt
@@ -1,7 +1,7 @@
 This text should animate from blue to green over a period of 1 second. The transition is not visible because the animation overrides it.
 
 PASS Verify CSS variable value before animation
-FAIL Verify substituted color value before animation assert_equals: color is blue before animation runs expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS Verify substituted color value before animation
 PASS Verify CSS variable value after animation
-FAIL Verify substituted color value after animation assert_equals: color is green after animation runs expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Verify substituted color value after animation
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL em units respond to font-size animation assert_equals: expected "15px" but got "1px"
-FAIL ex units respond to font-size animation assert_equals: expected "6.875px" but got "0.453125px"
-FAIL var() references respond to custom property animation assert_equals: expected "20px" but got "0px"
-

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL em units respond to font-size transition assert_equals: expected "15px" but got "20px"
-FAIL ex units respond to font-size transition assert_equals: expected "6.875px" but got "9.171875px"
-PASS var() references respond to custom property transition
-

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL em units respond to font-size transition assert_equals: expected "15px" but got "20px"
-FAIL ex units respond to font-size transition assert_equals: expected "6.703125px" but got "8.9375px"
-PASS var() references respond to custom property transition
-

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL em units respond to font-size animation assert_equals: expected "15px" but got "1px"
-FAIL ex units respond to font-size animation assert_equals: expected "6.703125px" but got "0.4375px"
-FAIL var() references respond to custom property animation assert_equals: expected "20px" but got "0px"
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt
@@ -1,5 +1,0 @@
-
-FAIL em units respond to font-size transition assert_equals: expected "15px" but got "20px"
-FAIL ex units respond to font-size transition assert_equals: expected "6.875px" but got "9.171875px"
-PASS var() references respond to custom property transition
-

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -140,7 +140,7 @@ void KeyframeEffectStack::setCSSAnimationList(RefPtr<const AnimationList>&& cssA
     m_isSorted = false;
 }
 
-OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle& targetStyle, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext)
+OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext)
 {
     OptionSet<AnimationImpact> impact;
 
@@ -174,13 +174,8 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
         };
 
         auto cssVariableChanged = [&]() {
-            auto customPropertyValueMapDidChange = [](const CustomPropertyValueMap& a, const CustomPropertyValueMap& b) {
-                return &a != &b && a != b;
-            };
-
             if (previousLastStyleChangeEventStyle && effect->containsCSSVariableReferences()) {
-                if (customPropertyValueMapDidChange(previousLastStyleChangeEventStyle->inheritedCustomProperties(), targetStyle.inheritedCustomProperties())
-                    || customPropertyValueMapDidChange(previousLastStyleChangeEventStyle->nonInheritedCustomProperties(), targetStyle.nonInheritedCustomProperties()))
+                if (!previousLastStyleChangeEventStyle->customPropertiesEqual(targetStyle))
                     return true;
             }
             return false;
@@ -206,6 +201,8 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
             ASSERT(animation->timeline());
             animation->timeline()->animationTimingDidChange(*animation);
         }
+
+        affectedProperties.formUnion(effect->animatedProperties());
     }
 
     return impact;

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -55,7 +55,7 @@ public:
     bool containsProperty(CSSPropertyID) const;
     bool isCurrentlyAffectingProperty(CSSPropertyID) const;
     bool requiresPseudoElement() const;
-    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
+    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
     bool hasEffectWithImplicitKeyframes() const;
 
     void effectAbilityToBeAcceleratedDidChange(const KeyframeEffect&);

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -53,7 +53,7 @@ struct WebAnimationsMarkableDoubleTraits {
     }
 };
 
-enum class AnimationImpact {
+enum class AnimationImpact : uint8_t {
     RequiresRecomposite     = 1 << 0,
     ForcesStackingContext   = 1 << 1
 };

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -81,7 +81,7 @@ class Text;
 class UniqueElementData;
 class WebAnimation;
 
-enum class AnimationImpact;
+enum class AnimationImpact : uint8_t;
 enum class EventHandling : uint8_t;
 enum class EventProcessing : uint8_t;
 enum class FullscreenNavigationUI : uint8_t;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -137,7 +137,7 @@ std::optional<Style::ElementStyle> TextControlInnerElement::resolveCustomStyle(c
         newStyle->setFlexBasis(Length { pixels, LengthType::Fixed });
     }
 
-    return { WTFMove(newStyle) };
+    return Style::ElementStyle { WTFMove(newStyle) };
 }
 
 // MARK: TextControlInnerTextElement
@@ -198,7 +198,7 @@ RenderTextControlInnerBlock* TextControlInnerTextElement::renderer() const
 std::optional<Style::ElementStyle> TextControlInnerTextElement::resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle)
 {
     auto style = downcast<HTMLTextFormControlElement>(*shadowHost()).createInnerTextStyle(*shadowHostStyle);
-    return { makeUnique<RenderStyle>(WTFMove(style)) };
+    return Style::ElementStyle { makeUnique<RenderStyle>(WTFMove(style)) };
 }
 
 // MARK: TextControlPlaceholderElement

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2669,6 +2669,12 @@ void RenderStyle::setNonInheritedCustomPropertyValue(const AtomString& name, Ref
     m_rareNonInheritedData.access().customProperties.access().setCustomPropertyValue(name, WTFMove(value));
 }
 
+bool RenderStyle::customPropertiesEqual(const RenderStyle& other) const
+{
+    return m_rareNonInheritedData->customProperties == other.m_rareNonInheritedData->customProperties
+        && m_rareInheritedData->customProperties == other.m_rareInheritedData->customProperties;
+}
+
 const LengthBox& RenderStyle::scrollMargin() const
 {
     return m_rareNonInheritedData->scrollMargin;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -198,6 +198,7 @@ public:
     const CSSCustomPropertyValue* getCustomProperty(const AtomString&) const;
     void setInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
     void setNonInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
+    bool customPropertiesEqual(const RenderStyle&) const;
 
     void setUsesViewportUnits() { m_nonInheritedFlags.usesViewportUnits = true; }
     bool usesViewportUnits() const { return m_nonInheritedFlags.usesViewportUnits; }

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -86,6 +86,8 @@ public:
     bool hasAnyMatchingRules(const RuleSet&);
 
     const MatchResult& matchResult() const;
+    std::unique_ptr<MatchResult> releaseMatchResult();
+
     const Vector<RefPtr<const StyleRule>>& matchedRuleList() const;
 
     void clearMatchedRules();
@@ -120,7 +122,7 @@ private:
     void sortMatchedRules();
 
     enum class DeclarationOrigin { UserAgent, User, Author };
-    static Vector<MatchedProperties>& declarationsForOrigin(MatchResult&, DeclarationOrigin);
+    Vector<MatchedProperties>& declarationsForOrigin(DeclarationOrigin);
     void sortAndTransferMatchedRules(DeclarationOrigin);
     void transferMatchedRules(DeclarationOrigin, std::optional<ScopeOrdinal> forScope = { });
 
@@ -146,7 +148,7 @@ private:
     // Output.
     Vector<RefPtr<const StyleRule>> m_matchedRuleList;
     bool m_didMatchUncommonAttributeSelector { false };
-    MatchResult m_result;
+    std::unique_ptr<MatchResult> m_result;
     Relations m_styleRelations;
     PseudoIdSet m_matchedPseudoElementIds;
 };

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -45,6 +45,8 @@ struct MatchedProperties {
 };
 
 struct MatchResult {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
     bool isCacheable { true };
     Vector<MatchedProperties> userAgentDeclarations;
     Vector<MatchedProperties> userDeclarations;

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -38,7 +38,7 @@ class RenderStyle;
 class SVGElement;
 class Settings;
 
-enum class AnimationImpact;
+enum class AnimationImpact : uint8_t;
 
 namespace Style {
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -77,8 +77,8 @@ inline bool isValidVisitedLinkProperty(CSSPropertyID id)
     return false;
 }
 
-Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, PropertyCascade::IncludedProperties includedProperties)
-    : m_cascade(matchResult, cascadeLevel, includedProperties)
+Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, PropertyCascade::IncludedProperties includedProperties, const HashSet<AnimatableProperty>* animatedPropertes)
+    : m_cascade(matchResult, cascadeLevel, includedProperties, animatedPropertes)
     , m_state(*this, style, WTFMove(context))
 {
 }
@@ -87,6 +87,9 @@ Builder::~Builder() = default;
 
 void Builder::applyAllProperties()
 {
+    if (m_cascade.isEmpty())
+        return;
+
     applyTopPriorityProperties();
     applyHighPriorityProperties();
     applyNonHighPriorityProperties();

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -35,7 +35,7 @@ namespace Style {
 class Builder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties = PropertyCascade::IncludedProperties::All);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, PropertyCascade::IncludedProperties = PropertyCascade::IncludedProperties::All, const HashSet<AnimatableProperty>* = nullptr);
     ~Builder();
 
     void applyAllProperties();

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -271,7 +271,7 @@ ElementStyle Resolver::styleForElement(const Element& element, const ResolutionC
     if (state.style()->usesViewportUnits())
         document().setHasStyleWithViewportUnits();
 
-    return { state.takeStyle(), WTFMove(elementStyleRelations) };
+    return { state.takeStyle(), WTFMove(elementStyleRelations), collector.releaseMatchResult() };
 }
 
 std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, KeyframeValue& keyframeValue)

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -73,13 +73,9 @@ namespace Style {
 struct SelectorMatchingState;
 
 struct ElementStyle {
-    ElementStyle(std::unique_ptr<RenderStyle> renderStyle, std::unique_ptr<Relations> relations = { })
-        : renderStyle(WTFMove(renderStyle))
-        , relations(WTFMove(relations))
-    { }
-
     std::unique_ptr<RenderStyle> renderStyle;
-    std::unique_ptr<Relations> relations;
+    std::unique_ptr<Relations> relations { };
+    std::unique_ptr<MatchResult> matchResult { };
 };
 
 struct ResolutionContext {

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -45,6 +45,8 @@ class ShadowRoot;
 namespace Style {
 
 class Resolver;
+struct ElementStyle;
+struct MatchResult;
 struct ResolutionContext;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(TreeResolverScope);
@@ -59,7 +61,7 @@ public:
 
 private:
     enum class ResolutionType : uint8_t { FastPathInherit, Full };
-    std::unique_ptr<RenderStyle> styleForStyleable(const Styleable&, ResolutionType, const ResolutionContext&);
+    ElementStyle styleForStyleable(const Styleable&, ResolutionType, const ResolutionContext&);
 
     void resolveComposedTree();
 
@@ -72,7 +74,9 @@ private:
 
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 
-    ElementUpdate createAnimatedElementUpdate(std::unique_ptr<RenderStyle>, const Styleable&, Change, const ResolutionContext&);
+    ElementUpdate createAnimatedElementUpdate(ElementStyle&&, const Styleable&, Change, const ResolutionContext&);
+    void applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableProperty>&, const MatchResult&, const Element&, const ResolutionContext&);
+
     std::optional<ElementUpdate> resolvePseudoElement(Element&, PseudoId, const ElementUpdate&);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, PseudoId, const ElementUpdate&);
     std::unique_ptr<RenderStyle> resolveAncestorFirstLinePseudoElement(Element&, const ElementUpdate&);

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -98,9 +98,9 @@ struct Styleable {
         return element.hasKeyframeEffects(pseudoId);
     }
 
-    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
+    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
     {
-        return element.ensureKeyframeEffectStack(pseudoId).applyKeyframeEffects(targetStyle, previousLastStyleChangeEventStyle, resolutionContext);
+        return element.ensureKeyframeEffectStack(pseudoId).applyKeyframeEffects(targetStyle, affectedProperties, previousLastStyleChangeEventStyle, resolutionContext);
     }
 
     const AnimationCollection* animations() const


### PR DESCRIPTION
#### eb9e694c2fc9a95c38298f28b922a0844579feae
<pre>
CSS animations should participate in the cascade
<a href="https://bugs.webkit.org/show_bug.cgi?id=210963">https://bugs.webkit.org/show_bug.cgi?id=210963</a>
rdar://62301534

Reviewed by Antoine Quint.

Property animation can affect other properties, for example via em units when animating font-size or var() when animating custom properties.
Animated values can also be overridden by !important properties.

With this patch we start applying the cascade after computing animated style. Only the properties that may be affected are recomputed.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-base-response-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/keyframes-unrelated-custom-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-base-response-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-animation-from-to-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-animation-over-transition-expected.txt:

A pile of progressions.

* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):

Collected animated properties.

* Source/WebCore/animation/KeyframeEffectStack.h:
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerElement::resolveCustomStyle):
(WebCore::TextControlInnerTextElement::resolveCustomStyle):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::customPropertiesEqual const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ElementRuleCollector):

Switch to std::unique_ptr&lt;MatchResult&gt; for easier shuffling around.

(WebCore::Style::ElementRuleCollector::matchResult const):
(WebCore::Style::ElementRuleCollector::releaseMatchResult):
(WebCore::Style::ElementRuleCollector::addElementStyleProperties):
(WebCore::Style::ElementRuleCollector::declarationsForOrigin):
(WebCore::Style::ElementRuleCollector::transferMatchedRules):
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
(WebCore::Style::ElementRuleCollector::addAuthorKeyframeRules):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/MatchResult.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::AnimationLayer::AnimationLayer):

Animations behave like a cascade layer, that&apos;s where the name of this helper struct comes from.

(WebCore::Style::PropertyCascade::set):
(WebCore::Style::PropertyCascade::setDeferred):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):

Build a cascade that only contains properties that require re-resolving after animation.

(WebCore::Style::initializeCSSValue): Deleted.
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::isEmpty const):

In normal cases there is nothing to apply after animations so we can bail out.

* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
(WebCore::Style::Builder::applyAllProperties):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElement):

Return the MatchResult along with the style. This allows us to reapply the cascade without matching the selectors again.

* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::ElementStyle::ElementStyle): Deleted.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolvePseudoElement):
(WebCore::Style::TreeResolver::resolveAncestorPseudoElement):
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):

Build and apply the cascade.

* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::applyKeyframeEffects const):

Canonical link: <a href="https://commits.webkit.org/258514@main">https://commits.webkit.org/258514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70c95e217c74d7e59fd4a981f54a8f0305ff8901

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111499 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2233 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109233 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107954 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92694 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24175 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25599 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2038 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5836 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6730 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->