### PR TITLE
Live-ish resize sometimes pops to unexpected scroll position even if layout width doesn't change

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -938,7 +938,15 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
     if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _isAnimatingZoom] && !WebKit::scalesAreEssentiallyEqual([_scrollView zoomScale], layerTreeTransaction.pageScaleFactor())) {
         LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << layerTreeTransaction.pageScaleFactor());
+
+        // When web-process-originated scale changes occur, pin the
+        // vertical scroll position to the top edge of the content,
+        // instead of the center (which UIScrollView does by default).
+        CGFloat contentOffsetY = [_scrollView contentOffset].y * layerTreeTransaction.pageScaleFactor() / [_scrollView zoomScale];
+
         [_scrollView setZoomScale:layerTreeTransaction.pageScaleFactor()];
+
+        [_scrollView setContentOffset:CGPointMake([_scrollView contentOffset].x, contentOffsetY)];
     }
 }
 
@@ -1007,6 +1015,9 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         [self _didCommitLayerTreeDuringAnimatedResize:layerTreeTransaction];
         return;
     }
+
+    if (_perProcessState.liveResizeParameters)
+        return;
 
     if (_resizeAnimationView)
         WKWEBVIEW_RELEASE_LOG("%p -[WKWebView _didCommitLayerTree:] - dynamicViewportUpdateMode is NotResizing, but still have a live resizeAnimationView (unpaired begin/endAnimatedResize?)", self);
@@ -2491,8 +2502,8 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
         || _perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard) {
         _perProcessState.didDeferUpdateVisibleContentRectsForAnyReason = YES;
         _perProcessState.didDeferUpdateVisibleContentRectsForUnstableScrollView = YES;
-        WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - scroll view state is non-stable, bailing (dynamicViewportUpdateMode %d, needsResetViewStateAfterCommitLoadForMainFrame %d, sizeChangedSinceLastVisibleContentRectUpdate %d, [_scrollView isZoomBouncing] %d, currentlyAdjustingScrollViewInsetsForKeyboard %d)",
-            self, _page->identifier().toUInt64(), _perProcessState.dynamicViewportUpdateMode, _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame, [_contentView sizeChangedSinceLastVisibleContentRectUpdate], [_scrollView isZoomBouncing], _perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard);
+        WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - scroll view state is non-stable, bailing (shouldDeferGeometryUpdates %d, dynamicViewportUpdateMode %d, needsResetViewStateAfterCommitLoadForMainFrame %d, sizeChangedSinceLastVisibleContentRectUpdate %d, [_scrollView isZoomBouncing] %d, currentlyAdjustingScrollViewInsetsForKeyboard %d)",
+            self, _page->identifier().toUInt64(), self._shouldDeferGeometryUpdates, _perProcessState.dynamicViewportUpdateMode, _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame, [_contentView sizeChangedSinceLastVisibleContentRectUpdate], [_scrollView isZoomBouncing], _perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard);
         return;
     }
 


### PR DESCRIPTION
#### 1a1e7ad8f8a74fe4c00d54149795b14ee5626e3a
<pre>
Live-ish resize sometimes pops to unexpected scroll position even if layout width doesn&apos;t change
<a href="https://bugs.webkit.org/show_bug.cgi?id=250153">https://bugs.webkit.org/show_bug.cgi?id=250153</a>
rdar://96702143

Reviewed by Wenson Hsieh.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
By default, UIScrollView pins the center of the view when you change zoomScale.
When doing a live resize with a fixed layout width, the zoomScale changes on
every resize. Resizes normally pin the top edge of the content (or rather,
don&apos;t try to adjust the content offset -- at least until scroll anchoring
comes along), so this leads to surprising jumps. To fix this, when
web-process-originated scale changes occur, pin the vertical scroll position
to the top edge of the content, instead of the center. I don&apos;t expect any
clients are depending on the existing behavior, and hope that this
will be purely an improvement.

(-[WKWebView _didCommitLayerTree:]):
Like animated resize, bail from updating scroll view parameters and various
other incoming-commit-related things until *after* the live resize finishes.
This avoids us calling _updateScrollViewForTransaction and adjusting zoomScale
while the resize animation view is installed, which results in our scroll view
thinking that the current zoomScale is 1, and throwing all the math off, causing
further unexpected scrolling.

(-[WKWebView _updateVisibleContentRects]):
Fix this logging to indicate whether whether we&apos;re deferring geometry updates
for any reason; an earlier patch changed the condition but not the log.

Canonical link: <a href="https://commits.webkit.org/258521@main">https://commits.webkit.org/258521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf2d0d5ff54dca4a09f644dbf76903b7e3fe3f40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111510 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2245 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109240 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92702 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24183 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4876 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2045 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5838 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6742 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->