### PR TITLE
Add support for the Web Extensions Permissions API.

### DIFF
--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -166,6 +166,10 @@ public:
     template<typename OtherCollection>
     void formSymmetricDifference(const OtherCollection&);
 
+    // Returns true if all the elements of this set are also in the given collection.
+    template<typename OtherCollection>
+    bool isSubset(const OtherCollection&);
+
     // Overloads for smart pointer values that take the raw pointer type as the parameter.
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type find(typename GetPtrHelper<V>::PtrType) const;
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value, bool>::type contains(typename GetPtrHelper<V>::PtrType) const;
@@ -450,6 +454,13 @@ inline void HashSet<T, U, V, W>::formSymmetricDifference(const OtherCollection& 
         if (!remove(value))
             addVoid(value);
     }
+}
+
+template<typename T, typename U, typename V, typename W>
+template<typename OtherCollection>
+inline bool HashSet<T, U, V, W>::isSubset(const OtherCollection& other)
+{
+    return intersectionWith(other).size() == size();
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -322,6 +322,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -52,6 +52,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIRuntime.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIRuntime.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -595,6 +595,7 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIEvent \
     WebExtensionAPIExtension \
     WebExtensionAPINamespace \
+    WebExtensionAPIPermissions \
     WebExtensionAPIRuntime \
     WebExtensionAPITest \
     WebExtensionAPIWebNavigation \

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WKWebViewInternal.h"
+#import "WebExtensionController.h"
+#import "WebExtensionMatchPattern.h"
+#import "_WKWebExtensionControllerDelegatePrivate.h"
+#import "_WKWebExtensionControllerInternal.h"
+
+namespace WebKit {
+
+static NSString *permissionsKey = @"permissions";
+static NSString *originsKey = @"origins";
+
+void WebExtensionContext::permissionsGetAll(CompletionHandler<void(Vector<String>, Vector<String>)>&& completionHandler)
+{
+    Vector<String> permissions, origins;
+
+    for (auto& permission : currentPermissions())
+        permissions.append(permission);
+
+    for (auto& matchPattern : currentPermissionMatchPatterns())
+        origins.append(matchPattern->string());
+
+    completionHandler(permissions, origins);
+}
+
+void WebExtensionContext::permissionsContains(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler)
+{
+    MatchPatternSet matchPatterns;
+    parseMatchPatterns(origins, matchPatterns);
+
+    hasPermissions(permissions, matchPatterns) ? completionHandler(true) : completionHandler(false);
+}
+
+void WebExtensionContext::permissionsRequest(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler)
+{
+    HashSet<Ref<WebExtensionMatchPattern>> matchPatterns;
+    parseMatchPatterns(origins, matchPatterns);
+
+    if (hasPermissions(permissions, matchPatterns)) {
+        completionHandler(true);
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/250135> Call delegate method to prompt user for access.
+}
+
+void WebExtensionContext::permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler)
+{
+    HashSet<Ref<WebExtensionMatchPattern>> matchPatterns;
+    parseMatchPatterns(origins, matchPatterns);
+
+    bool removingAllHostsPattern = false;
+    for (auto& matchPattern : matchPatterns) {
+        if (matchPattern->matchesAllHosts()) {
+            removingAllHostsPattern = true;
+            break;
+        }
+    }
+
+    if (removingAllHostsPattern && m_requestedOptionalAccessToAllHosts)
+        m_requestedOptionalAccessToAllHosts = false;
+
+    removeGrantedPermissions(permissions);
+    removeGrantedPermissionMatchPatterns(matchPatterns, EqualityOnly::No);
+    completionHandler(true);
+}
+
+void WebExtensionContext::parseMatchPatterns(HashSet<String> origins, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns)
+{
+    for (auto& origin : origins) {
+        auto pattern = WebExtensionMatchPattern::getOrCreate(static_cast<NSString *>(origin));
+        matchPatterns.add(*pattern);
+    }
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -731,6 +731,29 @@ bool WebExtensionContext::hasPermission(const URL& url, _WKWebExtensionTab *tab,
     }
 }
 
+bool WebExtensionContext::hasPermissions(PermissionsSet permissions, MatchPatternSet matchPatterns)
+{
+    for (auto& permission : permissions) {
+        if (!m_grantedPermissions.contains(permission))
+            return false;
+    }
+
+    for (auto& pattern : matchPatterns) {
+        bool matchFound = false;
+        for (auto& grantedPattern : currentPermissionMatchPatterns()) {
+            if (pattern->matchesPattern(grantedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
+                matchFound = true;
+                break;
+            }
+        }
+
+        if (!matchFound)
+            return false;
+    }
+
+    return true;
+}
+
 WebExtensionContext::PermissionState WebExtensionContext::permissionState(const String& permission, _WKWebExtensionTab *tab, OptionSet<PermissionStateOptions> options)
 {
     ASSERT(!permission.isEmpty());
@@ -1246,17 +1269,6 @@ void WebExtensionContext::scheduleBackgroundContentToUnload()
     ASSERT(m_backgroundWebView);
 
     // FIXME: <https://webkit.org/b/246483> Don't unload the background page if there are open ports, pending website requests, or if an inspector window is open.
-
-    if (m_backgroundWebView.get()._isBeingInspected) {
-        RELEASE_LOG(Extensions, "Not unloading non-persistent background content for extension %{private}@ because it is being inspected.", static_cast<NSString*>(m_uniqueIdentifier));
-        scheduleBackgroundContentToUnload();
-    }
-
-    RELEASE_LOG(Extensions, "Unloading non-persistent background content for extension %{private}@.", static_cast<NSString*>(m_uniqueIdentifier));
-    NSTimeInterval backgroundPageLifetime = [NSDate.now timeIntervalSinceDate:static_cast<NSDate*>(m_lastBackgroundContentLoadDate)];
-    static constexpr NSTimeInterval fiveMinutesInSeconds = 60 * 5;
-    if (backgroundPageLifetime > fiveMinutesInSeconds)
-        unloadBackgroundWebView();
 }
 
 void WebExtensionContext::queueStartupAndInstallEventsForExtensionIfNecessary()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -198,6 +198,7 @@ public:
 
     bool hasPermission(const String& permission, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { });
     bool hasPermission(const URL&, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+    bool hasPermissions(PermissionsSet, MatchPatternSet);
 
     PermissionState permissionState(const String& permission, _WKWebExtensionTab * = nil, OptionSet<PermissionStateOptions> = { });
     void setPermissionState(PermissionState, const String& permission, WallTime expirationDate = WallTime::infinity());
@@ -290,6 +291,13 @@ private:
     // Event APIs
     void addListener(WebPageProxyIdentifier, WebExtensionEventListenerType);
     void removeListener(WebPageProxyIdentifier, WebExtensionEventListenerType);
+
+    // Permissions APIs
+    void permissionsGetAll(CompletionHandler<void(Vector<String> permissions, Vector<String> origins)>&&);
+    void permissionsContains(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
+    void permissionsRequest(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
+    void permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
+    void parseMatchPatterns(HashSet<String> origins, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -36,6 +36,12 @@ messages -> WebExtensionContext {
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type);
     RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type);
+
+    // Permissions APIs
+    PermissionsGetAll() -> (Vector<String> permissions, Vector<String> origins);
+    PermissionsContains(HashSet<String> permissions, HashSet<String> origins) -> (bool containsPermissions);
+    PermissionsRequest(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
+    PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1752,10 +1752,15 @@
 		AAFA634F234F7C6400FFA864 /* AsyncRevalidation.h in Headers */ = {isa = PBXBuildFile; fileRef = AAFA634E234F7C6300FFA864 /* AsyncRevalidation.h */; };
 		B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */ = {isa = PBXBuildFile; fileRef = B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */; };
+		B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */; };
+		B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */; };
+		B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */ = {isa = PBXBuildFile; fileRef = B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B62E7312143047B00069EC35 /* WKHitTestResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B62E7311143047B00069EC35 /* WKHitTestResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */; };
 		B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = B878B613133428DC006888E9 /* CorrectionPanel.h */; };
 		BC017D0716260FF4007054F5 /* WKDOMDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017CFF16260FF4007054F5 /* WKDOMDocument.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC017D0916260FF4007054F5 /* WKDOMElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017D0116260FF4007054F5 /* WKDOMElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6486,6 +6491,8 @@
 		B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIEvent.h; sourceTree = "<group>"; };
 		B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIEvent.mm; sourceTree = "<group>"; };
 		B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionEventListenerType.h; sourceTree = "<group>"; };
+		B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIPermissions.h; sourceTree = "<group>"; };
+		B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
 		B62E730F143047A60069EC35 /* WKHitTestResult.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKHitTestResult.cpp; sourceTree = "<group>"; };
 		B62E7311143047B00069EC35 /* WKHitTestResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHitTestResult.h; sourceTree = "<group>"; };
 		B63403F814910D57001070B5 /* APIObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIObject.cpp; sourceTree = "<group>"; };
@@ -6494,6 +6501,9 @@
 		B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIEvent.h; sourceTree = "<group>"; };
 		B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIEventCocoa.mm; sourceTree = "<group>"; };
 		B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIEventCocoa.mm; sourceTree = "<group>"; };
+		B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPIPermissions.h; path = WebProcess/Extensions/API/WebExtensionAPIPermissions.h; sourceTree = SOURCE_ROOT; };
+		B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIPermissionsCocoa.mm; sourceTree = "<group>"; };
+		B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIPermissionsCocoa.mm; sourceTree = "<group>"; };
 		B878B613133428DC006888E9 /* CorrectionPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorrectionPanel.h; sourceTree = "<group>"; };
 		B878B614133428DC006888E9 /* CorrectionPanel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CorrectionPanel.mm; sourceTree = "<group>"; };
 		BC017CFF16260FF4007054F5 /* WKDOMDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDOMDocument.h; sourceTree = "<group>"; };
@@ -8869,6 +8879,7 @@
 			isa = PBXGroup;
 			children = (
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
+				B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */,
 				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
 			);
 			path = API;
@@ -8893,6 +8904,7 @@
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
+				B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */,
 				1C5DC469290B239C0061EC62 /* WebExtensionAPIRuntime.h */,
 				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 				3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */,
@@ -8907,6 +8919,7 @@
 				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
+				B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */,
 				1C5DC464290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm */,
 				1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */,
 				3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */,
@@ -13563,6 +13576,8 @@
 				1C5DC460290B1C440061EC62 /* JSWebExtensionAPIExtension.mm */,
 				1C5DC4532908AC260061EC62 /* JSWebExtensionAPINamespace.h */,
 				1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */,
+				B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */,
+				B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */,
 				1C5DC461290B1C470061EC62 /* JSWebExtensionAPIRuntime.h */,
 				1C5DC463290B1C470061EC62 /* JSWebExtensionAPIRuntime.mm */,
 				1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */,
@@ -15097,6 +15112,7 @@
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
+				B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */,
 				1C5DC46F290B27260061EC62 /* JSWebExtensionWrappable.h in Headers */,
 				1C5DC46E290B27260061EC62 /* JSWebExtensionWrapper.h in Headers */,
 				DDA0A3FF27E66F5F005E086E /* KeyEventCodesIOS.h in Headers */,
@@ -15586,6 +15602,7 @@
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
 				1C5DC46B290B271E0061EC62 /* WebExtensionAPIObject.h in Headers */,
+				B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */,
 				1C5DC46A290B271A0061EC62 /* WebExtensionAPIRuntime.h in Headers */,
 				1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */,
 				3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */,
@@ -17962,6 +17979,7 @@
 				B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */,
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
+				B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */,
 				1C5DC472290B33A60061EC62 /* JSWebExtensionAPIRuntime.mm in Sources */,
 				1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */,
 				3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */,
@@ -18286,12 +18304,14 @@
 				B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */,
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
+				B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */,
 				1C5DC466290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm in Sources */,
 				1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */,
 				3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */,
 				33F68340293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
+				B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */,
 				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
 				1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */,
 				1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -38,6 +38,9 @@ namespace WebKit {
 
 bool WebExtensionAPINamespace::isPropertyAllowed(String name, WebPage*)
 {
+    if (name == "permissions"_s)
+        return true;
+
     // This property is only allowed in testing contexts.
     if (name == "test"_s)
         return extensionContext().inTestingMode();
@@ -54,6 +57,13 @@ WebExtensionAPIExtension& WebExtensionAPINamespace::extension()
     if (!m_extension)
         m_extension = WebExtensionAPIExtension::create(forMainWorld(), runtime(), extensionContext());
     return *m_extension;
+}
+
+WebExtensionAPIPermissions& WebExtensionAPINamespace::permissions()
+{
+    if (!m_permissions)
+        m_permissions = WebExtensionAPIPermissions::create(forMainWorld(), runtime(), extensionContext());
+    return *m_permissions;
 }
 
 WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIPermissions.h"
+
+#import "WebExtension.h"
+#import "WebExtensionContextMessages.h"
+#import "WebProcess.h"
+#import <wtf/cocoa/VectorCocoa.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+static NSString *permissionsKey = @"permissions";
+static NSString *originsKey = @"origins";
+
+void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    RELEASE_LOG(Extensions, "permissions.getAll()");
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<String> permissions, Vector<String> origins) {
+        callback->call(@{
+            permissionsKey: createNSArray(permissions).get(),
+            originsKey: createNSArray(origins).get()
+        });
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
+{
+    RELEASE_LOG(Extensions, "permissions.contains()");
+
+    HashSet<String> permissions, origins;
+    WebExtension::MatchPatternSet matchPatterns;
+    parseDetailsDictionary(details, permissions, origins);
+
+    NSString *errorMessage;
+    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"contains()", &errorMessage)) {
+        callback->reportError(errorMessage);
+        return;
+    }
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsContains(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool containsPermissions) {
+        callback->call(containsPermissions ? @YES : @NO);
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
+{
+    RELEASE_LOG(Extensions, "permissions.request()");
+
+    HashSet<String> permissions, origins;
+    parseDetailsDictionary(details, permissions, origins);
+
+    NSString *errorMessage;
+    WebExtension::MatchPatternSet matchPatterns;
+
+    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"request()", &errorMessage)) {
+        callback->reportError(errorMessage);
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/250135> Check to see if the request is being made from a user gesture.
+
+    if (!verifyRequestedPermissions(permissions, matchPatterns, @"request()", &errorMessage)) {
+        callback->reportError(errorMessage);
+        return;
+    }
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsRequest(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool success) {
+        callback->call(success ? @YES : @NO);
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
+{
+    RELEASE_LOG(Extensions, "permissions.remove()");
+
+    HashSet<String> permissions, origins;
+    parseDetailsDictionary(details, permissions, origins);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsRemove(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool success) {
+        callback->call(success ? @YES : @NO);
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIPermissions::parseDetailsDictionary(NSDictionary *details, HashSet<String>& permissions, HashSet<String>& origins)
+{
+    for (NSString *permission in details[permissionsKey])
+        permissions.add(permission);
+
+    for (NSString *origin in details[originsKey])
+        origins.add(origin);
+}
+
+bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& permissions, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns, NSString *callingAPIName, NSString **outExceptionString)
+{
+    WebExtension extension = WebExtension(extensionContext().manifest());
+    HashSet<String> allowedPermissions = extension.requestedPermissions();
+
+    if ([callingAPIName isEqualToString:@"remove()"]) {
+        if (bool requestingToRemoveFunctionalPermissions = permissions.size() && permissions.isSubset(allowedPermissions)) {
+            *outExceptionString = @"Required permissions cannot be removed.";
+            return false;
+        }
+    }
+
+    allowedPermissions.add(extension.optionalPermissions().begin(), extension.optionalPermissions().end());
+
+    bool requestingPermissionsNotDefinedInManifest = permissions.size() && !permissions.isSubset(allowedPermissions);
+
+    WebExtension::MatchPatternSet allowedPatterns = extension.requestedPermissionMatchPatterns();
+    for (auto& requestedPattern : matchPatterns) {
+        bool requestingAllowedOrigin = false;
+        for (auto& allowedPattern : allowedPatterns) {
+            if (requestedPattern->matchesPattern(allowedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
+                requestingAllowedOrigin = true;
+                break;
+            }
+        }
+
+        if (!requestingAllowedOrigin || requestingPermissionsNotDefinedInManifest) {
+            *outExceptionString = [callingAPIName isEqualToString:@"remove()"] ? @"Only permissions specified in the manifest may be removed" : @"Only permissions specified in the manifest may be requested.";
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& permissions, HashSet<String>& origins, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns, NSString *callingAPIName, NSString **outExceptionString)
+{
+    for (auto& permission : permissions) {
+        if (!WebExtension::supportedPermissions().contains(permission)) {
+            *outExceptionString = [NSString stringWithFormat:@"Invalid permission (%@) passed to %@.", static_cast<NSString *>(permission), callingAPIName];
+            return false;
+        }
+    }
+
+    NSError *error;
+    for (auto& origin : origins) {
+        auto pattern = WebExtensionMatchPattern::getOrCreate(static_cast<NSString *>(origin));
+        if (!pattern || !pattern->isSupported()) {
+            *outExceptionString = [NSString stringWithFormat:@"Invalid origin (%@) passed to %@. %@", static_cast<NSString *>(origin), callingAPIName, error];
+            return false;
+        }
+
+        matchPatterns.add(*pattern);
+    }
+
+    return true;
+}
+
+WebExtensionAPIEvent& WebExtensionAPIPermissions::onAdded()
+{
+    if (!m_onAdded)
+        m_onAdded = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext());
+
+    return *m_onAdded;
+}
+
+WebExtensionAPIEvent& WebExtensionAPIPermissions::onRemoved()
+{
+    if (!m_onRemoved)
+        m_onRemoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext());
+
+    return *m_onRemoved;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h
@@ -27,39 +27,36 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "JSWebExtensionAPINamespace.h"
-#include "WebExtensionAPIExtension.h"
+#include "JSWebExtensionAPIPermissions.h"
+#include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
-#include "WebExtensionAPIPermissions.h"
-#include "WebExtensionAPIRuntime.h"
-#include "WebExtensionAPITest.h"
-#include "WebExtensionAPIWebNavigation.h"
+#include "WebExtensionMatchPattern.h"
 
 namespace WebKit {
 
-class WebExtensionAPIExtension;
-class WebExtensionAPIRuntime;
+class WebPage;
 
-class WebExtensionAPINamespace : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINamespace, namespace);
+class WebExtensionAPIPermissions : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIPermissions, permissions);
 
 public:
 #if PLATFORM(COCOA)
-    bool isPropertyAllowed(String propertyName, WebPage*);
+    void getAll(Ref<WebExtensionCallbackHandler>&&);
+    void contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **errorString);
+    void request(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **errorString);
+    void remove(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **errorString);
 
-    WebExtensionAPIExtension& extension();
-    WebExtensionAPIPermissions& permissions();
-    WebExtensionAPIRuntime& runtime() final;
-    WebExtensionAPITest& test();
-    WebExtensionAPIWebNavigation& webNavigation();
-#endif
+    WebExtensionAPIEvent& onAdded();
+    WebExtensionAPIEvent& onRemoved();
 
 private:
-    RefPtr<WebExtensionAPIExtension> m_extension;
-    RefPtr<WebExtensionAPIPermissions> m_permissions;
-    RefPtr<WebExtensionAPIRuntime> m_runtime;
-    RefPtr<WebExtensionAPITest> m_test;
-    RefPtr<WebExtensionAPIWebNavigation> m_webNavigation;
+    RefPtr<WebExtensionAPIEvent> m_onAdded;
+    RefPtr<WebExtensionAPIEvent> m_onRemoved;
+
+    void parseDetailsDictionary(NSDictionary *, HashSet<String>& permissions, HashSet<String>& origins);
+    bool verifyRequestedPermissions(HashSet<String>& permissions, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns, NSString *callingAPIName, NSString **outExceptionString);
+    bool validatePermissionsDetails(HashSet<String>& permissions, HashSet<String>& origins, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns, NSString *callingAPIName, NSString **outExceptionString);
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -32,6 +32,8 @@
 
     readonly attribute WebExtensionAPIRuntime runtime;
 
+    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
+
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
 
     [Dynamic] readonly attribute WebExtensionAPITest test;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,
-    NeedsPageWithCallbackHandler,
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIPermissions {
 


### PR DESCRIPTION
#### 290f26cb9bdcb5fe32a70d108af0eb6d4702720f
<pre>
Add support for the Web Extensions Permissions API.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248555">https://bugs.webkit.org/show_bug.cgi?id=248555</a>

Reviewed by Timothy Hatcher.

This patch adds the implementation for the Permissions APIs defined in the  WebExtensionAPIPermissions idl file.
This includes consulting the WebExtensionContext for information on the current permissions the
extension has access to, and reporting that information back to WebProcess.

* Source/WTF/wtf/HashSet.h:
(WTF::W&gt;::isSubset):
Checks if the current set is a subset of a given set.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm: Added.
(WebKit::WebExtensionContext::getAll):
Get all the current granted permissions and match patterns for the extension.

(WebKit::WebExtensionContext::contains):
Checks that the current permissions/matches match the given permissions and match patterns.

(WebKit::WebExtensionContext::permissionsRequest):
<a href="https://webkit.org/b/250135">https://webkit.org/b/250135</a> is being used to track adding support for permissions.request().

(WebKit::WebExtensionContext::permissionsRemove):
Removes access for specified permissions and origins.

(WebKit::WebExtensionContext::parseMatchPatterns):
Parsing the input HashSet of origins and populates a MatchPatternSet.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::hasPermissions):
Checks if the extension has access to a set of permissions and match patterns.

(WebKit::WebExtensionContext::scheduleBackgroundContentToUnload):
Removed code that caused an infinite loop. Implementation being tracked in <a href="https://webkit.org/b/246483.">https://webkit.org/b/246483.</a>

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
(WebKit::WebExtensionAPINamespace::permissions):
Add support for the permissions API.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm: Added.
(WebKit::WebExtensionAPIPermissions::getAll):
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
(WebKit::WebExtensionAPIPermissions::parseDetailsDictionary):
Populates a set of permissions and origins to pass to the UIProcess.

(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):
Checks that the permissions being requested/removed are valid.

(WebKit::WebExtensionAPIPermissions::validatePermissionsDetails):
Validates the data passed in. Check that the permissions requested are supported.

(WebKit::WebExtensionAPIPermissions::onAdded):
(WebKit::WebExtensionAPIPermissions::onRemoved):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h:
Copied from Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl:

Canonical link: <a href="https://commits.webkit.org/258552@main">https://commits.webkit.org/258552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/080200ba16e3d268ed7f60f6a4d8c2d31163f167

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102330 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111639 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2387 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109349 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108111 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24290 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25713 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88895 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2645 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2155 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29546 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45206 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91819 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6872 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20544 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3102 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->