### PR TITLE
Remove NotificationEventEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4068,7 +4068,6 @@ NotificationEventEnabled:
   status: embedder
   humanReadableName: "NotificationEvent support"
   humanReadableDescription: "NotificationEvent and ServiceWorkerRegistration.showNotification() support"
-  webcoreBinding: DeprecatedGlobalSettings
   condition: ENABLE(NOTIFICATION_EVENT)
   defaultValue:
     WebCore:

--- a/Source/WebCore/Modules/notifications/NotificationEvent.idl
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=ServiceWorker,
     Conditional=NOTIFICATION_EVENT,
-    EnabledByDeprecatedGlobalSetting=NotificationEventEnabled,
+    EnabledBySetting=NotificationEventEnabled,
 ]
 interface NotificationEvent : ExtendableEvent {
     constructor([AtomString] DOMString type, NotificationEventInit eventInitDict);

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -259,11 +259,6 @@ public:
     static bool builtInNotificationsEnabled() { return shared().m_builtInNotificationsEnabled; }
 #endif
 
-#if ENABLE(NOTIFICATION_EVENT)
-    static void setNotificationEventEnabled(bool isEnabled) { shared().m_notificationEventEnabled = isEnabled; }
-    static bool notificationEventEnabled() { return shared().m_notificationEventEnabled; }
-#endif
-
 #if ENABLE(MODEL_ELEMENT)
     static void setModelDocumentEnabled(bool isEnabled) { shared().m_modelDocumentEnabled = isEnabled; }
     static bool modelDocumentEnabled() { return shared().m_modelDocumentEnabled; }
@@ -415,10 +410,6 @@ private:
 
 #if ENABLE(BUILT_IN_NOTIFICATIONS)
     bool m_builtInNotificationsEnabled { false };
-#endif
-
-#if ENABLE(NOTIFICATION_EVENT)
-    bool m_notificationEventEnabled { true };
 #endif
 
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.idl
@@ -46,6 +46,6 @@
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;
 
-    [Conditional=NOTIFICATION_EVENT, EnabledByDeprecatedGlobalSetting=NotificationEventEnabled] attribute EventHandler onnotificationclick;
-    [Conditional=NOTIFICATION_EVENT, EnabledByDeprecatedGlobalSetting=NotificationEventEnabled] attribute EventHandler onnotificationclose;
+    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled] attribute EventHandler onnotificationclick;
+    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled] attribute EventHandler onnotificationclose;
 };

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
@@ -45,8 +45,8 @@
     [NewObject] Promise<undefined> update();
     [NewObject] Promise<boolean> unregister();
 
-    [Conditional=NOTIFICATION_EVENT, EnabledByDeprecatedGlobalSetting=NotificationEventEnabled, CallWith=CurrentScriptExecutionContext] Promise<undefined> showNotification(DOMString title, optional NotificationOptions options);
-    [Conditional=NOTIFICATION_EVENT, EnabledByDeprecatedGlobalSetting=NotificationEventEnabled] Promise<sequence<Notification>> getNotifications(optional GetNotificationOptions filter);
+    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled, CallWith=CurrentScriptExecutionContext] Promise<undefined> showNotification(DOMString title, optional NotificationOptions options);
+    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled] Promise<sequence<Notification>> getNotifications(optional GetNotificationOptions filter);
 
     // event
     attribute EventHandler onupdatefound;


### PR DESCRIPTION
#### 8ae16e5ae4d3bf2d5371c8d91426f0e19093e057
<pre>
Remove NotificationEventEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250184">https://bugs.webkit.org/show_bug.cgi?id=250184</a>
rdar://103943444

Reviewed by Ryosuke Niwa.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/notifications/NotificationEvent.idl:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setNotificationEventEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::notificationEventEnabled): Deleted.
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.idl:
* Source/WebCore/workers/service/ServiceWorkerRegistration.idl:

Canonical link: <a href="https://commits.webkit.org/258529@main">https://commits.webkit.org/258529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e66095207ee3d10c896c3343fbe83af14664963b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111574 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2311 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92748 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24230 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4922 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25651 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88823 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2580 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2090 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29519 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45150 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91745 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5851 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6804 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20515 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->