### PR TITLE
Fix internal build after warning from 258484@main

### DIFF
--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -1268,12 +1268,12 @@ using Int128 = Int128Impl;
 #endif
 
 template<> struct DefaultHash<UInt128> {
-    static unsigned hash(const UInt128& i) { return pairIntHash(static_cast<uint64_t>(i >> 64), static_cast<uint64_t>(i)); }
+    static unsigned hash(const UInt128& i) { return pairIntHash(intHash(static_cast<uint64_t>(i >> 64)), intHash(static_cast<uint64_t>(i))); }
     static bool equal(const UInt128& a, const UInt128& b) { return a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 template<> struct DefaultHash<Int128> {
-    static unsigned hash(const UInt128& i) { return pairIntHash(static_cast<uint64_t>(i >> 64), static_cast<uint64_t>(i)); }
+    static unsigned hash(const UInt128& i) { return pairIntHash(intHash(static_cast<uint64_t>(i >> 64)), intHash(static_cast<uint64_t>(i))); }
     static bool equal(const Int128& a, const Int128& b) { return a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };


### PR DESCRIPTION
#### ab6088bdd4ab83d342c4985ba314306343c9dd0e
<pre>
Fix internal build after warning from 258484@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=250147">https://bugs.webkit.org/show_bug.cgi?id=250147</a>
rdar://103925489

Unreviewed.

Calling pairIntHash with uint64_t parameters not only ignores 32 bits of the uint64_t, but it caused a compiler warning in an internal file that includes Int128.h

* Source/WTF/wtf/Int128.h:
(WTF::DefaultHash&lt;UInt128&gt;::hash):
(WTF::DefaultHash&lt;Int128&gt;::hash):

Canonical link: <a href="https://commits.webkit.org/258507@main">https://commits.webkit.org/258507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77925476ff4d5532d29d65e8377580ebdb2ef581

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/102166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111491 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12291 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2225 "Failed to checkout and rebase branch from PR 8246") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107945 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/88730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/2497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/4977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/2225 "Failed to checkout and rebase branch from PR 8246") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/88730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91650 "Failed to checkout and rebase branch from PR 8246") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/91650 "Failed to checkout and rebase branch from PR 8246") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3082 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->