### PR TITLE
Encode 128 bits for IPC's destination identifier (Follow-up fix)

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -59,7 +59,7 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
@@ -58,7 +58,7 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -52,7 +52,7 @@ void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -131,7 +131,7 @@ void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connec
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -148,7 +148,7 @@ bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Co
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -49,7 +49,7 @@ void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection&
     if (connection.connection().ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::D
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -67,7 +67,7 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
     if (connection.connection().ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -74,7 +74,7 @@ bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC:
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -131,7 +131,7 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
 }
 
 bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -148,7 +148,7 @@ bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, I
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
     return false;
 }
 


### PR DESCRIPTION
#### 80ea46abdb2e7011662aa3d4026b3813cef732bf
<pre>
Encode 128 bits for IPC&apos;s destination identifier (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248929">https://bugs.webkit.org/show_bug.cgi?id=248929</a>
rdar://103386462

Reviewed by Alex Christensen.

258484@main (096f18835da5) broke unit tests.

* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
(WebKit::TestWithIfMessage::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
(WebKit::TestWithImageData::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage):
(WebKit::TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
(WebKit::TestWithSemaphore::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
(WebKit::TestWithStreamBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):

Canonical link: <a href="https://commits.webkit.org/258504@main">https://commits.webkit.org/258504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24d4e2b6fd1ebb49c23f7aa44ec476fd773ba230

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35233 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/111487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2220 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109222 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107941 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/105692 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4973 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3076 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->