### PR TITLE
Remove CacheAPIEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1143,12 +1143,13 @@ CacheAPIEnabled:
   status: embedder
   humanReadableName: "Cache API"
   humanReadableDescription: "Cache API"
-  webcoreBinding: DeprecatedGlobalSettings
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
       default: true
+    WebCore:
+      default: false
 
 CanvasColorSpaceEnabled:
   type: bool

--- a/Source/WebCore/Modules/cache/DOMCache.idl
+++ b/Source/WebCore/Modules/cache/DOMCache.idl
@@ -29,7 +29,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     ActiveDOMObject,
     SecureContext,
     Exposed=(Window,Worker),
-    EnabledByDeprecatedGlobalSetting=CacheAPIEnabled,
+    EnabledBySetting=CacheAPIEnabled,
     InterfaceName=Cache,
 ] interface DOMCache {
     [NewObject] Promise<any> match(RequestInfo request, optional CacheQueryOptions options);

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.idl
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.idl
@@ -29,7 +29,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     ActiveDOMObject,
     SecureContext,
     Exposed=(Window,Worker),
-    EnabledByDeprecatedGlobalSetting=CacheAPIEnabled,
+    EnabledBySetting=CacheAPIEnabled,
     InterfaceName=CacheStorage,
 ] interface DOMCacheStorage {
     [NewObject] Promise<any> match(RequestInfo request, optional MultiCacheQueryOptions options);

--- a/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl
+++ b/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl
@@ -25,7 +25,7 @@
 
 // https://w3c.github.io/ServiceWorker/#self-caches
 [
-    EnabledByDeprecatedGlobalSetting=CacheAPIEnabled,
+    EnabledBySetting=CacheAPIEnabled,
     ImplementedBy=WindowOrWorkerGlobalScopeCaches
 ] partial interface mixin WindowOrWorkerGlobalScope {
     [CallWith=CurrentScriptExecutionContext, SecureContext, SameObject] readonly attribute DOMCacheStorage caches;

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -99,9 +99,6 @@ public:
     static bool offscreenCanvasInWorkersEnabled() { return shared().m_isOffscreenCanvasInWorkersEnabled; }
 #endif
 
-    static void setCacheAPIEnabled(bool isEnabled) { shared().m_isCacheAPIEnabled = isEnabled; }
-    static bool cacheAPIEnabled() { return shared().m_isCacheAPIEnabled; }
-
     static void setWebSocketEnabled(bool isEnabled) { shared().m_isWebSocketEnabled = isEnabled; }
     static bool webSocketEnabled() { return shared().m_isWebSocketEnabled; }
 
@@ -287,7 +284,6 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     bool m_isOffscreenCanvasInWorkersEnabled { false };
 #endif
-    bool m_isCacheAPIEnabled { false };
     bool m_isWebSocketEnabled { true };
     bool m_fetchAPIKeepAliveEnabled { false };
     bool m_accessibilityObjectModelEnabled { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4190,8 +4190,7 @@ static void adjustSettingsForLockdownMode(Settings& settings, const WebPreferenc
     settings.setServiceWorkerNavigationPreloadEnabled(false);
 #endif
     settings.setWebLocksAPIEnabled(false);
-
-    DeprecatedGlobalSettings::setCacheAPIEnabled(false);
+    settings.setCacheAPIEnabled(false);
 
     settings.setAllowedMediaContainerTypes(store.getStringValueForKey(WebPreferencesKey::mediaContainerTypesAllowedInLockdownModeKey()));
     settings.setAllowedMediaCodecTypes(store.getStringValueForKey(WebPreferencesKey::mediaCodecTypesAllowedInLockdownModeKey()));


### PR DESCRIPTION
#### 49d3ee50409f4d73c745fa71a1ce8c792a6fc8f9
<pre>
Remove CacheAPIEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250180">https://bugs.webkit.org/show_bug.cgi?id=250180</a>
rdar://103945439

Reviewed by Youenn Fablet.

Use EnabledBySetting in IDL files.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/cache/DOMCache.idl:
* Source/WebCore/Modules/cache/DOMCacheStorage.idl:
* Source/WebCore/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setCacheAPIEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::cacheAPIEnabled): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::adjustSettingsForLockdownMode):

Canonical link: <a href="https://commits.webkit.org/258534@main">https://commits.webkit.org/258534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff65685086914d73030a8dd91f05c1fc436a983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111594 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2339 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108069 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92768 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24252 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88851 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2600 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5077 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45172 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91775 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5858 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6831 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20534 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->