### PR TITLE
REGRESSION (258031@main): Occasional crashes under WTF::Detail::CallableWrapper<WebCore::ThreadedScrollingTree::deferWheelEventTestCompletionForReason()

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -382,6 +382,9 @@ ScrollingNodeID ScrollingCoordinator::uniqueScrollingNodeID()
 void ScrollingCoordinator::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
     ASSERT(isMainThread());
+    if (!m_page)
+        return;
+
     if (auto monitor = m_page->wheelEventTestMonitor())
         monitor->receivedWheelEventWithPhases(phase, momentumPhase);
 }
@@ -389,6 +392,9 @@ void ScrollingCoordinator::receivedWheelEventWithPhases(PlatformWheelEventPhase 
 void ScrollingCoordinator::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     ASSERT(isMainThread());
+    if (!m_page)
+        return;
+
     if (auto monitor = m_page->wheelEventTestMonitor())
         monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }
@@ -396,6 +402,9 @@ void ScrollingCoordinator::deferWheelEventTestCompletionForReason(ScrollingNodeI
 void ScrollingCoordinator::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     ASSERT(isMainThread());
+    if (!m_page)
+        return;
+
     if (auto monitor = m_page->wheelEventTestMonitor())
         monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -575,6 +575,9 @@ void ThreadedScrollingTree::receivedWheelEventWithPhases(PlatformWheelEventPhase
 
 void ThreadedScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
+    if (!isMonitoringWheelEvents())
+        return;
+
     auto scrollingCoordinator = m_scrollingCoordinator;
     if (!scrollingCoordinator)
         return;
@@ -586,6 +589,9 @@ void ThreadedScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNode
 
 void ThreadedScrollingTree::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
+    if (!isMonitoringWheelEvents())
+        return;
+
     auto scrollingCoordinator = m_scrollingCoordinator;
     if (!scrollingCoordinator)
         return;


### PR DESCRIPTION
#### 8f60a59627c668cd200b5f0e6a717e7e7c8dcf95
<pre>
REGRESSION (258031@main): Occasional crashes under WTF::Detail::CallableWrapper&lt;WebCore::ThreadedScrollingTree::deferWheelEventTestCompletionForReason()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250133">https://bugs.webkit.org/show_bug.cgi?id=250133</a>
rdar://103918112

Reviewed by Ryosuke Niwa.

It&apos;s possible that `ThreadedScrollingTree::deferWheelEventTestCompletionForReason()` and
`ThreadedScrollingTree::removeWheelEventTestCompletionDeferralForReason()` can bounce to
the main thread after the ScrollingCoordinator&apos;s Page has been nulled out, so add some
null checks.

Also avoid these bounces altogether if wheel event monitoring is not active (it&apos;s a test-only
feature).

* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::receivedWheelEventWithPhases):
(WebCore::ScrollingCoordinator::deferWheelEventTestCompletionForReason):
(WebCore::ScrollingCoordinator::removeWheelEventTestCompletionDeferralForReason):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::deferWheelEventTestCompletionForReason):
(WebCore::ThreadedScrollingTree::removeWheelEventTestCompletionDeferralForReason):

Canonical link: <a href="https://commits.webkit.org/258581@main">https://commits.webkit.org/258581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38baba93c299b0b4362fe3225957247f6f4b0723

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111467 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171639 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2200 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109202 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37198 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4838 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25573 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2009 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5891 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6699 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->