### PR TITLE
[Live Range Selection] AcceptsFirstMouse fails

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
@@ -59,7 +59,7 @@ void AcceptsFirstMouse::runTest(View view)
     NSEvent *mouseEventInsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointInsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1];
     EXPECT_TRUE([[view hitTest:pointInsideSelection] acceptsFirstMouse:mouseEventInsideSelection]);
 
-    NSPoint pointOutsideSelection = NSMakePoint(50, viewHeight - 150);
+    NSPoint pointOutsideSelection = NSMakePoint(150, viewHeight - 150);
     NSEvent *mouseEventOutsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointOutsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1];
     EXPECT_FALSE([[view hitTest:pointInsideSelection] acceptsFirstMouse:mouseEventOutsideSelection]);
 }

--- a/Tools/TestWebKitAPI/Tests/mac/acceptsFirstMouse.html
+++ b/Tools/TestWebKitAPI/Tests/mac/acceptsFirstMouse.html
@@ -16,7 +16,8 @@
     <img class="selectable">
     <script>
         var target = document.getElementById("target");
-        getSelection().setBaseAndExtent(target, 0, target, 1);
+        var nodeIndex = [...target.parentNode.childNodes].indexOf(target);
+        getSelection().setBaseAndExtent(target.parentNode, nodeIndex, target.parentNode, nodeIndex + 1);
         scrollBy(0, 100);
     </script>
 </body>


### PR DESCRIPTION
#### ad60a462ad8d80096b054f8d9d2148fab18a3ebc
<pre>
[Live Range Selection] AcceptsFirstMouse fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=250145">https://bugs.webkit.org/show_bug.cgi?id=250145</a>

Reviewed by Wenson Hsieh.

The failure was caused by AcceptsFirstMouse.html using legacy editing offsets to select image.
Use valid offsets instead so that enabling live range selection doesn&apos;t break these test case.

Also workaround a bug that clicking on the next image doesn&apos;t clear selection by clicking
on the empty space right of the next image.

* Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm:
(TestWebKitAPI::AcceptsFirstMouse::runTest):
* Tools/TestWebKitAPI/Tests/mac/acceptsFirstMouse.html:

Canonical link: <a href="https://commits.webkit.org/258515@main">https://commits.webkit.org/258515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f6581423f6d0259c60c9b5a36c23f39b832918a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111492 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2226 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109227 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92690 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24171 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45092 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6724 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3087 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->