### PR TITLE
Fix internal build after 258484@main

### DIFF
--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -1268,12 +1268,12 @@ using Int128 = Int128Impl;
 #endif
 
 template<> struct DefaultHash<UInt128> {
-    static unsigned hash(const UInt128& i) { return pairIntHash(static_cast<uint64_t>(i >> 64), static_cast<uint64_t>(i)); }
+    static unsigned hash(const UInt128& i) { return pairIntHash(intHash(static_cast<uint64_t>(i >> 64)), intHash(static_cast<uint64_t>(i))); }
     static bool equal(const UInt128& a, const UInt128& b) { return a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 template<> struct DefaultHash<Int128> {
-    static unsigned hash(const UInt128& i) { return pairIntHash(static_cast<uint64_t>(i >> 64), static_cast<uint64_t>(i)); }
+    static unsigned hash(const UInt128& i) { return pairIntHash(intHash(static_cast<uint64_t>(i >> 64)), intHash(static_cast<uint64_t>(i))); }
     static bool equal(const Int128& a, const Int128& b) { return a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };


### PR DESCRIPTION
#### 089d887bc55dcc316722cbab42332a5f561fbb39
<pre>
Fix internal build after 258484@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=250143">https://bugs.webkit.org/show_bug.cgi?id=250143</a>
rdar://103925489

Unreviewed.

Calling pairIntHash with uint64_t parameters not only ignores 32 bits of the uint64_t, but it caused a compiler warning in an internal file that includes Int128.h

* Source/WTF/wtf/Int128.h:
(WTF::DefaultHash&lt;UInt128&gt;::hash):
(WTF::DefaultHash&lt;Int128&gt;::hash):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/089d887bc55dcc316722cbab42332a5f561fbb39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111486 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2219 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109221 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107940 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4856 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88724 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2492 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2027 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29489 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11023 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91644 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6718 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20483 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3080 "chirags27 does not have reviewer permissions") | | | | 
<!--EWS-Status-Bubble-End-->