### PR TITLE
Remove CSSTypedOMEnabled & CSSPaintingAPIEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1009,13 +1009,14 @@ CSSPaintingAPIEnabled:
   status: testable
   humanReadableName: "CSS Painting API"
   humanReadableDescription: "Enable the CSS Painting API"
-  webcoreBinding: DeprecatedGlobalSettings
   condition: ENABLE(CSS_PAINTING_API)
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
       "ENABLE(EXPERIMENTAL_FEATURES)": true
+      default: false
+    WebCore:
       default: false
 
 CSSRelativeColorSyntaxEnabled:

--- a/Source/WebCore/css/CSSPaintCallback.idl
+++ b/Source/WebCore/css/CSSPaintCallback.idl
@@ -24,7 +24,7 @@
 */
 
 [
-    EnabledByDeprecatedGlobalSetting=CSSPaintingAPIEnabled,
+    EnabledBySetting=CSSPaintingAPIEnabled,
     Conditional=CSS_PAINTING_API,
     CallbackThisObject=any
 ] callback CSSPaintCallback = undefined (PaintRenderingContext2D context, CSSPaintSize size, StylePropertyMapReadOnly styleMap, sequence<USVString> arguments);

--- a/Source/WebCore/css/CSSPaintSize.idl
+++ b/Source/WebCore/css/CSSPaintSize.idl
@@ -24,7 +24,7 @@
 */
 
 [
-    EnabledByDeprecatedGlobalSetting=CSSPaintingAPIEnabled,
+    EnabledBySetting=CSSPaintingAPIEnabled,
     Conditional=CSS_PAINTING_API,
     Exposed=PaintWorklet,
 ] interface CSSPaintSize {

--- a/Source/WebCore/css/DOMCSSNamespace+CSSPainting.idl
+++ b/Source/WebCore/css/DOMCSSNamespace+CSSPainting.idl
@@ -25,7 +25,7 @@
 
 // https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet
 [
-    EnabledByDeprecatedGlobalSetting=CSSPaintingAPIEnabled,
+    EnabledBySetting=CSSPaintingAPIEnabled,
     Conditional=CSS_PAINTING_API,
     ImplementedBy=DOMCSSPaintWorklet
 ] partial namespace DOMCSSNamespace {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -90,6 +90,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , subgridEnabled { document.settings().subgridEnabled() }
     , masonryEnabled { document.settings().masonryEnabled() }
     , cssNestingEnabled { document.settings().cssNestingEnabled() }
+    , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -125,6 +126,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
         && a.subgridEnabled == b.subgridEnabled
         && a.masonryEnabled == b.masonryEnabled
         && a.cssNestingEnabled == b.cssNestingEnabled
+        && a.cssPaintingAPIEnabled == b.cssPaintingAPIEnabled
         && a.propertySettings == b.propertySettings
     ;
 }
@@ -154,7 +156,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.subgridEnabled                            << 18
         | context.masonryEnabled                            << 19
         | context.cssNestingEnabled                         << 20
-        | (uint64_t)context.mode                            << 21; // This is multiple bits, so keep it last.
+        | context.cssPaintingAPIEnabled                     << 21
+        | (uint64_t)context.mode                            << 22; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -97,6 +97,7 @@ struct CSSParserContext {
     bool subgridEnabled { false };
     bool masonryEnabled { false };
     bool cssNestingEnabled { false };
+    bool cssPaintingAPIEnabled { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -78,7 +78,6 @@
 #include "ColorLuminance.h"
 #include "ColorNormalization.h"
 #include "Counter.h"
-#include "DeprecatedGlobalSettings.h"
 #include "FontFace.h"
 #include "Logging.h"
 #include "Pair.h"
@@ -4295,9 +4294,9 @@ static RefPtr<CSSValue> consumeFilterImage(CSSParserTokenRange& args, const CSSP
 }
 
 #if ENABLE(CSS_PAINTING_API)
-static RefPtr<CSSValue> consumeCustomPaint(CSSParserTokenRange& args)
+static RefPtr<CSSValue> consumeCustomPaint(CSSParserTokenRange& args, const CSSParserContext& context)
 {
-    if (!DeprecatedGlobalSettings::cssPaintingAPIEnabled())
+    if (!context.cssPaintingAPIEnabled)
         return nullptr;
     if (args.peek().type() != IdentToken)
         return nullptr;
@@ -4351,7 +4350,7 @@ static RefPtr<CSSValue> consumeGeneratedImage(CSSParserTokenRange& range, const 
         result = consumeFilterImage(args, context);
 #if ENABLE(CSS_PAINTING_API)
     else if (id == CSSValuePaint)
-        result = consumeCustomPaint(args);
+        result = consumeCustomPaint(args, context);
 #endif
     if (!result || !args.atEnd())
         return nullptr;

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.idl
@@ -25,7 +25,7 @@
 
 [
     CustomIsReachable,
-    EnabledByDeprecatedGlobalSetting=CSSPaintingAPIEnabled,
+    EnabledBySetting=CSSPaintingAPIEnabled,
     Conditional=CSS_PAINTING_API,
     JSGenerateToJSObject,
     JSCustomMarkFunction,

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -137,14 +137,6 @@ public:
     static void setInlineFormattingContextIntegrationEnabled(bool isEnabled) { shared().m_inlineFormattingContextIntegrationEnabled = isEnabled; }
     static bool inlineFormattingContextIntegrationEnabled() { return shared().m_inlineFormattingContextIntegrationEnabled; }
 
-#if ENABLE(CSS_PAINTING_API)
-    static void setCSSPaintingAPIEnabled(bool isEnabled) { shared().m_CSSPaintingAPIEnabled = isEnabled; }
-    static bool cssPaintingAPIEnabled() { return shared().m_CSSPaintingAPIEnabled; }
-#endif
-
-    static void setCSSTypedOMEnabled(bool isEnabled) { shared().m_CSSTypedOMEnabled = isEnabled; }
-    static bool cssTypedOMEnabled() { return shared().m_CSSTypedOMEnabled; }
-
     static void setWebSQLEnabled(bool isEnabled) { shared().m_webSQLEnabled = isEnabled; }
     static bool webSQLEnabled() { return shared().m_webSQLEnabled; }
 
@@ -320,12 +312,6 @@ private:
 
     bool m_layoutFormattingContextEnabled { false };
     bool m_inlineFormattingContextIntegrationEnabled { true };
-
-#if ENABLE(CSS_PAINTING_API)
-    bool m_CSSPaintingAPIEnabled { false };
-#endif
-
-    bool m_CSSTypedOMEnabled { false };
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     bool m_isAttachmentElementEnabled { false };

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.idl
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.idl
@@ -25,7 +25,7 @@
 
 [
     Exposed=PaintWorklet,
-    EnabledByDeprecatedGlobalSetting=CSSPaintingAPIEnabled,
+    EnabledBySetting=CSSPaintingAPIEnabled,
     Conditional=CSS_PAINTING_API,
     JSCustomMarkFunction,
     JSGenerateToNativeObject,


### PR DESCRIPTION
#### 2e85bd41607d68ddbab6b868681fe867cd815150
<pre>
Remove CSSTypedOMEnabled &amp; CSSPaintingAPIEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250176">https://bugs.webkit.org/show_bug.cgi?id=250176</a>
rdar://103941929

Reviewed by Ryosuke Niwa.

Add this info on CSSParserContext for consistency with other CSS features, and always query from Settings.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPaintCallback.idl:
* Source/WebCore/css/CSSPaintSize.idl:
* Source/WebCore/css/DOMCSSNamespace+CSSPainting.idl:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::operator==):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCustomPaint):
(WebCore::CSSPropertyParserHelpers::consumeGeneratedImage):
* Source/WebCore/html/canvas/PaintRenderingContext2D.idl:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setCSSPaintingAPIEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::cssPaintingAPIEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::setCSSTypedOMEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::cssTypedOMEnabled): Deleted.
* Source/WebCore/worklets/PaintWorkletGlobalScope.idl:

Canonical link: <a href="https://commits.webkit.org/258531@main">https://commits.webkit.org/258531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c89d02049a8c0fa0bda8875a9ae0b56b71809f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111575 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171721 "Failed to checkout and rebase branch from PR 8279") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2312 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109287 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108039 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92749 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24231 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4923 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2581 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2091 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29520 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45151 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91746 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6805 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20516 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3095 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->