### PR TITLE
Clean up from enabling lh/rlh units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-on-root-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-on-root-001.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ LineHeightUnitsEnabled=true ] -->
+<!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Values and Units Test: using lh and rlh units on the root element</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-001.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ LineHeightUnitsEnabled=true ] -->
+<!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Values and Units Test: using lh in line-height</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-002.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ LineHeightUnitsEnabled=true ] -->
+<!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Values and Units Test: using lh in font-size</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -49,14 +49,6 @@ CSSUnitType CSSUnitValue::parseUnit(const String& unit)
         return CSSUnitType::CSS_NUMBER;
     if (unit == "percent"_s)
         return CSSUnitType::CSS_PERCENTAGE;
-
-    // FIXME: Remove these when LineHeightUnitsEnabled is changed back to true or removed
-    // https://bugs.webkit.org/show_bug.cgi?id=211351
-    if (unit == "lh"_s)
-        return CSSUnitType::CSS_LHS;
-    if (unit == "rlh"_s)
-        return CSSUnitType::CSS_RLHS;
-
     return CSSParserToken::stringToUnitType(unit);
 }
 

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -262,9 +262,7 @@ private:
 
     bool m_isReadableByteStreamAPIEnabled { false };
 
-    // False by default until https://bugs.webkit.org/show_bug.cgi?id=211351 /
-    // https://github.com/w3c/csswg-drafts/issues/3257 have been sorted out.
-    bool m_lineHeightUnitsEnabled { false };
+    bool m_lineHeightUnitsEnabled { true };
 
     bool m_privateClickMeasurementDebugModeEnabled { false };
 #if HAVE(RSA_BSSA)

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -149,7 +149,6 @@ const TestFeatures& TestOptions::defaults()
             { "JavaScriptEnabled", true },
             { "KeygenElementEnabled", false },
             { "LayoutFormattingContextIntegrationEnabled", true },
-            { "LineHeightUnitsEnabled", false },
             { "LoadsImagesAutomatically", true },
             { "MainContentUserGestureOverrideEnabled", false },
             { "MenuItemElementEnabled", false },


### PR DESCRIPTION
#### c7a1baf90a09c93c204b2210210be060346fdd70
<pre>
Clean up from enabling lh/rlh units
<a href="https://bugs.webkit.org/show_bug.cgi?id=250163">https://bugs.webkit.org/show_bug.cgi?id=250163</a>
rdar://103933593

Reviewed by Tim Nguyen.

I looked through all the places where the preference name was mentioned.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-rlh-on-root-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/lh-unit-002.html:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::parseUnit):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/258603@main">https://commits.webkit.org/258603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/accc2572c183f59037ca0e214bd4cb858e5d68a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111747 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2514 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108259 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24380 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25799 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5232 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45296 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5909 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->