### PR TITLE
Remove WebAPIStatisticsEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6275,11 +6275,12 @@ WebAPIStatisticsEnabled:
   status: unstable
   humanReadableName: "Web API Statistics"
   humanReadableDescription: "Enable Web API Statistics"
-  webcoreBinding: DeprecatedGlobalSettings
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
+      default: false
+    WebCore:
       default: false
 
 WebAPIsInShadowRealmEnabled:

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -30,7 +30,6 @@
 #include "CSSFontSelector.h"
 #include "CachedFontLoadRequest.h"
 #include "CachedSVGFont.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "Font.h"
 #include "FontCache.h"
@@ -186,7 +185,7 @@ void CSSFontFaceSource::load(Document* document)
             fontDescription.setComputedSize(1);
             fontDescription.setShouldAllowUserInstalledFonts(m_face.allowUserInstalledFonts());
             success = FontCache::forCurrentThread().fontForFamily(fontDescription, m_fontFaceName, { }, true);
-            if (document && DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+            if (document && document->settings().webAPIStatisticsEnabled())
                 ResourceLoadObserver::shared().logFontLoad(*document, m_fontFaceName.string(), success);
         }
         setStatus(success ? Status::Success : Status::Failure);

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -38,7 +38,6 @@
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 #include "CachedResourceLoader.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "Font.h"
 #include "FontCache.h"
@@ -387,7 +386,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     auto* document = dynamicDowncast<Document>(m_context.get());
     auto* face = m_cssFontFaceSet->fontFace(fontDescriptionForLookup->fontSelectionRequest(), familyForLookup);
     if (face) {
-        if (document && DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+        if (document && document->settings().webAPIStatisticsEnabled())
             ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), true);
         return face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues);
     }
@@ -396,7 +395,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
         resolveAndAssignGenericFamily();
 
     auto font = FontCache::forCurrentThread().fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues });
-    if (document && DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (document && document->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), !!font);
     return FontRanges { WTFMove(font) };
 }
@@ -427,7 +426,7 @@ RefPtr<Font> CSSFontSelector::fallbackFontAt(const FontDescription& fontDescript
         return nullptr;
     auto& pictographFontFamily = m_context->settingsValues().fontGenericFamilies.pictographFontFamily();
     auto font = FontCache::forCurrentThread().fontForFamily(fontDescription, pictographFontFamily);
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled() && is<Document>(m_context))
+    if (is<Document>(m_context) && m_context->settingsValues().webAPIStatisticsEnabled)
         ResourceLoadObserver::shared().logFontLoad(downcast<Document>(*m_context), pictographFontFamily, !!font);
 
     return font;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -34,7 +34,6 @@
 #include "CanvasPattern.h"
 #include "CanvasRenderingContext2D.h"
 #include "CanvasRenderingContext2DSettings.h"
-#include "DeprecatedGlobalSettings.h"
 #include "DisplayListDrawingContext.h"
 #include "Document.h"
 #include "ElementInlines.h"
@@ -744,7 +743,7 @@ ExceptionOr<UncachedString> HTMLCanvasElement::toDataURL(const String& mimeType,
 
     if (size().isEmpty() || !buffer())
         return UncachedString { "data:,"_s };
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(document());
 
     auto encodingMIMEType = toEncodingMimeType(mimeType);
@@ -775,7 +774,7 @@ ExceptionOr<void> HTMLCanvasElement::toBlob(Ref<BlobCallback>&& callback, const 
         callback->scheduleCallback(document(), nullptr);
         return { };
     }
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(document());
 
     auto encodingMIMEType = toEncodingMimeType(mimeType);
@@ -822,7 +821,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
     if (!is<WebGLRenderingContextBase>(m_context))
         return nullptr;
 
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(document());
 
     auto pixelBuffer = downcast<WebGLRenderingContextBase>(*m_context).paintRenderingResultsToPixelBuffer();
@@ -842,7 +841,7 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
 #if PLATFORM(COCOA) || USE(GSTREAMER)
 #if ENABLE(WEBGL)
     if (is<WebGLRenderingContextBase>(m_context.get())) {
-        if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+        if (document().settings().webAPIStatisticsEnabled())
             ResourceLoadObserver::shared().logCanvasRead(document());
         return downcast<WebGLRenderingContextBase>(*m_context).paintCompositedResultsToVideoFrame();
     }
@@ -850,7 +849,7 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
     auto* imageBuffer = buffer();
     if (!imageBuffer)
         return nullptr;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(document());
 
     makeRenderingResultsAvailable();
@@ -881,7 +880,7 @@ ExceptionOr<Ref<MediaStream>> HTMLCanvasElement::captureStream(std::optional<dou
 {
     if (!originClean())
         return Exception(SecurityError, "Canvas is tainted"_s);
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(this->document());
 
     if (frameRequestRate && frameRequestRate.value() < 0)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -37,7 +37,6 @@
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSPropertyParserWorkerSafe.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Gradient.h"
 #include "ImageBuffer.h"
 #include "ImageData.h"
@@ -193,14 +192,14 @@ void CanvasRenderingContext2D::strokeText(const String& text, double x, double y
 
 Ref<TextMetrics> CanvasRenderingContext2D::measureText(const String& text)
 {
-    downcast<HTMLCanvasElement>(canvasBase()).document().updateStyleIfNeeded();
+    Ref document = canvas().document();
+    document->updateStyleIfNeeded();
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled()) {
-        auto& canvas = this->canvas();
-        ResourceLoadObserver::shared().logCanvasWriteOrMeasure(canvas.document(), text);
-        ResourceLoadObserver::shared().logCanvasRead(canvas.document());
+    if (document->settings().webAPIStatisticsEnabled()) {
+        ResourceLoadObserver::shared().logCanvasWriteOrMeasure(document, text);
+        ResourceLoadObserver::shared().logCanvasRead(document);
     }
 
     String normalizedText = normalizeSpaces(text);
@@ -226,12 +225,13 @@ auto CanvasRenderingContext2D::fontProxy() -> const FontProxy*
 
 void CanvasRenderingContext2D::drawTextInternal(const String& text, double x, double y, bool fill, std::optional<double> maxWidth)
 {
-    downcast<HTMLCanvasElement>(canvasBase()).document().updateStyleIfNeeded();
+    Ref document = canvas().document();
+    document->updateStyleIfNeeded();
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasWriteOrMeasure(this->canvas().document(), text);
+    if (document->settings().webAPIStatisticsEnabled())
+        ResourceLoadObserver::shared().logCanvasWriteOrMeasure(document, text);
 
     if (!canDrawText(x, y, fill, maxWidth))
         return;

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -120,9 +120,6 @@ public:
     static void setAttrStyleEnabled(bool isEnabled) { shared().m_attrStyleEnabled = isEnabled; }
     static bool attrStyleEnabled() { return shared().m_attrStyleEnabled; }
 
-    static void setWebAPIStatisticsEnabled(bool isEnabled) { shared().m_webAPIStatisticsEnabled = isEnabled; }
-    static bool webAPIStatisticsEnabled() { return shared().m_webAPIStatisticsEnabled; }
-
     static void setLayoutFormattingContextEnabled(bool isEnabled) { shared().m_layoutFormattingContextEnabled = isEnabled; }
     static bool layoutFormattingContextEnabled() { return shared().m_layoutFormattingContextEnabled; }
 
@@ -291,7 +288,6 @@ private:
     bool m_isRestrictedHTTPResponseAccess { true };
     bool m_isServerTimingEnabled { false };
     bool m_attrStyleEnabled { false };
-    bool m_webAPIStatisticsEnabled { false };
     bool m_syntheticEditingCommandsEnabled { true };
     bool m_webSQLEnabled { false };
     bool m_keygenElementEnabled { false };

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -30,7 +30,6 @@
 #include "DOMMimeTypeArray.h"
 #include "DOMPlugin.h"
 #include "DOMPluginArray.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "FeaturePolicy.h"
 #include "Frame.h"
@@ -75,7 +74,7 @@ String Navigator::appVersion() const
     auto* frame = this->frame();
     if (!frame)
         return String();
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::AppVersion);
     return NavigatorBase::appVersion();
 }
@@ -85,7 +84,7 @@ const String& Navigator::userAgent() const
     auto* frame = this->frame();
     if (!frame || !frame->page())
         return m_userAgent;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::UserAgent);
     if (m_userAgent.isNull())
         m_userAgent = frame->loader().userAgent(frame->document()->url());
@@ -302,20 +301,18 @@ void Navigator::initializePluginAndMimeTypeArrays()
 
 DOMPluginArray& Navigator::plugins()
 {
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled()) {
-        if (auto* frame = this->frame())
-            ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::Plugins);
-    }
+    if (auto* frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::Plugins);
+
     initializePluginAndMimeTypeArrays();
     return *m_plugins;
 }
 
 DOMMimeTypeArray& Navigator::mimeTypes()
 {
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled()) {
-        if (auto* frame = this->frame())
-            ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::MimeTypes);
-    }
+    if (auto* frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
+        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::MimeTypes);
+
     initializePluginAndMimeTypeArrays();
     return *m_mimeTypes;
 }
@@ -333,13 +330,13 @@ bool Navigator::cookieEnabled() const
     if (!frame)
         return false;
 
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->document(), NavigatorAPIsAccessed::CookieEnabled);
 
     auto* page = frame->page();
     if (!page)
         return false;
-    
+
     if (!page->settings().cookieEnabled())
         return false;
 

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -30,7 +30,6 @@
 #include "Screen.h"
 
 #include "DOMWindow.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "FloatRect.h"
 #include "Frame.h"
@@ -58,7 +57,7 @@ unsigned Screen::height() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Height);
     return static_cast<unsigned>(frame->screenSize().height());
 }
@@ -68,7 +67,7 @@ unsigned Screen::width() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Width);
     return static_cast<unsigned>(frame->screenSize().width());
 }
@@ -78,7 +77,7 @@ unsigned Screen::colorDepth() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::ColorDepth);
     return static_cast<unsigned>(screenDepth(frame->view()));
 }
@@ -88,7 +87,7 @@ unsigned Screen::pixelDepth() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::PixelDepth);
 
     auto* document = window()->document();
@@ -103,7 +102,7 @@ int Screen::availLeft() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailLeft);
     return static_cast<int>(screenAvailableRect(frame->view()).x());
 }
@@ -113,7 +112,7 @@ int Screen::availTop() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailTop);
     return static_cast<int>(screenAvailableRect(frame->view()).y());
 }
@@ -123,7 +122,7 @@ unsigned Screen::availHeight() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailHeight);
     return static_cast<unsigned>(screenAvailableRect(frame->view()).height());
 }
@@ -133,7 +132,7 @@ unsigned Screen::availWidth() const
     auto* frame = this->frame();
     if (!frame)
         return 0;
-    if (DeprecatedGlobalSettings::webAPIStatisticsEnabled())
+    if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailWidth);
     return static_cast<unsigned>(screenAvailableRect(frame->view()).width());
 }


### PR DESCRIPTION
#### df28ebcdf9d6a499e8bf3015494043a48af317bb
<pre>
Remove WebAPIStatisticsEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250181">https://bugs.webkit.org/show_bug.cgi?id=250181</a>
rdar://103946204

Reviewed by Ryosuke Niwa.

Use Settings instead.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::load):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontAt):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toDataURL):
(WebCore::HTMLCanvasElement::toBlob):
(WebCore::HTMLCanvasElement::getImageData):
(WebCore::HTMLCanvasElement::toVideoFrame):
(WebCore::HTMLCanvasElement::captureStream):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::measureText):
(WebCore::CanvasRenderingContext2D::drawTextInternal):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setWebAPIStatisticsEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::webAPIStatisticsEnabled): Deleted.
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::appVersion const):
(WebCore::Navigator::userAgent const):
(WebCore::Navigator::plugins):
(WebCore::Navigator::mimeTypes):
(WebCore::Navigator::cookieEnabled const):
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::height const):
(WebCore::Screen::width const):
(WebCore::Screen::colorDepth const):
(WebCore::Screen::pixelDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):

Canonical link: <a href="https://commits.webkit.org/258535@main">https://commits.webkit.org/258535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0199222aae2dd00551fbae5f49d512dadea66e38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111595 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2341 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108070 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92769 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24253 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25672 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88852 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2601 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29537 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45173 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91776 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5859 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6832 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20535 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->