### PR TITLE
Add plumbing for Gamepad.vibrationActuator support

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1519,6 +1519,7 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/gamepad/GamepadEffectParameters.idl
     Modules/gamepad/GamepadEvent.idl
     Modules/gamepad/GamepadHapticActuator.idl
+    Modules/gamepad/GamepadHapticEffectType.idl
     Modules/gamepad/Navigator+Gamepad.idl
     Modules/gamepad/WindowEventHandlers+Gamepad.idl
 )

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -303,6 +303,7 @@ $(PROJECT_DIR)/Modules/gamepad/GamepadButton.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadEffectParameters.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadEvent.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadHapticActuator.idl
+$(PROJECT_DIR)/Modules/gamepad/GamepadHapticEffectType.idl
 $(PROJECT_DIR)/Modules/gamepad/Navigator+Gamepad.idl
 $(PROJECT_DIR)/Modules/gamepad/WindowEventHandlers+Gamepad.idl
 $(PROJECT_DIR)/Modules/geolocation/Coordinates.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1261,6 +1261,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadHapticActuator.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadHapticActuator.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadHapticEffectType.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGamepadHapticEffectType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGenericTransformStream.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGenericTransformStream.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGeolocation.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -325,6 +325,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/gamepad/GamepadEffectParameters.idl \
     $(WebCore)/Modules/gamepad/GamepadEvent.idl \
     $(WebCore)/Modules/gamepad/GamepadHapticActuator.idl \
+    $(WebCore)/Modules/gamepad/GamepadHapticEffectType.idl \
     $(WebCore)/Modules/gamepad/Navigator+Gamepad.idl \
     $(WebCore)/Modules/gamepad/WindowEventHandlers+Gamepad.idl \
     $(WebCore)/Modules/geolocation/Geolocation.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -193,6 +193,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
     Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
 
+    Modules/gamepad/GamepadEffectParameters.h
+    Modules/gamepad/GamepadHapticEffectType.h
+
     Modules/geolocation/Geolocation.h
     Modules/geolocation/GeolocationClient.h
     Modules/geolocation/GeolocationController.h

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -41,8 +41,8 @@ Gamepad::Gamepad(const PlatformGamepad& platformGamepad)
     , m_connected(true)
     , m_timestamp(platformGamepad.lastUpdateTime())
     , m_mapping(platformGamepad.mapping())
+    , m_supportedEffectTypes(platformGamepad.supportedEffectTypes())
     , m_axes(platformGamepad.axisValues().size(), 0.0)
-    , m_vibrationActuator(GamepadHapticActuator::create())
 {
     unsigned buttonCount = platformGamepad.buttonValues().size();
     m_buttons.reserveInitialCapacity(buttonCount);
@@ -74,7 +74,9 @@ void Gamepad::updateFromPlatformGamepad(const PlatformGamepad& platformGamepad)
 
 GamepadHapticActuator& Gamepad::vibrationActuator()
 {
-    return m_vibrationActuator.get();
+    if (!m_vibrationActuator)
+        m_vibrationActuator = GamepadHapticActuator::create(*this);
+    return *m_vibrationActuator;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/Gamepad.h
+++ b/Source/WebCore/Modules/gamepad/Gamepad.h
@@ -27,9 +27,11 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "GamepadHapticEffectType.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -38,7 +40,7 @@ class GamepadButton;
 class GamepadHapticActuator;
 class PlatformGamepad;
 
-class Gamepad: public RefCounted<Gamepad> {
+class Gamepad: public RefCounted<Gamepad>, public CanMakeWeakPtr<Gamepad> {
 public:
     static Ref<Gamepad> create(const PlatformGamepad& platformGamepad)
     {
@@ -54,6 +56,7 @@ public:
     double timestamp() const { return m_timestamp.secondsSinceEpoch().seconds(); }
     const Vector<double>& axes() const;
     const Vector<Ref<GamepadButton>>& buttons() const;
+    const GamepadHapticEffectTypeSet& supportedEffectTypes() const { return m_supportedEffectTypes; }
 
     void updateFromPlatformGamepad(const PlatformGamepad&);
     void setConnected(bool connected) { m_connected = connected; }
@@ -67,11 +70,12 @@ private:
     bool m_connected;
     MonotonicTime m_timestamp;
     String m_mapping;
+    GamepadHapticEffectTypeSet m_supportedEffectTypes;
 
     Vector<double> m_axes;
     Vector<Ref<GamepadButton>> m_buttons;
 
-    Ref<GamepadHapticActuator> m_vibrationActuator;
+    RefPtr<GamepadHapticActuator> m_vibrationActuator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -28,34 +28,75 @@
 #if ENABLE(GAMEPAD)
 #include "GamepadHapticActuator.h"
 
+#include "Document.h"
+#include "EventLoop.h"
+#include "Gamepad.h"
 #include "GamepadEffectParameters.h"
+#include "GamepadProvider.h"
 #include "JSDOMPromiseDeferred.h"
+#include <wtf/CompletionHandler.h>
 
 namespace WebCore {
 
-Ref<GamepadHapticActuator> GamepadHapticActuator::create()
+Ref<GamepadHapticActuator> GamepadHapticActuator::create(Gamepad& gamepad)
 {
-    return adoptRef(*new GamepadHapticActuator);
+    return adoptRef(*new GamepadHapticActuator(gamepad));
 }
 
-GamepadHapticActuator::GamepadHapticActuator()
+GamepadHapticActuator::GamepadHapticActuator(Gamepad& gamepad)
     : m_type { Type::Vibration }
+    , m_gamepad { gamepad }
 {
 }
 
-bool GamepadHapticActuator::canPlayEffectType(EffectType) const
+GamepadHapticActuator::~GamepadHapticActuator() = default;
+
+bool GamepadHapticActuator::canPlayEffectType(EffectType effectType) const
 {
-    return false;
+    return m_gamepad && m_gamepad->supportedEffectTypes().contains(effectType);
 }
 
-void GamepadHapticActuator::playEffect(EffectType, GamepadEffectParameters&&, Ref<DeferredPromise>&& promise)
+void GamepadHapticActuator::playEffect(Document& document, EffectType effectType, GamepadEffectParameters&& effectParameters, Ref<DeferredPromise>&& promise)
 {
-    promise->reject(Exception { NotSupportedError });
+    if (!document.isFullyActive() || document.hidden() || !m_gamepad) {
+        promise->resolve<IDLEnumeration<Result>>(Result::Preempted);
+        return;
+    }
+    if (auto playingEffectPromise = std::exchange(m_playingEffectPromise, nullptr)) {
+        document.eventLoop().queueTask(TaskSource::Gamepad, [playingEffectPromise = WTFMove(playingEffectPromise)] {
+            playingEffectPromise->resolve<IDLEnumeration<Result>>(Result::Preempted);
+        });
+    }
+    if (!canPlayEffectType(effectType)) {
+        promise->reject(Exception { NotSupportedError, "This gamepad doesn't support playing such effect"_s });
+        return;
+    }
+    m_playingEffectPromise = WTFMove(promise);
+    GamepadProvider::singleton().playEffect(m_gamepad->index(), m_gamepad->id(), effectType, effectParameters, [this, protectedThis = Ref { *this }, document = Ref { document }, playingEffectPromise = m_playingEffectPromise](bool success) {
+        if (m_playingEffectPromise != playingEffectPromise)
+            return; // Was already pre-empted.
+        document->eventLoop().queueTask(TaskSource::Gamepad, [playingEffectPromise = std::exchange(m_playingEffectPromise, nullptr), success] {
+            playingEffectPromise->resolve<IDLEnumeration<Result>>(success ? Result::Complete : Result::Preempted);
+        });
+    });
 }
 
-void GamepadHapticActuator::reset(Ref<DeferredPromise>&& promise)
+void GamepadHapticActuator::reset(Document& document, Ref<DeferredPromise>&& promise)
 {
-    promise->reject(Exception { NotSupportedError });
+    if (!document.isFullyActive() || document.hidden() || !m_gamepad) {
+        promise->resolve<IDLEnumeration<Result>>(Result::Preempted);
+        return;
+    }
+    if (auto playingEffectPromise = std::exchange(m_playingEffectPromise, nullptr)) {
+        document.eventLoop().queueTask(TaskSource::Gamepad, [playingEffectPromise = WTFMove(playingEffectPromise)] {
+            playingEffectPromise->resolve<IDLEnumeration<Result>>(Result::Preempted);
+        });
+    }
+    GamepadProvider::singleton().stopEffects(m_gamepad->index(), m_gamepad->id(), [document = Ref { document }, promise = WTFMove(promise)]() mutable {
+        document->eventLoop().queueTask(TaskSource::Gamepad, [promise = WTFMove(promise)] {
+            promise->resolve<IDLEnumeration<Result>>(Result::Complete);
+        });
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl
@@ -28,10 +28,6 @@ enum GamepadHapticActuatorType {
   "dual-rumble"
 };
 
-enum GamepadHapticEffectType {
-  "dual-rumble"
-};
-
 enum GamepadHapticResult {
   "complete",
   "preempted"
@@ -44,6 +40,9 @@ enum GamepadHapticResult {
 ] interface GamepadHapticActuator {
     readonly attribute GamepadHapticActuatorType type;
     boolean canPlayEffectType(GamepadHapticEffectType type);
-    Promise<GamepadHapticResult> playEffect(GamepadHapticEffectType type, optional GamepadEffectParameters params = {});
-    Promise<GamepadHapticResult> reset();
+    [CallWith=RelevantDocument] Promise<GamepadHapticResult> playEffect(GamepadHapticEffectType type, optional GamepadEffectParameters params = {});
+    [CallWith=RelevantDocument] Promise<GamepadHapticResult> reset();
+
+    // Non standard: Supported for compatibility with Blink.
+    [ImplementedAs=canPlayEffectType] boolean canPlay(GamepadHapticEffectType type);
 };

--- a/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.h
@@ -27,39 +27,15 @@
 
 #if ENABLE(GAMEPAD)
 
-#include "GamepadHapticEffectType.h"
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/HashSet.h>
+#include <wtf/HashTraits.h>
 
 namespace WebCore {
 
-class DeferredPromise;
-class Document;
-class Gamepad;
-struct GamepadEffectParameters;
+enum class GamepadHapticEffectType : uint8_t { DualRumble };
 
-class GamepadHapticActuator : public RefCounted<GamepadHapticActuator> {
-public:
-    static Ref<GamepadHapticActuator> create(Gamepad&);
-    ~GamepadHapticActuator();
-
-    using EffectType = GamepadHapticEffectType;
-    enum class Type : uint8_t { Vibration, DualRumble };
-    enum class Result : uint8_t { Complete, Preempted };
-
-    Type type() const { return m_type; }
-    bool canPlayEffectType(EffectType) const;
-    void playEffect(Document&, EffectType, GamepadEffectParameters&&, Ref<DeferredPromise>&&);
-    void reset(Document&, Ref<DeferredPromise>&&);
-
-private:
-    explicit GamepadHapticActuator(Gamepad&);
-
-    Type m_type;
-    WeakPtr<Gamepad> m_gamepad;
-    RefPtr<DeferredPromise> m_playingEffectPromise;
-};
+using GamepadHapticEffectTypeSet = HashSet<GamepadHapticEffectType, IntHash<GamepadHapticEffectType>, WTF::StrongEnumHashTraits<GamepadHapticEffectType>>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
@@ -23,44 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#if ENABLE(GAMEPAD)
-
-#include "GamepadHapticEffectType.h"
-#include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-
-class DeferredPromise;
-class Document;
-class Gamepad;
-struct GamepadEffectParameters;
-
-class GamepadHapticActuator : public RefCounted<GamepadHapticActuator> {
-public:
-    static Ref<GamepadHapticActuator> create(Gamepad&);
-    ~GamepadHapticActuator();
-
-    using EffectType = GamepadHapticEffectType;
-    enum class Type : uint8_t { Vibration, DualRumble };
-    enum class Result : uint8_t { Complete, Preempted };
-
-    Type type() const { return m_type; }
-    bool canPlayEffectType(EffectType) const;
-    void playEffect(Document&, EffectType, GamepadEffectParameters&&, Ref<DeferredPromise>&&);
-    void reset(Document&, Ref<DeferredPromise>&&);
-
-private:
-    explicit GamepadHapticActuator(Gamepad&);
-
-    Type m_type;
-    WeakPtr<Gamepad> m_gamepad;
-    RefPtr<DeferredPromise> m_playingEffectPromise;
+[
+    Conditional=GAMEPAD
+] enum GamepadHapticEffectType {
+  "dual-rumble"
 };
-
-} // namespace WebCore
-
-#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3457,6 +3457,7 @@ JSGainOptions.cpp
 JSGamepad.cpp
 JSGamepadEffectParameters.cpp
 JSGamepadHapticActuator.cpp
+JSGamepadHapticEffectType.cpp
 JSGamepadButton.cpp
 JSGamepadEvent.cpp
 JSGeolocation.cpp

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -32,6 +32,7 @@ enum class TaskSource : uint8_t {
     DatabaseAccess,
     FileReading,
     FontLoading,
+    Gamepad,
     Geolocation,
     IdleTask,
     IndexedDB,

--- a/Source/WebCore/platform/gamepad/EmptyGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/EmptyGamepadProvider.cpp
@@ -47,6 +47,16 @@ const Vector<PlatformGamepad*>& EmptyGamepadProvider::platformGamepads()
     return emptyGamepads;
 }
 
+void EmptyGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(false);
+}
+
+void EmptyGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+
 }
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/EmptyGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/EmptyGamepadProvider.h
@@ -39,6 +39,8 @@ private:
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final;
+    void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 };
 
 }

--- a/Source/WebCore/platform/gamepad/GamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/GamepadProvider.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "GamepadHapticEffectType.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 
@@ -34,6 +35,7 @@ namespace WebCore {
 
 class GamepadProviderClient;
 class PlatformGamepad;
+struct GamepadEffectParameters;
 
 class GamepadProvider {
 public:
@@ -46,6 +48,9 @@ public:
     virtual void stopMonitoringGamepads(GamepadProviderClient&) = 0;
     virtual const Vector<PlatformGamepad*>& platformGamepads() = 0;
     virtual bool isMockGamepadProvider() const { return false; }
+
+    virtual void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) = 0;
+    virtual void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) = 0;
 
 protected:
     WEBCORE_EXPORT void dispatchPlatformGamepadInputActivity();

--- a/Source/WebCore/platform/gamepad/PlatformGamepad.h
+++ b/Source/WebCore/platform/gamepad/PlatformGamepad.h
@@ -27,12 +27,16 @@
 
 #if ENABLE(GAMEPAD)
 
+#include "GamepadHapticEffectType.h"
 #include "SharedGamepadValue.h"
+#include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+struct GamepadEffectParameters;
 
 class PlatformGamepad {
     WTF_MAKE_FAST_ALLOCATED;
@@ -44,9 +48,12 @@ public:
     unsigned index() const { return m_index; }
     virtual MonotonicTime lastUpdateTime() const { return m_lastUpdateTime; }
     MonotonicTime connectTime() const { return m_connectTime; }
+    const GamepadHapticEffectTypeSet& supportedEffectTypes() const { return m_supportedEffectTypes; }
     
     virtual const Vector<SharedGamepadValue>& axisValues() const = 0;
     virtual const Vector<SharedGamepadValue>& buttonValues() const = 0;
+    virtual void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
+    virtual void stopEffects(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
 
     virtual const char* source() const { return "Unknown"_s; }
 
@@ -61,6 +68,7 @@ protected:
     unsigned m_index;
     MonotonicTime m_lastUpdateTime;
     MonotonicTime m_connectTime;
+    GamepadHapticEffectTypeSet m_supportedEffectTypes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -44,6 +44,8 @@ public:
 
     const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
     const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+    void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(CompletionHandler<void()>&&) final;
 
     const char* source() const final { return "GameController"_s; }
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 #import "GameControllerGamepadProvider.h"
 #import "GamepadConstants.h"
+#import "NotImplemented.h"
 #import <GameController/GCControllerElement.h>
 #import <GameController/GameController.h>
 
@@ -68,6 +69,14 @@ void GameControllerGamepad::setupElements()
     m_buttonValues.resize(homeButton ? numberOfStandardGamepadButtonsWithHomeButton : numberOfStandardGamepadButtonsWithoutHomeButton);
 
     m_id = makeString(String(m_gcController.get().vendorName), m_gcController.get().extendedGamepad ? " Extended Gamepad"_s : " Gamepad"_s);
+
+    if (auto *haptics = [m_gcController haptics]) {
+        if (canLoad_GameController_GCHapticsLocalityLeftHandle() && canLoad_GameController_GCHapticsLocalityRightHandle()) {
+            if ([haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityLeftHandle()] && [haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityRightHandle()])
+                m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
+        }
+    }
+
     if (m_gcController.get().extendedGamepad)
         m_mapping = standardGamepadMappingString();
 
@@ -147,6 +156,20 @@ void GameControllerGamepad::setupElements()
         m_lastUpdateTime = MonotonicTime::now();
         GameControllerGamepadProvider::singleton().gamepadHadInput(*this, false);
     };
+}
+
+void GameControllerGamepad::playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    // FIXME(webkit.org/b/250217): Implement support.
+    notImplemented();
+    completionHandler(false);
+}
+
+void GameControllerGamepad::stopEffects(CompletionHandler<void()>&& completionHandler)
+{
+    // FIXME(webkit.org/b/250217): Implement support.
+    notImplemented();
+    completionHandler();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -49,6 +49,8 @@ public:
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 
     WEBCORE_EXPORT void stopMonitoringInput();
     WEBCORE_EXPORT void startMonitoringInput();

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -34,6 +34,7 @@
 #import "Logging.h"
 #import <GameController/GameController.h>
 #import <pal/spi/cocoa/IOKitSPI.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/NeverDestroyed.h>
 
 #import "GameControllerSoftLink.h"
@@ -264,6 +265,28 @@ void GameControllerGamepadProvider::inputNotificationTimerFired()
     m_shouldMakeInvisibleGamepadsVisible = false;
 
     dispatchPlatformGamepadInputActivity();
+}
+
+void GameControllerGamepadProvider::playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (gamepadIndex >= m_gamepadVector.size())
+        return completionHandler(false);
+    auto* gamepad = m_gamepadVector[gamepadIndex];
+    if (!gamepad || gamepad->id() != gamepadID)
+        return completionHandler(false);
+
+    gamepad->playEffect(type, parameters, WTFMove(completionHandler));
+}
+
+void GameControllerGamepadProvider::stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&& completionHandler)
+{
+    if (gamepadIndex >= m_gamepadVector.size())
+        return completionHandler();
+    auto* gamepad = m_gamepadVector[gamepadIndex];
+    if (!gamepad || gamepad->id() != gamepadID)
+        return completionHandler();
+
+    gamepad->stopEffects(WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
@@ -69,6 +69,10 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCInputRightThum
 
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCControllerDidConnectNotification, NSString *)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCControllerDidDisconnectNotification, NSString *)
+
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityLeftHandle, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityRightHandle, NSString *)
+
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, GameController, ControllerClassForService, Class, (IOHIDServiceClientRef service), (service))
 #endif

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
@@ -54,6 +54,9 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCInputRightThum
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCControllerDidConnectNotification, NSString *)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCControllerDidDisconnectNotification, NSString *)
 
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityLeftHandle, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityRightHandle, NSString *)
+
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, GameController, ControllerClassForService, Class, (IOHIDServiceClientRef service), (service))
 #endif

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -221,6 +221,18 @@ struct wpe_view_backend* GamepadProviderLibWPE::inputView()
     return wpe_gamepad_provider_get_view_backend(m_provider.get(), m_lastActiveGamepad);
 }
 
+void GamepadProviderLibWPE::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler(false);
+}
+
+void GamepadProviderLibWPE::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(GAMEPAD) && USE(LIBWPE)

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -52,6 +52,8 @@ public:
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
     enum class ShouldMakeGamepadsVisible : bool { No,
         Yes };

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -50,6 +50,8 @@ public:
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
     WEBCORE_EXPORT void stopMonitoringInput();
     WEBCORE_EXPORT void startMonitoringInput();

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -327,6 +327,18 @@ std::unique_ptr<HIDGamepad> HIDGamepadProvider::removeGamepadForDevice(IOHIDDevi
     return result;
 }
 
+void HIDGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler(false);
+}
+
+void HIDGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(GAMEPAD) && PLATFORM(MAC)

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -48,6 +48,8 @@ public:
     void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
     bool isMockGamepadProvider() const { return false; }
+    void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 
     // GamepadProviderClient
     void platformGamepadConnected(PlatformGamepad&, EventMakesGamepadsVisible) final;

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
@@ -76,6 +76,18 @@ void MultiGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
     }
 }
 
+void MultiGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler(false);
+}
+
+void MultiGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler();
+}
+
 unsigned MultiGamepadProvider::indexForNewlyConnectedDevice()
 {
     unsigned index = 0;

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
@@ -196,6 +196,18 @@ std::unique_ptr<ManetteGamepad> ManetteGamepadProvider::removeGamepadForDevice(M
     return result;
 }
 
+void ManetteGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler(false);
+}
+
+void ManetteGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+{
+    // Not supported by this provider.
+    completionHandler();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(GAMEPAD) && OS(LINUX)

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -49,6 +49,8 @@ public:
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
     void deviceConnected(ManetteDevice*);
     void deviceDisconnected(ManetteDevice*);

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -30,6 +30,7 @@
 
 #include "GamepadProviderClient.h"
 #include "MockGamepad.h"
+#include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -157,6 +158,16 @@ void MockGamepadProvider::clearMockGamepads()
             disconnectMockGamepad(i);
     }
     m_mockGamepadVector.clear();
+}
+
+void MockGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(true);
+}
+
+void MockGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -43,6 +43,8 @@ public:
     WEBCORE_TESTSUPPORT_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
     const Vector<PlatformGamepad*>& platformGamepads() final { return m_connectedGamepadVector; }
     bool isMockGamepadProvider() const final { return true; }
+    void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
     void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount);
     bool setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);

--- a/Source/WebKit/Shared/Gamepad/GamepadData.cpp
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.cpp
@@ -35,13 +35,14 @@ using WebCore::SharedGamepadValue;
 
 namespace WebKit {
 
-GamepadData::GamepadData(unsigned index, const String& id, const String& mapping, const Vector<SharedGamepadValue>& axisValues, const Vector<SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime)
+GamepadData::GamepadData(unsigned index, const String& id, const String& mapping, const Vector<SharedGamepadValue>& axisValues, const Vector<SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes)
     : m_index(index)
     , m_id(id)
     , m_mapping(mapping)
     , m_axisValues(WTF::map(axisValues, [](const auto& value) { return value.value(); }))
     , m_buttonValues(WTF::map(buttonValues, [](const auto& value) { return value.value(); }))
     , m_lastUpdateTime(lastUpdateTime)
+    , m_supportedEffectTypes(supportedEffectTypes)
 {
 }
 
@@ -51,7 +52,7 @@ void GamepadData::encode(IPC::Encoder& encoder) const
     if (m_isNull)
         return;
 
-    encoder << m_index << m_id << m_mapping << m_axisValues << m_buttonValues << m_lastUpdateTime;
+    encoder << m_index << m_id << m_mapping << m_axisValues << m_buttonValues << m_lastUpdateTime << m_supportedEffectTypes;
 }
 
 std::optional<GamepadData> GamepadData::decode(IPC::Decoder& decoder)
@@ -79,6 +80,9 @@ std::optional<GamepadData> GamepadData::decode(IPC::Decoder& decoder)
         return std::nullopt;
 
     if (!decoder.decode(data.m_lastUpdateTime))
+        return std::nullopt;
+
+    if (!decoder.decode(data.m_supportedEffectTypes))
         return std::nullopt;
 
     return data;

--- a/Source/WebKit/Shared/Gamepad/GamepadData.h
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Vector.h>
@@ -46,7 +47,7 @@ public:
     {
     }
 
-    GamepadData(unsigned index, const String& id, const String& mapping, const Vector<WebCore::SharedGamepadValue>& axisValues, const Vector<WebCore::SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime);
+    GamepadData(unsigned index, const String& id, const String& mapping, const Vector<WebCore::SharedGamepadValue>& axisValues, const Vector<WebCore::SharedGamepadValue>& buttonValues, MonotonicTime lastUpdateTime, const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes);
 
     void encode(IPC::Encoder&) const;
     static std::optional<GamepadData> decode(IPC::Decoder&);
@@ -59,6 +60,7 @@ public:
     const String& mapping() const { return m_mapping; }
     const Vector<double>& axisValues() const { return m_axisValues; }
     const Vector<double>& buttonValues() const { return m_buttonValues; }
+    const WebCore::GamepadHapticEffectTypeSet& supportedEffectTypes() const { return m_supportedEffectTypes; }
 
 private:
     unsigned m_index;
@@ -67,6 +69,7 @@ private:
     Vector<double> m_axisValues;
     Vector<double> m_buttonValues;
     MonotonicTime m_lastUpdateTime;
+    WebCore::GamepadHapticEffectTypeSet m_supportedEffectTypes;
 
     bool m_isNull { false };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2465,3 +2465,17 @@ enum class WebCore::FocusDirection : uint8_t {
     Left,
     Right
 };
+
+#if ENABLE(GAMEPAD)
+struct WebCore::GamepadEffectParameters {
+    double duration;
+    double startDelay;
+    double strongMagnitude;
+    double weakMagnitude;
+};
+
+header: <WebCore/GamepadHapticEffectType.h>
+enum class WebCore::GamepadHapticEffectType : uint8_t {
+    DualRumble
+};
+#endif

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp
@@ -39,6 +39,7 @@ UIGamepad::UIGamepad(WebCore::PlatformGamepad& platformGamepad)
     , m_id(platformGamepad.id())
     , m_mapping(platformGamepad.mapping())
     , m_lastUpdateTime(platformGamepad.lastUpdateTime())
+    , m_supportedEffectTypes(platformGamepad.supportedEffectTypes())
 {
     m_axisValues.resize(platformGamepad.axisValues().size());
     m_buttonValues.resize(platformGamepad.buttonValues().size());
@@ -59,9 +60,8 @@ void UIGamepad::updateFromPlatformGamepad(WebCore::PlatformGamepad& platformGame
 
 GamepadData UIGamepad::gamepadData() const
 {
-    return { m_index, m_id, m_mapping, m_axisValues, m_buttonValues, m_lastUpdateTime };
+    return { m_index, m_id, m_mapping, m_axisValues, m_buttonValues, m_lastUpdateTime, m_supportedEffectTypes };
 }
-
 
 }
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepad.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <WebCore/GamepadHapticEffectType.h>
 #include <WebCore/SharedGamepadValue.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Vector.h>
@@ -58,6 +59,7 @@ private:
     Vector<WebCore::SharedGamepadValue> m_axisValues;
     Vector<WebCore::SharedGamepadValue> m_buttonValues;
     MonotonicTime m_lastUpdateTime;
+    WebCore::GamepadHapticEffectTypeSet m_supportedEffectTypes;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -83,6 +83,7 @@
 #include "WebsiteDataStoreParameters.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <WebCore/ApplicationCacheStorage.h>
+#include <WebCore/GamepadProvider.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/PlatformScreen.h>
@@ -1648,6 +1649,16 @@ void WebProcessPool::stoppedUsingGamepads(IPC::Connection& connection, Completio
 
     ASSERT(m_processesUsingGamepads.contains(*proxy));
     processStoppedUsingGamepads(*proxy);
+}
+
+void WebProcessPool::playGamepadEffect(unsigned gamepadIndex, const String& gamepadID, WebCore::GamepadHapticEffectType type, const WebCore::GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    GamepadProvider::singleton().playEffect(gamepadIndex, gamepadID, type, parameters, WTFMove(completionHandler));
+}
+
+void WebProcessPool::stopGamepadEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&& completionHandler)
+{
+    GamepadProvider::singleton().stopEffects(gamepadIndex, gamepadID, WTFMove(completionHandler));
 }
 
 void WebProcessPool::processStoppedUsingGamepads(WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -94,6 +94,8 @@ class PageConfiguration;
 namespace WebCore {
 class RegistrableDomain;
 enum class EventMakesGamepadsVisible : bool;
+enum class GamepadHapticEffectType : uint8_t;
+struct GamepadEffectParameters;
 struct MockMediaDevice;
 #if PLATFORM(COCOA)
 class PowerSourceNotifier;
@@ -552,6 +554,8 @@ private:
 #if ENABLE(GAMEPAD)
     void startedUsingGamepads(IPC::Connection&);
     void stoppedUsingGamepads(IPC::Connection&, CompletionHandler<void()>&&);
+    void playGamepadEffect(unsigned gamepadIndex, const String& gamepadID, WebCore::GamepadHapticEffectType, const WebCore::GamepadEffectParameters&, CompletionHandler<void(bool)>&&);
+    void stopGamepadEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&);
 
     void processStoppedUsingGamepads(WebProcessProxy&);
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessPool.messages.in
@@ -25,8 +25,11 @@ messages -> WebProcessPool {
     HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous WantsConnection
 
 #if ENABLE(GAMEPAD)
+    // FIXME: Consider moving Gamepad messages to their own MessageListener.
     StartedUsingGamepads() WantsConnection
     StoppedUsingGamepads() -> () WantsConnection
+    PlayGamepadEffect(unsigned gamepadIndex, String gamepadID, enum:uint8_t WebCore::GamepadHapticEffectType type, struct WebCore::GamepadEffectParameters parameters) -> (bool success)
+    StopGamepadEffects(unsigned gamepadIndex, String gamepadID) -> ()
 #endif
 
     ReportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp
@@ -44,6 +44,7 @@ WebGamepad::WebGamepad(const GamepadData& gamepadData)
     m_mapping = gamepadData.mapping();
     m_axisValues.resize(gamepadData.axisValues().size());
     m_buttonValues.resize(gamepadData.buttonValues().size());
+    m_supportedEffectTypes = gamepadData.supportedEffectTypes();
 
     updateValues(gamepadData);
 }

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -153,6 +153,16 @@ const Vector<PlatformGamepad*>& WebGamepadProvider::platformGamepads()
     return m_rawGamepads;
 }
 
+void WebGamepadProvider::playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebProcessPool::PlayGamepadEffect(gamepadIndex, gamepadID, type, parameters), WTFMove(completionHandler));
+}
+
+void WebGamepadProvider::stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&& completionHandler)
+{
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebProcessPool::StopGamepadEffects(gamepadIndex, gamepadID), WTFMove(completionHandler));
+}
+
 }
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
@@ -61,6 +61,8 @@ private:
     void startMonitoringGamepads(WebCore::GamepadProviderClient&) final;
     void stopMonitoringGamepads(WebCore::GamepadProviderClient&) final;
     const Vector<WebCore::PlatformGamepad*>& platformGamepads() final;
+    void playEffect(unsigned gamepadIndex, const String& gamepadID, WebCore::GamepadHapticEffectType, const WebCore::GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 
     HashSet<WebCore::GamepadProviderClient*> m_clients;
 


### PR DESCRIPTION
#### 7203ee047b6ca60c82927f67daecc042e9a1cc58
<pre>
Add plumbing for Gamepad.vibrationActuator support
<a href="https://bugs.webkit.org/show_bug.cgi?id=250149">https://bugs.webkit.org/show_bug.cgi?id=250149</a>

Reviewed by Brent Fulgham.

Add plumbing for Gamepad.vibrationActuator support:
- <a href="https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuator">https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuator</a>

The Gamepad.vibrationActuator&apos;s playEffect() / reset() calls are now properly
forwarded to the corresponding PlatformGamepad object in the UIProcess.

The next step will be to implement them inside GameControllerGamepad to
make the API actually functional on macOS 13+.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
(WebCore::Gamepad::Gamepad):
(WebCore::Gamepad::vibrationActuator):
* Source/WebCore/Modules/gamepad/Gamepad.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::create):
(WebCore::GamepadHapticActuator::GamepadHapticActuator):
(WebCore::m_gamepad):
(WebCore::GamepadHapticActuator::canPlayEffectType const):
(WebCore::GamepadHapticActuator::playEffect):
(WebCore::GamepadHapticActuator::reset):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl:
* Source/WebCore/Modules/gamepad/GamepadHapticEffectType.h: Copied from Source/WebCore/platform/gamepad/EmptyGamepadProvider.h.
* Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl: Copied from Source/WebCore/platform/gamepad/EmptyGamepadProvider.h.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/TaskSource.h:
* Source/WebCore/platform/gamepad/EmptyGamepadProvider.cpp:
(WebCore::EmptyGamepadProvider::playEffect):
(WebCore::EmptyGamepadProvider::stopEffects):
* Source/WebCore/platform/gamepad/EmptyGamepadProvider.h:
* Source/WebCore/platform/gamepad/GamepadProvider.h:
* Source/WebCore/platform/gamepad/PlatformGamepad.h:
(WebCore::PlatformGamepad::supportedEffectTypes const):
(WebCore::PlatformGamepad::playEffect):
(WebCore::PlatformGamepad::stopEffects):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
(WebCore::GameControllerGamepad::playEffect):
(WebCore::GameControllerGamepad::stopEffects):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::playEffect):
(WebCore::GameControllerGamepadProvider::stopEffects):
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
(WebCore::HIDGamepadProvider::playEffect):
(WebCore::HIDGamepadProvider::stopEffects):
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm:
(WebCore::MultiGamepadProvider::playEffect):
(WebCore::MultiGamepadProvider::stopEffects):
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp:
(WebCore::ManetteGamepadProvider::playEffect):
(WebCore::ManetteGamepadProvider::stopEffects):
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::playEffect):
(WebCore::MockGamepadProvider::stopEffects):
* Source/WebCore/testing/MockGamepadProvider.h:
* Source/WebKit/Shared/Gamepad/GamepadData.cpp:
(WebKit::GamepadData::GamepadData):
(WebKit::m_supportedEffectTypes):
(WebKit::GamepadData::encode const):
(WebKit::GamepadData::decode):
(WebKit::m_lastUpdateTime): Deleted.
* Source/WebKit/Shared/Gamepad/GamepadData.h:
(WebKit::GamepadData::supportedEffectTypes const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Gamepad/UIGamepad.cpp:
(WebKit::UIGamepad::UIGamepad):
(WebKit::UIGamepad::gamepadData const):
* Source/WebKit/UIProcess/Gamepad/UIGamepad.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::playGamepadEffect):
(WebKit::WebProcessPool::stopGamepadEffects):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessPool.messages.in:
* Source/WebKit/WebProcess/Gamepad/WebGamepad.cpp:
(WebKit::WebGamepad::WebGamepad):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::playEffect):
(WebKit::WebGamepadProvider::stopEffects):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h:

Canonical link: <a href="https://commits.webkit.org/258559@main">https://commits.webkit.org/258559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a066b81b6f5cec54930b4b237ab0f7de6b7485b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102343 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111651 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2400 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108124 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25728 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2167 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45221 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5877 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6883 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->