### PR TITLE
Migrate CacheStorage data to origin directory

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -108,7 +108,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(IPC::Connection* c
     IPC::Connection::UniqueID connectionID;
     if (connection)
         connectionID = connection->uniqueID();
-    return NetworkStorageManager::create(parameters.sessionID, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, parameters.perOriginStorageQuota, parameters.perThirdPartyOriginStorageQuota, parameters.shouldUseCustomStoragePaths);
+    return NetworkStorageManager::create(parameters.sessionID, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, parameters.perOriginStorageQuota, parameters.perThirdPartyOriginStorageQuota, parameters.unifiedOriginStorageLevel);
 }
 
 NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -98,7 +98,7 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << shouldAcceptInsecureCertificatesForWebSockets;
 #endif
 
-    encoder << shouldUseCustomStoragePaths;
+    encoder << unifiedOriginStorageLevel;
     encoder << perOriginStorageQuota << perThirdPartyOriginStorageQuota;
     encoder << localStorageDirectory << localStorageDirectoryExtensionHandle;
     encoder << indexedDBDirectory << indexedDBDirectoryExtensionHandle;
@@ -356,9 +356,9 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         return std::nullopt;
 #endif
 
-    std::optional<bool> shouldUseCustomStoragePaths;
-    decoder >> shouldUseCustomStoragePaths;
-    if (!shouldUseCustomStoragePaths)
+    std::optional<UnifiedOriginStorageLevel> unifiedOriginStorageLevel;
+    decoder >> unifiedOriginStorageLevel;
+    if (!unifiedOriginStorageLevel)
         return std::nullopt;
 
     std::optional<uint64_t> perOriginStorageQuota;
@@ -491,7 +491,7 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
 #if !HAVE(NSURLSESSION_WEBSOCKET)
         , WTFMove(*shouldAcceptInsecureCertificatesForWebSockets)
 #endif
-        , *shouldUseCustomStoragePaths
+        , *unifiedOriginStorageLevel
         , WTFMove(*perOriginStorageQuota)
         , WTFMove(*perThirdPartyOriginStorageQuota)
         , WTFMove(*localStorageDirectory)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ResourceLoadStatisticsParameters.h"
+#include "UnifiedOriginStorageLevel.h"
 #include "WebPushDaemonConnectionConfiguration.h"
 #include <WebCore/NetworkStorageSession.h>
 #include <pal/SessionID.h>
@@ -115,7 +116,7 @@ struct NetworkSessionCreationParameters {
     bool shouldAcceptInsecureCertificatesForWebSockets { false };
 #endif
 
-    bool shouldUseCustomStoragePaths { false };
+    UnifiedOriginStorageLevel unifiedOriginStorageLevel { UnifiedOriginStorageLevel::Basic };
     uint64_t perOriginStorageQuota;
     uint64_t perThirdPartyOriginStorageQuota;
     String localStorageDirectory;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -44,14 +44,14 @@ struct CacheStorageRecordInformation;
 class CacheStorageManager : public CanMakeWeakPtr<CacheStorageManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static FileSystem::Salt cacheStorageSalt(const String& rootDirectory);
-    static String cacheStorageOriginDirectory(const String& rootDirectory, FileSystem::Salt, const WebCore::ClientOrigin&);
+    static String cacheStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin&);
+    static void copySaltFileToOriginDirectory(const String& rootDirectory, const String& originDirectory);
     static HashSet<WebCore::ClientOrigin> originsOfCacheStorageData(const String& rootDirectory);
     static uint64_t cacheStorageSize(const String& originDirectory);
     static bool hasCacheList(const String& cacheListDirectory);
 
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
-    CacheStorageManager(const String& path, FileSystem::Salt, CacheStorageRegistry&, const WebCore::ClientOrigin&, QuotaCheckFunction&&, Ref<WorkQueue>&&);
+    CacheStorageManager(const String& path, CacheStorageRegistry&, const std::optional<WebCore::ClientOrigin>&, QuotaCheckFunction&&, Ref<WorkQueue>&&);
     ~CacheStorageManager();
     void openCache(const String& name, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
     void removeCache(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
@@ -69,6 +69,7 @@ public:
     void sizeDecreased(uint64_t amount);
 
 private:
+    String saltFilePath() const;
     void makeDirty();
     bool initializeCaches();
     void removeUnusedCache(WebCore::DOMCacheIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -69,6 +69,7 @@ enum class StorageType : uint8_t;
 
 namespace WebKit {
 
+enum class UnifiedOriginStorageLevel : uint8_t;
 class FileSystemStorageHandleRegistry;
 class IDBStorageRegistry;
 class StorageAreaBase;
@@ -76,7 +77,7 @@ class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
 public:
-    static Ref<NetworkStorageManager> create(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);
+    static Ref<NetworkStorageManager> create(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
 
     void startReceivingMessageFromConnection(IPC::Connection&);
@@ -108,7 +109,7 @@ public:
 #endif
 
 private:
-    NetworkStorageManager(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);
+    NetworkStorageManager(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, UnifiedOriginStorageLevel);
     ~NetworkStorageManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
@@ -213,7 +214,7 @@ private:
     String m_customCacheStoragePath;
     uint64_t m_defaultOriginQuota;
     uint64_t m_defaultThirdPartyOriginQuota;
-    bool m_shouldUseCustomPaths;
+    UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
     IPC::Connection::UniqueID m_parentConnection;
     HashMap<IPC::Connection::UniqueID, HashSet<String>> m_temporaryBlobPathsByConnection WTF_GUARDED_BY_CAPABILITY(workQueue());
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -45,6 +45,7 @@ class IDBStorageRegistry;
 class LocalStorageManager;
 class SessionStorageManager;
 class StorageAreaRegistry;
+enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
 class OriginStorageManager {
@@ -52,7 +53,7 @@ class OriginStorageManager {
 public:
     static String originFileIdentifier();
 
-    OriginStorageManager(uint64_t quota, QuotaManager::IncreaseQuotaFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, FileSystem::Salt cacheStorageSalt, bool shouldUseCustomPaths);
+    OriginStorageManager(uint64_t quota, QuotaManager::IncreaseQuotaFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
@@ -95,13 +96,12 @@ private:
     String m_path;
     String m_customLocalStoragePath;
     String m_customIDBStoragePath;
-    String m_cacheStoragePath;
-    FileSystem::Salt m_cacheStorageSalt;
+    String m_customCacheStoragePath;
     uint64_t m_quota;
     QuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
     RefPtr<QuotaManager> m_quotaManager;
     bool m_persisted { false };
-    bool m_shouldUseCustomPaths;
+    UnifiedOriginStorageLevel m_level;
     std::optional<WallTime> m_originFileCreationTimestamp;
 #if PLATFORM(IOS_FAMILY)
     bool m_includedInBackup { false };

--- a/Source/WebKit/Shared/WebsiteData/UnifiedOriginStorageLevel.h
+++ b/Source/WebKit/Shared/WebsiteData/UnifiedOriginStorageLevel.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/EnumTraits.h>
+
+namespace WebKit {
+
+enum class UnifiedOriginStorageLevel : uint8_t {
+    None = 0,
+    Basic,
+    Standard
+};
+
+inline std::optional<UnifiedOriginStorageLevel> convertToUnifiedOriginStorageLevel(uint8_t value)
+{
+    if (value > static_cast<uint8_t>(UnifiedOriginStorageLevel::Standard))
+        return std::nullopt;
+
+    return static_cast<UnifiedOriginStorageLevel>(value);
+}
+
+} // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::UnifiedOriginStorageLevel> {
+    using values = EnumValues<
+        WebKit::UnifiedOriginStorageLevel,
+        WebKit::UnifiedOriginStorageLevel::None,
+        WebKit::UnifiedOriginStorageLevel::Basic,
+        WebKit::UnifiedOriginStorageLevel::Standard
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -26,6 +26,12 @@
 #import <Foundation/Foundation.h>
 #import <WebKit/WKFoundation.h>
 
+typedef NS_ENUM(NSInteger, _WKUnifiedOriginStorageLevel) {
+    _WKUnifiedOriginStorageLevelNone,
+    _WKUnifiedOriginStorageLevelBasic,
+    _WKUnifiedOriginStorageLevelStandard
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 NS_ASSUME_NONNULL_BEGIN
 
 WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
@@ -88,8 +94,8 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic, nullable, copy) NSURL *alternativeServicesStorageDirectory WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, nullable, copy) NSURL *standaloneApplicationURL WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, nullable, copy) NSURL *generalStorageDirectory WK_API_AVAILABLE(macos(13.0), ios(16.0));
-@property (nonatomic) BOOL shouldUseCustomStoragePaths WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, nullable, copy, setter=setWebPushPartitionString:) NSString *webPushPartitionString WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic) _WKUnifiedOriginStorageLevel unifiedOriginStorageLevel WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "_WKWebsiteDataStoreConfigurationInternal.h"
 
+#import "UnifiedOriginStorageLevel.h"
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
 
@@ -413,14 +414,38 @@ static void checkURLArgument(NSURL *url)
     _configuration->setGeneralStorageDirectory(url.path);
 }
 
-- (BOOL)shouldUseCustomStoragePaths
+static _WKUnifiedOriginStorageLevel toWKUnifiedOriginStorageLevel(WebKit::UnifiedOriginStorageLevel level)
 {
-    return _configuration->shouldUseCustomStoragePaths();
+    switch (level) {
+    case WebKit::UnifiedOriginStorageLevel::None:
+        return _WKUnifiedOriginStorageLevelNone;
+    case WebKit::UnifiedOriginStorageLevel::Basic:
+        return _WKUnifiedOriginStorageLevelBasic;
+    case WebKit::UnifiedOriginStorageLevel::Standard:
+        return _WKUnifiedOriginStorageLevelStandard;
+    }
 }
 
-- (void)setShouldUseCustomStoragePaths:(BOOL)use
+static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedOriginStorageLevel wkLevel)
 {
-    _configuration->setShouldUseCustomStoragePaths(use);
+    switch (wkLevel) {
+    case _WKUnifiedOriginStorageLevelNone:
+        return WebKit::UnifiedOriginStorageLevel::None;
+    case _WKUnifiedOriginStorageLevelBasic:
+        return WebKit::UnifiedOriginStorageLevel::Basic;
+    case _WKUnifiedOriginStorageLevelStandard:
+        return WebKit::UnifiedOriginStorageLevel::Standard;
+    }
+}
+
+- (_WKUnifiedOriginStorageLevel)unifiedOriginStorageLevel
+{
+    return toWKUnifiedOriginStorageLevel(_configuration->unifiedOriginStorageLevel());
+}
+
+- (void)setUnifiedOriginStorageLevel:(_WKUnifiedOriginStorageLevel)level
+{
+    _configuration->setUnifiedOriginStorageLevel(toUnifiedOriginStorageLevel(level));
 }
 
 - (NSString *)webPushPartitionString

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -38,6 +38,7 @@
 #include "NetworkProcessMessages.h"
 #include "ShouldGrandfatherStatistics.h"
 #include "StorageAccessStatus.h"
+#include "UnifiedOriginStorageLevel.h"
 #include "WebBackForwardCache.h"
 #include "WebKit2Initialize.h"
 #include "WebNotificationManagerProxy.h"
@@ -1873,7 +1874,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #if !HAVE(NSURLSESSION_WEBSOCKET)
     networkSessionParameters.shouldAcceptInsecureCertificatesForWebSockets = m_configuration->shouldAcceptInsecureCertificatesForWebSockets();
 #endif
-    networkSessionParameters.shouldUseCustomStoragePaths = m_configuration->shouldUseCustomStoragePaths();
+    networkSessionParameters.unifiedOriginStorageLevel = m_configuration->unifiedOriginStorageLevel();
     networkSessionParameters.perOriginStorageQuota = perOriginStorageQuota();
     networkSessionParameters.perThirdPartyOriginStorageQuota = perThirdPartyOriginStorageQuota();
     networkSessionParameters.localStorageDirectory = resolvedLocalStorageDirectory();
@@ -1990,10 +1991,11 @@ bool WebsiteDataStore::networkProcessHasEntitlementForTesting(const String&)
     return false;
 }
 
-bool WebsiteDataStore::defaultShouldUseCustomStoragePaths()
+UnifiedOriginStorageLevel WebsiteDataStore::defaultUnifiedOriginStorageLevel()
 {
-    return true;
+    return UnifiedOriginStorageLevel::None;
 }
+
 #endif // !PLATFORM(COCOA)
 
 #if !USE(GLIB) && !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -96,6 +96,7 @@ class WebProcessPool;
 class WebProcessProxy;
 class WebResourceLoadStatisticsStore;
 enum class CacheModel : uint8_t;
+enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataFetchOption : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
@@ -372,7 +373,7 @@ public:
     static String defaultJavaScriptConfigurationDirectory(const String& baseDataDirectory = nullString());
 
     static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
-    static bool defaultShouldUseCustomStoragePaths();
+    static UnifiedOriginStorageLevel defaultUnifiedOriginStorageLevel();
 
     void resetQuota(CompletionHandler<void()>&&);
     void clearStorage(CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebsiteDataStoreConfiguration.h"
 
+#include "UnifiedOriginStorageLevel.h"
 #include "WebPushDaemonConnectionConfiguration.h"
 #include "WebsiteDataStore.h"
 
@@ -33,7 +34,7 @@ namespace WebKit {
 
 WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(IsPersistent isPersistent, ShouldInitializePaths shouldInitializePaths)
     : m_isPersistent(isPersistent)
-    , m_shouldUseCustomStoragePaths(WebsiteDataStore::defaultShouldUseCustomStoragePaths())
+    , m_unifiedOriginStorageLevel(WebsiteDataStore::defaultUnifiedOriginStorageLevel())
     , m_perOriginStorageQuota(WebsiteDataStore::defaultPerOriginQuota())
 {
     if (isPersistent == IsPersistent::Yes && shouldInitializePaths == ShouldInitializePaths::Yes) {
@@ -56,7 +57,7 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(IsPersistent isPers
 
 WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const UUID& identifier)
     : m_isPersistent(IsPersistent::Yes)
-    , m_shouldUseCustomStoragePaths(WebsiteDataStore::defaultShouldUseCustomStoragePaths())
+    , m_unifiedOriginStorageLevel(WebsiteDataStore::defaultUnifiedOriginStorageLevel())
     , m_identifier(identifier)
     , m_baseCacheDirectory(WebsiteDataStore::defaultWebsiteDataStoreDirectory(identifier))
     , m_baseDataDirectory(WebsiteDataStore::defaultWebsiteDataStoreDirectory(identifier))
@@ -75,7 +76,7 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const UUID& identif
 #if !PLATFORM(COCOA)
 WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const String& baseCacheDirectory, const String& baseDataDirectory)
     : m_isPersistent(IsPersistent::Yes)
-    , m_shouldUseCustomStoragePaths(WebsiteDataStore::defaultShouldUseCustomStoragePaths())
+    , m_unifiedOriginStorageLevel(WebsiteDataStore::defaultUnifiedOriginStorageLevel())
     , m_baseCacheDirectory(baseCacheDirectory)
     , m_baseDataDirectory(baseDataDirectory)
     , m_perOriginStorageQuota(WebsiteDataStore::defaultPerOriginQuota())
@@ -124,7 +125,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_staleWhileRevalidateEnabled = this->m_staleWhileRevalidateEnabled;
     copy->m_cacheStorageDirectory = this->m_cacheStorageDirectory;
     copy->m_generalStorageDirectory = this->m_generalStorageDirectory;
-    copy->m_shouldUseCustomStoragePaths = this->m_shouldUseCustomStoragePaths;
+    copy->m_unifiedOriginStorageLevel = this->m_unifiedOriginStorageLevel;
     copy->m_perOriginStorageQuota = this->m_perOriginStorageQuota;
     copy->m_networkCacheDirectory = this->m_networkCacheDirectory;
     copy->m_applicationCacheDirectory = this->m_applicationCacheDirectory;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -32,6 +32,8 @@
 
 namespace WebKit {
 
+enum class UnifiedOriginStorageLevel : uint8_t;
+
 namespace WebPushD {
 struct WebPushDaemonConnectionConfiguration;
 }
@@ -148,10 +150,8 @@ public:
     const String& generalStorageDirectory() const { return m_generalStorageDirectory; }
     void setGeneralStorageDirectory(String&& directory) { m_generalStorageDirectory = WTFMove(directory); }
 
-    // If true, store data in localStorageDirectory and indexedDBDatabaseDirectory. Otherwise,
-    // migrate data from these locations to generalStorageDirectory.
-    bool shouldUseCustomStoragePaths() const { return m_shouldUseCustomStoragePaths; }
-    void setShouldUseCustomStoragePaths(bool use) { m_shouldUseCustomStoragePaths = use; }
+    UnifiedOriginStorageLevel unifiedOriginStorageLevel() const { return m_unifiedOriginStorageLevel; }
+    void setUnifiedOriginStorageLevel(UnifiedOriginStorageLevel level) { m_unifiedOriginStorageLevel = level; }
 
     const String& webPushPartitionString() const { return m_webPushPartitionString; }
     void setWebPushPartitionString(String&& string) { m_webPushPartitionString = WTFMove(string); }
@@ -235,7 +235,7 @@ private:
 
     IsPersistent m_isPersistent { IsPersistent::No };
 
-    bool m_shouldUseCustomStoragePaths;
+    UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
     std::optional<UUID> m_identifier;
     String m_baseCacheDirectory;
     String m_baseDataDirectory;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1593,6 +1593,7 @@
 		93B631F127ABACA900443A44 /* QuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631EF27ABACA900443A44 /* QuotaManager.h */; };
 		93B631F327ABAD8000443A44 /* QuotaIncreaseRequestIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631F227ABAD7F00443A44 /* QuotaIncreaseRequestIdentifier.h */; };
 		93BDEB01171DD7AF00BFEE1B /* WKPageLoadTypesPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BDEB00171DD7AF00BFEE1B /* WKPageLoadTypesPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		93D1EEF529669D74009B31D6 /* UnifiedOriginStorageLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D1EEF429669D73009B31D6 /* UnifiedOriginStorageLevel.h */; };
 		93D6B772254BB5190058DD3A /* SpeechRecognitionServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D6B76C254B89580058DD3A /* SpeechRecognitionServer.h */; };
 		93D6B773254BB8C70058DD3A /* WebSpeechRecognitionConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D6B768254B7BC60058DD3A /* WebSpeechRecognitionConnection.h */; };
 		93D6B782254CCCF40058DD3A /* SpeechRecognitionServerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93D6B781254CCABC0058DD3A /* SpeechRecognitionServerMessageReceiver.cpp */; };
@@ -6202,6 +6203,7 @@
 		93BA04E02151ADF4007F455F /* WebSWServerConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSWServerConnection.h; sourceTree = "<group>"; };
 		93BA04E12151ADF4007F455F /* WebSWServerConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWServerConnection.cpp; sourceTree = "<group>"; };
 		93BDEB00171DD7AF00BFEE1B /* WKPageLoadTypesPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageLoadTypesPrivate.h; sourceTree = "<group>"; };
+		93D1EEF429669D73009B31D6 /* UnifiedOriginStorageLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnifiedOriginStorageLevel.h; sourceTree = "<group>"; };
 		93D6B767254B7BC60058DD3A /* WebSpeechRecognitionConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSpeechRecognitionConnection.cpp; sourceTree = "<group>"; };
 		93D6B768254B7BC60058DD3A /* WebSpeechRecognitionConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSpeechRecognitionConnection.h; sourceTree = "<group>"; };
 		93D6B769254B7BC60058DD3A /* WebSpeechRecognitionProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSpeechRecognitionProvider.h; sourceTree = "<group>"; };
@@ -8786,6 +8788,7 @@
 			isa = PBXGroup;
 			children = (
 				93B631F227ABAD7F00443A44 /* QuotaIncreaseRequestIdentifier.h */,
+				93D1EEF429669D73009B31D6 /* UnifiedOriginStorageLevel.h */,
 				1A4832D41A9CDF96008B4DFE /* WebsiteData.cpp */,
 				1A4832D51A9CDF96008B4DFE /* WebsiteData.h */,
 				1A28B8CB1C80ED59006FD743 /* WebsiteDataFetchOption.h */,
@@ -15457,6 +15460,7 @@
 				CEE4AE2B1A5DCF430002F49B /* UIKitSPI.h in Headers */,
 				461CCCA5231485A700B659B9 /* UIRemoteObjectRegistry.h in Headers */,
 				5C4B9D8B210A8CCF008F14D1 /* UndoOrRedo.h in Headers */,
+				93D1EEF529669D74009B31D6 /* UnifiedOriginStorageLevel.h in Headers */,
 				1A64245E12DE29A100CAAE2C /* UpdateInfo.h in Headers */,
 				5C19A5201FD0B29500EEA323 /* URLSchemeTaskParameters.h in Headers */,
 				1AC1336818565B5700F3EC05 /* UserData.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
@@ -53,7 +53,7 @@ static void runTest()
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     // We need to create custom WebsiteDataStore that uses custom IndexedDB paths to test old migration code.
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = true;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     // Custom WebsiteDataStore must have a different general storage directory than default WebsiteDataStore.
     websiteDataStoreConfiguration.get().generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
@@ -182,7 +182,7 @@ TEST(IndexedDB, IndexedDBFileNameAPI)
     
     auto types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = true;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     websiteDataStoreConfiguration.get().generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -415,7 +415,7 @@ TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = idbDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
@@ -515,7 +515,7 @@ TEST(WKWebView, LocalStorageNoSizeOverflow)
 TEST(WKWebView, LocalStorageDirectoryExcludedFromBackup)
 {
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = true;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     RetainPtr<NSURL> webStorageDirectory = [websiteDataStoreConfiguration _webStorageDirectory];
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -106,7 +106,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultResourceLoadStatisticsPath.path]);
 
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = true;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = idbPath;
     websiteDataStoreConfiguration.get()._webStorageDirectory = localStoragePath;
     websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile;
@@ -815,7 +815,7 @@ TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._webStorageDirectory = localStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = true;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
 
     @autoreleasepool {
@@ -840,7 +840,7 @@ TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)
     }
 
     // Create a new WebsiteDataStore that performs migration.
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
@@ -896,7 +896,7 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = indexedDBDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = true;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
 
     @autoreleasepool {
@@ -919,7 +919,7 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
     }
 
     // Create a new WebsiteDataStore that performs migration.
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
@@ -973,7 +973,7 @@ TEST(WebKit, FetchDataAfterEnablingGeneralStorageDirectory)
     websiteDataStoreConfiguration.get()._webStorageDirectory = customLocalStorageDirectory;
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = customIndexedDBStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     // Ensure data is fetched from both custom path and new path.
@@ -1051,7 +1051,7 @@ TEST(WebKit, DeleteDataAfterEnablingGeneralStorageDirectory)
     websiteDataStoreConfiguration.get()._webStorageDirectory = customLocalStorageDirectory;
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = customIndexedDBStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     auto dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeLocalStorage, WKWebsiteDataTypeIndexedDBDatabases, nil];
@@ -1091,7 +1091,7 @@ TEST(WebKit, CreateOriginFileWhenNeeded)
 
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [fileManager removeItemAtURL:websiteDataStoreConfiguration.get()._webStorageDirectory error:nil];
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
@@ -1184,7 +1184,7 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenFetchData)
 
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [fileManager removeItemAtURL:websiteDataStoreConfiguration.get()._webStorageDirectory error:nil];
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     done = false;
@@ -1213,7 +1213,7 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenOriginIsGone)
 
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [fileManager removeItemAtURL:websiteDataStoreConfiguration.get()._webStorageDirectory error:nil];
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -1254,7 +1254,7 @@ TEST(WebKit, OriginDirectoryExcludedFromBackup)
 
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    websiteDataStoreConfiguration.get().shouldUseCustomStoragePaths = false;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     NSString *htmlString = @"<script> \
@@ -1402,4 +1402,82 @@ TEST(WKWebsiteDataStoreConfiguration, SetPathOnConfigurationWithIdentifier)
         hasException = true;
     }
     EXPECT_TRUE(hasException);
+}
+
+TEST(WKWebsiteDataStore, MigrateCacheStorageDataToGeneralStorageDirectory)
+{
+    RetainPtr<NSURL> cacheStorageOriginDirectory = nullptr;
+    NSURL *cacheStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CacheStorage" stringByExpandingTildeInPath] isDirectory:YES];
+    NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Origins" stringByExpandingTildeInPath] isDirectory:YES];
+    NSURL *resourceSalt = [[NSBundle mainBundle] URLForResource:@"general-storage-directory" withExtension:@"salt" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *newCacheStorageOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/CacheStorage/"];
+    NSURL *newCacheStorageCachesListFile = [newCacheStorageOriginDirectory URLByAppendingPathComponent:@"cacheslist"];
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:cacheStorageDirectory error:nil];
+    [fileManager removeItemAtURL:generalStorageDirectory error:nil];
+    [fileManager createDirectoryAtURL:generalStorageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+    [fileManager copyItemAtURL:resourceSalt toURL:[generalStorageDirectory URLByAppendingPathComponent:@"salt"] error:nil];
+    
+    NSString *htmlString = @"<script> \
+        var put = false; \
+        window.caches.keys().then((keys) => { \
+            if (!keys.length) put = true; \
+            return window.caches.open('testCache'); \
+        }).then((cache) => { \
+            if (put) \
+                return cache.put('https://webkit.org/test', new Response('this is response')); \
+            return cache.match(new Request('https://webkit.org/test')); \
+        }).then((result) => { \
+            if (put) \
+                window.webkit.messageHandlers.testHandler.postMessage('put succeeded'); \
+            else if (!result) \
+                window.webkit.messageHandlers.testHandler.postMessage('match failed'); \
+            else { \
+                result.text().then((resultText) => { \
+                    window.webkit.messageHandlers.testHandler.postMessage('matched: ' + resultText); \
+                }); \
+            } \
+        }).catch(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('failed'); \
+        }); \
+        </script>";
+    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    websiteDataStoreConfiguration.get()._cacheStorageDirectory = cacheStorageDirectory;
+    websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
+    auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+
+    @autoreleasepool {
+        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
+        [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        receivedScriptMessage = false;
+        [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ("put succeeded", getNextMessage().body);
+
+        NSArray *children = [fileManager contentsOfDirectoryAtPath:cacheStorageDirectory.path error:nullptr];
+        EXPECT_EQ(2U, [children count]);
+        for (NSString *child in children) {
+            if ([child isEqualToString:@"salt"])
+                continue;
+            cacheStorageOriginDirectory = [cacheStorageDirectory URLByAppendingPathComponent:child];
+        }
+    }
+
+    // Create a new WebsiteDataStore that performs migration.
+    websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelStandard;
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    receivedScriptMessage = false;
+    [thirdWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ("matched: this is response", getNextMessage().body);
+    EXPECT_FALSE([fileManager fileExistsAtPath:cacheStorageOriginDirectory.get().path]);
+    EXPECT_TRUE([fileManager fileExistsAtPath:newCacheStorageOriginDirectory.path]);
+    EXPECT_TRUE([fileManager fileExistsAtPath:newCacheStorageCachesListFile.path]);
 }


### PR DESCRIPTION
#### 5d9c260954a94cf6ce71bf69ab4b23c92b8e3e02
<pre>
Migrate CacheStorage data to origin directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=250159">https://bugs.webkit.org/show_bug.cgi?id=250159</a>
rdar://103931715

Reviewed by Youenn Fablet.

Each partitioned origin has a directory that stores data only that origin can access. The directory is owned by
OriginStorageManager. Now that CacheStorage is managed by OriginStorageManager, we could migrate its data from
CacheStorage directory to origin directory. This change has a few benefits:
1. Current CacheStorage directory is under Caches/, which could be evicted as http cache and does not match spec
(<a href="https://w3c.github.io/ServiceWorker/#cache-lifetimes).">https://w3c.github.io/ServiceWorker/#cache-lifetimes).</a> Moving CacheStorage data to origin direcotry will make it not
purgeable.
2. Current CacheStorage directory also separates data by origin -- in CacheStorage/, each origin has a directory, and
each origin directory has an origin file. By moving data to origin directory, we no longer need the duplicate origin
file and directory under CacheStorage/.
3. Client does not need to set a separate CacheStorageDirectory, WebKit would use GeneralStorageDirectory (where origin
directories are located) for different types.

When we did this (migrating data from custom directory to unified origin directory) for LocalStorage and IndexedDB,
we used a boolean shouldUseCustomStoragePaths to indicate whether the data should be put under origin directory. We
cannot reuse this binary-state flag, since there will be three states:
1. All types use custom directory (non-Cocoa platforms)
2. IndexdDB and LocalStorage use origin directory (Cocoa platforms nowadays)
3. CacheStorage, IndexdDB and LocalStorage use origin directory (Cocoa platforms after the change is shipped)
Therefore, this patch adds UnifiedOriginStorageLevel to replace shouldUseCustomStoragePaths, which can represent more
states.

Test: WKWebsiteDataStore.MigrateCacheStorageDataToGeneralStorageDirectory

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::cacheStorageOriginDirectory):
(WebKit::CacheStorageManager::copySaltFileToOriginDirectory):
(WebKit::CacheStorageManager::saltFilePath const):
(WebKit::CacheStorageManager::CacheStorageManager):
(WebKit::CacheStorageManager::cacheStorageSalt): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::originStorageManager):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::StorageBucket):
(WebKit::OriginStorageManager::StorageBucket::cacheStorageManager):
(WebKit::OriginStorageManager::StorageBucket::isEmpty):
(WebKit::OriginStorageManager::StorageBucket::fetchDataTypesInListFromDisk):
(WebKit::OriginStorageManager::StorageBucket::deleteCacheStorageData):
(WebKit::OriginStorageManager::StorageBucket::deleteEmptyDirectory):
(WebKit::OriginStorageManager::StorageBucket::resolvedLocalStoragePath):
(WebKit::OriginStorageManager::StorageBucket::resolvedIDBStoragePath):
(WebKit::OriginStorageManager::StorageBucket::resolvedCacheStoragePath):
(WebKit::OriginStorageManager::StorageBucket::resolvedPath):
(WebKit::OriginStorageManager::OriginStorageManager):
(WebKit::OriginStorageManager::defaultBucket):
(WebKit::OriginStorageManager::quotaManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/Shared/WebsiteData/UnifiedOriginStorageLevel.h: Added.
(WebKit::convertToUnifiedOriginStorageLevel):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(toWKUnifiedOriginStorageLevel):
(toUnifiedOriginStorageLevel):
(-[_WKWebsiteDataStoreConfiguration unifiedOriginStorageLevel]):
(-[_WKWebsiteDataStoreConfiguration setUnifiedOriginStorageLevel:]):
(-[_WKWebsiteDataStoreConfiguration shouldUseCustomStoragePaths]): Deleted.
(-[_WKWebsiteDataStoreConfiguration setShouldUseCustomStoragePaths:]): Deleted.
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultUnifiedOriginStorageLevel):
(WebKit::internalFeatureEnabled): Deleted.
(WebKit::WebsiteDataStore::defaultShouldUseCustomStoragePaths): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::defaultUnifiedOriginStorageLevel):
(WebKit::WebsiteDataStore::defaultShouldUseCustomStoragePaths): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration):
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::unifiedOriginStorageLevel const):
(WebKit::WebsiteDataStoreConfiguration::setUnifiedOriginStorageLevel):
(WebKit::WebsiteDataStoreConfiguration::shouldUseCustomStoragePaths const): Deleted.
(WebKit::WebsiteDataStoreConfiguration::setShouldUseCustomStoragePaths): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm:
(runTest):
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(runWebsiteDataStoreCustomPaths):
(TEST):

Canonical link: <a href="https://commits.webkit.org/258591@main">https://commits.webkit.org/258591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b8e8d9b3e32178fecdc022b60ce1a065f599a36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102370 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111675 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2426 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9572 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37294 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24326 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25749 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2187 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45242 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5896 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6900 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->