### PR TITLE
[Live Range Selection] image-overlay-maintain-selection-during-size-change.html fails

### DIFF
--- a/LayoutTests/fast/images/text-recognition/mac/image-overlay-maintain-selection-during-size-change.html
+++ b/LayoutTests/fast/images/text-recognition/mac/image-overlay-maintain-selection-during-size-change.html
@@ -36,7 +36,8 @@ addEventListener("load", async () => {
         ]);
     }
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).querySelector(".image-overlay-text"));
+    const imageOverlay = internals.shadowRoot(image).querySelector(".image-overlay-text");
+    internals.setSelectionWithoutValidation(imageOverlay, 0, imageOverlay, imageOverlay.childNodes.length);
     updateSelectionDimensions();
 
     shouldBe("selectionWidth", "200");


### PR DESCRIPTION
#### 8df0ee601cafe133423eff6618b1d11d67be8de1
<pre>
[Live Range Selection] image-overlay-maintain-selection-during-size-change.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=250140">https://bugs.webkit.org/show_bug.cgi?id=250140</a>

Reviewed by Wenson Hsieh.

Like 258476@main, this test was relying on setBaseAndExtent to select contents inside a UA shadow tree,
which is no longer allowed once live range selection is enabled. Use internals.setSelectionWithoutValidation instead.

* LayoutTests/fast/images/text-recognition/mac/image-overlay-maintain-selection-during-size-change.html:

Canonical link: <a href="https://commits.webkit.org/258506@main">https://commits.webkit.org/258506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/770793b0cb6ad9568569a5abff602e051b046b79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111477 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2210 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109212 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107931 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37205 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24154 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25578 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2016 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45075 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6709 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3081 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->