### PR TITLE
[text-group-align] Implement group alignment

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -52,6 +52,10 @@ public:
 
     LineBox(PathVariant&&);
 
+    float left() const;
+    float right() const;
+    float width() const { return right() - left(); }
+
     float top() const;
     float bottom() const;
     float height() const { return bottom() - top(); }
@@ -187,6 +191,20 @@ inline float LineBox::bottom() const
 {
     return WTF::switchOn(m_pathVariant, [](const auto& path) {
         return path.bottom();
+    });
+}
+
+inline float LineBox::left() const
+{
+    return WTF::switchOn(m_pathVariant, [](const auto& path) {
+        return path.left();
+    });
+}
+
+inline float LineBox::right() const
+{
+    return WTF::switchOn(m_pathVariant, [](const auto& path) {
+        return path.right();
     });
 }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -48,8 +48,12 @@ public:
     float contentLogicalBottom() const { return m_rootInlineBox->lineBottom().toFloat(); }
     float contentLogicalTopAdjustedForPrecedingLineBox() const { return m_rootInlineBox->selectionTop().toFloat(); }
     float contentLogicalBottomAdjustedForFollowingLineBox() const { return m_rootInlineBox->selectionBottom().toFloat(); }
+
     float top() const { return m_rootInlineBox->lineBoxTop().toFloat(); }
     float bottom() const { return m_rootInlineBox->lineBoxBottom().toFloat(); }
+    float left() const { return m_rootInlineBox->blockFlow().logicalLeftOffsetForLine(m_rootInlineBox->lineBoxTop(), IndentTextOrNot::IndentText).toFloat(); }
+    float right() const { return m_rootInlineBox->blockFlow().logicalRightOffsetForLine(m_rootInlineBox->lineBoxTop(), IndentTextOrNot::IndentText).toFloat(); }
+
     float inkOverflowTop() const { return m_rootInlineBox->logicalTopVisualOverflow(); }
     float inkOverflowBottom() const { return m_rootInlineBox->logicalBottomVisualOverflow(); }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -51,6 +51,8 @@ public:
     float contentLogicalBottom() const { return line().enclosingContentBottom(); }
     float top() const { return line().lineBoxTop(); }
     float bottom() const { return line().lineBoxBottom(); }
+    float left() const { return line().lineBoxLeft(); }
+    float right() const { return line().lineBoxRight(); }
     float inkOverflowTop() const { return line().inkOverflow().y(); }
     float inkOverflowBottom() const { return line().inkOverflow().maxY(); }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -606,9 +606,15 @@ void LineLayout::updateInlineContentConstraints()
     auto padding = logicalPadding(flow, isLeftToRightInlineDirection, writingMode);
     auto border = logicalBorder(flow, isLeftToRightInlineDirection, writingMode);
     auto scrollbarSize = scrollbarLogicalSize(flow);
+    auto* renderLayoutState = flow.view().frameView().layoutContext().layoutState();
 
+    auto [groupAlignSpacingLeft, groupAlignSpacingRight] = renderLayoutState->groupAlignSpacing();
+    if (flow.style().textGroupAlign() != TextGroupAlign::None)
+        ALWAYS_LOG_WITH_STREAM(stream << "LineLayout::updateInlineContentConstraints (" << groupAlignSpacingLeft << ", " << groupAlignSpacingRight << ")");
     auto contentBoxWidth = WebCore::isHorizontalWritingMode(writingMode) ? flow.contentWidth() : flow.contentHeight();
-    auto contentBoxLeft = border.horizontal.left + padding.horizontal.left;
+    contentBoxWidth -= groupAlignSpacingLeft + groupAlignSpacingRight;
+
+    auto contentBoxLeft = border.horizontal.left + padding.horizontal.left + LayoutUnit(groupAlignSpacingLeft);
     auto contentBoxTop = border.vertical.top + padding.vertical.top;
 
     auto horizontalConstraints = Layout::HorizontalConstraints { contentBoxLeft, contentBoxWidth };

--- a/Source/WebCore/page/FrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/FrameViewLayoutContext.cpp
@@ -612,7 +612,8 @@ bool FrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const LayoutSi
             , pageHeightChanged
             , layoutState ? layoutState->maximumLineCountForLineClamp() : std::nullopt
             , layoutState ? layoutState->visibleLineCountForLineClamp() : std::nullopt
-            , layoutState ? layoutState->leadingTrim() : RenderLayoutState::LeadingTrim()));
+            , layoutState ? layoutState->leadingTrim() : RenderLayoutState::LeadingTrim()
+            , layoutState ? layoutState->groupAlignSpacing() : std::pair<float, float> { 0.0, 0.0 }));
         return true;
     }
     return false;

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -531,6 +531,11 @@ private:
     void setLeadingTrimForSubtree(const RenderBlockFlow* inlineFormattingContextRootForLeadingTrimEnd = nullptr);
     void adjustLeadingTrimAfterLayout();
 
+    bool computeGroupAlignmentSpacing();
+    float groupAlignmentExtraSpacing() const;
+
+    bool m_groupAligned { false };
+
 #if ENABLE(TEXT_AUTOSIZING)
     int m_widthForTextAutosizing;
     unsigned m_lineCountForTextAutosizing : 2;

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -62,7 +62,7 @@ RenderLayoutState::RenderLayoutState(RenderElement& renderer, IsPaginated isPagi
     }
 }
 
-RenderLayoutState::RenderLayoutState(const FrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, std::optional<size_t> maximumLineCountForLineClamp, std::optional<size_t> visibleLineCountForLineClamp, std::optional<LeadingTrim> leadingTrim)
+RenderLayoutState::RenderLayoutState(const FrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, std::optional<size_t> maximumLineCountForLineClamp, std::optional<size_t> visibleLineCountForLineClamp, std::optional<LeadingTrim> leadingTrim, std::pair<float, float> groupAlignSpacing)
     : m_clipped(false)
     , m_isPaginated(false)
     , m_pageLogicalHeightChanged(false)
@@ -73,6 +73,7 @@ RenderLayoutState::RenderLayoutState(const FrameViewLayoutContext::LayoutStateSt
     , m_maximumLineCountForLineClamp(maximumLineCountForLineClamp)
     , m_visibleLineCountForLineClamp(visibleLineCountForLineClamp)
     , m_leadingTrim(leadingTrim)
+    , m_groupAlignSpacing(groupAlignSpacing)
 #if ASSERT_ENABLED
     , m_renderer(&renderer)
 #endif

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -58,7 +58,7 @@ public:
 #endif
     {
     }
-    RenderLayoutState(const FrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<size_t> maximumLineCountForLineClamp, std::optional<size_t> visibleLineCountForLineClamp, std::optional<LeadingTrim>);
+    RenderLayoutState(const FrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<size_t> maximumLineCountForLineClamp, std::optional<size_t> visibleLineCountForLineClamp, std::optional<LeadingTrim>, std::pair<float, float>);
     enum class IsPaginated { No, Yes };
     explicit RenderLayoutState(RenderElement&, IsPaginated = IsPaginated::No);
 
@@ -111,6 +111,21 @@ public:
     void addLeadingTrimEnd(const RenderBlockFlow& targetInlineFormattingContext);
     void resetLeadingTrim() { m_leadingTrim = { }; }
 
+    std::pair<float, float> groupAlignSpacing()
+    {
+        return m_groupAlignSpacing;
+    }
+
+    void setGroupAlignSpacing(float left, float right)
+    {
+        m_groupAlignSpacing = { left, right };
+    }
+
+    void resetGroupAlignSpacing()
+    {
+        m_groupAlignSpacing = { 0, 0 };
+    }
+
 private:
     void computeOffsets(const RenderLayoutState& ancestor, RenderBox&, LayoutSize offset);
     void computeClipRect(const RenderLayoutState& ancestor, RenderBox&);
@@ -154,6 +169,7 @@ private:
     std::optional<size_t> m_maximumLineCountForLineClamp;
     std::optional<size_t> m_visibleLineCountForLineClamp;
     std::optional<LeadingTrim> m_leadingTrim;
+    std::pair<float, float> m_groupAlignSpacing { 0, 0 };
 #if ASSERT_ENABLED
     RenderElement* m_renderer { nullptr };
 #endif


### PR DESCRIPTION
#### 47140adfdf0e35d0e3b1708969f431df87e6052c
<pre>
[text-group-align] Implement group alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=249839">https://bugs.webkit.org/show_bug.cgi?id=249839</a>
rdar://103663524

Reviewed by NOBODY (OOPS!).

* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::width const):
(WebCore::InlineIterator::LineBox::left const):
(WebCore::InlineIterator::LineBox::right const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::left const):
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::right const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::left const):
(WebCore::InlineIterator::LineBoxIteratorModernPath::right const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateInlineContentConstraints):
* Source/WebCore/page/FrameViewLayoutContext.cpp:
(WebCore::FrameViewLayoutContext::pushLayoutState):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::computeGroupAlignmentSpacing):
(WebCore::RenderBlockFlow::groupAlignmentExtraSpacing const):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
* Source/WebCore/rendering/RenderLayoutState.h:
(WebCore::RenderLayoutState::groupAlignSpacing):
(WebCore::RenderLayoutState::setGroupAlignSpacing):
(WebCore::RenderLayoutState::resetGroupAlignSpacing):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47140adfdf0e35d0e3b1708969f431df87e6052c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111522 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171683 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2257 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109250 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37227 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78969 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4886 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25617 "Found 1 new test failure: inspector/sampling-profiler/call-frame-with-dom-functions.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2057 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45114 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6754 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->