### PR TITLE
Remove unused AlignContent enum class

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1454,57 +1454,6 @@ template<> inline CSSPrimitiveValue::operator FlexDirection() const
     return FlexDirection::Row;
 }
 
-template<> inline CSSPrimitiveValue::CSSPrimitiveValue(AlignContent e)
-    : CSSValue(PrimitiveClass)
-{
-    setPrimitiveUnitType(CSSUnitType::CSS_VALUE_ID);
-    switch (e) {
-    case AlignContent::FlexStart:
-        m_value.valueID = CSSValueFlexStart;
-        break;
-    case AlignContent::FlexEnd:
-        m_value.valueID = CSSValueFlexEnd;
-        break;
-    case AlignContent::Center:
-        m_value.valueID = CSSValueCenter;
-        break;
-    case AlignContent::SpaceBetween:
-        m_value.valueID = CSSValueSpaceBetween;
-        break;
-    case AlignContent::SpaceAround:
-        m_value.valueID = CSSValueSpaceAround;
-        break;
-    case AlignContent::Stretch:
-        m_value.valueID = CSSValueStretch;
-        break;
-    }
-}
-
-template<> inline CSSPrimitiveValue::operator AlignContent() const
-{
-    ASSERT(isValueID());
-
-    switch (m_value.valueID) {
-    case CSSValueFlexStart:
-        return AlignContent::FlexStart;
-    case CSSValueFlexEnd:
-        return AlignContent::FlexEnd;
-    case CSSValueCenter:
-        return AlignContent::Center;
-    case CSSValueSpaceBetween:
-        return AlignContent::SpaceBetween;
-    case CSSValueSpaceAround:
-        return AlignContent::SpaceAround;
-    case CSSValueStretch:
-        return AlignContent::Stretch;
-    default:
-        break;
-    }
-
-    ASSERT_NOT_REACHED();
-    return AlignContent::Stretch;
-}
-
 template<> inline CSSPrimitiveValue::CSSPrimitiveValue(FlexWrap e)
     : CSSValue(PrimitiveClass)
 {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -419,15 +419,6 @@ enum class BoxDirection : uint8_t {
 
 // CSS3 Flexbox Properties
 
-enum class AlignContent : uint8_t {
-    FlexStart,
-    FlexEnd,
-    Center,
-    SpaceBetween,
-    SpaceAround,
-    Stretch
-};
-
 enum class FlexDirection : uint8_t {
     Row,
     RowReverse,


### PR DESCRIPTION
#### 19d6f99587d7777b066ff2f1886be97ed694b182
<pre>
Remove unused AlignContent enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250139">https://bugs.webkit.org/show_bug.cgi?id=250139</a>

Reviewed by Brent Fulgham and Rob Buis.

align-content is now represented by StyleContentAlignmentData which can handle more complex combinations like:
- first baseline
- last baseline
- unsafe/safe center

AlignContent is a leftover from the implementation of those new combinations, that is confusing to keep in the codebase.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::operator AlignContent const): Deleted.
* Source/WebCore/rendering/style/RenderStyleConstants.h:

Canonical link: <a href="https://commits.webkit.org/258509@main">https://commits.webkit.org/258509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fcef429baa17d928383b40204612486bc3a53be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111481 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2214 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109216 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107935 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92679 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24160 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25584 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2022 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45081 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6713 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3084 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->