### PR TITLE
Remove DirectoryUploadEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1826,12 +1826,13 @@ DirectoryUploadEnabled:
   status: embedder
   humanReadableName: "Directory Upload"
   humanReadableDescription: "input.webkitdirectory / dataTransferItem.webkitGetAsEntry()"
-  webcoreBinding: DeprecatedGlobalSettings
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
+      default: false
+    WebCore:
       default: false
 
 # FIXME: Starting the preference name with "Disable" is inconsistent with most other preferences and should be changed.

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.idl
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled,
+    EnabledBySetting=DirectoryUploadEnabled,
     InterfaceName=FileSystem,
     Exposed=Window
 ] interface DOMFileSystem {

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled,
+    EnabledBySetting=DirectoryUploadEnabled,
     Exposed=Window
 ] interface FileSystemDirectoryEntry : FileSystemEntry {
     [CallWith=CurrentScriptExecutionContext] FileSystemDirectoryReader createReader();

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.idl
@@ -25,7 +25,7 @@
 
 [
     ActiveDOMObject,
-    EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled,
+    EnabledBySetting=DirectoryUploadEnabled,
     Exposed=Window
 ] interface FileSystemDirectoryReader {
     [CallWith=CurrentScriptExecutionContext] undefined readEntries(FileSystemEntriesCallback successCallback, optional ErrorCallback? errorCallback);

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.idl
@@ -26,7 +26,7 @@
 [
     ActiveDOMObject,
     CustomToJSObject,
-    EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled,
+    EnabledBySetting=DirectoryUploadEnabled,
     Exposed=Window
 ] interface FileSystemEntry {
     readonly attribute boolean isFile;

--- a/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled,
+    EnabledBySetting=DirectoryUploadEnabled,
     Exposed=Window
 ] interface FileSystemFileEntry : FileSystemEntry {
     [CallWith=CurrentScriptExecutionContext] undefined file(FileCallback successCallback, optional ErrorCallback? errorCallback);

--- a/Source/WebCore/Modules/entriesapi/HTMLInputElement+EntriesAPI.idl
+++ b/Source/WebCore/Modules/entriesapi/HTMLInputElement+EntriesAPI.idl
@@ -25,7 +25,7 @@
 
 // https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory
 [
-    EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled,
+    EnabledBySetting=DirectoryUploadEnabled,
     ImplementedBy=HTMLInputElementEntriesAPI
 ] partial interface HTMLInputElement {
     [Reflect] attribute boolean webkitdirectory;

--- a/Source/WebCore/fileapi/File.idl
+++ b/Source/WebCore/fileapi/File.idl
@@ -37,7 +37,7 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     readonly attribute long long lastModified;
 
     // https://wicg.github.io/entries-api/#file-interface
-    [EnabledByDeprecatedGlobalSetting=DirectoryUploadEnabled, ImplementedAs=relativePath] readonly attribute USVString webkitRelativePath;
+    [EnabledBySetting=DirectoryUploadEnabled, ImplementedAs=relativePath] readonly attribute USVString webkitRelativePath;
 };
 
 dictionary FilePropertyBag : BlobPropertyBag {

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -24,7 +24,6 @@
 
 #include "Chrome.h"
 #include "DOMFormData.h"
-#include "DeprecatedGlobalSettings.h"
 #include "DirectoryFileListCreator.h"
 #include "DragData.h"
 #include "ElementChildIterator.h"
@@ -349,9 +348,9 @@ void FileInputType::applyFileChooserSettings()
 
 bool FileInputType::allowsDirectories() const
 {
-    if (!DeprecatedGlobalSettings::directoryUploadEnabled())
-        return false;
     ASSERT(element());
+    if (!element()->document().settings().directoryUploadEnabled())
+        return false;
     return element()->hasAttributeWithoutSynchronization(webkitdirectoryAttr);
 }
 

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -91,9 +91,6 @@ public:
     static void setMenuItemElementEnabled(bool isEnabled) { shared().m_isMenuItemElementEnabled = isEnabled; }
     static bool menuItemElementEnabled() { return shared().m_isMenuItemElementEnabled; }
 
-    static void setDirectoryUploadEnabled(bool isEnabled) { shared().m_isDirectoryUploadEnabled = isEnabled; }
-    static bool directoryUploadEnabled() { return shared().m_isDirectoryUploadEnabled; }
-
     static void setCustomPasteboardDataEnabled(bool isEnabled) { shared().m_isCustomPasteboardDataEnabled = isEnabled; }
     static bool customPasteboardDataEnabled() { return shared().m_isCustomPasteboardDataEnabled; }
 
@@ -299,7 +296,6 @@ private:
 
     bool m_isPaintTimingEnabled { false };
     bool m_isMenuItemElementEnabled { false };
-    bool m_isDirectoryUploadEnabled { false };
     bool m_isCustomPasteboardDataEnabled { false };
 #if ENABLE(OFFSCREEN_CANVAS)
     bool m_isOffscreenCanvasEnabled { false };


### PR DESCRIPTION
#### e48898fa33c50350cd7c1a8773e925107a6fabd5
<pre>
Remove DirectoryUploadEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250179">https://bugs.webkit.org/show_bug.cgi?id=250179</a>
rdar://103943916

Reviewed by Ryosuke Niwa.

Use EnabledBySetting and Document::settings().

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/entriesapi/DOMFileSystem.idl:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.idl:
* Source/WebCore/Modules/entriesapi/FileSystemEntry.idl:
* Source/WebCore/Modules/entriesapi/FileSystemFileEntry.idl:
* Source/WebCore/Modules/entriesapi/HTMLInputElement+EntriesAPI.idl:
* Source/WebCore/fileapi/File.idl:
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::allowsDirectories const):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setDirectoryUploadEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::directoryUploadEnabled): Deleted.

Canonical link: <a href="https://commits.webkit.org/258530@main">https://commits.webkit.org/258530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/068d5f9f9baf8bd934fcbd9bfdac1b4da1dcade0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111577 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2314 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108042 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92752 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24234 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25655 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88826 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2583 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5055 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29524 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45154 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91749 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5850 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6807 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20518 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->