### PR TITLE
Make more of WheelEventTestMonitor work with UI-side compositing

### DIFF
--- a/Source/WebCore/page/WheelEventTestMonitor.cpp
+++ b/Source/WebCore/page/WheelEventTestMonitor.cpp
@@ -116,6 +116,8 @@ void WheelEventTestMonitor::receivedWheelEventWithPhases(PlatformWheelEventPhase
 #if ENABLE(KINETIC_SCROLLING)
     Locker locker { m_lock };
 
+    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "      (=) WheelEventTestMonitor::receivedWheelEventWithPhases: phase=" << phase << " momentumPhase=" << momentumPhase);
+
     if (phase == PlatformWheelEventPhase::Ended || phase == PlatformWheelEventPhase::Cancelled)
         m_receivedWheelEndOrCancel = true;
 

--- a/Source/WebCore/page/WheelEventTestMonitor.h
+++ b/Source/WebCore/page/WheelEventTestMonitor.h
@@ -113,7 +113,26 @@ private:
     WheelEventTestMonitor::DeferReason m_reason;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, WheelEventTestMonitor::DeferReason);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelEventTestMonitor::DeferReason);
 WTF::TextStream& operator<<(WTF::TextStream&, const WheelEventTestMonitor::ScrollableAreaReasonMap&);
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::WheelEventTestMonitor::DeferReason> {
+    using values = EnumValues<
+        WebCore::WheelEventTestMonitor::DeferReason,
+        WebCore::WheelEventTestMonitor::DeferReason::HandlingWheelEvent,
+        WebCore::WheelEventTestMonitor::DeferReason::HandlingWheelEventOnMainThread,
+        WebCore::WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling,
+        WebCore::WheelEventTestMonitor::DeferReason::RubberbandInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::ScrollSnapInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::ScrollAnimationInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::ScrollingThreadSyncNeeded,
+        WebCore::WheelEventTestMonitor::DeferReason::ContentScrollInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::RequestedScrollPosition
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -67,9 +67,6 @@ enum class PlatformWheelEventPhase : uint8_t {
 #endif
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, PlatformWheelEventPhase);
-
-
 #if PLATFORM(WIN)
 // How many pixels should we scroll per line? Gecko uses the height of the
 // current line, which means scroll distance changes as you go through the
@@ -283,5 +280,26 @@ inline FloatSize PlatformWheelEvent::swipeVelocity() const
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PlatformWheelEvent&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, EventHandling);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelScrollGestureState);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformWheelEventPhase);
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::PlatformWheelEventPhase> {
+    using values = EnumValues<
+        WebCore::PlatformWheelEventPhase,
+        WebCore::PlatformWheelEventPhase::None
+#if ENABLE(KINETIC_SCROLLING)
+        ,
+        WebCore::PlatformWheelEventPhase::Began,
+        WebCore::PlatformWheelEventPhase::Stationary,
+        WebCore::PlatformWheelEventPhase::Changed,
+        WebCore::PlatformWheelEventPhase::Ended,
+        WebCore::PlatformWheelEventPhase::Cancelled,
+        WebCore::PlatformWheelEventPhase::MayBegin
+#endif
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -735,6 +735,7 @@ def headers_for_type(type):
         'WebCore::PasteboardURL': ['<WebCore/Pasteboard.h>'],
         'WebCore::PasteboardWebContent': ['<WebCore/Pasteboard.h>'],
         'WebCore::PixelFormat': ['<WebCore/ImageBufferBackend.h>'],
+        'WebCore::PlatformWheelEventPhase': ['<WebCore/PlatformWheelEvent.h>'],
         'WebCore::PlatformTextTrackData': ['<WebCore/PlatformTextTrack.h>'],
         'WebCore::PlaybackSessionModel::PlaybackState': ['<WebCore/PlaybackSessionModel.h>'],
         'WebCore::PluginInfo': ['<WebCore/PluginData.h>'],

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -218,7 +218,7 @@ void ArgumentCoder<ScrollingStateScrollingNode>::encode(Encoder& encoder, const 
 #if ENABLE(SCROLLING_THREAD)
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::ReasonsForSynchronousScrolling, synchronousScrollingReasons)
 #endif
-    // We don't encode isMonitoringWheelEvents; this needs to be a sync message to the UI process.
+    SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::IsMonitoringWheelEvents, isMonitoringWheelEvents)
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::ScrollableAreaParams, scrollableAreaParameters)
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::RequestedScrollPosition, requestedScrollData)
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::KeyboardScrollData, keyboardScrollData)
@@ -317,6 +317,7 @@ bool ArgumentCoder<ScrollingStateScrollingNode>::decode(Decoder& decoder, Scroll
 #if ENABLE(SCROLLING_THREAD)
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ReasonsForSynchronousScrolling, OptionSet<SynchronousScrollingReason>, setSynchronousScrollingReasons)
 #endif
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::IsMonitoringWheelEvents, bool, setIsMonitoringWheelEvents);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ScrollableAreaParams, ScrollableAreaParameters, setScrollableAreaParameters);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::RequestedScrollPosition, RequestedScrollData, setRequestedScrollData);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
@@ -769,6 +770,9 @@ static void dump(TextStream& ts, const ScrollingStateScrollingNode& node, bool c
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::ReasonsForSynchronousScrolling))
         ts.dumpProperty("synchronous scrolling reasons", node.synchronousScrollingReasons());
 #endif
+
+    if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::IsMonitoringWheelEvents))
+        ts.dumpProperty("is monitoring wheel events", node.isMonitoringWheelEvents());
 
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::KeyboardScrollData)) {
         const auto& keyboardScrollData = node.keyboardScrollData();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -91,7 +91,6 @@ struct WKAppPrivacyReportTestingData {
 - (void)_setThrottleStateForTesting:(int)type;
 
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action;
-- (void)_startMonitoringWheelEvents;
 
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier;
 + (void)_clearApplicationBundleIdentifierTestingOverride;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -293,11 +293,6 @@
     });
 }
 
-- (void)_startMonitoringWheelEvents
-{
-    _page->startMonitoringWheelEventsForTesting();
-}
-
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier
 {
     WebCore::setApplicationBundleIdentifierOverride(String(bundleIdentifier));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -286,9 +286,20 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
     m_webPageProxy.logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode), timestamp, reasons.toRaw());
 }
 
-void RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting()
+void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    m_scrollingTree->setIsMonitoringWheelEvents(true);
+    ALWAYS_LOG_WITH_STREAM(stream << "  RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases " << phase << " momentumPhase " << momentumPhase);
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase));
+}
+
+void RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(nodeID, reason));
+}
+
+void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -125,7 +125,9 @@ public:
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>);
 
-    void startMonitoringWheelEventsForTesting();
+    void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
+    void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+    void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -110,6 +110,21 @@ void RemoteScrollingTree::reportSynchronousScrollingReasonsChanged(MonotonicTime
     m_scrollingCoordinatorProxy.reportSynchronousScrollingReasonsChanged(timestamp, reasons);
 }
 
+void RemoteScrollingTree::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
+{
+    m_scrollingCoordinatorProxy.receivedWheelEventWithPhases(phase, momentumPhase);
+}
+
+void RemoteScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_scrollingCoordinatorProxy.deferWheelEventTestCompletionForReason(nodeID, reason);
+}
+
+void RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_scrollingCoordinatorProxy.removeWheelEventTestCompletionDeferralForReason(nodeID, reason);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -30,6 +30,7 @@
 #include "RemoteScrollingCoordinator.h"
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingTree.h>
+#include <WebCore/WheelEventTestMonitor.h>
 
 namespace WebCore {
 class PlatformMouseEvent;
@@ -64,6 +65,10 @@ protected:
     explicit RemoteScrollingTree(RemoteScrollingCoordinatorProxy&);
 
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
+
+    void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase) override;
+    void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
+    void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
 
     RemoteScrollingCoordinatorProxy& m_scrollingCoordinatorProxy;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3099,14 +3099,6 @@ void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
     }
 }
 
-void WebPageProxy::startMonitoringWheelEventsForTesting()
-{
-#if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
-    if (m_scrollingCoordinatorProxy)
-        m_scrollingCoordinatorProxy->startMonitoringWheelEventsForTesting();
-#endif
-}
-
 #if HAVE(CVDISPLAYLINK)
 void WebPageProxy::wheelEventHysteresisUpdated(PAL::HysteresisState)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1058,7 +1058,6 @@ public:
 
     bool isProcessingWheelEvents() const;
     void handleWheelEvent(const NativeWebWheelEvent&);
-    void startMonitoringWheelEventsForTesting();
 
     bool isProcessingKeyboardEvents() const;
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -82,6 +82,10 @@ private:
     void animatedScrollDidEndForNode(WebCore::ScrollingNodeID);
     void currentSnapPointIndicesChangedForNode(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
+    void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
+    void startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+    void stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+
     WebPage* m_webPage;
 
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveRubberBanding;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -27,6 +27,10 @@ messages -> RemoteScrollingCoordinator {
     AnimatedScrollDidEndForNode(uint64_t nodeID);
     CurrentSnapPointIndicesChangedForNode(uint64_t nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
     ScrollingStateInUIProcessChanged(WebKit::RemoteScrollingUIState uiState);
+
+    ReceivedWheelEventWithPhases(enum:uint8_t WebCore::PlatformWheelEventPhase phase, enum:uint8_t WebCore::PlatformWheelEventPhase momentumPhase);
+    StartDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
+    StopDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
 }
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -40,11 +40,12 @@
 #import <WebCore/Frame.h>
 #import <WebCore/FrameView.h>
 #import <WebCore/GraphicsLayer.h>
+#import <WebCore/Page.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderView.h>
 #import <WebCore/ScrollingTreeFixedNodeCocoa.h>
 #import <WebCore/ScrollingTreeStickyNodeCocoa.h>
-
+#import <WebCore/WheelEventTestMonitor.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -144,6 +145,24 @@ void RemoteScrollingCoordinator::addNodeWithActiveRubberBanding(ScrollingNodeID 
 void RemoteScrollingCoordinator::removeNodeWithActiveRubberBanding(ScrollingNodeID nodeID)
 {
     m_nodesWithActiveRubberBanding.remove(nodeID);
+}
+
+void RemoteScrollingCoordinator::receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase)
+{
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->receivedWheelEventWithPhases(phase, momentumPhase);
+}
+
+void RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, WebCore::WheelEventTestMonitor::DeferReason reason)
+{
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+}
+
+void RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, WebCore::WheelEventTestMonitor::DeferReason reason)
+{
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }
 
 } // namespace WebKit

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -68,7 +68,6 @@ public:
     void setWheelHasPreciseDeltas(bool);
 #endif
     void continuousMouseScrollBy(int x, int y, bool paged);
-    void monitorWheelEvents();
 
 #if PLATFORM(MAC)
     enum class WheelEventPhase : uint8_t {

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -516,10 +516,6 @@ void EventSendingController::monitorWheelEvents(MonitorWheelEventsOptions* optio
     m_sentWheelPhaseEndOrCancel = false;
     m_sentWheelMomentumPhaseEnd = false;
     WKBundlePageStartMonitoringScrollOperations(page, options ? options->resetLatching : true);
-
-    auto body = adoptWK(WKMutableDictionaryCreate());
-    setValue(body, "SubMessage", "MonitorWheelEvents");
-    postPageMessage("EventSender", body);
 }
 
 struct ScrollCompletionCallbackData {

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
@@ -99,10 +99,6 @@ void EventSenderProxy::continuousMouseScrollBy(int x, int y, bool paged)
 {
 }
 
-void EventSenderProxy::monitorWheelEvents()
-{
-}
-
 #if ENABLE(TOUCH_EVENTS)
 
 void EventSenderProxy::addTouchPoint(int x, int y)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1861,11 +1861,6 @@ void TestController::didReceiveMessageFromInjectedBundle(WKStringRef messageName
             return;
         }
 
-        if (WKStringIsEqualToUTF8CString(subMessageName, "MonitorWheelEvents")) {
-            m_eventSenderProxy->monitorWheelEvents();
-            return;
-        }
-
 #if PLATFORM(GTK)
         if (WKStringIsEqualToUTF8CString(subMessageName, "SetWheelHasPreciseDeltas")) {
             auto hasPreciseDeltas = booleanValue(dictionary, "HasPreciseDeltas");

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -312,10 +312,6 @@ void EventSenderProxy::continuousMouseScrollBy(int horizontal, int vertical, boo
         horizontal / pixelsPerScrollTick, vertical / pixelsPerScrollTick, m_position.x, m_position.y, WheelEventPhase::NoPhase, WheelEventPhase::NoPhase, m_hasPreciseDeltas);
 }
 
-void EventSenderProxy::monitorWheelEvents()
-{
-}
-
 void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int horizontal, int vertical, int phase, int momentum)
 {
     WheelEventPhase eventPhase = WheelEventPhase::NoPhase;

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -194,10 +194,6 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
-void EventSenderProxy::monitorWheelEvents()
-{
-}
-
 void EventSenderProxy::leapForward(int milliseconds)
 {
     m_time += milliseconds / 1000.0;

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -824,11 +824,6 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
     }
 }
 
-void EventSenderProxy::monitorWheelEvents()
-{
-    [m_testController->mainWebView()->platformView() _startMonitoringWheelEvents];
-}
-
 #if ENABLE(MAC_GESTURE_EVENTS)
 
 void EventSenderProxy::scaleGestureStart(double scale)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -149,10 +149,6 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
-void EventSenderProxy::monitorWheelEvents()
-{
-}
-
 void EventSenderProxy::leapForward(int milliseconds)
 {
     Sleep(milliseconds);


### PR DESCRIPTION
#### c87ffdc4dd04a58334af508245cd9a4aa5b75380
<pre>
Make more of WheelEventTestMonitor work with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250183">https://bugs.webkit.org/show_bug.cgi?id=250183</a>
rdar://103941080

Reviewed by Brent Fulgham.

In 258002@main I made a misguided attempt to make `eventSender.monitorWheelEvents` work
with UI-side compositing by updating &quot;monitoringWheelEvents&quot; state directly in the UI process,
but this just gets clobbered by a scrolling tree commit from the web process. So revert most
of 258002@main.

Now that all tests wait for a rendering update after calling `monitorWheelEvents` (258483@main)
we can just rely on &quot;IsMonitoringWheelEvents&quot; state to propagate from the web process to the
UI process, so start encoding it in RemoteScrollingCoordinatorTransaction.

We also have to hook up &quot;defer&quot;/&quot;stop deferring&quot; reasons from the UI process to the web process,
which go via RemoteScrollingCoordinatorProxy/RemoteScrollingCoordinator.

* Source/WebCore/page/WheelEventTestMonitor.cpp:
(WebCore::WheelEventTestMonitor::receivedWheelEventWithPhases):
* Source/WebCore/page/WheelEventTestMonitor.h:
* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::decode):
(WebKit::dump):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _startMonitoringWheelEvents]): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason):
(WebKit::RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingTree::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startMonitoringWheelEventsForTesting): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode):
(WebKit::RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode):
* Tools/WebKitTestRunner/EventSenderProxy.h:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::monitorWheelEvents):
* Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm:
(WTR::EventSenderProxy::monitorWheelEvents): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveMessageFromInjectedBundle):
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::EventSenderProxy::monitorWheelEvents): Deleted.
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
(WTR::EventSenderProxy::monitorWheelEvents): Deleted.
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::monitorWheelEvents): Deleted.
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:
(WTR::EventSenderProxy::monitorWheelEvents): Deleted.

Canonical link: <a href="https://commits.webkit.org/258549@main">https://commits.webkit.org/258549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df120786faa64ea365f5ef34947b78f72d077e31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102263 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111579 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171779 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2316 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109291 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37253 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/105799 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24235 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4927 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25656 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2095 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45155 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5874 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6809 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->