### PR TITLE
Implement StorageManager.estimate()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-indexeddb.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-indexeddb.https.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL estimate() method exists and returns a Promise assert_true: expected true got false
-FAIL estimate() resolves to dictionary with members promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
-FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+PASS estimate() method exists and returns a Promise
+PASS estimate() resolves to dictionary with members
+PASS estimate() shows usage increase after large value is stored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-indexeddb.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-indexeddb.https.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL estimate() method exists and returns a Promise assert_true: expected true got false
-FAIL estimate() resolves to dictionary with members promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
-FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+PASS estimate() method exists and returns a Promise
+PASS estimate() resolves to dictionary with members
+PASS estimate() shows usage increase after large value is stored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-parallel.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-parallel.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Multiple estimate() calls in parallel should complete promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+PASS Multiple estimate() calls in parallel should complete
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-parallel.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-parallel.https.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Multiple estimate() calls in parallel should complete promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+PASS Multiple estimate() calls in parallel should complete
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-application-cache.https.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-application-cache.https.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL estimate() shows usage increase after app is cached promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() shows usage increase after app is cached promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'estimate.usageDetails.applicationCache')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-caches.https.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-caches.https.tentative.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'estimate.usageDetails.caches')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-caches.https.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-caches.https.tentative.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'estimate.usageDetails.caches')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-indexeddb.https.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-indexeddb.https.tentative.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL estimate() resolves to dictionary with usageDetails member promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
-FAIL estimate() usage details reflects increase in indexedDB after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() resolves to dictionary with usageDetails member assert_equals: expected "object" but got "undefined"
+FAIL estimate() usage details reflects increase in indexedDB after large value is stored promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'estimate.usageDetails.indexedDB')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-indexeddb.https.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-indexeddb.https.tentative.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL estimate() resolves to dictionary with usageDetails member promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
-FAIL estimate() usage details reflects increase in indexedDB after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() resolves to dictionary with usageDetails member assert_equals: expected "object" but got "undefined"
+FAIL estimate() usage details reflects increase in indexedDB after large value is stored promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'estimate.usageDetails.indexedDB')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-service-workers.https.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-service-workers.https.tentative.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() shows usage increase after large value is stored promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'estimate.usageDetails.serviceWorkerRegistrations')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details.https.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details.https.tentative.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL estimate() resolves to dictionary with members, including usageDetails promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() resolves to dictionary with members, including usageDetails assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details.https.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details.https.tentative.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL estimate() resolves to dictionary with members, including usageDetails promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+FAIL estimate() resolves to dictionary with members, including usageDetails assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/idlharness.https.any-expected.txt
@@ -23,12 +23,12 @@ PASS StorageManager interface: existence and properties of interface prototype o
 PASS StorageManager interface: existence and properties of interface prototype object's @@unscopables property
 PASS StorageManager interface: operation persisted()
 PASS StorageManager interface: operation persist()
-FAIL StorageManager interface: operation estimate() assert_own_property: interface prototype object missing non-static operation expected property "estimate" missing
+PASS StorageManager interface: operation estimate()
 PASS StorageManager must be primary interface of navigator.storage
 PASS Stringification of navigator.storage
 PASS StorageManager interface: navigator.storage must inherit property "persisted()" with the proper type
 PASS StorageManager interface: navigator.storage must inherit property "persist()" with the proper type
-FAIL StorageManager interface: navigator.storage must inherit property "estimate()" with the proper type assert_inherits: property "estimate" not found in prototype chain
+PASS StorageManager interface: navigator.storage must inherit property "estimate()" with the proper type
 PASS Navigator interface: attribute storage
 PASS Navigator interface: navigator must inherit property "storage" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/idlharness.https.any.worker-expected.txt
@@ -23,12 +23,12 @@ PASS StorageManager interface: existence and properties of interface prototype o
 PASS StorageManager interface: existence and properties of interface prototype object's @@unscopables property
 PASS StorageManager interface: operation persisted()
 PASS StorageManager interface: member persist
-FAIL StorageManager interface: operation estimate() assert_own_property: interface prototype object missing non-static operation expected property "estimate" missing
+PASS StorageManager interface: operation estimate()
 PASS StorageManager must be primary interface of navigator.storage
 PASS Stringification of navigator.storage
 PASS StorageManager interface: navigator.storage must inherit property "persisted()" with the proper type
 PASS StorageManager interface: navigator.storage must not have property "persist"
-FAIL StorageManager interface: navigator.storage must inherit property "estimate()" with the proper type assert_inherits: property "estimate" not found in prototype chain
+PASS StorageManager interface: navigator.storage must inherit property "estimate()" with the proper type
 PASS WorkerNavigator interface: attribute storage
 PASS WorkerNavigator interface: navigator must inherit property "storage" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/opaque-origin.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/opaque-origin.https.window-expected.txt
@@ -1,8 +1,8 @@
 
 PASS navigator.storage.persisted() in non-sandboxed iframe should not reject
 PASS navigator.storage.persisted() in sandboxed iframe should reject with TypeError
-FAIL navigator.storage.estimate() in non-sandboxed iframe should not reject assert_equals: navigator.storage.estimate() should not reject expected "no rejection" but got "API access threw"
-FAIL navigator.storage.estimate() in sandboxed iframe should reject with TypeError assert_equals: navigator.storage.estimate() should reject with TypeError expected "correct rejection" but got "API access threw"
+PASS navigator.storage.estimate() in non-sandboxed iframe should not reject
+PASS navigator.storage.estimate() in sandboxed iframe should reject with TypeError
 PASS navigator.storage.persist() in non-sandboxed iframe should not reject
 PASS navigator.storage.persist() in sandboxed iframe should reject with TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL estimate() method returns a Promise navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)
-FAIL estimate() resolves to dictionary with members navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)
-FAIL estimate() shows usage increase after 1MB IndexedDB record is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+PASS estimate() method returns a Promise
+PASS estimate() resolves to dictionary with members
+PASS estimate() shows usage increase after 1MB IndexedDB record is stored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL estimate() method returns a Promise navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)
-FAIL estimate() resolves to dictionary with members navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)
-FAIL estimate() shows usage increase after 1MB IndexedDB record is stored promise_test: Unhandled rejection with value: object "TypeError: navigator.storage.estimate is not a function. (In 'navigator.storage.estimate()', 'navigator.storage.estimate' is undefined)"
+PASS estimate() method returns a Promise
+PASS estimate() resolves to dictionary with members
+PASS estimate() shows usage increase after 1MB IndexedDB record is stored
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5551,6 +5551,19 @@ StorageAPIEnabled:
       "PLATFORM(COCOA)" : true
       default: false
 
+StorageAPIEstimateEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "Storage API Estimate"
+  humanReadableDescription: "Enable Storage API Estimate"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 StorageAccessAPIEnabled:
   type: bool
   status: developer

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -375,6 +375,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/storage/DummyStorageProvider.h
     Modules/storage/StorageConnection.h
+    Modules/storage/StorageEstimate.h
     Modules/storage/StorageManager.h
     Modules/storage/StorageProvider.h
     Modules/storage/WorkerStorageConnection.h

--- a/Source/WebCore/Modules/storage/DummyStorageProvider.h
+++ b/Source/WebCore/Modules/storage/DummyStorageProvider.h
@@ -27,6 +27,7 @@
 
 #include "FileSystemStorageConnection.h"
 #include "StorageConnection.h"
+#include "StorageEstimate.h"
 #include "StorageProvider.h"
 
 namespace WebCore {
@@ -55,6 +56,11 @@ private:
         }
 
         void fileSystemGetDirectory(ClientOrigin&&, StorageConnection::GetDirectoryCallback&& completionHandler) final
+        {
+            completionHandler(Exception { NotSupportedError });
+        }
+
+        void getEstimate(ClientOrigin&&, GetEstimateCallback&& completionHandler) final
         {
             completionHandler(Exception { NotSupportedError });
         }

--- a/Source/WebCore/Modules/storage/StorageConnection.h
+++ b/Source/WebCore/Modules/storage/StorageConnection.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class FileSystemStorageConnection;
 template<typename> class ExceptionOr;
 struct ClientOrigin;
+struct StorageEstimate;
 
 class StorageConnection : public ThreadSafeRefCounted<StorageConnection> {
 public:
@@ -44,6 +45,8 @@ public:
     using DirectoryInfo = std::pair<FileSystemHandleIdentifier, RefPtr<FileSystemStorageConnection>>;
     using GetDirectoryCallback = CompletionHandler<void(ExceptionOr<DirectoryInfo>&&)>;
     virtual void fileSystemGetDirectory(ClientOrigin&&, GetDirectoryCallback&&) = 0;
+    using GetEstimateCallback = CompletionHandler<void(ExceptionOr<StorageEstimate>&&)>;
+    virtual void getEstimate(ClientOrigin&&, GetEstimateCallback&&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/storage/StorageEstimate.h
+++ b/Source/WebCore/Modules/storage/StorageEstimate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,30 +25,17 @@
 
 #pragma once
 
-#include <WebCore/StorageConnection.h>
-
-namespace IPC {
-class Connection;
-}
+#include "IDLTypes.h"
+#include <wtf/IsoMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
-template<typename> class ExceptionOr;
-class FileSystemDirectoryHandle;
-}
 
-namespace WebKit {
+struct StorageEstimate {
+    uint64_t usage { 0 };
+    uint64_t quota { 0 };
 
-class WebStorageConnection final : public WebCore::StorageConnection {
-public:
-    static Ref<WebStorageConnection> create();
-
-private:
-    void getPersisted(WebCore::ClientOrigin&&, StorageConnection::PersistCallback&&) final;
-    void persist(const WebCore::ClientOrigin&, StorageConnection::PersistCallback&&) final;
-    void getEstimate(WebCore::ClientOrigin&&, StorageConnection::GetEstimateCallback&&) final;
-    void fileSystemGetDirectory(WebCore::ClientOrigin&&, StorageConnection::GetDirectoryCallback&&) final;
-
-    IPC::Connection& connection();
+    StorageEstimate isolatedCopy() const { return *this; }
 };
 
-} // namespace WebKit
+} // namespace WebCore

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -33,6 +33,7 @@
 #include "FileSystemStorageConnection.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSFileSystemDirectoryHandle.h"
+#include "JSStorageManager.h"
 #include "NavigatorBase.h"
 #include "SecurityOrigin.h"
 #include "WorkerGlobalScope.h"
@@ -107,6 +108,18 @@ void StorageManager::persist(DOMPromiseDeferred<IDLBoolean>&& promise)
     auto connectionInfo = connectionInfoOrException.releaseReturnValue();
     connectionInfo.connection.persist(connectionInfo.origin, [promise = WTFMove(promise)](bool persisted) mutable {
         promise.resolve(persisted);
+    });
+}
+
+void StorageManager::estimate(DOMPromiseDeferred<IDLDictionary<StorageEstimate>>&& promise)
+{
+    auto connectionInfoOrException = connectionInfo(m_navigator.get());
+    if (connectionInfoOrException.hasException())
+        return promise.reject(connectionInfoOrException.releaseException());
+
+    auto connectionInfo = connectionInfoOrException.releaseReturnValue();
+    connectionInfo.connection.getEstimate(WTFMove(connectionInfo.origin), [promise = WTFMove(promise)](auto&& result) mutable {
+        promise.settle(WTFMove(result));
     });
 }
 

--- a/Source/WebCore/Modules/storage/StorageManager.h
+++ b/Source/WebCore/Modules/storage/StorageManager.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IDLTypes.h"
+#include "StorageEstimate.h"
 #include <wtf/IsoMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,6 +43,8 @@ public:
     static Ref<StorageManager> create(NavigatorBase&);
     void persisted(DOMPromiseDeferred<IDLBoolean>&&);
     void persist(DOMPromiseDeferred<IDLBoolean>&&);
+    using Estimate = StorageEstimate;
+    void estimate(DOMPromiseDeferred<IDLDictionary<Estimate>>&&);
     void fileSystemAccessGetDirectory(DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&&);
 
 private:

--- a/Source/WebCore/Modules/storage/StorageManager.idl
+++ b/Source/WebCore/Modules/storage/StorageManager.idl
@@ -32,6 +32,12 @@
 ] interface StorageManager {
     Promise<boolean> persisted();
     [Exposed=Window] Promise<boolean> persist();
+    [EnabledBySetting=StorageAPIEstimateEnabled] Promise<StorageEstimate> estimate();
+};
 
-    // FIXME: add Promise<StorageEstimate> estimate();
+[
+    JSGenerateToJSObject
+] dictionary StorageEstimate {
+    unsigned long long usage;
+    unsigned long long quota;
 };

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.h
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class WeakPtrImplWithEventTargetData;
 class WorkerGlobalScope;
+struct StorageEstimate;
 
 class WorkerStorageConnection final : public StorageConnection  {
 public:
@@ -41,15 +42,18 @@ public:
 private:
     explicit WorkerStorageConnection(WorkerGlobalScope&);
     void didGetPersisted(uint64_t callbackIdentifier, bool result);
+    void didGetEstimate(uint64_t callbackIdentifier, ExceptionOr<StorageEstimate>&&);
     void didGetDirectory(uint64_t callbackIdentifier, ExceptionOr<StorageConnection::DirectoryInfo>&&);
 
     // StorageConnection
     void getPersisted(ClientOrigin&&, StorageConnection::PersistCallback&&) final;
+    void getEstimate(ClientOrigin&&, StorageConnection::GetEstimateCallback&&) final;
     void fileSystemGetDirectory(ClientOrigin&&, StorageConnection::GetDirectoryCallback&&) final;
 
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     uint64_t m_lastCallbackIdentifier { 0 };
     HashMap<uint64_t, StorageConnection::PersistCallback> m_getPersistedCallbacks;
+    HashMap<uint64_t, StorageConnection::GetEstimateCallback> m_getEstimateCallbacks;
     HashMap<uint64_t, StorageConnection::GetDirectoryCallback> m_getDirectoryCallbacks;
 };
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -338,6 +338,13 @@ void NetworkStorageManager::persist(const WebCore::ClientOrigin& origin, Complet
     completionHandler(true);
 }
 
+void NetworkStorageManager::estimate(const WebCore::ClientOrigin& origin, CompletionHandler<void(std::optional<WebCore::StorageEstimate>)>&& completionHandler)
+{
+    ASSERT(!RunLoop::isMain());
+
+    completionHandler(originStorageManager(origin).estimate());
+}
+
 void NetworkStorageManager::clearStorageForTesting(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -131,6 +131,7 @@ private:
     // Message handlers for FileSystem.
     void persisted(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
     void persist(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
+    void estimate(const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::StorageEstimate>)>&&);
     void fileSystemGetDirectory(IPC::Connection&, WebCore::ClientOrigin&&, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
     void closeHandle(WebCore::FileSystemHandleIdentifier);
     void isSameEntry(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -26,6 +26,7 @@
  messages -> NetworkStorageManager {
     Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)
+    Estimate(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::StorageEstimate> result);
     FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result) WantsConnection
     CloseHandle(WebCore::FileSystemHandleIdentifier identifier)
     IsSameEntry(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (bool result)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -697,6 +697,13 @@ void OriginStorageManager::setPersisted(bool value)
     defaultBucket().setMode(value ? StorageBucketMode::Persistent : StorageBucketMode::BestEffort);
 }
 
+WebCore::StorageEstimate OriginStorageManager::estimate()
+{
+    ASSERT(!RunLoop::isMain());
+
+    return WebCore::StorageEstimate { quotaManager().usage(), quotaManager().quota() };
+}
+
 OriginStorageManager::DataTypeSizeMap OriginStorageManager::fetchDataTypesInList(OptionSet<WebsiteDataType> types, bool shouldComputeSize)
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 struct ClientOrigin;
+struct StorageEstimate;
 }
 
 namespace WebKit {
@@ -59,6 +60,7 @@ public:
     void connectionClosed(IPC::Connection::UniqueID);
     bool persisted() const { return m_persisted; }
     void setPersisted(bool value);
+    WebCore::StorageEstimate estimate();
     const String& path() const { return m_path; }
     QuotaManager& quotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);

--- a/Source/WebKit/NetworkProcess/storage/QuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/QuotaManager.cpp
@@ -44,6 +44,11 @@ QuotaManager::QuotaManager(uint64_t quota, GetUsageFunction&& getUsageFunction, 
     ASSERT(m_quota);
 }
 
+uint64_t QuotaManager::usage()
+{
+    return m_getUsageFunction();
+}
+
 void QuotaManager::requestSpace(uint64_t spaceRequested, RequestCallback&& callback)
 {
     m_requests.append(QuotaManager::Request { spaceRequested, WTFMove(callback), QuotaIncreaseRequestIdentifier { } });

--- a/Source/WebKit/NetworkProcess/storage/QuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/QuotaManager.h
@@ -38,7 +38,8 @@ public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;
     static Ref<QuotaManager> create(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&&);
-
+    uint64_t quota() const { return m_quota; }
+    uint64_t usage();
     enum class Decision : bool { Deny, Grant };
     using RequestCallback = CompletionHandler<void(Decision)>;
     void requestSpace(uint64_t spaceRequested, RequestCallback&&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2478,3 +2478,9 @@ enum class WebCore::GamepadHapticEffectType : uint8_t {
     DualRumble
 };
 #endif
+
+header: <WebCore/StorageEstimate.h>
+struct WebCore::StorageEstimate {
+    uint64_t usage
+    uint64_t quota
+};

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
+#include <WebCore/StorageEstimate.h>
 
 namespace WebKit {
 
@@ -49,6 +50,16 @@ void WebStorageConnection::getPersisted(WebCore::ClientOrigin&& origin, StorageC
 void WebStorageConnection::persist(const WebCore::ClientOrigin& origin, StorageConnection::PersistCallback&& completionHandler)
 {
     connection().sendWithAsyncReply(Messages::NetworkStorageManager::Persist(origin), WTFMove(completionHandler));
+}
+
+void WebStorageConnection::getEstimate(WebCore::ClientOrigin&& origin, StorageConnection::GetEstimateCallback&& completionHandler)
+{
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::Estimate(origin), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+        if (!result)
+            return completionHandler(WebCore::Exception { WebCore::TypeError });
+
+        return completionHandler(WTFMove(*result));
+    });
 }
 
 void WebStorageConnection::fileSystemGetDirectory(WebCore::ClientOrigin&& origin, StorageConnection::GetDirectoryCallback&& completionHandler)


### PR DESCRIPTION
#### a793d8b68a12b37482e8734a578926405f7edc45
<pre>
Implement StorageManager.estimate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248918">https://bugs.webkit.org/show_bug.cgi?id=248918</a>
rdar://problem/103380414

Reviewed by Chris Dumez.

Spec: <a href="https://storage.spec.whatwg.org/#dom-storagemanager-estimate">https://storage.spec.whatwg.org/#dom-storagemanager-estimate</a>

* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-indexeddb.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-indexeddb.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-parallel.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-parallel.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-application-cache.https.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-caches.https.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-caches.https.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-indexeddb.https.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-indexeddb.https.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details-service-workers.https.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details.https.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/estimate-usage-details.https.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/idlharness.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/opaque-origin.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-estimate.https.any.worker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/storage/DummyStorageProvider.h:
* Source/WebCore/Modules/storage/StorageConnection.h:
* Source/WebCore/Modules/storage/StorageEstimate.h: Copied from Source/WebCore/Modules/storage/StorageManager.idl.
(WebCore::StorageEstimate::isolatedCopy const):
* Source/WebCore/Modules/storage/StorageManager.cpp:
(WebCore::StorageManager::estimate):
* Source/WebCore/Modules/storage/StorageManager.h:
* Source/WebCore/Modules/storage/StorageManager.idl:
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp:
(WebCore::WorkerStorageConnection::getEstimate):
(WebCore::WorkerStorageConnection::didGetEstimate):
* Source/WebCore/Modules/storage/WorkerStorageConnection.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::estimate):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::estimate):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/storage/QuotaManager.cpp:
(WebKit::QuotaManager::usage):
* Source/WebKit/NetworkProcess/storage/QuotaManager.h:
(WebKit::QuotaManager::quota const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp:
(WebKit::WebStorageConnection::getEstimate):
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/258610@main">https://commits.webkit.org/258610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71f326a9ec84e95c4216866906cec01239a88ac0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111764 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2532 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108277 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24395 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25816 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89066 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2772 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2263 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29605 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45309 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91991 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5919 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6982 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20609 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->