### PR TITLE
Introduce and adopt ScopedURL

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1271,6 +1271,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/RemoteFrameClient.h
     page/RemoteFrameView.h
     page/RenderingUpdateScheduler.h
+    page/ScopedURL.h
     page/ScreenOrientationLockType.h
     page/ScreenOrientationType.h
     page/ScrollBehavior.h

--- a/Source/WebCore/Modules/mediasource/MediaSourceRegistry.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceRegistry.cpp
@@ -35,6 +35,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "MediaSource.h"
+#include "ScopedURL.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
@@ -62,7 +63,7 @@ void MediaSourceRegistry::registerURL(const ScriptExecutionContext& context, con
     m_mediaSources.add(urlString, std::pair { RefPtr { &source }, context.identifier() });
 }
 
-void MediaSourceRegistry::unregisterURL(const URL& url)
+void MediaSourceRegistry::unregisterURL(const ScopedURL& url)
 {
     // MediaSource objects are not exposed to workers.
     if (!isMainThread())

--- a/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
@@ -40,6 +40,7 @@
 namespace WebCore {
 
 class MediaSource;
+class ScopedURL;
 
 class MediaSourceRegistry final : public URLRegistry {
     friend class NeverDestroyed<MediaSourceRegistry>;
@@ -49,7 +50,7 @@ public:
 
     // Registers a blob URL referring to the specified media source.
     void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) final;
-    void unregisterURL(const URL&) final;
+    void unregisterURL(const ScopedURL&) final;
     void unregisterURLsForContext(const ScriptExecutionContext&) final;
     URLRegistrable* lookup(const String&) const final;
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -265,7 +265,7 @@ Document* BaseAudioContext::document() const
     return downcast<Document>(scriptExecutionContext());
 }
 
-bool BaseAudioContext::wouldTaintOrigin(const URL& url) const
+bool BaseAudioContext::wouldTaintOrigin(const ScopedURL& url) const
 {
     if (url.protocolIsData())
         return false;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -68,6 +68,7 @@ class MediaElementAudioSourceNode;
 class OscillatorNode;
 class PannerNode;
 class PeriodicWave;
+class ScopedURL;
 class ScriptProcessorNode;
 class SecurityOrigin;
 class StereoPannerNode;
@@ -123,7 +124,7 @@ public:
 
     AudioWorklet& audioWorklet() { return m_worklet.get(); }
 
-    bool wouldTaintOrigin(const URL&) const;
+    bool wouldTaintOrigin(const ScopedURL&) const;
 
     // The AudioNode create methods are called on the main thread (from JavaScript).
     ExceptionOr<Ref<AudioBufferSourceNode>> createBufferSource();

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -50,6 +50,7 @@
 #include "MessageEvent.h"
 #include "MixedContentChecker.h"
 #include "ResourceLoadObserver.h"
+#include "ScopedURL.h"
 #include "ScriptController.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
@@ -226,7 +227,7 @@ void WebSocket::failAsynchronously()
 ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& protocols)
 {
     LOG(Network, "WebSocket %p connect() url='%s'", this, url.utf8().data());
-    m_url = URL { url };
+    m_url = ScopedURL { url };
 
     ASSERT(scriptExecutionContext());
     auto& context = *scriptExecutionContext();
@@ -478,7 +479,7 @@ RefPtr<ThreadableWebSocketChannel> WebSocket::channel() const
     return m_channel;
 }
 
-const URL& WebSocket::url() const
+const ScopedURL& WebSocket::url() const
 {
     return m_url;
 }

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -46,6 +46,7 @@ class ArrayBufferView;
 namespace WebCore {
 
 class Blob;
+class ScopedURL;
 class ThreadableWebSocketChannel;
 
 class WebSocket final : public RefCounted<WebSocket>, public EventTarget, public ActiveDOMObject, private WebSocketChannelClient {
@@ -81,7 +82,7 @@ public:
 
     RefPtr<ThreadableWebSocketChannel> channel() const;
 
-    const URL& url() const;
+    const ScopedURL& url() const;
     State readyState() const;
     unsigned bufferedAmount() const;
 
@@ -131,7 +132,7 @@ private:
     RefPtr<ThreadableWebSocketChannel> m_channel;
 
     State m_state { CONNECTING };
-    URL m_url;
+    ScopedURL m_url;
     unsigned m_bufferedAmount { 0 };
     unsigned m_bufferedAmountAfterClose { 0 };
     BinaryType m_binaryType { BinaryType::Blob };

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -110,7 +110,7 @@ String WebSocketHandshake::getExpectedWebSocketAccept(const String& secWebSocket
     return base64EncodeToString(hash.data(), SHA1::hashSize);
 }
 
-WebSocketHandshake::WebSocketHandshake(const URL& url, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated)
+WebSocketHandshake::WebSocketHandshake(const ScopedURL& url, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated)
     : m_url(url)
     , m_clientProtocol(protocol)
     , m_secure(m_url.protocolIs("wss"_s))

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -34,6 +34,7 @@
 #include "CookieRequestHeaderFieldProxy.h"
 #include <wtf/URL.h>
 #include "ResourceResponse.h"
+#include "ScopedURL.h"
 #include "WebSocketExtensionDispatcher.h"
 #include "WebSocketExtensionProcessor.h"
 #include <wtf/WeakPtr.h>
@@ -49,7 +50,7 @@ public:
     enum Mode {
         Incomplete, Normal, Failed, Connected
     };
-    WEBCORE_EXPORT WebSocketHandshake(const URL&, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated);
+    WEBCORE_EXPORT WebSocketHandshake(const ScopedURL&, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated);
     WEBCORE_EXPORT ~WebSocketHandshake();
 
     const URL& url() const;
@@ -95,7 +96,7 @@ private:
     void processHeaders();
     bool checkResponseHeaders();
 
-    URL m_url;
+    ScopedURL m_url;
     String m_clientProtocol;
     bool m_secure;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6608,7 +6608,7 @@ bool Document::isContextThread() const
 }
 
 // https://w3c.github.io/webappsec-secure-contexts/#is-url-trustworthy
-static bool isURLPotentiallyTrustworthy(const URL& url)
+static bool isURLPotentiallyTrustworthy(const ScopedURL& url)
 {
     if (url.protocolIsAbout())
         return url.isAboutBlank() || url.isAboutSrcDoc();

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -30,6 +30,7 @@
 #include "ContentSecurityPolicy.h"
 #include "HTMLParserIdioms.h"
 #include "PolicyContainer.h"
+#include "ScopedURL.h"
 #include "SecurityOrigin.h"
 #include "SecurityOriginPolicy.h"
 #include <wtf/text/StringBuilder.h>
@@ -59,7 +60,7 @@ void SecurityContext::setContentSecurityPolicy(std::unique_ptr<ContentSecurityPo
     m_contentSecurityPolicy = WTFMove(contentSecurityPolicy);
 }
 
-bool SecurityContext::isSecureTransitionTo(const URL& url) const
+bool SecurityContext::isSecureTransitionTo(const ScopedURL& url) const
 {
     // If we haven't initialized our security origin by now, this is probably
     // a new window created via the API (i.e., that lacks an origin and lacks
@@ -67,7 +68,7 @@ bool SecurityContext::isSecureTransitionTo(const URL& url) const
     if (!haveInitializedSecurityOrigin())
         return true;
 
-    return securityOriginPolicy()->origin().isSameOriginDomain(SecurityOrigin::create(url).get());
+    return securityOrigin()->isSameOriginDomain(SecurityOrigin::create(url).get());
 }
 
 void SecurityContext::enforceSandboxFlags(SandboxFlags mask, SandboxFlagsSource source)

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class SecurityOrigin;
 class SecurityOriginPolicy;
 class ContentSecurityPolicy;
+class ScopedURL;
 struct CrossOriginOpenerPolicy;
 struct PolicyContainer;
 enum class ReferrerPolicy : uint8_t;
@@ -74,7 +75,7 @@ public:
     SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
     ContentSecurityPolicy* contentSecurityPolicy() { return m_contentSecurityPolicy.get(); }
 
-    bool isSecureTransitionTo(const URL&) const;
+    bool isSecureTransitionTo(const ScopedURL&) const;
 
     enum class SandboxFlagsSource : bool { CSP, Other };
     void enforceSandboxFlags(SandboxFlags, SandboxFlagsSource = SandboxFlagsSource::Other);

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -40,6 +40,7 @@
 #include "PolicyContainer.h"
 #include "ReadableStream.h"
 #include "ReadableStreamSource.h"
+#include "ScopedURL.h"
 #include "ScriptExecutionContext.h"
 #include "SharedBuffer.h"
 #include "ThreadableBlobRegistry.h"
@@ -58,7 +59,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Blob);
 class BlobURLRegistry final : public URLRegistry {
 public:
     void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) final;
-    void unregisterURL(const URL&) final;
+    void unregisterURL(const ScopedURL&) final;
     void unregisterURLsForContext(const ScriptExecutionContext&) final;
 
     static URLRegistry& registry();
@@ -77,7 +78,7 @@ void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const U
     ThreadableBlobRegistry::registerBlobURL(context.securityOrigin(), context.policyContainer(), publicURL, static_cast<Blob&>(blob).url());
 }
 
-void BlobURLRegistry::unregisterURL(const URL& url)
+void BlobURLRegistry::unregisterURL(const ScopedURL& url)
 {
     bool isURLRegistered = false;
     {

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -53,6 +53,7 @@ class Blob;
 class BlobLoader;
 class DeferredPromise;
 class ReadableStream;
+class ScopedURL;
 class ScriptExecutionContext;
 class FragmentedSharedBuffer;
 class WebCoreOpaqueRoot;
@@ -95,7 +96,7 @@ public:
 
     virtual ~Blob();
 
-    URL url() const { return m_internalURL; }
+    ScopedURL url() const { return m_internalURL; }
     const String& type() const { return m_type; }
 
     WEBCORE_EXPORT unsigned long long size() const;
@@ -154,7 +155,7 @@ private:
     // This is an internal URL referring to the blob data associated with this object. It serves
     // as an identifier for this blob. The internal URL is never used to source the blob's content
     // into an HTML or for FileRead'ing, public blob URLs must be used for those purposes.
-    URL m_internalURL;
+    ScopedURL m_internalURL;
 
     HashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
 };

--- a/Source/WebCore/fileapi/BlobLoader.h
+++ b/Source/WebCore/fileapi/BlobLoader.h
@@ -30,6 +30,7 @@
 #include "ExceptionCode.h"
 #include "FileReaderLoader.h"
 #include "FileReaderLoaderClient.h"
+#include "ScopedURL.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/CompletionHandler.h>

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -32,6 +32,7 @@
 
 #include "BlobURL.h"
 #include "Document.h"
+#include "ScopedURL.h"
 #include "SecurityOrigin.h"
 #include "ThreadableBlobRegistry.h"
 
@@ -66,7 +67,7 @@ static const Document* blobOwner(const SecurityOrigin& blobOrigin)
     return nullptr;
 }
 
-URL BlobURL::getOriginURL(const URL& url)
+URL BlobURL::getOriginURL(const ScopedURL& url)
 {
     ASSERT(url.protocolIs(kBlobProtocol));
 
@@ -77,7 +78,7 @@ URL BlobURL::getOriginURL(const URL& url)
     return SecurityOrigin::extractInnerURL(url);
 }
 
-bool BlobURL::isSecureBlobURL(const URL& url)
+bool BlobURL::isSecureBlobURL(const ScopedURL& url)
 {
     ASSERT(url.protocolIs(kBlobProtocol));
 
@@ -86,7 +87,7 @@ bool BlobURL::isSecureBlobURL(const URL& url)
         if (auto* document = blobOwner(*origin))
             return document->isSecureContext();
     }
-    return SecurityOrigin::isSecure(url);
+    return false;
 }
 
 URL BlobURL::createBlobURL(StringView originString)

--- a/Source/WebCore/fileapi/BlobURL.h
+++ b/Source/WebCore/fileapi/BlobURL.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class ScopedURL;
 class SecurityOrigin;
 
 // Blob URLs are of the form
@@ -50,8 +51,8 @@ public:
     static URL createPublicURL(SecurityOrigin*);
     static URL createInternalURL();
 
-    static URL getOriginURL(const URL&);
-    static bool isSecureBlobURL(const URL&);
+    static URL getOriginURL(const ScopedURL&);
+    static bool isSecureBlobURL(const ScopedURL&);
 
 private:
     static URL createBlobURL(StringView originString);

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -79,7 +79,7 @@ void FileReaderLoader::start(ScriptExecutionContext* scriptExecutionContext, Blo
     start(scriptExecutionContext, blob.url());
 }
 
-void FileReaderLoader::start(ScriptExecutionContext* scriptExecutionContext, const URL& blobURL)
+void FileReaderLoader::start(ScriptExecutionContext* scriptExecutionContext, const ScopedURL& blobURL)
 {
     ASSERT(scriptExecutionContext);
 

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -32,6 +32,7 @@
 
 #include "BlobResourceHandle.h"
 #include "ExceptionCode.h"
+#include "ScopedURL.h"
 #include "ThreadableLoaderClient.h"
 #include <pal/text/TextEncoding.h>
 #include <wtf/Forward.h>
@@ -67,7 +68,7 @@ public:
     ~FileReaderLoader();
 
     WEBCORE_EXPORT void start(ScriptExecutionContext*, Blob&);
-    void start(ScriptExecutionContext*, const URL&);
+    void start(ScriptExecutionContext*, const ScopedURL&);
     WEBCORE_EXPORT void cancel();
 
     // ThreadableLoaderClient
@@ -104,7 +105,7 @@ private:
     PAL::TextEncoding m_encoding;
     String m_dataType;
 
-    URL m_urlForReading;
+    ScopedURL m_urlForReading;
     RefPtr<ThreadableLoader> m_loader;
 
     RefPtr<JSC::ArrayBuffer> m_rawData;

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.h
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.h
@@ -36,23 +36,24 @@
 namespace WebCore {
 
 class BlobPart;
+class ScopedURL;
 class SecurityOrigin;
 
 struct PolicyContainer;
 
 class ThreadableBlobRegistry {
 public:
-    static void registerFileBlobURL(const URL&, const String& path, const String& replacementPath, const String& contentType);
-    static void registerBlobURL(const URL&, Vector<BlobPart>&& blobParts, const String& contentType);
-    static void registerBlobURL(SecurityOrigin*, PolicyContainer&&, const URL&, const URL& srcURL);
-    static void registerBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, const String& fileBackedPath, const String& contentType);
-    static void registerBlobURLForSlice(const URL& newURL, const URL& srcURL, long long start, long long end, const String& contentType);
-    static void unregisterBlobURL(const URL&);
+    static void registerFileBlobURL(const ScopedURL&, const String& path, const String& replacementPath, const String& contentType);
+    static void registerBlobURL(const ScopedURL&, Vector<BlobPart>&& blobParts, const String& contentType);
+    static void registerBlobURL(SecurityOrigin*, PolicyContainer&&, const ScopedURL&, const ScopedURL& srcURL);
+    static void registerBlobURLOptionallyFileBacked(const ScopedURL&, const ScopedURL& srcURL, const String& fileBackedPath, const String& contentType);
+    static void registerBlobURLForSlice(const ScopedURL& newURL, const ScopedURL& srcURL, long long start, long long end, const String& contentType);
+    static void unregisterBlobURL(const ScopedURL&);
 
-    static void registerBlobURLHandle(const URL&);
-    static void unregisterBlobURLHandle(const URL&);
+    static void registerBlobURLHandle(const ScopedURL&);
+    static void unregisterBlobURLHandle(const ScopedURL&);
 
-    WEBCORE_EXPORT static unsigned long long blobSize(const URL&);
+    WEBCORE_EXPORT static unsigned long long blobSize(const ScopedURL&);
 
     // Returns the origin for the given blob URL. This is because we are not able to embed the unique security origin or the origin of file URL
     // in the blob URL.

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-URLKeepingBlobAlive::URLKeepingBlobAlive(URL&& url)
+URLKeepingBlobAlive::URLKeepingBlobAlive(ScopedURL&& url)
     : m_url(WTFMove(url))
 {
     registerBlobURLHandleIfNecessary();
@@ -47,7 +47,7 @@ URLKeepingBlobAlive::~URLKeepingBlobAlive()
     unregisterBlobURLHandleIfNecessary();
 }
 
-URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URL&& url)
+URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(ScopedURL&& url)
 {
     unregisterBlobURLHandleIfNecessary();
     m_url = WTFMove(url);
@@ -72,7 +72,7 @@ URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URLKeepingBlobAlive&& other)
         return *this;
 
     unregisterBlobURLHandleIfNecessary();
-    m_url = std::exchange(other.m_url, URL { });
+    m_url = std::exchange(other.m_url, ScopedURL { });
     return *this;
 }
 

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ScopedURL.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -33,8 +34,9 @@ namespace WebCore {
 class URLKeepingBlobAlive {
 public:
     URLKeepingBlobAlive() = default;
-    URLKeepingBlobAlive(URL&&);
-    URLKeepingBlobAlive(const URL& url) : URLKeepingBlobAlive(URL { url }) { }
+    URLKeepingBlobAlive(ScopedURL&&);
+    URLKeepingBlobAlive(const ScopedURL& url)
+        : URLKeepingBlobAlive(ScopedURL { url }) { }
     ~URLKeepingBlobAlive();
 
     URLKeepingBlobAlive(URLKeepingBlobAlive&&) = default;
@@ -42,11 +44,11 @@ public:
     URLKeepingBlobAlive& operator=(const URLKeepingBlobAlive&);
     URLKeepingBlobAlive& operator=(URLKeepingBlobAlive&&);
 
-    operator const URL&() const { return m_url; }
-    const URL& url() const { return m_url; }
+    operator const ScopedURL&() const { return m_url; }
+    const ScopedURL& url() const { return m_url; }
 
-    URLKeepingBlobAlive& operator=(URL&&);
-    URLKeepingBlobAlive& operator=(const URL& url) { return *this = URL { url }; }
+    URLKeepingBlobAlive& operator=(ScopedURL&&);
+    URLKeepingBlobAlive& operator=(const ScopedURL& url) { return *this = ScopedURL { url }; }
 
     URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() const &;
     URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() &&;
@@ -55,7 +57,7 @@ private:
     void registerBlobURLHandleIfNecessary();
     void unregisterBlobURLHandleIfNecessary();
 
-    URL m_url;
+    ScopedURL m_url;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -31,6 +31,7 @@
 #include "LinkLoader.h"
 #include "LinkLoaderClient.h"
 #include "LinkRelAttribute.h"
+#include "ScopedURL.h"
 
 namespace WebCore {
 
@@ -146,7 +147,7 @@ private:
     String m_type;
     String m_media;
     String m_integrityMetadataForPendingSheetRequest;
-    URL m_url;
+    ScopedURL m_url;
     std::unique_ptr<DOMTokenList> m_sizes;
     std::unique_ptr<DOMTokenList> m_relList;
     DisabledState m_disabledState;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -40,6 +40,7 @@
 #include "MediaProducer.h"
 #include "MediaUniqueIdentifier.h"
 #include "ReducedResolutionSeconds.h"
+#include "ScopedURL.h"
 #include "TextTrackClient.h"
 #include "VideoTrackClient.h"
 #include "VisibilityChangeClient.h"
@@ -1233,7 +1234,7 @@ private:
     friend class TrackDisplayUpdateScope;
 
     RefPtr<Blob> m_blob;
-    URL m_blobURLForReading;
+    ScopedURL m_blobURLForReading;
     MediaProvider m_mediaProvider;
     WTF::Observer<WebCoreOpaqueRoot()> m_opaqueRootProvider;
 

--- a/Source/WebCore/html/PublicURLManager.cpp
+++ b/Source/WebCore/html/PublicURLManager.cpp
@@ -55,7 +55,7 @@ void PublicURLManager::registerURL(const URL& url, URLRegistrable& registrable)
     registrable.registry().registerURL(*scriptExecutionContext(), url, registrable);
 }
 
-void PublicURLManager::revoke(const URL& url)
+void PublicURLManager::revoke(const ScopedURL& url)
 {
     if (m_isStopped || !scriptExecutionContext())
         return;

--- a/Source/WebCore/html/PublicURLManager.h
+++ b/Source/WebCore/html/PublicURLManager.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class SecurityOrigin;
+class ScopedURL;
 class URLRegistry;
 class URLRegistrable;
 
@@ -45,7 +45,7 @@ public:
     static std::unique_ptr<PublicURLManager> create(ScriptExecutionContext*);
 
     void registerURL(const URL&, URLRegistrable&);
-    void revoke(const URL&);
+    void revoke(const ScopedURL&);
 
 private:
     // ActiveDOMObject API.

--- a/Source/WebCore/html/URLRegistry.h
+++ b/Source/WebCore/html/URLRegistry.h
@@ -35,6 +35,7 @@
 
 namespace WebCore {
 
+class ScopedURL;
 class ScriptExecutionContext;
 class URLRegistry;
 
@@ -53,7 +54,7 @@ public:
 
     virtual ~URLRegistry();
     virtual void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) = 0;
-    virtual void unregisterURL(const URL&) = 0;
+    virtual void unregisterURL(const ScopedURL&) = 0;
     virtual void unregisterURLsForContext(const ScriptExecutionContext&) = 0;
 
     // This is an optional API

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -175,7 +175,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const ImageBitmap* imageBitmap)
     return !imageBitmap->originClean();
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const URL& url)
+bool CanvasRenderingContext::wouldTaintOrigin(const ScopedURL& url)
 {
     if (!m_canvas.originClean())
         return false;
@@ -186,7 +186,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const URL& url)
     return !m_canvas.securityOrigin()->canRequest(url);
 }
 
-void CanvasRenderingContext::checkOrigin(const URL& url)
+void CanvasRenderingContext::checkOrigin(const ScopedURL& url)
 {
     if (wouldTaintOrigin(url))
         m_canvas.setOriginTainted();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -44,6 +44,7 @@ class HTMLImageElement;
 class HTMLVideoElement;
 class ImageBitmap;
 class CSSStyleImageValue;
+class ScopedURL;
 class WebGLObject;
 enum class PixelFormat : uint8_t;
 
@@ -99,14 +100,14 @@ protected:
     bool wouldTaintOrigin(const HTMLImageElement*);
     bool wouldTaintOrigin(const HTMLVideoElement*);
     bool wouldTaintOrigin(const ImageBitmap*);
-    bool wouldTaintOrigin(const URL&);
+    bool wouldTaintOrigin(const ScopedURL&);
 
     template<class T> void checkOrigin(const T* arg)
     {
         if (wouldTaintOrigin(arg))
             m_canvas.setOriginTainted();
     }
-    void checkOrigin(const URL&);
+    void checkOrigin(const ScopedURL&);
     void checkOrigin(const CSSStyleImageValue&);
 
     bool m_hasActiveInspectorCanvasCallTracer { false };

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-URL PreloadRequest::completeURL(Document& document)
+ScopedURL PreloadRequest::completeURL(Document& document)
 {
     return document.completeURL(m_resourceURL, m_baseURL.isEmpty() ? document.baseURL() : m_baseURL);
 }

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class ScopedURL;
+
 class PreloadRequest {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -56,7 +58,7 @@ public:
     CachedResource::Type resourceType() const { return m_resourceType; }
 
 private:
-    URL completeURL(Document&);
+    ScopedURL completeURL(Document&);
 
     ASCIILiteral m_initiatorType;
     String m_resourceURL;

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-ApplicationManifestLoader::ApplicationManifestLoader(DocumentLoader& documentLoader, const URL& url, bool useCredentials)
+ApplicationManifestLoader::ApplicationManifestLoader(DocumentLoader& documentLoader, const ScopedURL& url, bool useCredentials)
     : m_documentLoader(documentLoader)
     , m_url(url)
     , m_useCredentials(useCredentials)

--- a/Source/WebCore/loader/ApplicationManifestLoader.h
+++ b/Source/WebCore/loader/ApplicationManifestLoader.h
@@ -30,6 +30,7 @@
 #include "ApplicationManifest.h"
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
+#include "ScopedURL.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/URL.h>
 
@@ -43,7 +44,7 @@ WTF_MAKE_NONCOPYABLE(ApplicationManifestLoader); WTF_MAKE_FAST_ALLOCATED;
 public:
     typedef Function<void (CachedResourceHandle<CachedApplicationManifest>)> CompletionHandlerType;
 
-    ApplicationManifestLoader(DocumentLoader&, const URL&, bool);
+    ApplicationManifestLoader(DocumentLoader&, const ScopedURL&, bool);
     virtual ~ApplicationManifestLoader();
 
     bool startLoading();
@@ -56,7 +57,7 @@ private:
 
     DocumentLoader& m_documentLoader;
     std::optional<ApplicationManifest> m_processedManifest;
-    URL m_url;
+    ScopedURL m_url;
     bool m_useCredentials;
     CachedResourceHandle<CachedApplicationManifest> m_resource;
 };

--- a/Source/WebCore/loader/ContentFilterClient.h
+++ b/Source/WebCore/loader/ContentFilterClient.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class ContentFilterUnblockHandler;
 class ResourceError;
+class ScopedURL;
 class SharedBuffer;
 class SubstituteData;
 
@@ -45,7 +46,7 @@ public:
     virtual void dataReceivedThroughContentFilter(const SharedBuffer&, size_t) = 0;
     virtual ResourceError contentFilterDidBlock(ContentFilterUnblockHandler, String&& unblockRequestDeniedScript) = 0;
     virtual void cancelMainResourceLoadForContentFilter(const ResourceError&) = 0;
-    virtual void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, SubstituteData&) = 0;
+    virtual void handleProvisionalLoadFailureFromContentFilter(const ScopedURL& blockedPageURL, SubstituteData&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -325,7 +325,7 @@ static inline bool shouldCrossOriginResourcePolicyCancelLoad(CrossOriginEmbedder
     return false;
 }
 
-std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue coep, const SecurityOrigin& origin, const URL& requestURL, const ResourceResponse& response, ForNavigation forNavigation)
+std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue coep, const SecurityOrigin& origin, const ScopedURL& requestURL, const ResourceResponse& response, ForNavigation forNavigation)
 {
     if (shouldCrossOriginResourcePolicyCancelLoad(coep, origin, response, forNavigation))
         return ResourceError { errorDomainWebKitInternal, 0, requestURL, makeString("Cancelled load to ", response.url().stringCenterEllipsizedToLength(), " because it violates the resource's Cross-Origin-Resource-Policy response header."), ResourceError::Type::AccessControl };

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -45,6 +45,7 @@ class HTTPHeaderMap;
 class ResourceError;
 class ResourceRequest;
 class ResourceResponse;
+class ScopedURL;
 class SecurityOrigin;
 
 struct ResourceLoaderOptions;
@@ -88,7 +89,7 @@ WEBCORE_EXPORT Expected<void, String> passesAccessControlCheck(const ResourceRes
 WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin&, const CrossOriginAccessControlCheckDisabler*);
 
 enum class ForNavigation : bool { No, Yes };
-WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const URL&, const ResourceResponse&, ForNavigation);
+WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const ScopedURL&, const ResourceResponse&, ForNavigation);
 std::optional<ResourceError> validateRangeRequestedFlag(const ResourceRequest&, const ResourceResponse&);
 String validateCrossOriginRedirectionURL(const URL&);
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2491,7 +2491,7 @@ ResourceError DocumentLoader::contentFilterDidBlock(ContentFilterUnblockHandler 
     return handleContentFilterDidBlock(unblockHandler, WTFMove(unblockRequestDeniedScript));
 }
 
-void DocumentLoader::handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, SubstituteData& substituteData)
+void DocumentLoader::handleProvisionalLoadFailureFromContentFilter(const ScopedURL& blockedPageURL, SubstituteData& substituteData)
 {
     frameLoader()->load(FrameLoadRequest(*frame(), blockedPageURL, substituteData));
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -530,7 +530,7 @@ private:
     WEBCORE_EXPORT void dataReceivedThroughContentFilter(const SharedBuffer&, size_t) final;
     WEBCORE_EXPORT ResourceError contentFilterDidBlock(ContentFilterUnblockHandler, String&& unblockRequestDeniedScript) final;
     WEBCORE_EXPORT void cancelMainResourceLoadForContentFilter(const ResourceError&) final;
-    WEBCORE_EXPORT void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, SubstituteData&) final;
+    WEBCORE_EXPORT void handleProvisionalLoadFailureFromContentFilter(const ScopedURL& blockedPageURL, SubstituteData&) final;
 #endif
 
     void dataReceived(const SharedBuffer&);

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -300,7 +300,7 @@ public:
 
     void loadProgressingStatusChanged();
 
-    const URL& previousURL() const { return m_previousURL; }
+    const ScopedURL& previousURL() const { return m_previousURL; }
 
     WEBCORE_EXPORT void completePageTransitionIfNeeded();
 
@@ -507,7 +507,7 @@ private:
 
     bool m_checkingLoadCompleteForDetachment { false };
 
-    URL m_previousURL;
+    ScopedURL m_previousURL;
     RefPtr<HistoryItem> m_requestedHistoryItem;
 
     bool m_alwaysAllowLocalWebarchive { false };

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -291,7 +291,7 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
     if (!type)
         return nullptr;
 
-    URL url;
+    ScopedURL url;
     if (document.settings().linkPreloadResponsiveImagesEnabled() && type == CachedResource::Type::ImageResource && !params.imageSrcSet.isEmpty()) {
         auto sourceSize = SizesAttributeParser(params.imageSizes, document).length();
         auto candidate = bestFitSourceForImageAttributes(document.deviceScaleFactor(), AtomString { params.href.string() }, AtomString { params.imageSrcSet }, sourceSize);

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -44,7 +44,7 @@
 namespace WebCore {
 
 // static
-bool MixedContentChecker::isMixedContent(SecurityOrigin& securityOrigin, const URL& url)
+bool MixedContentChecker::isMixedContent(SecurityOrigin& securityOrigin, const ScopedURL& url)
 {
     if (securityOrigin.protocol() != "https"_s)
         return false; // We only care about HTTPS security origins.

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class Frame;
 class FrameLoaderClient;
+class ScopedURL;
 class SecurityOrigin;
 
 class MixedContentChecker {
@@ -57,7 +58,7 @@ public:
     static bool canDisplayInsecureContent(Frame&, SecurityOrigin&, ContentType, const URL&, AlwaysDisplayInNonStrictMode = AlwaysDisplayInNonStrictMode::No);
     static bool canRunInsecureContent(Frame&, SecurityOrigin&, const URL&);
     static void checkFormForMixedContent(Frame&, SecurityOrigin&, const URL&);
-    static bool isMixedContent(SecurityOrigin&, const URL&);
+    static bool isMixedContent(SecurityOrigin&, const ScopedURL&);
     static std::optional<String> checkForMixedContentInFrameTree(const Frame&, const URL&);
 };
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-ApplicationCacheGroup::ApplicationCacheGroup(Ref<ApplicationCacheStorage>&& storage, const URL& manifestURL)
+ApplicationCacheGroup::ApplicationCacheGroup(Ref<ApplicationCacheStorage>&& storage, const ScopedURL& manifestURL)
     : m_storage(WTFMove(storage))
     , m_manifestURL(manifestURL)
     , m_origin(SecurityOrigin::create(manifestURL))
@@ -461,7 +461,7 @@ void ApplicationCacheGroup::update(Frame& frame, ApplicationCacheUpdateOption up
     });
 }
 
-ResourceRequest ApplicationCacheGroup::createRequest(URL&& url, ApplicationCacheResource* resource)
+ResourceRequest ApplicationCacheGroup::createRequest(ScopedURL&& url, ApplicationCacheResource* resource)
 {
     ResourceRequest request { WTFMove(url) };
     request.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
@@ -27,6 +27,7 @@
 
 #include "ApplicationCacheResourceLoader.h"
 #include "DOMApplicationCache.h"
+#include "ScopedURL.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -53,7 +54,7 @@ class ApplicationCacheGroup : public CanMakeWeakPtr<ApplicationCacheGroup> {
     WTF_MAKE_NONCOPYABLE(ApplicationCacheGroup);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit ApplicationCacheGroup(Ref<ApplicationCacheStorage>&&, const URL& manifestURL);
+    explicit ApplicationCacheGroup(Ref<ApplicationCacheStorage>&&, const ScopedURL& manifestURL);
     virtual ~ApplicationCacheGroup();
     
     enum UpdateStatus { Idle, Checking, Downloading };
@@ -65,7 +66,7 @@ public:
     static void selectCacheWithoutManifestURL(Frame&);
 
     ApplicationCacheStorage& storage() { return m_storage; }
-    const URL& manifestURL() const { return m_manifestURL; }
+    const ScopedURL& manifestURL() const { return m_manifestURL; }
     const SecurityOrigin& origin() const { return m_origin.get(); }
     UpdateStatus updateStatus() const { return m_updateStatus; }
     void setUpdateStatus(UpdateStatus status);
@@ -124,11 +125,11 @@ private:
     
     void stopLoading();
 
-    ResourceRequest createRequest(URL&&, ApplicationCacheResource*);
+    ResourceRequest createRequest(ScopedURL&&, ApplicationCacheResource*);
 
     Ref<ApplicationCacheStorage> m_storage;
 
-    URL m_manifestURL;
+    ScopedURL m_manifestURL;
     Ref<SecurityOrigin> m_origin;
     UpdateStatus m_updateStatus { Idle };
     

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -91,7 +91,7 @@ static unsigned urlHostHash(const URL& url)
     return AlreadyHashed::avoidDeletedValue(StringHasher::computeHashAndMaskTop8Bits(host.characters16(), host.length()));
 }
 
-ApplicationCacheGroup* ApplicationCacheStorage::loadCacheGroup(const URL& manifestURL)
+ApplicationCacheGroup* ApplicationCacheStorage::loadCacheGroup(const ScopedURL& manifestURL)
 {
     SQLiteTransactionInProgressAutoCounter transactionCounter;
 
@@ -126,7 +126,7 @@ ApplicationCacheGroup* ApplicationCacheStorage::loadCacheGroup(const URL& manife
     return &group;
 }    
 
-ApplicationCacheGroup* ApplicationCacheStorage::findOrCreateCacheGroup(const URL& manifestURL)
+ApplicationCacheGroup* ApplicationCacheStorage::findOrCreateCacheGroup(const ScopedURL& manifestURL)
 {
     ASSERT(!manifestURL.hasFragmentIdentifier());
 
@@ -180,7 +180,7 @@ void ApplicationCacheStorage::loadManifestHostHashes()
         m_cacheHostSet.add(static_cast<unsigned>(statement->columnInt64(0)));
 }    
 
-ApplicationCacheGroup* ApplicationCacheStorage::cacheGroupForURL(const URL& url)
+ApplicationCacheGroup* ApplicationCacheStorage::cacheGroupForURL(const ScopedURL& url)
 {
     ASSERT(!url.hasFragmentIdentifier());
     
@@ -254,7 +254,7 @@ ApplicationCacheGroup* ApplicationCacheStorage::cacheGroupForURL(const URL& url)
     return nullptr;
 }
 
-ApplicationCacheGroup* ApplicationCacheStorage::fallbackCacheGroupForURL(const URL& url)
+ApplicationCacheGroup* ApplicationCacheStorage::fallbackCacheGroupForURL(const ScopedURL& url)
 {
     SQLiteTransactionInProgressAutoCounter transactionCounter;
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
@@ -70,10 +70,10 @@ public:
     WEBCORE_EXPORT bool storeUpdatedQuotaForOrigin(const SecurityOrigin*, int64_t quota);
     bool checkOriginQuota(ApplicationCacheGroup*, ApplicationCache* oldCache, ApplicationCache* newCache, int64_t& totalSpaceNeeded);
 
-    ApplicationCacheGroup* cacheGroupForURL(const URL&); // Cache to load a main resource from.
-    ApplicationCacheGroup* fallbackCacheGroupForURL(const URL&); // Cache that has a fallback entry to load a main resource from if normal loading fails.
+    ApplicationCacheGroup* cacheGroupForURL(const ScopedURL&); // Cache to load a main resource from.
+    ApplicationCacheGroup* fallbackCacheGroupForURL(const ScopedURL&); // Cache that has a fallback entry to load a main resource from if normal loading fails.
 
-    ApplicationCacheGroup* findOrCreateCacheGroup(const URL& manifestURL);
+    ApplicationCacheGroup* findOrCreateCacheGroup(const ScopedURL& manifestURL);
     void cacheGroupDestroyed(ApplicationCacheGroup&);
     void cacheGroupMadeObsolete(ApplicationCacheGroup&);
 
@@ -106,7 +106,7 @@ private:
     WEBCORE_EXPORT ApplicationCacheStorage(const String& cacheDirectory, const String& flatFileSubdirectoryName);
 
     RefPtr<ApplicationCache> loadCache(unsigned storageID);
-    ApplicationCacheGroup* loadCacheGroup(const URL& manifestURL);
+    ApplicationCacheGroup* loadCacheGroup(const ScopedURL& manifestURL);
     std::optional<Vector<URL>> manifestURLs();
     ApplicationCacheGroup* findInMemoryCacheGroup(const URL& manifestURL) const;
     bool deleteCacheGroup(const String& manifestURL);

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -76,7 +76,7 @@ CachedImage::CachedImage(Image* image, PAL::SessionID sessionID, const CookieJar
 {
 }
 
-CachedImage::CachedImage(const URL& url, Image* image, PAL::SessionID sessionID, const CookieJar* cookieJar, const String& domainForCachePartition)
+CachedImage::CachedImage(const ScopedURL& url, Image* image, PAL::SessionID sessionID, const CookieJar* cookieJar, const String& domainForCachePartition)
     : CachedResource(url, Type::ImageResource, sessionID, cookieJar)
     , m_image(image)
     , m_updateImageDataCount(0)

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -40,6 +40,7 @@ class FloatSize;
 class MemoryCache;
 class RenderElement;
 class RenderObject;
+class ScopedURL;
 class SecurityOrigin;
 
 struct Length;
@@ -51,7 +52,7 @@ public:
     CachedImage(CachedResourceRequest&&, PAL::SessionID, const CookieJar*);
     CachedImage(Image*, PAL::SessionID, const CookieJar*);
     // Constructor to use for manually cached images.
-    CachedImage(const URL&, Image*, PAL::SessionID, const CookieJar*, const String& domainForCachePartition);
+    CachedImage(const ScopedURL&, Image*, PAL::SessionID, const CookieJar*, const String& domainForCachePartition);
     virtual ~CachedImage();
 
     WEBCORE_EXPORT Image* image() const; // Returns the nullImage() if the image is not available yet.

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -121,7 +121,7 @@ CachedResource::CachedResource(CachedResourceRequest&& request, Type type, PAL::
 }
 
 // FIXME: For this constructor, we should probably mandate that the URL has no fragment identifier.
-CachedResource::CachedResource(const URL& url, Type type, PAL::SessionID sessionID, const CookieJar* cookieJar)
+CachedResource::CachedResource(const ScopedURL& url, Type type, PAL::SessionID sessionID, const CookieJar* cookieJar)
     : m_resourceRequest(url)
     , m_decodedDataDeletionTimer(*this, &CachedResource::destroyDecodedData, deadDecodedDataDeletionIntervalForResourceType(type))
     , m_sessionID(sessionID)

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -303,7 +303,7 @@ public:
 
 protected:
     // CachedResource constructor that may be used when the CachedResource can already be filled with response data.
-    CachedResource(const URL&, Type, PAL::SessionID, const CookieJar*);
+    CachedResource(const ScopedURL&, Type, PAL::SessionID, const CookieJar*);
 
     void setEncodedSize(unsigned);
     void setDecodedSize(unsigned);

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -275,7 +275,7 @@ void CachedResourceRequest::updateUserAgentHeader(FrameLoader& frameLoader)
     frameLoader.applyUserAgentIfNeeded(m_resourceRequest);
 }
 
-bool isRequestCrossOrigin(SecurityOrigin* origin, const URL& requestURL, const ResourceLoaderOptions& options)
+bool isRequestCrossOrigin(SecurityOrigin* origin, const ScopedURL& requestURL, const ResourceLoaderOptions& options)
 {
     if (!origin)
         return false;

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -41,10 +41,11 @@ struct ContentRuleListResults;
 class Document;
 class FrameLoader;
 class Page;
+class ScopedURL;
 struct ServiceWorkerRegistrationData;
 enum class ReferrerPolicy : uint8_t;
 
-bool isRequestCrossOrigin(SecurityOrigin*, const URL& requestURL, const ResourceLoaderOptions&);
+bool isRequestCrossOrigin(SecurityOrigin*, const ScopedURL& requestURL, const ResourceLoaderOptions&);
 
 class CachedResourceRequest {
 public:

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -43,7 +43,7 @@
 
 namespace WebCore {
 
-IconLoader::IconLoader(DocumentLoader& documentLoader, const URL& url)
+IconLoader::IconLoader(DocumentLoader& documentLoader, const ScopedURL& url)
     : m_documentLoader(documentLoader)
     , m_url(url)
 {

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -27,9 +27,9 @@
 
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
+#include "ScopedURL.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/URL.h>
 
 namespace WebCore {
 
@@ -40,7 +40,7 @@ class Frame;
 class IconLoader final : private CachedRawResourceClient {
     WTF_MAKE_NONCOPYABLE(IconLoader); WTF_MAKE_FAST_ALLOCATED;
 public:
-    IconLoader(DocumentLoader&, const URL&);
+    IconLoader(DocumentLoader&, const ScopedURL&);
     virtual ~IconLoader();
 
     void startLoading();
@@ -50,7 +50,7 @@ private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
 
     DocumentLoader& m_documentLoader;
-    URL m_url;
+    ScopedURL m_url;
     CachedResourceHandle<CachedRawResource> m_resource;
 };
 

--- a/Source/WebCore/page/ScopedURL.h
+++ b/Source/WebCore/page/ScopedURL.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SecurityOrigin.h"
+#include <wtf/HashTraits.h>
+#include <wtf/Hasher.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/URL.h>
+
+namespace WebCore {
+
+class ScopedURL : public URL {
+public:
+    ScopedURL(URL&& url)
+        : ScopedURL { WTFMove(url), SecurityOrigin::emptyOrigin() } { }
+    ScopedURL(String&& url)
+        : ScopedURL { url } { }
+    ScopedURL(const URL& url)
+        : ScopedURL { URL { url } } { }
+    ScopedURL(const URL& base, const String& relative, const WTF::URLTextEncoding* encoding = nullptr)
+        : ScopedURL { URL { base, relative, encoding } } { }
+    explicit ScopedURL(const String& absoluteURL, const WTF::URLTextEncoding* encoding = nullptr)
+        : ScopedURL { URL { absoluteURL, encoding } } { }
+    ScopedURL()
+        : ScopedURL { URL { } } { }
+
+    bool operator==(const ScopedURL&) const;
+    bool operator==(const URL&) const;
+
+#if USE(CF)
+    ScopedURL(CFURLRef cfURL)
+        : ScopedURL { URL { cfURL } } { }
+    RetainPtr<CFURLRef> createCFURL() const { return URL::createCFURL(); }
+
+#endif
+
+#if USE(FOUNDATION)
+    ScopedURL(NSURL *cocoaURL)
+        : ScopedURL { URL { cocoaURL } } { }
+    operator NSURL *() const { return URL::operator NSURL *(); }
+#endif
+
+#if USE(GLIB) && HAVE(GURI)
+    ScopedURL(GUri* gURI) : ScopedURL { URL { gURI } } { };
+    GRefPtr<GUri> createGUri() const { return URL::createGUri(); }
+#endif
+
+    ScopedURL isolatedCopy() const & { return { URL::isolatedCopy(), m_topOrigin->isolatedCopy() }; }
+    ScopedURL isolatedCopy() && { return { WTFMove(static_cast<URL&>(*this)).isolatedCopy(), m_topOrigin->isolatedCopy() }; }
+
+    String toString() const { return String { string() + ":"_s + m_topOrigin->toString() }; }
+
+    URL& asURL() { return *this; }
+    const URL& asURL() const { return *this; }
+
+    Ref<SecurityOrigin> topOrigin() const { return m_topOrigin; }
+
+private:
+
+    ScopedURL(URL&& url, Ref<SecurityOrigin> topOrigin)
+        : URL { WTFMove(url) }, m_topOrigin { topOrigin } { }
+    Ref<SecurityOrigin> m_topOrigin;
+};
+
+inline void add(Hasher& hasher, const ScopedURL& url)
+{
+    add(hasher, url.string(), url.topOrigin());
+}
+
+inline bool ScopedURL::operator==(const URL& other) const
+{
+    return asURL() == other;
+}
+
+inline bool ScopedURL::operator==(const ScopedURL& other) const
+{
+    return asURL() == other.asURL() && m_topOrigin == other.m_topOrigin;
+}
+
+struct ScopedURLKeyHash {
+    static unsigned hash(const WebCore::ScopedURL& key) { return computeHash(key); }
+    static bool equal(const WebCore::ScopedURL& a, const WebCore::ScopedURL& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = false;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+
+template<> struct HashTraits<WebCore::ScopedURL> : GenericHashTraits<WebCore::ScopedURL> {
+    static WebCore::ScopedURL emptyValue() { return { }; }
+    static void constructDeletedValue(WebCore::ScopedURL& slot)
+    {
+        new (NotNull, static_cast<URL*>(&slot)) URL(WTF::HashTableDeletedValue);
+    }
+
+    static bool isDeletedValue(const WebCore::ScopedURL& slot) { return slot.isHashTableDeletedValue(); }
+};
+
+template<> struct DefaultHash<WebCore::ScopedURL> : WebCore::ScopedURLKeyHash { };
+
+} // namespace WTF

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -38,6 +38,8 @@
 
 namespace WebCore {
 
+class ScopedURL;
+
 class SecurityOrigin : public ThreadSafeRefCounted<SecurityOrigin> {
 public:
     enum Policy {
@@ -46,7 +48,7 @@ public:
         Ask
     };
 
-    WEBCORE_EXPORT static Ref<SecurityOrigin> create(const URL&);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> create(const ScopedURL&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> createOpaque();
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> createFromString(const String&);
@@ -56,7 +58,7 @@ public:
     // be allowed to display their own file: URLs in order to perform reloads and same-document
     // navigations. This lets those documents specify the file path that should be allowed to be
     // displayed from their non-local origin.
-    static Ref<SecurityOrigin> createNonLocalWithAllowedFilePath(const URL&, const String& filePath);
+    static Ref<SecurityOrigin> createNonLocalWithAllowedFilePath(const ScopedURL&, const String& filePath);
 
     // Some URL schemes use nested URLs for their security context. For example,
     // filesystem URLs look like the following:
@@ -91,7 +93,7 @@ public:
     // Returns true if a given URL is secure, based either directly on its
     // own protocol, or, when relevant, on the protocol of its "inner URL"
     // Protocols like blob: and filesystem: fall into this latter category.
-    WEBCORE_EXPORT static bool isSecure(const URL&);
+    WEBCORE_EXPORT static bool isSecure(const ScopedURL&);
 
     // This method implements the "same origin-domain" algorithm from the HTML Standard:
     // https://html.spec.whatwg.org/#same-origin-domain
@@ -104,7 +106,7 @@ public:
     // Returns true if this SecurityOrigin can read content retrieved from
     // the given URL. For example, call this function before issuing
     // XMLHttpRequests.
-    WEBCORE_EXPORT bool canRequest(const URL&) const;
+    WEBCORE_EXPORT bool canRequest(const ScopedURL&) const;
 
     // Returns true if this SecurityOrigin can receive drag content from the
     // initiator. For example, call this function before allowing content to be
@@ -114,7 +116,7 @@ public:
     // Returns true if |document| can display content from the given URL (e.g.,
     // in an iframe or as an image). For example, web sites generally cannot
     // display content from the user's files system.
-    WEBCORE_EXPORT bool canDisplay(const URL&) const;
+    WEBCORE_EXPORT bool canDisplay(const ScopedURL&) const;
 
     // Returns true if this SecurityOrigin can load local resources, such
     // as images, iframes, and style sheets, and can link to local URLs.
@@ -215,10 +217,11 @@ public:
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static RefPtr<SecurityOrigin> decode(Decoder&);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> emptyOrigin();
 
 private:
     WEBCORE_EXPORT SecurityOrigin();
-    explicit SecurityOrigin(const URL&);
+    explicit SecurityOrigin(const ScopedURL&);
     explicit SecurityOrigin(const SecurityOrigin*);
 
     // FIXME: Rename this function to something more semantic.
@@ -306,5 +309,8 @@ inline void add(Hasher& hasher, const SecurityOrigin& origin)
 {
     add(hasher, origin.protocol(), origin.host(), origin.port());
 }
+
+static bool operator==(const SecurityOrigin& a, const SecurityOrigin& b) { return a.equal(&b); }
+inline bool operator!=(const SecurityOrigin& first, const SecurityOrigin& second) { return !(first == second); }
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -89,7 +89,7 @@ String SecurityPolicy::referrerToOriginString(const String& referrer)
     return originString + "/";
 }
 
-String SecurityPolicy::generateReferrerHeader(ReferrerPolicy referrerPolicy, const URL& url, const String& referrer)
+String SecurityPolicy::generateReferrerHeader(ReferrerPolicy referrerPolicy, const ScopedURL& url, const String& referrer)
 {
     ASSERT(referrer == URL { referrer }.strippedForUseAsReferrer()
         || referrer == SecurityOrigin::create(URL { referrer })->toString());
@@ -142,7 +142,7 @@ String SecurityPolicy::generateReferrerHeader(ReferrerPolicy referrerPolicy, con
     return shouldHideReferrer(url, referrer) ? String() : referrer;
 }
 
-String SecurityPolicy::generateOriginHeader(ReferrerPolicy referrerPolicy, const URL& url, const SecurityOrigin& securityOrigin)
+String SecurityPolicy::generateOriginHeader(ReferrerPolicy referrerPolicy, const ScopedURL& url, const SecurityOrigin& securityOrigin)
 {
     switch (referrerPolicy) {
     case ReferrerPolicy::NoReferrer:
@@ -202,7 +202,7 @@ bool SecurityPolicy::allowSubstituteDataAccessToLocal()
     return localLoadPolicy != SecurityPolicy::AllowLocalLoadsForLocalOnly;
 }
 
-bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const SecurityOrigin& targetOrigin, const URL& targetURL)
+bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const SecurityOrigin& targetOrigin, const ScopedURL& targetURL)
 {
     ASSERT(targetOrigin.equal(SecurityOrigin::create(targetURL).ptr()));
     {
@@ -222,7 +222,7 @@ bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const S
     return false;
 }
 
-bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const URL& url)
+bool SecurityPolicy::isAccessAllowed(const SecurityOrigin& activeOrigin, const ScopedURL& url)
 {
     return isAccessAllowed(activeOrigin, SecurityOrigin::create(url).get(), url);
 }

--- a/Source/WebCore/page/SecurityPolicy.h
+++ b/Source/WebCore/page/SecurityPolicy.h
@@ -49,9 +49,9 @@ public:
     // Returns the referrer modified according to the referrer policy for a
     // navigation to a given URL. If the referrer returned is empty, the
     // referrer header should be omitted.
-    WEBCORE_EXPORT static String generateReferrerHeader(ReferrerPolicy, const URL&, const String& referrer);
+    WEBCORE_EXPORT static String generateReferrerHeader(ReferrerPolicy, const ScopedURL&, const String& referrer);
 
-    static String generateOriginHeader(ReferrerPolicy, const URL&, const SecurityOrigin&);
+    static String generateOriginHeader(ReferrerPolicy, const ScopedURL&, const SecurityOrigin&);
 
     static bool shouldInheritSecurityOriginFromOwner(const URL&);
 
@@ -72,8 +72,8 @@ public:
     WEBCORE_EXPORT static void removeOriginAccessAllowlistEntry(const SecurityOrigin& sourceOrigin, const String& destinationProtocol, const String& destinationDomain, bool allowDestinationSubdomains);
     WEBCORE_EXPORT static void resetOriginAccessAllowlists();
 
-    static bool isAccessAllowed(const SecurityOrigin& activeOrigin, const SecurityOrigin& targetOrigin, const URL& targetURL);
-    static bool isAccessAllowed(const SecurityOrigin& activeOrigin, const URL& targetURL);
+    static bool isAccessAllowed(const SecurityOrigin& activeOrigin, const SecurityOrigin& targetOrigin, const ScopedURL& targetURL);
+    static bool isAccessAllowed(const SecurityOrigin& activeOrigin, const ScopedURL& targetURL);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/BlobPart.h
+++ b/Source/WebCore/platform/network/BlobPart.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/URL.h>
+#include "ScopedURL.h"
 
 namespace WebCore {
 
@@ -47,7 +47,7 @@ public:
     {
     }
 
-    BlobPart(const URL& url)
+    BlobPart(const ScopedURL& url)
         : m_type(Type::Blob)
         , m_url(url)
     {
@@ -67,7 +67,7 @@ public:
         return WTFMove(m_data);
     }
 
-    const URL& url() const
+    const ScopedURL& url() const
     {
         ASSERT(m_type == Type::Blob);
         return m_url;
@@ -81,7 +81,7 @@ public:
 private:
     Type m_type;
     Vector<uint8_t> m_data;
-    URL m_url;
+    ScopedURL m_url;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/BlobRegistry.h
+++ b/Source/WebCore/platform/network/BlobRegistry.h
@@ -40,6 +40,7 @@ class BlobDataFileReference;
 class BlobPart;
 class BlobRegistry;
 class BlobRegistryImpl;
+class ScopedURL;
 
 struct PolicyContainer;
 
@@ -50,26 +51,26 @@ class WEBCORE_EXPORT BlobRegistry {
 public:
 
     // Registers a blob URL referring to the specified file.
-    virtual void registerFileBlobURL(const URL&, Ref<BlobDataFileReference>&&, const String& path, const String& contentType) = 0;
+    virtual void registerFileBlobURL(const ScopedURL&, Ref<BlobDataFileReference>&&, const String& path, const String& contentType) = 0;
 
     // Registers a blob URL referring to the specified blob data.
-    virtual void registerBlobURL(const URL&, Vector<BlobPart>&&, const String& contentType) = 0;
+    virtual void registerBlobURL(const ScopedURL&, Vector<BlobPart>&&, const String& contentType) = 0;
     
     // Registers a new blob URL referring to the blob data identified by the specified srcURL.
-    virtual void registerBlobURL(const URL&, const URL& srcURL, const PolicyContainer&) = 0;
+    virtual void registerBlobURL(const ScopedURL&, const ScopedURL& srcURL, const PolicyContainer&) = 0;
 
     // Registers a new blob URL referring to the blob data identified by the specified srcURL or, if none found, referring to the file found at the given path.
-    virtual void registerBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, RefPtr<BlobDataFileReference>&&, const String& contentType) = 0;
+    virtual void registerBlobURLOptionallyFileBacked(const ScopedURL&, const ScopedURL& srcURL, RefPtr<BlobDataFileReference>&&, const String& contentType) = 0;
 
     // Negative start and end values select from the end.
-    virtual void registerBlobURLForSlice(const URL&, const URL& srcURL, long long start, long long end, const String& contentType) = 0;
+    virtual void registerBlobURLForSlice(const ScopedURL&, const ScopedURL& srcURL, long long start, long long end, const String& contentType) = 0;
 
-    virtual void unregisterBlobURL(const URL&) = 0;
+    virtual void unregisterBlobURL(const ScopedURL&) = 0;
 
-    virtual void registerBlobURLHandle(const URL&) = 0;
-    virtual void unregisterBlobURLHandle(const URL&) = 0;
+    virtual void registerBlobURLHandle(const ScopedURL&) = 0;
+    virtual void unregisterBlobURLHandle(const ScopedURL&) = 0;
 
-    virtual unsigned long long blobSize(const URL&) = 0;
+    virtual unsigned long long blobSize(const ScopedURL&) = 0;
 
     virtual void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&) = 0;
 

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -110,7 +110,7 @@ void BlobRegistryImpl::appendStorageItems(BlobData* blobData, const BlobDataItem
     ASSERT(!length);
 }
 
-void BlobRegistryImpl::registerFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& file, const String& contentType)
+void BlobRegistryImpl::registerFileBlobURL(const ScopedURL& url, Ref<BlobDataFileReference>&& file, const String& contentType)
 {
     ASSERT(isMainThread());
     registerBlobResourceHandleConstructor();
@@ -156,7 +156,7 @@ Ref<DataSegment> BlobRegistryImpl::createDataSegment(Vector<uint8_t>&& movedData
     return data;
 }
 
-void BlobRegistryImpl::registerBlobURL(const URL& url, Vector<BlobPart>&& blobParts, const String& contentType)
+void BlobRegistryImpl::registerBlobURL(const ScopedURL& url, Vector<BlobPart>&& blobParts, const String& contentType)
 {
     ASSERT(isMainThread());
     registerBlobResourceHandleConstructor();
@@ -186,12 +186,12 @@ void BlobRegistryImpl::registerBlobURL(const URL& url, Vector<BlobPart>&& blobPa
     addBlobData(url.string(), WTFMove(blobData));
 }
 
-void BlobRegistryImpl::registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer)
+void BlobRegistryImpl::registerBlobURL(const ScopedURL& url, const ScopedURL& srcURL, const PolicyContainer& policyContainer)
 {
     registerBlobURLOptionallyFileBacked(url, srcURL, nullptr, { }, policyContainer);
 }
 
-void BlobRegistryImpl::registerBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<BlobDataFileReference>&& file, const String& contentType, const PolicyContainer& policyContainer)
+void BlobRegistryImpl::registerBlobURLOptionallyFileBacked(const ScopedURL& url, const ScopedURL& srcURL, RefPtr<BlobDataFileReference>&& file, const String& contentType, const PolicyContainer& policyContainer)
 {
     ASSERT(isMainThread());
     registerBlobResourceHandleConstructor();
@@ -218,7 +218,7 @@ void BlobRegistryImpl::registerBlobURLOptionallyFileBacked(const URL& url, const
     addBlobData(url.string(), WTFMove(backingFile));
 }
 
-void BlobRegistryImpl::registerBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType)
+void BlobRegistryImpl::registerBlobURLForSlice(const ScopedURL& url, const ScopedURL& srcURL, long long start, long long end, const String& contentType)
 {
     ASSERT(isMainThread());
     BlobData* originalData = getBlobDataFromURL(srcURL);
@@ -254,14 +254,14 @@ void BlobRegistryImpl::registerBlobURLForSlice(const URL& url, const URL& srcURL
     addBlobData(url.string(), WTFMove(newData));
 }
 
-void BlobRegistryImpl::unregisterBlobURL(const URL& url)
+void BlobRegistryImpl::unregisterBlobURL(const ScopedURL& url)
 {
     ASSERT(isMainThread());
     if (m_blobReferences.remove(url.string()))
         m_blobs.remove(url.string());
 }
 
-BlobData* BlobRegistryImpl::getBlobDataFromURL(const URL& url) const
+BlobData* BlobRegistryImpl::getBlobDataFromURL(const ScopedURL& url) const
 {
     ASSERT(isMainThread());
     if (url.hasFragmentIdentifier())
@@ -269,7 +269,7 @@ BlobData* BlobRegistryImpl::getBlobDataFromURL(const URL& url) const
     return m_blobs.get(url.string());
 }
 
-unsigned long long BlobRegistryImpl::blobSize(const URL& url)
+unsigned long long BlobRegistryImpl::blobSize(const ScopedURL& url)
 {
     ASSERT(isMainThread());
     BlobData* data = getBlobDataFromURL(url);
@@ -370,7 +370,7 @@ void BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB(const Vector<Strin
     });
 }
 
-void BlobRegistryImpl::writeBlobToFilePath(const URL& blobURL, const String& path, Function<void(bool success)>&& completionHandler)
+void BlobRegistryImpl::writeBlobToFilePath(const ScopedURL& blobURL, const String& path, Function<void(bool success)>&& completionHandler)
 {
     Vector<BlobForFileWriting> blobsForWriting;
     if (!populateBlobsForFileWriting({ blobURL.string() }, blobsForWriting) || blobsForWriting.size() != 1) {
@@ -386,7 +386,7 @@ void BlobRegistryImpl::writeBlobToFilePath(const URL& blobURL, const String& pat
     });
 }
 
-Vector<RefPtr<BlobDataFileReference>> BlobRegistryImpl::filesInBlob(const URL& url) const
+Vector<RefPtr<BlobDataFileReference>> BlobRegistryImpl::filesInBlob(const ScopedURL& url) const
 {
     auto* blobData = getBlobDataFromURL(url);
     if (!blobData)
@@ -408,14 +408,14 @@ void BlobRegistryImpl::addBlobData(const String& url, RefPtr<BlobData>&& blobDat
         m_blobReferences.add(url);
 }
 
-void BlobRegistryImpl::registerBlobURLHandle(const URL& url)
+void BlobRegistryImpl::registerBlobURLHandle(const ScopedURL& url)
 {
     auto urlKey = url.stringWithoutFragmentIdentifier();
     if (m_blobs.contains(urlKey))
         m_blobReferences.add(urlKey);
 }
 
-void BlobRegistryImpl::unregisterBlobURLHandle(const URL& url)
+void BlobRegistryImpl::unregisterBlobURLHandle(const ScopedURL& url)
 {
     auto urlKey = url.stringWithoutFragmentIdentifier();
     if (m_blobReferences.remove(urlKey))

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -44,6 +44,7 @@ namespace WebCore {
 class ResourceHandle;
 class ResourceHandleClient;
 class ResourceRequest;
+class ScopedURL;
 class ThreadSafeDataBuffer;
 struct PolicyContainer;
 
@@ -53,24 +54,24 @@ class WEBCORE_EXPORT BlobRegistryImpl {
 public:
     virtual ~BlobRegistryImpl();
 
-    BlobData* getBlobDataFromURL(const URL&) const;
+    BlobData* getBlobDataFromURL(const ScopedURL&) const;
 
     Ref<ResourceHandle> createResourceHandle(const ResourceRequest&, ResourceHandleClient*);
-    void writeBlobToFilePath(const URL& blobURL, const String& path, Function<void(bool success)>&& completionHandler);
+    void writeBlobToFilePath(const ScopedURL& blobURL, const String& path, Function<void(bool success)>&& completionHandler);
 
     void appendStorageItems(BlobData*, const BlobDataItemList&, long long offset, long long length);
 
-    void registerFileBlobURL(const URL&, Ref<BlobDataFileReference>&&, const String& contentType);
-    void registerBlobURL(const URL&, Vector<BlobPart>&&, const String& contentType);
-    void registerBlobURL(const URL&, const URL& srcURL, const PolicyContainer&);
-    void registerBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, RefPtr<BlobDataFileReference>&&, const String& contentType, const PolicyContainer&);
-    void registerBlobURLForSlice(const URL&, const URL& srcURL, long long start, long long end, const String& contentType);
-    void unregisterBlobURL(const URL&);
+    void registerFileBlobURL(const ScopedURL&, Ref<BlobDataFileReference>&&, const String& contentType);
+    void registerBlobURL(const ScopedURL&, Vector<BlobPart>&&, const String& contentType);
+    void registerBlobURL(const ScopedURL&, const ScopedURL& srcURL, const PolicyContainer&);
+    void registerBlobURLOptionallyFileBacked(const ScopedURL&, const ScopedURL& srcURL, RefPtr<BlobDataFileReference>&&, const String& contentType, const PolicyContainer&);
+    void registerBlobURLForSlice(const ScopedURL&, const ScopedURL& srcURL, long long start, long long end, const String& contentType);
+    void unregisterBlobURL(const ScopedURL&);
 
-    void registerBlobURLHandle(const URL&);
-    void unregisterBlobURLHandle(const URL&);
+    void registerBlobURLHandle(const ScopedURL&);
+    void unregisterBlobURLHandle(const ScopedURL&);
 
-    unsigned long long blobSize(const URL&);
+    unsigned long long blobSize(const ScopedURL&);
 
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&);
 
@@ -80,7 +81,7 @@ public:
     };
 
     bool populateBlobsForFileWriting(const Vector<String>& blobURLs, Vector<BlobForFileWriting>&);
-    Vector<RefPtr<BlobDataFileReference>> filesInBlob(const URL&) const;
+    Vector<RefPtr<BlobDataFileReference>> filesInBlob(const ScopedURL&) const;
 
     void setFileDirectory(String&&);
 

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -128,7 +128,7 @@ unsigned FormData::imageOrMediaFilesCount() const
     return imageOrMediaFilesCount;
 }
 
-uint64_t FormDataElement::lengthInBytes(const Function<uint64_t(const URL&)>& blobSize) const
+uint64_t FormDataElement::lengthInBytes(const Function<uint64_t(const ScopedURL&)>& blobSize) const
 {
     return WTF::switchOn(data,
         [] (const Vector<uint8_t>& bytes) {
@@ -187,7 +187,7 @@ void FormData::appendFileRange(const String& filename, long long start, long lon
     m_lengthInBytes = std::nullopt;
 }
 
-void FormData::appendBlob(const URL& blobURL)
+void FormData::appendBlob(const ScopedURL& blobURL)
 {
     m_elements.append(FormDataElement(blobURL));
     m_lengthInBytes = std::nullopt;
@@ -296,7 +296,7 @@ String FormData::flattenToString() const
     return PAL::Latin1Encoding().decode(bytes.data(), bytes.size());
 }
 
-static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formData, const URL& url)
+static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formData, const ScopedURL& url)
 {
     if (!blobRegistry) {
         LOG_ERROR("Tried to resolve a blob without a usable registry");

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "BlobData.h"
+#include "ScopedURL.h"
 #include <variant>
 #include <wtf/Forward.h>
 #include <wtf/IsoMalloc.h>
@@ -51,10 +52,10 @@ struct FormDataElement {
         : data(WTFMove(array)) { }
     FormDataElement(const String& filename, int64_t fileStart, int64_t fileLength, std::optional<WallTime> expectedFileModificationTime)
         : data(EncodedFileData { filename, fileStart, fileLength, expectedFileModificationTime }) { }
-    explicit FormDataElement(const URL& blobURL)
+    explicit FormDataElement(const ScopedURL& blobURL)
         : data(EncodedBlobData { blobURL }) { }
 
-    uint64_t lengthInBytes(const Function<uint64_t(const URL&)>&) const;
+    uint64_t lengthInBytes(const Function<uint64_t(const ScopedURL&)>&) const;
     uint64_t lengthInBytes() const;
 
     FormDataElement isolatedCopy() const;
@@ -82,7 +83,7 @@ struct FormDataElement {
     };
 
     struct EncodedBlobData {
-        URL url;
+        ScopedURL url;
 
         bool operator==(const EncodedBlobData& other) const
         {
@@ -158,7 +159,7 @@ public:
     WEBCORE_EXPORT void appendData(const void* data, size_t);
     void appendFile(const String& filePath);
     WEBCORE_EXPORT void appendFileRange(const String& filename, long long start, long long length, std::optional<WallTime> expectedModificationTime);
-    WEBCORE_EXPORT void appendBlob(const URL& blobURL);
+    WEBCORE_EXPORT void appendBlob(const ScopedURL& blobURL);
 
     WEBCORE_EXPORT Vector<uint8_t> flatten() const; // omits files
     String flattenToString() const; // omits files

--- a/Source/WebCore/platform/network/TimingAllowOrigin.cpp
+++ b/Source/WebCore/platform/network/TimingAllowOrigin.cpp
@@ -28,6 +28,7 @@
 
 #include "HTTPParsers.h"
 #include "ResourceResponse.h"
+#include "ScopedURL.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -32,6 +32,7 @@
 #include "BlobRegistryImpl.h"
 #include "FormData.h"
 #include "PlatformStrategies.h"
+#include "ScopedURL.h"
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <wtf/Assertions.h>

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -32,6 +32,7 @@
 #include "AbstractWorker.h"
 
 #include "ContentSecurityPolicy.h"
+#include "ScopedURL.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "WorkerOptions.h"

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-WorkerFontLoadRequest::WorkerFontLoadRequest(URL&& url, LoadedFromOpaqueSource loadedFromOpaqueSource)
+WorkerFontLoadRequest::WorkerFontLoadRequest(ScopedURL&& url, LoadedFromOpaqueSource loadedFromOpaqueSource)
     : m_url(WTFMove(url))
     , m_loadedFromOpaqueSource(loadedFromOpaqueSource)
 {

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -28,9 +28,9 @@
 
 #include "FontLoadRequest.h"
 #include "ResourceLoaderOptions.h"
+#include "ScopedURL.h"
 #include "SharedBuffer.h"
 #include "ThreadableLoaderClient.h"
-#include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -44,13 +44,13 @@ struct FontCustomPlatformData;
 class WorkerFontLoadRequest : public FontLoadRequest, public ThreadableLoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);
+    WorkerFontLoadRequest(ScopedURL&&, LoadedFromOpaqueSource);
     ~WorkerFontLoadRequest() = default;
 
     void load(WorkerGlobalScope&);
 
 private:
-    const URL& url() const final { return m_url; }
+    const ScopedURL& url() const final { return m_url; }
     bool isPending() const final { return !m_isLoading && !m_errorOccurred && !m_data; }
     bool isLoading() const final { return m_isLoading; }
     bool errorOccurred() const final { return m_errorOccurred; }
@@ -67,7 +67,7 @@ private:
     void didFinishLoading(ResourceLoaderIdentifier, const NetworkLoadMetrics&) final;
     void didFail(const ResourceError&) final;
 
-    URL m_url;
+    ScopedURL m_url;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource;
 
     bool m_isLoading { false };

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -33,6 +33,7 @@
 #include "ResourceError.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
+#include "ScopedURL.h"
 #include "ScriptBuffer.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerRegistrationData.h"
@@ -74,7 +75,7 @@ public:
     const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy() const { return m_contentSecurityPolicy; }
     const String& referrerPolicy() const { return m_referrerPolicy; }
     const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const { return m_crossOriginEmbedderPolicy; }
-    const URL& url() const { return m_url; }
+    const ScopedURL& url() const { return m_url; }
     const URL& responseURL() const;
     ResourceResponse::Source responseSource() const { return m_responseSource; }
     bool isRedirected() const { return m_isRedirected; }
@@ -138,7 +139,7 @@ private:
     RefPtr<ThreadableLoader> m_threadableLoader;
     RefPtr<TextResourceDecoder> m_decoder;
     ScriptBuffer m_script;
-    URL m_url;
+    ScopedURL m_url;
     URL m_responseURL;
     CertificateInfo m_certificateInfo;
     String m_responseMIMEType;

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
@@ -47,7 +47,7 @@ SharedWorkerObjectConnection::SharedWorkerObjectConnection() = default;
 
 SharedWorkerObjectConnection::~SharedWorkerObjectConnection() = default;
 
-void SharedWorkerObjectConnection::fetchScriptInClient(URL&& url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WorkerOptions&& workerOptions, CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&& completionHandler)
+void SharedWorkerObjectConnection::fetchScriptInClient(ScopedURL&& url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WorkerOptions&& workerOptions, CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&& completionHandler)
 {
     ASSERT(isMainThread());
 

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class MessagePort;
 class ResourceError;
+class ScopedURL;
 class SharedWorkerScriptLoader;
 
 struct SharedWorkerKey;
@@ -53,7 +54,7 @@ public:
 
 protected:
     // IPC messages.
-    WEBCORE_EXPORT void fetchScriptInClient(URL&&, WebCore::SharedWorkerObjectIdentifier, WorkerOptions&&, CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
+    WEBCORE_EXPORT void fetchScriptInClient(ScopedURL&&, WebCore::SharedWorkerObjectIdentifier, WorkerOptions&&, CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
     WEBCORE_EXPORT void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const ResourceError&);
     WEBCORE_EXPORT void postExceptionToWorkerObject(SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
 

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-SharedWorkerScriptLoader::SharedWorkerScriptLoader(URL&& url, SharedWorker& worker, WorkerOptions&& options)
+SharedWorkerScriptLoader::SharedWorkerScriptLoader(ScopedURL&& url, SharedWorker& worker, WorkerOptions&& options)
     : m_options(WTFMove(options))
     , m_worker(worker)
     , m_loader(WorkerScriptLoader::create())

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
@@ -28,6 +28,7 @@
 #include "MessagePortIdentifier.h"
 #include "ResourceLoaderIdentifier.h"
 #include "ResourceResponse.h"
+#include "ScopedURL.h"
 #include "WorkerOptions.h"
 #include "WorkerScriptLoaderClient.h"
 #include <wtf/CompletionHandler.h>
@@ -45,7 +46,7 @@ struct WorkerInitializationData;
 class SharedWorkerScriptLoader : private WorkerScriptLoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    SharedWorkerScriptLoader(URL&&, SharedWorker&, WorkerOptions&&);
+    SharedWorkerScriptLoader(ScopedURL&&, SharedWorker&, WorkerOptions&&);
 
     void load(CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
 
@@ -60,7 +61,7 @@ private:
     const WorkerOptions m_options;
     const Ref<SharedWorker> m_worker;
     const Ref<WorkerScriptLoader> m_loader;
-    const URL m_url;
+    const ScopedURL m_url;
     CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)> m_completionHandler;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -895,7 +895,7 @@ void NetworkConnectionToWebProcess::allCookiesDeleted()
 
 #endif
 
-void NetworkConnectionToWebProcess::registerFileBlobURL(const URL& url, const String& path, const String& replacementPath, SandboxExtension::Handle&& extensionHandle, const String& contentType)
+void NetworkConnectionToWebProcess::registerFileBlobURL(const ScopedURL& url, const String& path, const String& replacementPath, SandboxExtension::Handle&& extensionHandle, const String& contentType)
 {
     NETWORK_PROCESS_MESSAGE_CHECK(!url.isEmpty());
 
@@ -907,7 +907,7 @@ void NetworkConnectionToWebProcess::registerFileBlobURL(const URL& url, const St
     session->blobRegistry().registerFileBlobURL(url, BlobDataFileReferenceWithSandboxExtension::create(path, replacementPath, SandboxExtension::create(WTFMove(extensionHandle))), contentType);
 }
 
-void NetworkConnectionToWebProcess::registerBlobURL(const URL& url, Vector<BlobPart>&& blobParts, const String& contentType)
+void NetworkConnectionToWebProcess::registerBlobURL(const ScopedURL& url, Vector<BlobPart>&& blobParts, const String& contentType)
 {
     auto* session = networkSession();
     if (!session)
@@ -917,7 +917,7 @@ void NetworkConnectionToWebProcess::registerBlobURL(const URL& url, Vector<BlobP
     session->blobRegistry().registerBlobURL(url, WTFMove(blobParts), contentType);
 }
 
-void NetworkConnectionToWebProcess::registerBlobURLFromURL(const URL& url, const URL& srcURL, PolicyContainer&& policyContainer)
+void NetworkConnectionToWebProcess::registerBlobURLFromURL(const ScopedURL& url, const ScopedURL& srcURL, PolicyContainer&& policyContainer)
 {
     auto* session = networkSession();
     if (!session)
@@ -927,7 +927,7 @@ void NetworkConnectionToWebProcess::registerBlobURLFromURL(const URL& url, const
     session->blobRegistry().registerBlobURL(url, srcURL, WTFMove(policyContainer));
 }
 
-void NetworkConnectionToWebProcess::registerBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, const String& fileBackedPath, const String& contentType)
+void NetworkConnectionToWebProcess::registerBlobURLOptionallyFileBacked(const ScopedURL& url, const ScopedURL& srcURL, const String& fileBackedPath, const String& contentType)
 {
     NETWORK_PROCESS_MESSAGE_CHECK(!url.isEmpty() && !srcURL.isEmpty() && !fileBackedPath.isEmpty());
 
@@ -939,7 +939,7 @@ void NetworkConnectionToWebProcess::registerBlobURLOptionallyFileBacked(const UR
     session->blobRegistry().registerBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReferenceWithSandboxExtension::create(fileBackedPath), contentType, { });
 }
 
-void NetworkConnectionToWebProcess::registerBlobURLForSlice(const URL& url, const URL& srcURL, int64_t start, int64_t end, const String& contentType)
+void NetworkConnectionToWebProcess::registerBlobURLForSlice(const ScopedURL& url, const ScopedURL& srcURL, int64_t start, int64_t end, const String& contentType)
 {
     auto* session = networkSession();
     if (!session)
@@ -949,7 +949,7 @@ void NetworkConnectionToWebProcess::registerBlobURLForSlice(const URL& url, cons
     session->blobRegistry().registerBlobURLForSlice(url, srcURL, start, end, contentType);
 }
 
-void NetworkConnectionToWebProcess::unregisterBlobURL(const URL& url)
+void NetworkConnectionToWebProcess::unregisterBlobURL(const ScopedURL& url)
 {
     auto* session = networkSession();
     if (!session)
@@ -959,7 +959,7 @@ void NetworkConnectionToWebProcess::unregisterBlobURL(const URL& url)
     session->blobRegistry().unregisterBlobURL(url);
 }
 
-void NetworkConnectionToWebProcess::registerBlobURLHandle(const URL& url)
+void NetworkConnectionToWebProcess::registerBlobURLHandle(const ScopedURL& url)
 {
     auto* session = networkSession();
     if (!session)
@@ -969,7 +969,7 @@ void NetworkConnectionToWebProcess::registerBlobURLHandle(const URL& url)
     session->blobRegistry().registerBlobURLHandle(url);
 }
 
-void NetworkConnectionToWebProcess::unregisterBlobURLHandle(const URL& url)
+void NetworkConnectionToWebProcess::unregisterBlobURLHandle(const ScopedURL& url)
 {
     auto* session = networkSession();
     if (!session)
@@ -979,7 +979,7 @@ void NetworkConnectionToWebProcess::unregisterBlobURLHandle(const URL& url)
     session->blobRegistry().unregisterBlobURLHandle(url);
 }
 
-void NetworkConnectionToWebProcess::blobSize(const URL& url, CompletionHandler<void(uint64_t)>&& completionHandler)
+void NetworkConnectionToWebProcess::blobSize(const ScopedURL& url, CompletionHandler<void(uint64_t)>&& completionHandler)
 {
     auto* session = networkSession();
     completionHandler(session ? session->blobRegistry().blobSize(url) : 0);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -71,6 +71,7 @@ class MockContentFilterSettings;
 enum class NetworkConnectionIntegrity : uint8_t;
 class ResourceError;
 class ResourceRequest;
+class ScopedURL;
 enum class ApplyTrackingPrevention : bool;
 enum class StorageAccessScope : bool;
 struct PolicyContainer;
@@ -245,17 +246,17 @@ private:
     void setRawCookie(const WebCore::Cookie&);
     void deleteCookie(const URL&, const String& cookieName, CompletionHandler<void()>&&);
 
-    void registerFileBlobURL(const URL&, const String& path, const String& replacementPath, SandboxExtension::Handle&&, const String& contentType);
-    void registerBlobURL(const URL&, Vector<WebCore::BlobPart>&&, const String& contentType);
-    void registerBlobURLFromURL(const URL&, const URL& srcURL, WebCore::PolicyContainer&&);
-    void registerBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, const String& fileBackedPath, const String& contentType);
-    void registerBlobURLForSlice(const URL&, const URL& srcURL, int64_t start, int64_t end, const String& contentType);
-    void blobSize(const URL&, CompletionHandler<void(uint64_t)>&&);
-    void unregisterBlobURL(const URL&);
+    void registerFileBlobURL(const WebCore::ScopedURL&, const String& path, const String& replacementPath, SandboxExtension::Handle&&, const String& contentType);
+    void registerBlobURL(const WebCore::ScopedURL&, Vector<WebCore::BlobPart>&&, const String& contentType);
+    void registerBlobURLFromURL(const WebCore::ScopedURL&, const WebCore::ScopedURL& srcURL, WebCore::PolicyContainer&&);
+    void registerBlobURLOptionallyFileBacked(const WebCore::ScopedURL&, const WebCore::ScopedURL& srcURL, const String& fileBackedPath, const String& contentType);
+    void registerBlobURLForSlice(const WebCore::ScopedURL&, const WebCore::ScopedURL& srcURL, int64_t start, int64_t end, const String& contentType);
+    void blobSize(const WebCore::ScopedURL&, CompletionHandler<void(uint64_t)>&&);
+    void unregisterBlobURL(const WebCore::ScopedURL&);
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&&);
 
-    void registerBlobURLHandle(const URL&);
-    void unregisterBlobURLHandle(const URL&);
+    void registerBlobURLHandle(const WebCore::ScopedURL&);
+    void unregisterBlobURLHandle(const WebCore::ScopedURL&);
 
     void setCaptureExtraNetworkLoadMetricsEnabled(bool);
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -48,16 +48,16 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     UnsubscribeFromCookieChangeNotifications(HashSet<String> hosts)
 #endif
 
-    RegisterFileBlobURL(URL url, String path, String replacementPath, WebKit::SandboxExtension::Handle extensionHandle, String contentType)
-    RegisterBlobURL(URL url, Vector<WebCore::BlobPart> blobParts, String contentType)
-    RegisterBlobURLFromURL(URL url, URL srcURL, struct WebCore::PolicyContainer policyContainer)
-    RegisterBlobURLOptionallyFileBacked(URL url, URL srcURL, String fileBackedPath, String contentType)
-    RegisterBlobURLForSlice(URL url, URL srcURL, int64_t start, int64_t end, String contentType)
-    UnregisterBlobURL(URL url)
-    BlobSize(URL url) -> (uint64_t resultSize) Synchronous
+    RegisterFileBlobURL(WebCore::ScopedURL url, String path, String replacementPath, WebKit::SandboxExtension::Handle extensionHandle, String contentType)
+    RegisterBlobURL(WebCore::ScopedURL url, Vector<WebCore::BlobPart> blobParts, String contentType)
+    RegisterBlobURLFromURL(WebCore::ScopedURL url, WebCore::ScopedURL srcURL, struct WebCore::PolicyContainer policyContainer)
+    RegisterBlobURLOptionallyFileBacked(WebCore::ScopedURL url, WebCore::ScopedURL srcURL, String fileBackedPath, String contentType)
+    RegisterBlobURLForSlice(WebCore::ScopedURL url, WebCore::ScopedURL srcURL, int64_t start, int64_t end, String contentType)
+    UnregisterBlobURL(WebCore::ScopedURL url)
+    BlobSize(WebCore::ScopedURL url) -> (uint64_t resultSize) Synchronous
     WriteBlobsToTemporaryFilesForIndexedDB(Vector<String> blobURLs) -> (Vector<String> fileNames)
-    RegisterBlobURLHandle(URL url);
-    UnregisterBlobURLHandle(URL url);
+    RegisterBlobURLHandle(WebCore::ScopedURL url);
+    UnregisterBlobURLHandle(WebCore::ScopedURL url);
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginPreflightResultCache.h>
 #include <WebCore/LegacySchemeRegistry.h>
+#include <WebCore/ScopedURL.h>
 #include <wtf/Scope.h>
 
 #define LOAD_CHECKER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkLoadChecker::" fmt, this, ##__VA_ARGS__)
@@ -47,7 +48,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static inline bool isSameOrigin(const URL& url, const SecurityOrigin* origin)
+static inline bool isSameOrigin(const ScopedURL& url, const SecurityOrigin* origin)
 {
     return url.protocolIsData() || url.protocolIsBlob() || !origin || origin->canRequest(url);
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
@@ -57,16 +57,17 @@ BlobRegistry* NetworkProcessPlatformStrategies::createBlobRegistry()
 {
     using namespace WebCore;
     class EmptyBlobRegistry : public WebCore::BlobRegistry {
-        void registerFileBlobURL(const URL&, Ref<BlobDataFileReference>&&, const String& path, const String& contentType) final { ASSERT_NOT_REACHED(); }
-        void registerBlobURL(const URL&, Vector<BlobPart>&&, const String& contentType) final { ASSERT_NOT_REACHED(); }
-        void registerBlobURL(const URL&, const URL& srcURL, const PolicyContainer&) final { ASSERT_NOT_REACHED(); }
-        void registerBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, RefPtr<BlobDataFileReference>&&, const String& contentType) final { ASSERT_NOT_REACHED(); }
-        void registerBlobURLForSlice(const URL&, const URL& srcURL, long long start, long long end, const String& contentType) final { ASSERT_NOT_REACHED(); }
-        void unregisterBlobURL(const URL&) final { ASSERT_NOT_REACHED(); }
-        unsigned long long blobSize(const URL&) final { ASSERT_NOT_REACHED(); return 0; }
+        private:
+        void registerFileBlobURL(const ScopedURL&, Ref<BlobDataFileReference>&&, const String& path, const String& contentType) final { ASSERT_NOT_REACHED(); }
+        void registerBlobURL(const ScopedURL&, Vector<BlobPart>&&, const String& contentType) final { ASSERT_NOT_REACHED(); }
+        void registerBlobURL(const ScopedURL&, const ScopedURL& srcURL, const PolicyContainer&) final { ASSERT_NOT_REACHED(); }
+        void registerBlobURLOptionallyFileBacked(const ScopedURL&, const ScopedURL& srcURL, RefPtr<BlobDataFileReference>&&, const String& contentType) final { ASSERT_NOT_REACHED(); }
+        void registerBlobURLForSlice(const ScopedURL&, const ScopedURL& srcURL, long long start, long long end, const String& contentType) final { ASSERT_NOT_REACHED(); }
+        void unregisterBlobURL(const ScopedURL&) final { ASSERT_NOT_REACHED(); }
+        unsigned long long blobSize(const ScopedURL&) final { ASSERT_NOT_REACHED(); return 0; }
         void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&) final { ASSERT_NOT_REACHED(); }
-        void registerBlobURLHandle(const URL&) final { ASSERT_NOT_REACHED(); }
-        void unregisterBlobURLHandle(const URL&) final { ASSERT_NOT_REACHED(); }
+        void registerBlobURLHandle(const ScopedURL&) final { ASSERT_NOT_REACHED(); }
+        void unregisterBlobURLHandle(const ScopedURL&) final { ASSERT_NOT_REACHED(); }
     };
     static NeverDestroyed<EmptyBlobRegistry> blobRegistry;
     return &blobRegistry.get();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1991,7 +1991,7 @@ void NetworkResourceLoader::cancelMainResourceLoadForContentFilter(const WebCore
     RELEASE_ASSERT(m_contentFilter);
 }
 
-void NetworkResourceLoader::handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, WebCore::SubstituteData& substituteData)
+void NetworkResourceLoader::handleProvisionalLoadFailureFromContentFilter(const ScopedURL& blockedPageURL, WebCore::SubstituteData& substituteData)
 {
     send(Messages::WebResourceLoader::ContentFilterDidBlockLoad(m_unblockHandler, m_unblockRequestDeniedScript, m_contentFilter->blockedError(), blockedPageURL, substituteData));
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -188,7 +188,7 @@ private:
     void dataReceivedThroughContentFilter(const WebCore::SharedBuffer&, size_t) final;
     WebCore::ResourceError contentFilterDidBlock(WebCore::ContentFilterUnblockHandler, String&& unblockRequestDeniedScript) final;
     void cancelMainResourceLoadForContentFilter(const WebCore::ResourceError&) final;
-    void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, WebCore::SubstituteData&) final;
+    void handleProvisionalLoadFailureFromContentFilter(const WebCore::ScopedURL& blockedPageURL, WebCore::SubstituteData&) final;
 #endif
 
     void processClearSiteDataHeader(const WebCore::ResourceResponse&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -36,6 +36,7 @@
 #include "NetworkProcess.h"
 #include "PreconnectTask.h"
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <WebCore/ScopedURL.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -28,6 +28,7 @@
 #include "NetworkCacheBlobStorage.h"
 #include "NetworkCacheData.h"
 #include "NetworkCacheKey.h"
+#include <WebCore/ScopedURL.h>
 #include <WebCore/Timer.h>
 #include <wtf/BloomFilter.h>
 #include <wtf/CompletionHandler.h>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1428,7 +1428,7 @@ header: <WebCore/FormData.h>
 }
 
 [Nested] struct WebCore::FormDataElement::EncodedBlobData {
-    URL url;
+    WebCore::ScopedURL url;
 }
 
 header: <WebCore/NetworkLoadInformation.h>
@@ -1573,6 +1573,10 @@ struct WebCore::SecurityOriginData {
 struct WebCore::ClientOrigin {
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData topOrigin;
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData clientOrigin;
+};
+
+class WebCore::ScopedURL {
+    String string();
 };
 
 enum class WebCore::AlphaPremultiplication : uint8_t {

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
@@ -37,7 +37,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-void BlobRegistryProxy::registerFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& file, const String& path, const String& contentType)
+void BlobRegistryProxy::registerFileBlobURL(const ScopedURL& url, Ref<BlobDataFileReference>&& file, const String& path, const String& contentType)
 {
     SandboxExtension::Handle extensionHandle;
 
@@ -51,43 +51,43 @@ void BlobRegistryProxy::registerFileBlobURL(const URL& url, Ref<BlobDataFileRefe
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterFileBlobURL(url, path, replacementPath, extensionHandle, contentType), 0);
 }
 
-void BlobRegistryProxy::registerBlobURL(const URL& url, Vector<BlobPart>&& blobParts, const String& contentType)
+void BlobRegistryProxy::registerBlobURL(const ScopedURL& url, Vector<BlobPart>&& blobParts, const String& contentType)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURL(url, blobParts, contentType), 0);
 }
 
-void BlobRegistryProxy::registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer)
+void BlobRegistryProxy::registerBlobURL(const ScopedURL& url, const ScopedURL& srcURL, const PolicyContainer& policyContainer)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLFromURL { url, srcURL, policyContainer }, 0);
 }
 
-void BlobRegistryProxy::registerBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<WebCore::BlobDataFileReference>&& file, const String& contentType)
+void BlobRegistryProxy::registerBlobURLOptionallyFileBacked(const ScopedURL& url, const ScopedURL& srcURL, RefPtr<WebCore::BlobDataFileReference>&& file, const String& contentType)
 {
     ASSERT(file);
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLOptionallyFileBacked(url, srcURL, file->path(), contentType), 0);
 }
 
-void BlobRegistryProxy::unregisterBlobURL(const URL& url)
+void BlobRegistryProxy::unregisterBlobURL(const ScopedURL& url)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURL(url), 0);
 }
 
-void BlobRegistryProxy::registerBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType)
+void BlobRegistryProxy::registerBlobURLForSlice(const ScopedURL& url, const ScopedURL& srcURL, long long start, long long end, const String& contentType)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLForSlice(url, srcURL, start, end, contentType), 0);
 }
 
-void BlobRegistryProxy::registerBlobURLHandle(const URL& url)
+void BlobRegistryProxy::registerBlobURLHandle(const ScopedURL& url)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLHandle(url), 0);
 }
 
-void BlobRegistryProxy::unregisterBlobURLHandle(const URL& url)
+void BlobRegistryProxy::unregisterBlobURLHandle(const ScopedURL& url)
 {
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURLHandle(url), 0);
 }
 
-unsigned long long BlobRegistryProxy::blobSize(const URL& url)
+unsigned long long BlobRegistryProxy::blobSize(const ScopedURL& url)
 {
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobSize(url), 0);
     auto [resultSize] = sendResult.takeReplyOr(0);

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h
@@ -31,16 +31,16 @@ namespace WebKit {
 
 class BlobRegistryProxy final : public WebCore::BlobRegistry {
 public:
-    void registerFileBlobURL(const URL&, Ref<WebCore::BlobDataFileReference>&&, const String& path, const String& contentType) final;
-    void registerBlobURL(const URL&, Vector<WebCore::BlobPart>&&, const String& contentType) final;
-    void registerBlobURL(const URL&, const URL& srcURL, const WebCore::PolicyContainer&) final;
-    void registerBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, RefPtr<WebCore::BlobDataFileReference>&&, const String& contentType) final;
-    void unregisterBlobURL(const URL&) final;
-    void registerBlobURLForSlice(const URL&, const URL& srcURL, long long start, long long end, const String& contentType) final;
-    unsigned long long blobSize(const URL&) final;
+    void registerFileBlobURL(const ScopedURL&, Ref<WebCore::BlobDataFileReference>&&, const String& path, const String& contentType) final;
+    void registerBlobURL(const ScopedURL&, Vector<WebCore::BlobPart>&&, const String& contentType) final;
+    void registerBlobURL(const ScopedURL&, const ScopedURL& srcURL, const WebCore::PolicyContainer&) final;
+    void registerBlobURLOptionallyFileBacked(const ScopedURL&, const ScopedURL& srcURL, RefPtr<WebCore::BlobDataFileReference>&&, const String& contentType) final;
+    void unregisterBlobURL(const ScopedURL&) final;
+    void registerBlobURLForSlice(const ScopedURL&, const ScopedURL& srcURL, long long start, long long end, const String& contentType) final;
+    unsigned long long blobSize(const ScopedURL&) final;
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&) final;
-    void registerBlobURLHandle(const URL&) final;
-    void unregisterBlobURLHandle(const URL&) final;
+    void registerBlobURLHandle(const ScopedURL&) final;
+    void unregisterBlobURLHandle(const ScopedURL&) final;
 };
 
 }

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> WebSharedWorkerObjectConnection {
-    FetchScriptInClient(URL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
+    FetchScriptInClient(WebCore::ScopedURL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
     NotifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::ResourceError error)
     PostExceptionToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL)
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -83,16 +83,16 @@ MediaStrategy* WebPlatformStrategies::createMediaStrategy()
 
 class WebBlobRegistry final : public BlobRegistry {
 private:
-    void registerFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& reference, const String&, const String& contentType) final { m_blobRegistry.registerFileBlobURL(url, WTFMove(reference), contentType); }
-    void registerBlobURL(const URL& url, Vector<BlobPart>&& parts, const String& contentType) final { m_blobRegistry.registerBlobURL(url, WTFMove(parts), contentType); }
-    void registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer) final { m_blobRegistry.registerBlobURL(url, srcURL, policyContainer); }
-    void registerBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<BlobDataFileReference>&& reference, const String& contentType) final { m_blobRegistry.registerBlobURLOptionallyFileBacked(url, srcURL, WTFMove(reference), contentType, { }); }
-    void registerBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType) final { m_blobRegistry.registerBlobURLForSlice(url, srcURL, start, end, contentType); }
-    void unregisterBlobURL(const URL& url) final { m_blobRegistry.unregisterBlobURL(url); }
-    unsigned long long blobSize(const URL& url) final { return m_blobRegistry.blobSize(url); }
+    void registerFileBlobURL(const ScopedURL& url, Ref<BlobDataFileReference>&& reference, const String&, const String& contentType) final { m_blobRegistry.registerFileBlobURL(url, WTFMove(reference), contentType); }
+    void registerBlobURL(const ScopedURL& url, Vector<BlobPart>&& parts, const String& contentType) final { m_blobRegistry.registerBlobURL(url, WTFMove(parts), contentType); }
+    void registerBlobURL(const ScopedURL& url, const ScopedURL& srcURL, const PolicyContainer& policyContainer) final { m_blobRegistry.registerBlobURL(url, srcURL, policyContainer); }
+    void registerBlobURLOptionallyFileBacked(const ScopedURL& url, const ScopedURL& srcURL, RefPtr<BlobDataFileReference>&& reference, const String& contentType) final { m_blobRegistry.registerBlobURLOptionallyFileBacked(url, srcURL, WTFMove(reference), contentType, { }); }
+    void registerBlobURLForSlice(const ScopedURL& url, const ScopedURL& srcURL, long long start, long long end, const String& contentType) final { m_blobRegistry.registerBlobURLForSlice(url, srcURL, start, end, contentType); }
+    void unregisterBlobURL(const ScopedURL& url) final { m_blobRegistry.unregisterBlobURL(url); }
+    unsigned long long blobSize(const ScopedURL& url) final { return m_blobRegistry.blobSize(url); }
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler) final { m_blobRegistry.writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler)); }
-    void registerBlobURLHandle(const URL& url) final { m_blobRegistry.registerBlobURLHandle(url); }
-    void unregisterBlobURLHandle(const URL& url) final { m_blobRegistry.unregisterBlobURLHandle(url); }
+    void registerBlobURLHandle(const ScopedURL& url) final { m_blobRegistry.registerBlobURLHandle(url); }
+    void unregisterBlobURLHandle(const ScopedURL& url) final { m_blobRegistry.unregisterBlobURLHandle(url); }
 
     BlobRegistryImpl* blobRegistryImpl() final { return &m_blobRegistry; }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
@@ -32,9 +32,9 @@
 #import "WebDatabaseQuotaManager.h"
 #import "WebQuotaManager.h"
 #import <WebCore/DatabaseTracker.h>
+#import <WebCore/ScopedURL.h>
 #import <WebCore/SecurityOrigin.h>
 #import <WebCore/SecurityOriginData.h>
-#import <wtf/URL.h>
 
 using namespace WebCore;
 
@@ -59,7 +59,7 @@ using namespace WebCore;
     if (!self)
         return nil;
 
-    _private = reinterpret_cast<WebSecurityOriginPrivate *>(&SecurityOrigin::create(URL([url absoluteURL])).leakRef());
+    _private = reinterpret_cast<WebSecurityOriginPrivate *>(&SecurityOrigin::create(ScopedURL([url absoluteURL])).leakRef());
     return self;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
@@ -27,10 +27,10 @@
 #include "config.h"
 
 #include "Test.h"
+#include <WebCore/ScopedURL.h>
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
-#include <wtf/URL.h>
 
 using namespace WebCore;
 
@@ -82,8 +82,8 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     auto o2 = SecurityOrigin::create("http"_s, "example.com"_s, std::optional<uint16_t>());
     auto o3 = SecurityOrigin::createFromString("http://example.com"_s);
     auto o4 = SecurityOrigin::createFromString("http://example.com:80"_s);
-    auto o5 = SecurityOrigin::create(URL { "http://example.com"_str });
-    auto o6 = SecurityOrigin::create(URL { "http://example.com:80"_str });
+    auto o5 = SecurityOrigin::create(ScopedURL { "http://example.com"_str });
+    auto o6 = SecurityOrigin::create(ScopedURL { "http://example.com:80"_str });
     auto o7 = SecurityOrigin::createFromString("http://example.com:81"_s);
     auto o8 = SecurityOrigin::createFromString("unrecognized://host"_s);
 #if PLATFORM(COCOA)
@@ -164,10 +164,10 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
 
 TEST_F(SecurityOriginTest, SecurityOriginFileBasedConstructors)
 {
-    auto tempFileOrigin = SecurityOrigin::create(URL { "file:///" + tempFilePath() });
-    auto spaceContainingOrigin = SecurityOrigin::create(URL { "file:///" + spaceContainingFilePath() });
-    auto bangContainingOrigin = SecurityOrigin::create(URL { "file:///" + bangContainingFilePath() });
-    auto quoteContainingOrigin = SecurityOrigin::create(URL { "file:///" + quoteContainingFilePath() });
+    auto tempFileOrigin = SecurityOrigin::create(ScopedURL { "file:///" + tempFilePath() });
+    auto spaceContainingOrigin = SecurityOrigin::create(ScopedURL { "file:///" + spaceContainingFilePath() });
+    auto bangContainingOrigin = SecurityOrigin::create(ScopedURL { "file:///" + bangContainingFilePath() });
+    auto quoteContainingOrigin = SecurityOrigin::create(ScopedURL { "file:///" + quoteContainingFilePath() });
     
     EXPECT_EQ(String("file"_s), tempFileOrigin->protocol());
     EXPECT_EQ(String("file"_s), spaceContainingOrigin->protocol());
@@ -190,7 +190,7 @@ TEST_F(SecurityOriginTest, SecurityOriginFileBasedConstructors)
 TEST_F(SecurityOriginTest, IsPotentiallyTrustworthy)
 {
     // Potentially Trustworthy
-    EXPECT_TRUE(SecurityOrigin::create(URL { "file:///" + tempFilePath() })->isPotentiallyTrustworthy());
+    EXPECT_TRUE(SecurityOrigin::create(ScopedURL { "file:///" + tempFilePath() })->isPotentiallyTrustworthy());
     EXPECT_TRUE(SecurityOrigin::createFromString("blob:http://127.0.0.1/3D45F36F-C126-493A-A8AA-457FA495247B"_s)->isPotentiallyTrustworthy());
     EXPECT_TRUE(SecurityOrigin::createFromString("blob:http://localhost/3D45F36F-C126-493A-A8AA-457FA495247B"_s)->isPotentiallyTrustworthy());
     EXPECT_TRUE(SecurityOrigin::createFromString("blob:http://[::1]/3D45F36F-C126-493A-A8AA-457FA495247B"_s)->isPotentiallyTrustworthy());
@@ -237,7 +237,7 @@ TEST_F(SecurityOriginTest, IsPotentiallyTrustworthy)
 
 TEST_F(SecurityOriginTest, IsRegistrableDomainSuffix)
 {
-    auto exampleOrigin = SecurityOrigin::create(URL { "http://www.example.com"_str });
+    auto exampleOrigin = SecurityOrigin::create(ScopedURL { "http://www.example.com"_str });
     EXPECT_TRUE(exampleOrigin->isMatchingRegistrableDomainSuffix("example.com"_s));
     EXPECT_TRUE(exampleOrigin->isMatchingRegistrableDomainSuffix("www.example.com"_s));
 #if !ENABLE(PUBLIC_SUFFIX_LIST)
@@ -252,7 +252,7 @@ TEST_F(SecurityOriginTest, IsRegistrableDomainSuffix)
     EXPECT_FALSE(exampleOrigin->isMatchingRegistrableDomainSuffix("com"_s));
 #endif
 
-    auto exampleDotOrigin = SecurityOrigin::create(URL { "http://www.example.com."_str });
+    auto exampleDotOrigin = SecurityOrigin::create(ScopedURL { "http://www.example.com."_str });
     EXPECT_TRUE(exampleDotOrigin->isMatchingRegistrableDomainSuffix("example.com."_s));
     EXPECT_TRUE(exampleDotOrigin->isMatchingRegistrableDomainSuffix("www.example.com."_s));
 #if !ENABLE(PUBLIC_SUFFIX_LIST)
@@ -267,11 +267,11 @@ TEST_F(SecurityOriginTest, IsRegistrableDomainSuffix)
     EXPECT_FALSE(exampleDotOrigin->isMatchingRegistrableDomainSuffix("com"_s));
 #endif
 
-    auto ipOrigin = SecurityOrigin::create(URL { "http://127.0.0.1"_str });
+    auto ipOrigin = SecurityOrigin::create(ScopedURL { "http://127.0.0.1"_str });
     EXPECT_TRUE(ipOrigin->isMatchingRegistrableDomainSuffix("127.0.0.1"_s, true));
     EXPECT_FALSE(ipOrigin->isMatchingRegistrableDomainSuffix("127.0.0.2"_s, true));
 
-    auto comOrigin = SecurityOrigin::create(URL { "http://com"_str });
+    auto comOrigin = SecurityOrigin::create(ScopedURL { "http://com"_str });
     EXPECT_TRUE(comOrigin->isMatchingRegistrableDomainSuffix("com"_s));
 }
 


### PR DESCRIPTION
#### 8c9cd0051d9e42a36f200439272ae731864ff07a
<pre>
Introduce and adopt ScopedURL
<a href="https://bugs.webkit.org/show_bug.cgi?id=250032">https://bugs.webkit.org/show_bug.cgi?id=250032</a>
rdar://problem/103840054

Reviewed by NOBODY (OOPS!).

We introduce a new ScopedURL type that inherits from URL. This type is useful
because it tightly couples a URL and the SecurityOrigin of the main frame,
therefore capturing the context within which the URL was created. The adoption
of ScopedURL in this patch is roughly a no-op, and conversions between
ScopedURL and URL are implicit. In the future this class will provide important
context when the URL is a Blob URL.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/mediasource/MediaSourceRegistry.cpp:
(WebCore::MediaSourceRegistry::unregisterURL):
* Source/WebCore/Modules/mediasource/MediaSourceRegistry.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::wouldTaintOrigin const):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
(WebCore::WebSocket::url const):
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::WebSocketHandshake):
* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::isURLPotentiallyTrustworthy):
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::isSecureTransitionTo const):
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::BlobURLRegistry::unregisterURL):
* Source/WebCore/fileapi/Blob.h:
(WebCore::Blob::url const):
* Source/WebCore/fileapi/BlobLoader.h:
* Source/WebCore/fileapi/BlobURL.cpp:
(WebCore::BlobURL::getOriginURL):
(WebCore::BlobURL::isSecureBlobURL):
* Source/WebCore/fileapi/BlobURL.h:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::start):
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::ThreadableBlobRegistry::registerFileBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURL):
(WebCore::unregisterBlobURLOriginIfNecessary):
(WebCore::ThreadableBlobRegistry::registerBlobURLOptionallyFileBacked):
(WebCore::ThreadableBlobRegistry::registerBlobURLForSlice):
(WebCore::ThreadableBlobRegistry::blobSize):
(WebCore::ThreadableBlobRegistry::unregisterBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURLHandle):
(WebCore::ThreadableBlobRegistry::unregisterBlobURLHandle):
* Source/WebCore/fileapi/ThreadableBlobRegistry.h:
* Source/WebCore/fileapi/URLKeepingBlobAlive.cpp:
(WebCore::URLKeepingBlobAlive::URLKeepingBlobAlive):
(WebCore::URLKeepingBlobAlive::operator=):
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
(WebCore::URLKeepingBlobAlive::URLKeepingBlobAlive):
(WebCore::URLKeepingBlobAlive::operator const ScopedURL&amp; const):
(WebCore::URLKeepingBlobAlive::url const):
(WebCore::URLKeepingBlobAlive::operator=):
(WebCore::URLKeepingBlobAlive::operator const URL&amp; const): Deleted.
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/PublicURLManager.cpp:
(WebCore::PublicURLManager::revoke):
* Source/WebCore/html/PublicURLManager.h:
* Source/WebCore/html/URLRegistry.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::wouldTaintOrigin):
(WebCore::CanvasRenderingContext::checkOrigin):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::PreloadRequest::completeURL):
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::ApplicationManifestLoader):
* Source/WebCore/loader/ApplicationManifestLoader.h:
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::validateCrossOriginResourcePolicy):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::isMixedContent):
* Source/WebCore/loader/MixedContentChecker.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::ApplicationCacheGroup):
(WebCore::ApplicationCacheGroup::createRequest):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.h:
(WebCore::ApplicationCacheGroup::manifestURL const):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::loadCacheGroup):
(WebCore::ApplicationCacheStorage::findOrCreateCacheGroup):
(WebCore::ApplicationCacheStorage::cacheGroupForURL):
(WebCore::ApplicationCacheStorage::fallbackCacheGroupForURL):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::CachedImage):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::isRequestCrossOrigin):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::IconLoader):
* Source/WebCore/loader/icon/IconLoader.h:
* Source/WebCore/page/ScopedURL.h: Added.
(WebCore::ScopedURL::ScopedURL):
(WebCore::ScopedURL::createCFURL const):
(WebCore::ScopedURL::operator NSURL * const):
(WebCore::ScopedURL::createGUri const):
(WebCore::ScopedURL::isolatedCopy const):
(WebCore::ScopedURL::isolatedCopy):
(WebCore::ScopedURL::toString const):
(WebCore::ScopedURL::asURL):
(WebCore::ScopedURL::asURL const):
(WebCore::ScopedURL::topOrigin const):
(WebCore::add):
(WebCore::ScopedURL::operator== const):
(WebCore::ScopedURLKeyHash::hash):
(WebCore::ScopedURLKeyHash::equal):
(WTF::HashTraits&lt;WebCore::ScopedURL&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::ScopedURL&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::ScopedURL&gt;::isDeletedValue):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::getCachedOrigin):
(WebCore::SecurityOrigin::SecurityOrigin):
(WebCore::SecurityOrigin::create):
(WebCore::SecurityOrigin::emptyOrigin):
(WebCore::SecurityOrigin::createNonLocalWithAllowedFilePath):
(WebCore::SecurityOrigin::isSecure):
(WebCore::SecurityOrigin::canRequest const):
(WebCore::SecurityOrigin::canDisplay const):
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::operator==):
(WebCore::operator!=):
* Source/WebCore/page/SecurityPolicy.cpp:
(WebCore::SecurityPolicy::generateReferrerHeader):
(WebCore::SecurityPolicy::isAccessAllowed):
* Source/WebCore/page/SecurityPolicy.h:
* Source/WebCore/platform/network/BlobPart.h:
(WebCore::BlobPart::BlobPart):
(WebCore::BlobPart::url const):
* Source/WebCore/platform/network/BlobRegistry.h:
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::registerFileBlobURL):
(WebCore::BlobRegistryImpl::registerBlobURL):
(WebCore::BlobRegistryImpl::registerBlobURLOptionallyFileBacked):
(WebCore::BlobRegistryImpl::registerBlobURLForSlice):
(WebCore::BlobRegistryImpl::unregisterBlobURL):
(WebCore::BlobRegistryImpl::getBlobDataFromURL const):
(WebCore::BlobRegistryImpl::blobSize):
(WebCore::BlobRegistryImpl::writeBlobToFilePath):
(WebCore::BlobRegistryImpl::filesInBlob const):
(WebCore::BlobRegistryImpl::registerBlobURLHandle):
(WebCore::BlobRegistryImpl::unregisterBlobURLHandle):
* Source/WebCore/platform/network/BlobRegistryImpl.h:
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormDataElement::lengthInBytes const):
(WebCore::FormData::appendBlob):
(WebCore::appendBlobResolved):
* Source/WebCore/platform/network/FormData.h:
(WebCore::FormDataElement::FormDataElement):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
* Source/WebCore/workers/AbstractWorker.cpp:
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::WorkerFontLoadRequest):
* Source/WebCore/workers/WorkerFontLoadRequest.h:
* Source/WebCore/workers/WorkerScriptLoader.h:
(WebCore::WorkerScriptLoader::url const):
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp:
(WebCore::SharedWorkerObjectConnection::fetchScriptInClient):
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.h:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::SharedWorkerScriptLoader):
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::registerFileBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerBlobURLFromURL):
(WebKit::NetworkConnectionToWebProcess::registerBlobURLOptionallyFileBacked):
(WebKit::NetworkConnectionToWebProcess::registerBlobURLForSlice):
(WebKit::NetworkConnectionToWebProcess::unregisterBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerBlobURLHandle):
(WebKit::NetworkConnectionToWebProcess::unregisterBlobURLHandle):
(WebKit::NetworkConnectionToWebProcess::blobSize):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::isSameOrigin):
(WebKit::performCORPCheck):
* Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp:
(WebKit::NetworkProcessPlatformStrategies::createBlobRegistry):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::handleProvisionalLoadFailureFromContentFilter):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::constructRevalidationRequest):
(WebKit::NetworkCache::SpeculativeLoadManager::preconnectForSubresource):
(WebKit::NetworkCache::SpeculativeLoadManager::revalidateSubresource):
(WebKit::NetworkCache::SpeculativeLoadManager::preloadEntry):
(WebKit::NetworkCache::SpeculativeLoadManager::startSpeculativeRevalidation):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp:
(WebKit::BlobRegistryProxy::registerFileBlobURL):
(WebKit::BlobRegistryProxy::registerBlobURL):
(WebKit::BlobRegistryProxy::registerBlobURLOptionallyFileBacked):
(WebKit::BlobRegistryProxy::unregisterBlobURL):
(WebKit::BlobRegistryProxy::registerBlobURLForSlice):
(WebKit::BlobRegistryProxy::registerBlobURLHandle):
(WebKit::BlobRegistryProxy::unregisterBlobURLHandle):
(WebKit::BlobRegistryProxy::blobSize):
* Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm:
(-[WebSecurityOrigin initWithURL:]):
* Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp:
(TestWebKitAPI::TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c9cd0051d9e42a36f200439272ae731864ff07a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102322 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111631 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171807 "Hash 8c9cd005 for PR 8253 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2379 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94652 "Hash 8c9cd005 for PR 8253 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109342 "Hash 8c9cd005 for PR 8253 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108103 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9533 "Found 1 new test failure: css3/font-variant-font-face-override.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92799 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (warnings); re-run-api-tests (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_1 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_2 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_3 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_4 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_5 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_6 (cancelled)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/94652 "Hash 8c9cd005 for PR 8253 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91401 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24285 "Found 2 new test failures: http/tests/security/clean-origin-css-exposed-resource-timing.html, http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/94652 "Hash 8c9cd005 for PR 8253 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2150 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45201 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6864 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->