### PR TITLE
Remove MenuItemElement from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3827,11 +3827,12 @@ MediaVideoCodecIDsAllowedInLockdownMode:
 MenuItemElementEnabled:
   type: bool
   status: embedder
-  webcoreBinding: DeprecatedGlobalSettings
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
+      default: false
+    WebCore:
       default: false
 
 MinimumFontSize:

--- a/Source/WebCore/html/HTMLMenuElement.cpp
+++ b/Source/WebCore/html/HTMLMenuElement.cpp
@@ -25,7 +25,6 @@
 
 #include "Chrome.h"
 #include "ChromeClient.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "ElementChildIterator.h"
 #include "HTMLMenuItemElement.h"
@@ -48,7 +47,7 @@ inline HTMLMenuElement::HTMLMenuElement(const QualifiedName& tagName, Document& 
 Node::InsertedIntoAncestorResult HTMLMenuElement::insertedIntoAncestor(InsertionType type, ContainerNode& ancestor)
 {
     auto result = HTMLElement::insertedIntoAncestor(type, ancestor);
-    if (type.connectedToDocument && DeprecatedGlobalSettings::menuItemElementEnabled() && m_isTouchBarMenu) {
+    if (type.connectedToDocument && document().settings().menuItemElementEnabled() && m_isTouchBarMenu) {
         if (auto* page = document().page())
             page->chrome().client().didInsertMenuElement(*this);
     }
@@ -58,7 +57,7 @@ Node::InsertedIntoAncestorResult HTMLMenuElement::insertedIntoAncestor(Insertion
 void HTMLMenuElement::removedFromAncestor(RemovalType type, ContainerNode& ancestor)
 {
     HTMLElement::removedFromAncestor(type, ancestor);
-    if (type.disconnectedFromDocument && DeprecatedGlobalSettings::menuItemElementEnabled() && m_isTouchBarMenu) {
+    if (type.disconnectedFromDocument && document().settings().menuItemElementEnabled() && m_isTouchBarMenu) {
         if (auto* page = document().page())
             page->chrome().client().didRemoveMenuElement(*this);
     }
@@ -66,7 +65,7 @@ void HTMLMenuElement::removedFromAncestor(RemovalType type, ContainerNode& ances
 
 void HTMLMenuElement::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
-    if (name != typeAttr || !DeprecatedGlobalSettings::menuItemElementEnabled()) {
+    if (name != typeAttr || !document().settings().menuItemElementEnabled()) {
         HTMLElement::parseAttribute(name, value);
         return;
     }

--- a/Source/WebCore/html/HTMLMenuItemElement.idl
+++ b/Source/WebCore/html/HTMLMenuItemElement.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledByDeprecatedGlobalSetting=MenuItemElementEnabled,
+    EnabledBySetting=MenuItemElementEnabled,
     Exposed=Window
 ] interface HTMLMenuItemElement : HTMLElement {
 };

--- a/Source/WebCore/html/HTMLTagNames.in
+++ b/Source/WebCore/html/HTMLTagNames.in
@@ -84,7 +84,7 @@ map
 mark interfaceName=HTMLElement
 marquee
 menu
-menuitem interfaceName=HTMLMenuItemElement, deprecatedGlobalSettingsConditional=menuItemElement
+menuitem interfaceName=HTMLMenuItemElement, settingsConditional=menuItemElementEnabled
 meta
 meter interfaceName=HTMLMeterElement
 model interfaceName=HTMLModelElement, conditional=MODEL_ELEMENT, settingsConditional=modelElementEnabled

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -88,9 +88,6 @@ public:
     static void setPaintTimingEnabled(bool isEnabled) { shared().m_isPaintTimingEnabled = isEnabled; }
     static bool paintTimingEnabled() { return shared().m_isPaintTimingEnabled; }
 
-    static void setMenuItemElementEnabled(bool isEnabled) { shared().m_isMenuItemElementEnabled = isEnabled; }
-    static bool menuItemElementEnabled() { return shared().m_isMenuItemElementEnabled; }
-
     static void setCustomPasteboardDataEnabled(bool isEnabled) { shared().m_isCustomPasteboardDataEnabled = isEnabled; }
     static bool customPasteboardDataEnabled() { return shared().m_isCustomPasteboardDataEnabled; }
 
@@ -262,7 +259,7 @@ private:
     String m_networkInterfaceName;
 
     bool m_isPaintTimingEnabled { false };
-    bool m_isMenuItemElementEnabled { false };
+
     bool m_isCustomPasteboardDataEnabled { false };
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     bool m_isOffscreenCanvasInWorkersEnabled { false };


### PR DESCRIPTION
#### a0c7afb23fb7de44ef76df186560d3e78600dbd9
<pre>
Remove MenuItemElement from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250178">https://bugs.webkit.org/show_bug.cgi?id=250178</a>
rdar://103942356

Reviewed by Ryosuke Niwa.

Consult from document().settings() instead.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLMenuElement.cpp:
(WebCore::HTMLMenuElement::insertedIntoAncestor):
(WebCore::HTMLMenuElement::removedFromAncestor):
(WebCore::HTMLMenuElement::parseAttribute):
* Source/WebCore/html/HTMLMenuItemElement.idl:
* Source/WebCore/html/HTMLTagNames.in:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setMenuItemElementEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::menuItemElementEnabled): Deleted.

Canonical link: <a href="https://commits.webkit.org/258570@main">https://commits.webkit.org/258570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23427d50364d18ef2769a4d15fe900ab4f18ff80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111676 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2427 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108152 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24325 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25748 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88937 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2682 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5155 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29562 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45241 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91861 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5884 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20562 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->