### PR TITLE
Use an alpha-less pixel format for 32 bit IOSurfaces when RemoteLayerBackingStore::Parameters::isOpaque is true

### DIFF
--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -38,6 +38,7 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
     case PixelFormat::BGRA8:
         return true;
 
+    case PixelFormat::BGRX8:
     case PixelFormat::RGB10:
     case PixelFormat::RGB10A8:
         return false;

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -55,12 +55,13 @@ static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferForm
             else
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
 
+        case PixelFormat::BGRX8:
         case PixelFormat::RGB10:
         case PixelFormat::RGB10A8:
             break;
         }
 
-        // We currently only support 8 bit pixel formats for these conversions.
+        // We currently only support 8 bit pixel formats with alpha for these conversions.
 
         ASSERT_NOT_REACHED();
         return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
@@ -236,7 +237,7 @@ static void convertImagePixelsUnaccelerated(const ConstPixelBufferConversionView
 
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    // We don't currently support converting pixel data with non-8-bit buffers.
+    // We currently only support converting between RGBA8 and BGRA8.
     ASSERT(source.format.pixelFormat == PixelFormat::RGBA8 || source.format.pixelFormat == PixelFormat::BGRA8);
     ASSERT(destination.format.pixelFormat == PixelFormat::RGBA8 || destination.format.pixelFormat == PixelFormat::BGRA8);
 

--- a/Source/WebCore/platform/graphics/PixelFormat.cpp
+++ b/Source/WebCore/platform/graphics/PixelFormat.cpp
@@ -36,6 +36,9 @@ TextStream& operator<<(TextStream& ts, PixelFormat pixelFormat)
     case PixelFormat::RGBA8:
         ts << "RGBA8";
         break;
+    case PixelFormat::BGRX8:
+        ts << "BGRX8";
+        break;
     case PixelFormat::BGRA8:
         ts << "BGRA8";
         break;

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 enum class PixelFormat : uint8_t {
     RGBA8,
+    BGRX8,
     BGRA8,
     RGB10,
     RGB10A8,

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -58,6 +58,7 @@ class IOSurface final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Format {
+        BGRX,
         BGRA,
         YUV422,
 #if HAVE(IOSURFACE_RGB10)
@@ -140,11 +141,11 @@ public:
 
     WEBCORE_EXPORT SetNonVolatileResult setVolatile(bool);
 
+    Format format() const { return m_format; }
     IntSize size() const { return m_size; }
     size_t totalBytes() const { return m_totalBytes; }
 
     WEBCORE_EXPORT DestinationColorSpace colorSpace();
-    WEBCORE_EXPORT Format format() const;
     WEBCORE_EXPORT IOSurfaceID surfaceID() const;
     WEBCORE_EXPORT size_t bytesPerRow() const;
 
@@ -181,6 +182,7 @@ private:
 
     BitmapConfiguration bitmapConfiguration() const;
 
+    Format m_format;
     std::optional<DestinationColorSpace> m_colorSpace;
     IntSize m_size;
     size_t m_totalBytes;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -68,6 +68,27 @@ std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, 
     return surface;
 }
 
+static IOSurface::Format formatFromSurface(IOSurfaceRef surface)
+{
+    unsigned pixelFormat = IOSurfaceGetPixelFormat(surface);
+    if (pixelFormat == 'BGRA')
+        return IOSurface::Format::BGRA;
+
+#if HAVE(IOSURFACE_RGB10)
+    if (pixelFormat == 'w30r')
+        return IOSurface::Format::RGB10;
+
+    if (pixelFormat == 'b3a8')
+        return IOSurface::Format::RGB10A8;
+#endif
+
+    if (pixelFormat == '422f')
+        return IOSurface::Format::YUV422;
+
+    ASSERT_NOT_REACHED();
+    return IOSurface::Format::BGRA;
+}
+
 std::unique_ptr<IOSurface> IOSurface::createFromSendRight(const MachSendRight&& sendRight)
 {
     ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
@@ -180,7 +201,8 @@ static NSDictionary *optionsFor32BitSurface(IntSize size, unsigned pixelFormat)
 }
 
 IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Format format, bool& success)
-    : m_colorSpace(colorSpace)
+    : m_format(format)
+    , m_colorSpace(colorSpace)
     , m_size(size)
 {
     ASSERT(!success);
@@ -189,6 +211,7 @@ IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Form
     NSDictionary *options;
 
     switch (format) {
+    case Format::BGRX:
     case Format::BGRA:
         options = optionsFor32BitSurface(size, 'BGRA');
         break;
@@ -214,7 +237,8 @@ IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Form
 }
 
 IOSurface::IOSurface(IOSurfaceRef surface, std::optional<DestinationColorSpace>&& colorSpace)
-    : m_colorSpace(WTFMove(colorSpace))
+    : m_format(formatFromSurface(surface))
+    , m_colorSpace(WTFMove(colorSpace))
     , m_surface(surface)
 {
     m_size = IntSize(IOSurfaceGetWidth(surface), IOSurfaceGetHeight(surface));
@@ -331,6 +355,9 @@ IOSurface::BitmapConfiguration IOSurface::bitmapConfiguration() const
     size_t bitsPerComponent = 8;
     
     switch (format()) {
+    case Format::BGRX:
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
+        break;
     case Format::BGRA:
         break;
 #if HAVE(IOSURFACE_RGB10)
@@ -437,27 +464,6 @@ DestinationColorSpace IOSurface::colorSpace()
 {
     ensureColorSpace();
     return *m_colorSpace;
-}
-
-IOSurface::Format IOSurface::format() const
-{
-    unsigned pixelFormat = IOSurfaceGetPixelFormat(m_surface.get());
-    if (pixelFormat == 'BGRA')
-        return Format::BGRA;
-
-#if HAVE(IOSURFACE_RGB10)
-    if (pixelFormat == 'w30r')
-        return Format::RGB10;
-
-    if (pixelFormat == 'b3a8')
-        return Format::RGB10A8;
-#endif
-
-    if (pixelFormat == '422f')
-        return Format::YUV422;
-
-    ASSERT_NOT_REACHED();
-    return Format::BGRA;
 }
 
 IOSurfaceID IOSurface::surfaceID() const
@@ -605,6 +611,8 @@ IOSurface::Format IOSurface::formatForPixelFormat(PixelFormat format)
     case PixelFormat::RGBA8:
         RELEASE_ASSERT_NOT_REACHED();
         return IOSurface::Format::BGRA;
+    case PixelFormat::BGRX8:
+        return IOSurface::Format::BGRX;
     case PixelFormat::BGRA8:
         return IOSurface::Format::BGRA;
 #if HAVE(IOSURFACE_RGB10)
@@ -627,6 +635,9 @@ IOSurface::Format IOSurface::formatForPixelFormat(PixelFormat format)
 TextStream& operator<<(TextStream& ts, IOSurface::Format format)
 {
     switch (format) {
+    case IOSurface::Format::BGRX:
+        ts << "BGRX";
+        break;
     case IOSurface::Format::BGRA:
         ts << "BGRA";
         break;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -201,13 +201,14 @@ PixelFormat RemoteLayerBackingStore::pixelFormat() const
     if (usesDeepColorBackingStore())
         return m_parameters.isOpaque ? PixelFormat::RGB10 : PixelFormat::RGB10A8;
 
-    return PixelFormat::BGRA8;
+    return m_parameters.isOpaque ? PixelFormat::BGRX8 : PixelFormat::BGRA8;
 }
 
 unsigned RemoteLayerBackingStore::bytesPerPixel() const
 {
     switch (pixelFormat()) {
     case PixelFormat::RGBA8: return 4;
+    case PixelFormat::BGRX8: return 4;
     case PixelFormat::BGRA8: return 4;
     case PixelFormat::RGB10: return 4;
     case PixelFormat::RGB10A8: return 5;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1582,6 +1582,7 @@ enum class WebCore::AlphaPremultiplication : uint8_t {
 
 enum class WebCore::PixelFormat : uint8_t {
     RGBA8,
+    BGRX8,
     BGRA8,
     RGB10,
     RGB10A8,


### PR DESCRIPTION
#### 031263226f11431625f17f2d67acedfec43156da
<pre>
Use an alpha-less pixel format for 32 bit IOSurfaces when RemoteLayerBackingStore::Parameters::isOpaque is true
<a href="https://bugs.webkit.org/show_bug.cgi?id=250100">https://bugs.webkit.org/show_bug.cgi?id=250100</a>
rdar://103885395

Reviewed by Tim Horton.

* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::supportedPixelFormat):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::makeVImageCGImageFormat):
(WebCore::convertImagePixels):
* Source/WebCore/platform/graphics/PixelFormat.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PixelFormat.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::formatFromSurface):
(WebCore::IOSurface::IOSurface):
(WebCore::IOSurface::bitmapConfiguration const):
(WebCore::IOSurface::formatForPixelFormat):
(WebCore::operator&lt;&lt;):
(WebCore::IOSurface::format const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::pixelFormat const):
(WebKit::RemoteLayerBackingStore::bytesPerPixel const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/258523@main">https://commits.webkit.org/258523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c7a1173145a2ba84795c1b6e581ddaabec56f7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102205 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111526 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2261 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107985 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92716 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24198 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25621 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5011 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45118 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6758 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3093 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->