### PR TITLE
Remove PrivateClickMeasurementFraudPreventionEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4507,15 +4507,17 @@ PrivateClickMeasurementEnabled:
       default: true
 
 PrivateClickMeasurementFraudPreventionEnabled:
-   type: bool
-   status: developer
-   humanReadableName: "Private Click Measurement Fraud Prevention"
-   humanReadableDescription: "Enable Private Click Measurement Fraud Prevention"
-   webcoreBinding: DeprecatedGlobalSettings
-   defaultValue:
-     WebKit:
-       "HAVE(RSA_BSSA)": true
-       default: false
+  type: bool
+  status: developer
+  humanReadableName: "Private Click Measurement Fraud Prevention"
+  humanReadableDescription: "Enable Private Click Measurement Fraud Prevention"
+  defaultValue:
+    WebKit:
+      "HAVE(RSA_BSSA)": true
+      default: false
+    WebCore:
+      "HAVE(RSA_BSSA)": true
+      default: false
 
 ProcessSwapOnCrossSiteNavigationEnabled:
   type: bool

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -146,8 +146,6 @@ public:
 
     static bool privateClickMeasurementDebugModeEnabled() { return shared().m_privateClickMeasurementDebugModeEnabled; }
     static void setPrivateClickMeasurementDebugModeEnabled(bool isEnabled) { shared().m_privateClickMeasurementDebugModeEnabled = isEnabled; }
-    static bool privateClickMeasurementFraudPreventionEnabled() { return shared().m_privateClickMeasurementFraudPreventionEnabled; }
-    static void setPrivateClickMeasurementFraudPreventionEnabled(bool isEnabled) { shared().m_privateClickMeasurementFraudPreventionEnabled = isEnabled; }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     static void setIsAccessibilityIsolatedTreeEnabled(bool isEnabled) { shared().m_accessibilityIsolatedTree = isEnabled; }
@@ -265,11 +263,6 @@ private:
     bool m_lineHeightUnitsEnabled { true };
 
     bool m_privateClickMeasurementDebugModeEnabled { false };
-#if HAVE(RSA_BSSA)
-    bool m_privateClickMeasurementFraudPreventionEnabled { true };
-#else
-    bool m_privateClickMeasurementFraudPreventionEnabled { false };
-#endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     bool m_accessibilityIsolatedTree { false };

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -417,13 +417,6 @@ PreventKeyboardDOMEventDispatch:
     WebCore:
       default: false
 
-PrivateClickMeasurementFraudPreventionEnabled:
-  type: bool
-  defaultValue:
-    WebCore:
-      "HAVE(RSA_BSSA)": true
-      default: false
-
 RepaintOutsideLayoutEnabled:
   type: bool
   defaultValue:


### PR DESCRIPTION
#### 0b5034cadd20760b3c71b6c9ee6d6d73f311830e
<pre>
Remove PrivateClickMeasurementFraudPreventionEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250191">https://bugs.webkit.org/show_bug.cgi?id=250191</a>
rdar://103944928

Reviewed by Brent Fulgham and John Wilander.

The only usage of the setting uses `EnabledBySetting` which doesn&apos;t rely on `DeprecatedGlobalSettings`.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setPrivateClickMeasurementDebugModeEnabled):
(WebCore::DeprecatedGlobalSettings::privateClickMeasurementFraudPreventionEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::setPrivateClickMeasurementFraudPreventionEnabled): Deleted.
* Source/WebCore/page/Settings.yaml:

Canonical link: <a href="https://commits.webkit.org/258605@main">https://commits.webkit.org/258605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/058366cc639690398054a58b2073f61111850bf5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111669 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171877 "Build was cancelled. Recent messages:Pull request contains relevant changes; Deleted stale build files; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2419 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94681 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109385 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; compiling") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9569 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37293 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24319 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92661 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25742 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88928 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2675 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2181 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29558 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45235 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91852 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5915 "Build was cancelled. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by John Wilander and Brent Fulgham; Validated commit message; Compiled WebKit (cancelled)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6896 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20558 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3137 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->