### PR TITLE
Port NetworkResourceLoadParameters to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -77,24 +77,24 @@ ExceptionOr<FetchBody> FetchBody::extract(Init&& value, String& contentType)
     });
 }
 
-std::optional<FetchBody> FetchBody::fromFormData(ScriptExecutionContext& context, FormData& formData)
+std::optional<FetchBody> FetchBody::fromFormData(ScriptExecutionContext& context, Ref<FormData>&& formData)
 {
-    ASSERT(!formData.isEmpty());
+    ASSERT(!formData->isEmpty());
 
-    if (auto buffer = formData.asSharedBuffer()) {
+    if (auto buffer = formData->asSharedBuffer()) {
         FetchBody body;
         body.m_consumer.setData(buffer.releaseNonNull());
         return body;
     }
 
-    auto url = formData.asBlobURL();
+    auto url = formData->asBlobURL();
     if (!url.isNull()) {
         // FIXME: Properly set mime type and size of the blob.
         Ref<const Blob> blob = Blob::deserialize(&context, url, { }, { }, 0, { });
         return FetchBody { WTFMove(blob) };
     }
 
-    return FetchBody { Ref { formData } };
+    return FetchBody { WTFMove(formData) };
 }
 
 void FetchBody::arrayBuffer(FetchBodyOwner& owner, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -57,7 +57,7 @@ public:
     static ExceptionOr<FetchBody> extract(Init&&, String&);
     FetchBody() = default;
 
-    WEBCORE_EXPORT static std::optional<FetchBody> fromFormData(ScriptExecutionContext&, FormData&);
+    WEBCORE_EXPORT static std::optional<FetchBody> fromFormData(ScriptExecutionContext&, Ref<FormData>&&);
 
     void loadingFailed(const Exception&);
     void loadingSucceeded(const String& contentType);

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -40,6 +40,7 @@
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "ViolationReportType.h"
+#include <wtf/persistence/PersistentCoders.h>
 
 namespace WebCore {
 
@@ -143,6 +144,41 @@ void sendCOEPCORPViolation(ReportingClient& reportingClient, const URL& embedder
         body.setString("destination"_s, convertEnumerationToString(destination));
     });
     reportingClient.sendReportToEndpoints(embedderURL, { }, { endpoint }, WTFMove(reportFormData), ViolationReportType::CORPViolation);
+}
+
+void CrossOriginEmbedderPolicy::encode(WTF::Persistence::Encoder& encoder) const
+{
+    encoder << value << reportingEndpoint << reportOnlyValue << reportOnlyReportingEndpoint;
+}
+
+std::optional<CrossOriginEmbedderPolicy> CrossOriginEmbedderPolicy::decode(WTF::Persistence::Decoder& decoder)
+{
+    std::optional<CrossOriginEmbedderPolicyValue> value;
+    decoder >> value;
+    if (!value)
+        return std::nullopt;
+
+    std::optional<String> reportingEndpoint;
+    decoder >> reportingEndpoint;
+    if (!reportingEndpoint)
+        return std::nullopt;
+
+    std::optional<CrossOriginEmbedderPolicyValue> reportOnlyValue;
+    decoder >> reportOnlyValue;
+    if (!reportOnlyValue)
+        return std::nullopt;
+
+    std::optional<String> reportOnlyReportingEndpoint;
+    decoder >> reportOnlyReportingEndpoint;
+    if (!reportOnlyReportingEndpoint)
+        return std::nullopt;
+
+    return { {
+        *value,
+        WTFMove(*reportingEndpoint),
+        *reportOnlyValue,
+        WTFMove(*reportOnlyReportingEndpoint)
+    } };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
@@ -28,6 +28,13 @@
 #include "FetchOptions.h"
 #include <wtf/text/WTFString.h>
 
+namespace WTF::Persistence {
+
+class Decoder;
+class Encoder;
+
+}
+
 namespace WebCore {
 
 class Frame;
@@ -52,8 +59,8 @@ struct CrossOriginEmbedderPolicy {
 
     CrossOriginEmbedderPolicy isolatedCopy() const &;
     CrossOriginEmbedderPolicy isolatedCopy() &&;
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CrossOriginEmbedderPolicy> decode(Decoder&);
+    void encode(WTF::Persistence::Encoder&) const;
+    static std::optional<CrossOriginEmbedderPolicy> decode(WTF::Persistence::Decoder &);
 
     void addPolicyHeadersTo(ResourceResponse&) const;
 };
@@ -61,43 +68,6 @@ struct CrossOriginEmbedderPolicy {
 inline bool operator==(const CrossOriginEmbedderPolicy& a, const CrossOriginEmbedderPolicy& b)
 {
     return a.value == b.value && a.reportingEndpoint == b.reportingEndpoint && a.reportOnlyValue == b.reportOnlyValue && a.reportOnlyReportingEndpoint == b.reportOnlyReportingEndpoint;
-}
-
-template<class Encoder>
-void CrossOriginEmbedderPolicy::encode(Encoder& encoder) const
-{
-    encoder << value << reportingEndpoint << reportOnlyValue << reportOnlyReportingEndpoint;
-}
-
-template<class Decoder>
-std::optional<CrossOriginEmbedderPolicy> CrossOriginEmbedderPolicy::decode(Decoder& decoder)
-{
-    std::optional<CrossOriginEmbedderPolicyValue> value;
-    decoder >> value;
-    if (!value)
-        return std::nullopt;
-
-    std::optional<String> reportingEndpoint;
-    decoder >> reportingEndpoint;
-    if (!reportingEndpoint)
-        return std::nullopt;
-
-    std::optional<CrossOriginEmbedderPolicyValue> reportOnlyValue;
-    decoder >> reportOnlyValue;
-    if (!reportOnlyValue)
-        return std::nullopt;
-
-    std::optional<String> reportOnlyReportingEndpoint;
-    decoder >> reportOnlyReportingEndpoint;
-    if (!reportOnlyReportingEndpoint)
-        return std::nullopt;
-
-    return {{
-        *value,
-        WTFMove(*reportingEndpoint),
-        *reportOnlyValue,
-        WTFMove(*reportOnlyReportingEndpoint)
-    }};
 }
 
 enum class COEPDisposition : bool { Reporting , Enforce };

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -60,11 +60,13 @@ std::optional<NavigationRequester> NavigationRequester::decode(Decoder& decoder)
     if (!url)
         return std::nullopt;
 
-    auto securityOrigin = SecurityOrigin::decode(decoder);
+    std::optional<Ref<SecurityOrigin>> securityOrigin;
+    decoder >> securityOrigin;
     if (!securityOrigin)
         return std::nullopt;
 
-    auto topOrigin = SecurityOrigin::decode(decoder);
+    std::optional<Ref<SecurityOrigin>> topOrigin;
+    decoder >> topOrigin;
     if (!topOrigin)
         return std::nullopt;
 
@@ -78,7 +80,7 @@ std::optional<NavigationRequester> NavigationRequester::decode(Decoder& decoder)
     if (!globalFrameIdentifier)
         return std::nullopt;
 
-    return NavigationRequester { WTFMove(*url), securityOrigin.releaseNonNull(), topOrigin.releaseNonNull(), WTFMove(*policyContainer), *globalFrameIdentifier };
+    return NavigationRequester { WTFMove(*url), WTFMove(*securityOrigin), WTFMove(*topOrigin), WTFMove(*policyContainer), *globalFrameIdentifier };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -40,7 +40,7 @@ KeepaliveRequestTracker::~KeepaliveRequestTracker()
 bool KeepaliveRequestTracker::tryRegisterRequest(CachedResource& resource)
 {
     ASSERT(resource.options().keepAlive);
-    auto* body = resource.resourceRequest().httpBody();
+    auto body = resource.resourceRequest().httpBody();
     if (!body)
         return true;
 
@@ -55,7 +55,7 @@ bool KeepaliveRequestTracker::tryRegisterRequest(CachedResource& resource)
 void KeepaliveRequestTracker::registerRequest(CachedResource& resource)
 {
     ASSERT(resource.options().keepAlive);
-    auto* body = resource.resourceRequest().httpBody();
+    auto body = resource.resourceRequest().httpBody();
     if (!body)
         return;
     ASSERT(!m_inflightKeepaliveRequests.contains(&resource));

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1203,7 +1203,7 @@ DiagnosticLoggingClient& Page::diagnosticLoggingClient() const
     return *m_diagnosticLoggingClient;
 }
 
-void Page::logMediaDiagnosticMessage(const FormData* formData) const
+void Page::logMediaDiagnosticMessage(const RefPtr<FormData>& formData) const
 {
     unsigned imageOrMediaFilesCount = formData ? formData->imageOrMediaFilesCount() : 0;
     if (!imageOrMediaFilesCount)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -551,7 +551,7 @@ public:
 
     WEBCORE_EXPORT DiagnosticLoggingClient& diagnosticLoggingClient() const;
 
-    WEBCORE_EXPORT void logMediaDiagnosticMessage(const FormData*) const;
+    WEBCORE_EXPORT void logMediaDiagnosticMessage(const RefPtr<FormData>&) const;
 
     PerformanceLoggingClient* performanceLoggingClient() const { return m_performanceLoggingClient.get(); }
 

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -596,6 +596,23 @@ Ref<SecurityOrigin> SecurityOrigin::create(const String& protocol, const String&
     return origin;
 }
 
+Ref<SecurityOrigin> SecurityOrigin::create(WebCore::SecurityOriginData&& data, String&& domain, String&& filePath, Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>&& opaqueOriginIdentifier, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal)
+{
+    auto origin = adoptRef(*new SecurityOrigin);
+    origin->m_data = WTFMove(data);
+    origin->m_domain = WTFMove(domain);
+    origin->m_filePath = WTFMove(filePath);
+    origin->m_opaqueOriginIdentifier = WTFMove(opaqueOriginIdentifier);
+    origin->m_universalAccess = universalAccess;
+    origin->m_domainWasSetInDOM = domainWasSetInDOM;
+    origin->m_canLoadLocalResources = canLoadLocalResources;
+    origin->m_enforcesFilePathSeparation = enforcesFilePathSeparation;
+    origin->m_needsStorageAccessFromFileURLsQuirk = needsStorageAccessFromFileURLsQuirk;
+    origin->m_isPotentiallyTrustworthy = isPotentiallyTrustworthy;
+    origin->m_isLocal = isLocal;
+    return origin;
+}
+
 bool SecurityOrigin::equal(const SecurityOrigin* other) const 
 {
     if (other == this)

--- a/Source/WebCore/platform/network/CookieRequestHeaderFieldProxy.h
+++ b/Source/WebCore/platform/network/CookieRequestHeaderFieldProxy.h
@@ -40,52 +40,6 @@ struct CookieRequestHeaderFieldProxy {
     std::optional<FrameIdentifier> frameID;
     std::optional<PageIdentifier> pageID;
     IncludeSecureCookies includeSecureCookies { IncludeSecureCookies::No };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CookieRequestHeaderFieldProxy> decode(Decoder&);
 };
-
-template<class Encoder>
-void CookieRequestHeaderFieldProxy::encode(Encoder& encoder) const
-{
-    encoder << firstParty;
-    encoder << sameSiteInfo;
-    encoder << url;
-    encoder << frameID;
-    encoder << pageID;
-    encoder << includeSecureCookies;
-}
-
-template<class Decoder>
-std::optional<CookieRequestHeaderFieldProxy> CookieRequestHeaderFieldProxy::decode(Decoder& decoder)
-{
-    URL firstParty;
-    if (!decoder.decode(firstParty))
-        return std::nullopt;
-
-    SameSiteInfo sameSiteInfo;
-    if (!decoder.decode(sameSiteInfo))
-        return std::nullopt;
-
-    URL url;
-    if (!decoder.decode(url))
-        return std::nullopt;
-
-    std::optional<std::optional<FrameIdentifier>> frameID;
-    decoder >> frameID;
-    if (!frameID)
-        return std::nullopt;
-
-    std::optional<std::optional<PageIdentifier>> pageID;
-    decoder >> pageID;
-    if (!pageID)
-        return std::nullopt;
-
-    IncludeSecureCookies includeSecureCookies;
-    if (!decoder.decode(includeSecureCookies))
-        return std::nullopt;
-
-    return CookieRequestHeaderFieldProxy { WTFMove(firstParty), WTFMove(sameSiteInfo), WTFMove(url), *frameID, *pageID, includeSecureCookies };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -91,6 +91,16 @@ Ref<FormData> FormData::create(const DOMFormData& formData, EncodingType encodin
     return result;
 }
 
+Ref<FormData> FormData::create(bool alwaysStream, Vector<char>&& boundary, Vector<WebCore::FormDataElement>&& elements, int64_t identifier)
+{
+    auto result = create();
+    result->setAlwaysStream(alwaysStream);
+    result->m_boundary = WTFMove(boundary);
+    result->m_elements = WTFMove(elements);
+    result->setIdentifier(identifier);
+    return result;
+}
+
 Ref<FormData> FormData::createMultiPart(const DOMFormData& formData)
 {
     auto result = create();

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -492,16 +492,16 @@ void ResourceRequestBase::setResponseContentDispositionEncodingFallbackArray(con
     m_platformRequestUpdated = false;
 }
 
-FormData* ResourceRequestBase::httpBody() const
+RefPtr<FormData> ResourceRequestBase::httpBody() const
 {
     updateResourceRequest(HTTPBodyUpdatePolicy::UpdateHTTPBody);
 
-    return m_httpBody.get();
+    return m_httpBody;
 }
 
 bool ResourceRequestBase::hasUpload() const
 {
-    if (auto* body = httpBody()) {
+    if (auto body = httpBody()) {
         for (auto& element : body->elements()) {
             if (std::holds_alternative<WebCore::FormDataElement::EncodedFileData>(element.data) || std::holds_alternative<WebCore::FormDataElement::EncodedBlobData>(element.data))
                 return true;

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -205,7 +205,7 @@ public:
     WEBCORE_EXPORT void setResponseContentDispositionEncodingFallbackArray(const String& encoding1, const String& encoding2 = String(), const String& encoding3 = String());
     void setResponseContentDispositionEncodingFallbackArray(const Vector<String>& array) { m_requestData.m_responseContentDispositionEncodingFallbackArray = array; }
 
-    WEBCORE_EXPORT FormData* httpBody() const;
+    WEBCORE_EXPORT RefPtr<FormData> httpBody() const;
     WEBCORE_EXPORT bool hasUpload() const;
     WEBCORE_EXPORT void setHTTPBody(RefPtr<FormData>&&);
     

--- a/Source/WebCore/platform/network/SameSiteInfo.h
+++ b/Source/WebCore/platform/network/SameSiteInfo.h
@@ -37,29 +37,6 @@ struct SameSiteInfo {
     bool isSameSite { false };
     bool isTopSite { false };
     bool isSafeHTTPMethod { false };
-
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, SameSiteInfo&);
 };
-
-template <class Encoder>
-void SameSiteInfo::encode(Encoder& encoder) const
-{
-    encoder << isSameSite;
-    encoder << isTopSite;
-    encoder << isSafeHTTPMethod;
-}
-
-template <class Decoder>
-bool SameSiteInfo::decode(Decoder& decoder, SameSiteInfo& info)
-{
-    if (!decoder.decode(info.isSameSite))
-        return false;
-    if (!decoder.decode(info.isTopSite))
-        return false;
-    if (!decoder.decode(info.isSafeHTTPMethod))
-        return false;
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -389,7 +389,7 @@ RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData& formData)
     return adoptCF(CFReadStreamCreate(nullptr, static_cast<const void*>(&callBacks), formContext));
 }
 
-void setHTTPBody(CFMutableURLRequestRef request, FormData* formData)
+void setHTTPBody(CFMutableURLRequestRef request, const RefPtr<FormData>& formData)
 {
     if (!formData)
         return;

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.h
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class FormData;
 
-void setHTTPBody(CFMutableURLRequestRef, FormData*);
+void setHTTPBody(CFMutableURLRequestRef, const RefPtr<FormData>&);
 RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData&);
 
 FormData* httpBodyFromStream(CFReadStreamRef);

--- a/Source/WebCore/platform/network/cf/ResourceHandleCFURLConnectionDelegate.cpp
+++ b/Source/WebCore/platform/network/cf/ResourceHandleCFURLConnectionDelegate.cpp
@@ -147,9 +147,9 @@ ResourceRequest ResourceHandleCFURLConnectionDelegate::createResourceRequest(CFU
                 _CFURLRequestSetStorageSession(mutableRequest.get(), storageSession);
             CFURLRequestSetHTTPRequestMethod(mutableRequest.get(), lastHTTPMethod.get());
 
-            FormData* body = m_handle->firstRequest().httpBody();
+            auto body = m_handle->firstRequest().httpBody();
             if (!equalLettersIgnoringASCIICase(m_handle->firstRequest().httpMethod(), "get"_s) && body && !body->isEmpty())
-                WebCore::setHTTPBody(mutableRequest.get(), body);
+                WebCore::setHTTPBody(mutableRequest.get(), WTFMove(body));
 
             String originalContentType = m_handle->firstRequest().httpContentType();
             if (!originalContentType.isEmpty())

--- a/Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp
@@ -250,9 +250,9 @@ void ResourceRequest::doUpdatePlatformHTTPBody()
     } else
         cfRequest = adoptCF(CFURLRequestCreateMutable(0, url.get(), toPlatformRequestCachePolicy(cachePolicy()), timeoutInterval, firstPartyForCookies.get()));
 
-    FormData* formData = httpBody();
+    auto formData = httpBody();
     if (formData && !formData->isEmpty())
-        WebCore::setHTTPBody(cfRequest.get(), formData);
+        WebCore::setHTTPBody(cfRequest.get(), WTFMove(formData));
 
     if (RetainPtr<CFReadStreamRef> bodyStream = adoptCF(CFURLRequestCopyHTTPRequestBodyStream(cfRequest.get()))) {
         // For streams, provide a Content-Length to avoid using chunked encoding, and to get accurate total length in callbacks.

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -339,9 +339,9 @@ void ResourceRequest::doUpdatePlatformHTTPBody()
     nsRequest.get().attribution = m_requestData.m_isAppInitiated ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;
 #endif
 
-    FormData* formData = httpBody();
+    auto formData = httpBody();
     if (formData && !formData->isEmpty())
-        WebCore::setHTTPBody(nsRequest.get(), formData);
+        WebCore::setHTTPBody(nsRequest.get(), WTFMove(formData));
 
     if (NSInputStream *bodyStream = [nsRequest HTTPBodyStream]) {
         // For streams, provide a Content-Length to avoid using chunked encoding, and to get accurate total length in callbacks.

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-CurlFormDataStream::CurlFormDataStream(const FormData* formData)
+CurlFormDataStream::CurlFormDataStream(const RefPtr<FormData>& formData)
 {
     ASSERT(isMainThread());
 

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.h
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class CurlFormDataStream {
 public:
-    explicit CurlFormDataStream(const FormData*);
+    explicit CurlFormDataStream(const RefPtr<FormData>&);
     WEBCORE_EXPORT ~CurlFormDataStream();
 
     void clean();

--- a/Source/WebCore/platform/network/mac/FormDataStreamMac.h
+++ b/Source/WebCore/platform/network/mac/FormDataStreamMac.h
@@ -38,8 +38,8 @@ namespace WebCore {
 
 class FormData;
 
-void setHTTPBody(NSMutableURLRequest *, FormData*);
-WEBCORE_EXPORT RetainPtr<NSInputStream> createHTTPBodyNSInputStream(FormData&);
+void setHTTPBody(NSMutableURLRequest *, const RefPtr<FormData>&);
+WEBCORE_EXPORT RetainPtr<NSInputStream> createHTTPBodyNSInputStream(Ref<FormData>&&);
 FormData* httpBodyFromStream(NSInputStream *);
 
 CFStringRef formDataStreamLengthPropertyName();

--- a/Source/WebCore/platform/network/mac/FormDataStreamMac.mm
+++ b/Source/WebCore/platform/network/mac/FormDataStreamMac.mm
@@ -34,12 +34,12 @@
 
 namespace WebCore {
 
-void setHTTPBody(NSMutableURLRequest *request, FormData* formData)
+void setHTTPBody(NSMutableURLRequest *request, const RefPtr<FormData>& formData)
 {
     setHTTPBody(const_cast<CFMutableURLRequestRef>([request _CFURLRequest]), formData);
 }
 
-RetainPtr<NSInputStream> createHTTPBodyNSInputStream(FormData& formData)
+RetainPtr<NSInputStream> createHTTPBodyNSInputStream(Ref<FormData>&& formData)
 {
     return (__bridge NSInputStream *)createHTTPBodyCFReadStream(formData).get();
 }

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -416,9 +416,9 @@ void ResourceHandle::willSendRequest(ResourceRequest&& request, ResourceResponse
         if (!equalIgnoringASCIICase(lastHTTPMethod, request.httpMethod())) {
             request.setHTTPMethod(lastHTTPMethod);
     
-            FormData* body = d->m_firstRequest.httpBody();
+            auto body = d->m_firstRequest.httpBody();
             if (!equalLettersIgnoringASCIICase(lastHTTPMethod, "get"_s) && body && !body->isEmpty())
-                request.setHTTPBody(body);
+                request.setHTTPBody(WTFMove(body));
 
             String originalContentType = d->m_firstRequest.httpContentType();
             if (!originalContentType.isEmpty())

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -94,7 +94,7 @@ GRefPtr<SoupMessage> ResourceRequest::createSoupMessage(BlobRegistryImpl& blobRe
 
 void ResourceRequest::updateSoupMessageBody(SoupMessage* soupMessage, BlobRegistryImpl& blobRegistry) const
 {
-    auto* formData = httpBody();
+    auto formData = httpBody();
     if (!formData || formData->isEmpty())
         return;
 

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -133,7 +133,7 @@ Ref<FetchResponse> ServiceWorkerInternals::createOpaqueWithBlobBodyResponse(Scri
     ResourceResponse response;
     response.setType(ResourceResponse::Type::Cors);
     response.setTainting(ResourceResponse::Tainting::Opaque);
-    auto fetchResponse = FetchResponse::create(&context, FetchBody::fromFormData(context, formData), FetchHeaders::Guard::Response, WTFMove(response));
+    auto fetchResponse = FetchResponse::create(&context, FetchBody::fromFormData(context, WTFMove(formData)), FetchHeaders::Guard::Response, WTFMove(response));
     fetchResponse->initializeOpaqueLoadIdentifierForTesting();
     return fetchResponse;
 }

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -173,10 +173,10 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
     // FIXME: we should use the same path for registration changes as for fetch events.
     ASSERT(globalScope.registration().active()->state() == ServiceWorkerState::Activated || globalScope.registration().active()->state() == ServiceWorkerState::Activating);
 
-    auto* formData = request.httpBody();
+    auto formData = request.httpBody();
     std::optional<FetchBody> body;
     if (formData && !formData->isEmpty()) {
-        body = FetchBody::fromFormData(globalScope, *formData);
+        body = FetchBody::fromFormData(globalScope, formData.releaseNonNull());
         if (!body) {
             client->didNotHandle();
             return;

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -523,6 +523,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
 
     NetworkProcess/NetworkProcessCreationParameters.serialization.in
+    NetworkProcess/NetworkResourceLoadParameters.serialization.in
 
     Shared/EditorState.serialization.in
     Shared/FocusedElementInformation.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -106,6 +106,7 @@ $(PROJECT_DIR)/NetworkProcess/NetworkConnectionToWebProcess.messages.in
 $(PROJECT_DIR)/NetworkProcess/NetworkContentRuleListManager.messages.in
 $(PROJECT_DIR)/NetworkProcess/NetworkProcess.messages.in
 $(PROJECT_DIR)/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+$(PROJECT_DIR)/NetworkProcess/NetworkResourceLoadParameters.serialization.in
 $(PROJECT_DIR)/NetworkProcess/NetworkResourceLoader.messages.in
 $(PROJECT_DIR)/NetworkProcess/NetworkSocketChannel.messages.in
 $(PROJECT_DIR)/NetworkProcess/NetworkSocketStream.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -465,6 +465,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	NetworkProcess/NetworkProcessCreationParameters.serialization.in \
 	Shared/API/APIError.serialization.in \
 	Shared/API/APIFrameHandle.serialization.in \
+	NetworkProcess/NetworkResourceLoadParameters.serialization.in \
 	Shared/API/APIGeometry.serialization.in \
 	Shared/API/APIPageHandle.serialization.in \
 	Shared/API/APIURL.serialization.in \

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -527,7 +527,7 @@ Vector<RefPtr<WebCore::BlobDataFileReference>> NetworkConnectionToWebProcess::re
     auto& blobRegistry = session->blobRegistry();
 
     Vector<RefPtr<WebCore::BlobDataFileReference>> files;
-    if (auto* body = loadParameters.request.httpBody()) {
+    if (auto body = loadParameters.request.httpBody()) {
         for (auto& element : body->elements()) {
             if (auto* blobData = std::get_if<FormDataElement::EncodedBlobData>(&element.data))
                 files.appendVector(blobRegistry.filesInBlob(blobData->url));

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -44,6 +44,32 @@ enum class PreconnectOnly : bool { No, Yes };
 
 class NetworkLoadParameters {
 public:
+    NetworkLoadParameters() = default;
+    NetworkLoadParameters(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, WebCore::FrameIdentifier webFrameID, RefPtr<WebCore::SecurityOrigin>&& topOrigin, RefPtr<WebCore::SecurityOrigin>&& sourceOrigin, WTF::ProcessID parentPID, WebCore::ResourceRequest&& request, WebCore::ContentSniffingPolicy contentSniffingPolicy, WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, WebCore::ClientCredentialPolicy clientCredentialPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool needsCertificateInfo, bool isMainFrameNavigation, bool isMainResourceNavigationForAnyFrame, WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, PreconnectOnly shouldPreconnectOnly, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy)
+        : webPageProxyID(webPageProxyID)
+        , webPageID(webPageID)
+        , webFrameID(webFrameID)
+        , topOrigin(WTFMove(topOrigin))
+        , sourceOrigin(WTFMove(sourceOrigin))
+        , parentPID(parentPID)
+        , request(WTFMove(request))
+        , contentSniffingPolicy(contentSniffingPolicy)
+        , contentEncodingSniffingPolicy(contentEncodingSniffingPolicy)
+        , storedCredentialsPolicy(storedCredentialsPolicy)
+        , clientCredentialPolicy(clientCredentialPolicy)
+        , shouldClearReferrerOnHTTPSToHTTPRedirect(shouldClearReferrerOnHTTPSToHTTPRedirect)
+        , needsCertificateInfo(needsCertificateInfo)
+        , isMainFrameNavigation(isMainFrameNavigation)
+        , isMainResourceNavigationForAnyFrame(isMainResourceNavigationForAnyFrame)
+        , shouldRelaxThirdPartyCookieBlocking(shouldRelaxThirdPartyCookieBlocking)
+        , shouldPreconnectOnly(shouldPreconnectOnly)
+        , isNavigatingToAppBoundDomain(isNavigatingToAppBoundDomain)
+        , hadMainFrameMainResourcePrivateRelayed(hadMainFrameMainResourcePrivateRelayed)
+        , allowPrivacyProxy(allowPrivacyProxy)
+        , networkConnectionIntegrityPolicy(networkConnectionIntegrityPolicy)
+    {
+    }
+    
     WebPageProxyIdentifier webPageProxyID;
     WebCore::PageIdentifier webPageID;
     WebCore::FrameIdentifier webFrameID;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -47,8 +47,51 @@ namespace WebKit {
 
 class NetworkResourceLoadParameters : public NetworkLoadParameters {
 public:
-    void encode(IPC::Encoder&) const;
-    static std::optional<NetworkResourceLoadParameters> decode(IPC::Decoder&);
+    NetworkResourceLoadParameters() = default;
+    NetworkResourceLoadParameters(
+        NetworkLoadParameters&&
+        , WebCore::ResourceLoaderIdentifier
+        , RefPtr<WebCore::FormData>&& httpBody
+        , std::optional<Vector<SandboxExtension::Handle>>&& sandboxExtensionIfHttpBody
+        , std::optional<SandboxExtension::Handle>&& sandboxExtensionIflocalFile
+        , Seconds maximumBufferingTime
+        , WebCore::FetchOptions&&
+        , std::optional<WebCore::ContentSecurityPolicyResponseHeaders>&& cspResponseHeaders
+        , URL&& parentFrameURL
+        , URL&& frameURL
+        , WebCore::CrossOriginEmbedderPolicy parentCrossOriginEmbedderPolicy
+        , WebCore::CrossOriginEmbedderPolicy
+        , WebCore::HTTPHeaderMap&& originalRequestHeaders
+        , bool shouldRestrictHTTPResponseAccess
+        , WebCore::PreflightPolicy
+        , bool shouldEnableCrossOriginResourcePolicy
+        , Vector<RefPtr<WebCore::SecurityOrigin>>&& frameAncestorOrigins
+        , bool pageHasResourceLoadClient
+        , std::optional<WebCore::FrameIdentifier> parentFrameID
+        , bool crossOriginAccessControlCheckEnabled
+        , URL&& documentURL
+        , bool isCrossOriginOpenerPolicyEnabled
+        , bool isClearSiteDataHeaderEnabled
+        , bool isDisplayingInitialEmptyDocument
+        , WebCore::SandboxFlags effectiveSandboxFlags
+        , URL&& openerURL
+        , WebCore::CrossOriginOpenerPolicy&& sourceCrossOriginOpenerPolicy
+        , uint64_t navigationID
+        , std::optional<WebCore::NavigationRequester>&&
+#if ENABLE(SERVICE_WORKER)
+        , WebCore::ServiceWorkersMode
+        , std::optional<WebCore::ServiceWorkerRegistrationIdentifier>
+        , OptionSet<WebCore::HTTPHeadersToKeepFromCleaning>
+        , std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier
+#endif
+#if ENABLE(CONTENT_EXTENSIONS)
+        , URL&& mainDocumentURL
+        , std::optional<UserContentControllerIdentifier>
+#endif
+    );
+    
+    std::optional<Vector<SandboxExtension::Handle>> sandboxExtensionsIfHttpBody() const;
+    std::optional<SandboxExtension::Handle> sandboxExtensionIflocalFile() const;
 
     RefPtr<WebCore::SecurityOrigin> parentOrigin() const;
 
@@ -92,8 +135,6 @@ public:
     URL mainDocumentURL;
     std::optional<UserContentControllerIdentifier> userContentControllerIdentifier;
 #endif
-    
-    std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain { NavigatingToAppBoundDomain::No };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -1,0 +1,107 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+headers: "NetworkResourceLoadParameters.h"
+
+enum class WebKit::PreconnectOnly : bool;
+
+class WebKit::NetworkLoadParameters {
+    WebKit::WebPageProxyIdentifier webPageProxyID;
+    WebCore::PageIdentifier webPageID;
+    WebCore::FrameIdentifier webFrameID;
+    RefPtr<WebCore::SecurityOrigin> topOrigin;
+    RefPtr<WebCore::SecurityOrigin> sourceOrigin;
+    WTF::ProcessID parentPID;
+    WebCore::ResourceRequest request;
+    
+    WebCore::ContentSniffingPolicy contentSniffingPolicy;
+    WebCore::ContentEncodingSniffingPolicy contentEncodingSniffingPolicy;
+    WebCore::StoredCredentialsPolicy storedCredentialsPolicy;
+    WebCore::ClientCredentialPolicy clientCredentialPolicy;
+    
+    bool shouldClearReferrerOnHTTPSToHTTPRedirect;
+    bool needsCertificateInfo;
+    bool isMainFrameNavigation;
+    bool isMainResourceNavigationForAnyFrame;
+    WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking;
+    
+    WebKit::PreconnectOnly shouldPreconnectOnly;
+    std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
+    bool hadMainFrameMainResourcePrivateRelayed;
+    bool allowPrivacyProxy;
+    OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy;
+}
+
+class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
+    WebCore::ResourceLoaderIdentifier identifier;
+    
+    RefPtr<WebCore::FormData> request.httpBody();
+    std::optional<Vector<WebKit::SandboxExtension::Handle>> sandboxExtensionsIfHttpBody();
+
+    std::optional<WebKit::SandboxExtension::Handle> sandboxExtensionIflocalFile();
+
+    Seconds maximumBufferingTime;
+    
+    WebCore::FetchOptions options;
+    std::optional<WebCore::ContentSecurityPolicyResponseHeaders> cspResponseHeaders;
+    URL parentFrameURL;
+    URL frameURL;
+    WebCore::CrossOriginEmbedderPolicy parentCrossOriginEmbedderPolicy;
+    WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
+    WebCore::HTTPHeaderMap originalRequestHeaders;
+    
+    bool shouldRestrictHTTPResponseAccess;
+    
+    WebCore::PreflightPolicy preflightPolicy;
+    
+    bool shouldEnableCrossOriginResourcePolicy;
+    
+    Vector<RefPtr<WebCore::SecurityOrigin>> frameAncestorOrigins;
+    bool pageHasResourceLoadClient;
+    std::optional<WebCore::FrameIdentifier> parentFrameID;
+    bool crossOriginAccessControlCheckEnabled;
+    
+    URL documentURL;
+
+    bool isCrossOriginOpenerPolicyEnabled;
+    bool isClearSiteDataHeaderEnabled;
+    bool isDisplayingInitialEmptyDocument;
+    WebCore::SandboxFlags effectiveSandboxFlags;
+    URL openerURL;
+    WebCore::CrossOriginOpenerPolicy sourceCrossOriginOpenerPolicy;
+    
+    uint64_t navigationID;
+    std::optional<WebCore::NavigationRequester> navigationRequester;
+    
+#if ENABLE(SERVICE_WORKER)
+    WebCore::ServiceWorkersMode serviceWorkersMode;
+    std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
+    OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
+    std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier;
+#endif
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    URL mainDocumentURL;
+    std::optional<WebKit::UserContentControllerIdentifier> userContentControllerIdentifier;
+#endif
+
+};

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -364,10 +364,10 @@ void NetworkResourceLoader::startNetworkLoad(ResourceRequest&& request, FirstLoa
 
     if (m_parameters.pageHasResourceLoadClient) {
         std::optional<IPC::FormDataReference> httpBody;
-        if (auto* formData = request.httpBody()) {
+        if (auto formData = request.httpBody()) {
             static constexpr auto maxSerializedRequestSize = 1024 * 1024;
             if (formData->lengthInBytes() <= maxSerializedRequestSize)
-                httpBody = IPC::FormDataReference { formData };
+                httpBody = IPC::FormDataReference { WTFMove(formData) };
         }
         m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ResourceLoadDidSendRequest(m_parameters.webPageProxyID, resourceLoadInfo(), request, httpBody), 0);
     }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -563,9 +563,9 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
 
     if (redirectResponse.httpStatusCode() == 307 || redirectResponse.httpStatusCode() == 308) {
         ASSERT(m_lastHTTPMethod == request.httpMethod());
-        WebCore::FormData* body = m_firstRequest.httpBody();
+        auto body = m_firstRequest.httpBody();
         if (body && !body->isEmpty() && !equalLettersIgnoringASCIICase(m_lastHTTPMethod, "get"_s))
-            request.setHTTPBody(body);
+            request.setHTTPBody(WTFMove(body));
         
         String originalContentType = m_firstRequest.httpContentType();
         if (!originalContentType.isEmpty())

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -535,13 +535,13 @@ static String stringForSSLCipher(SSLCipherSuite cipher)
         return;
     }
 
-    auto* body = networkDataTask->firstRequest().httpBody();
+    auto body = networkDataTask->firstRequest().httpBody();
     if (!body) {
         completionHandler(nil);
         return;
     }
 
-    completionHandler(WebCore::createHTTPBodyNSInputStream(*body).get());
+    completionHandler(WebCore::createHTTPBodyNSInputStream(body.releaseNonNull()).get());
 }
 
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/Platform/IPC/FormDataReference.h
+++ b/Source/WebKit/Platform/IPC/FormDataReference.h
@@ -70,7 +70,8 @@ public:
         if (!hasFormData.value())
             return FormDataReference { };
 
-        auto formData = WebCore::FormData::decode(decoder);
+        std::optional<Ref<WebCore::FormData>> formData;
+        decoder >> formData;
         if (!formData)
             return std::nullopt;
 
@@ -81,7 +82,7 @@ public:
 
         WebKit::SandboxExtension::consumePermanently(*sandboxExtensionHandles);
 
-        return FormDataReference { formData.releaseNonNull() };
+        return FormDataReference { WTFMove(*formData) };
     }
 
 private:

--- a/Source/WebKit/Shared/URLSchemeTaskParameters.cpp
+++ b/Source/WebKit/Shared/URLSchemeTaskParameters.cpp
@@ -39,7 +39,7 @@ void URLSchemeTaskParameters::encode(IPC::Encoder& encoder) const
     encoder << request;
     if (request.httpBody()) {
         encoder << true;
-        request.httpBody()->encode(encoder);
+        encoder << request.httpBody();
     } else
         encoder << false;
     encoder << frameInfo;
@@ -66,10 +66,11 @@ std::optional<URLSchemeTaskParameters> URLSchemeTaskParameters::decode(IPC::Deco
     if (!hasHTTPBody)
         return std::nullopt;
     if (*hasHTTPBody) {
-        RefPtr<WebCore::FormData> formData = WebCore::FormData::decode(decoder);
+        std::optional<RefPtr<WebCore::FormData>> formData;
+        decoder >> formData;
         if (!formData)
             return std::nullopt;
-        request.setHTTPBody(WTFMove(formData));
+        request.setHTTPBody(WTFMove(*formData));
     }
     
     std::optional<FrameInfoData> frameInfo;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -185,7 +185,7 @@ void ArgumentCoder<DOMCacheEngine::Record>::encode(Encoder& encoder, const DOMCa
     }, [&](const Ref<FormData>& formData) {
         encoder << false;
         encoder << true;
-        formData->encode(encoder);
+        encoder << formData;
     }, [&](const std::nullptr_t&) {
         encoder << false;
         encoder << false;
@@ -246,10 +246,11 @@ std::optional<DOMCacheEngine::Record> ArgumentCoder<DOMCacheEngine::Record>::dec
         if (!decoder.decode(hasFormDataBody))
             return std::nullopt;
         if (hasFormDataBody) {
-            auto formData = FormData::decode(decoder);
+            std::optional<Ref<WebCore::FormData>> formData;
+            decoder >> formData;
             if (!formData)
                 return std::nullopt;
-            responseBody = formData.releaseNonNull();
+            responseBody = *formData;
         }
     }
 
@@ -1159,32 +1160,6 @@ bool ArgumentCoder<ServiceWorkerOrClientIdentifier>::decode(Decoder& decoder, Se
 }
 
 #endif
-
-void ArgumentCoder<RefPtr<SecurityOrigin>>::encode(Encoder& encoder, const RefPtr<SecurityOrigin>& origin)
-{
-    encoder << *origin;
-}
-
-std::optional<RefPtr<SecurityOrigin>> ArgumentCoder<RefPtr<SecurityOrigin>>::decode(Decoder& decoder)
-{
-    auto origin = SecurityOrigin::decode(decoder);
-    if (!origin)
-        return std::nullopt;
-    return origin;
-}
-
-void ArgumentCoder<Ref<SecurityOrigin>>::encode(Encoder& encoder, const Ref<SecurityOrigin>& origin)
-{
-    encoder << origin.get();
-}
-
-std::optional<Ref<SecurityOrigin>> ArgumentCoder<Ref<SecurityOrigin>>::decode(Decoder& decoder)
-{
-    auto origin = SecurityOrigin::decode(decoder);
-    if (!origin)
-        return std::nullopt;
-    return origin.releaseNonNull();
-}
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -137,7 +137,6 @@ class ResourceError;
 class ResourceRequest;
 class ResourceResponse;
 class ScriptBuffer;
-class SecurityOrigin;
 class SerializedScriptValue;
 class FragmentedSharedBuffer;
 class StickyPositionViewportConstraints;
@@ -433,16 +432,6 @@ template<> struct ArgumentCoder<WebCore::ServiceWorkerOrClientIdentifier> {
 };
 
 #endif
-
-template<> struct ArgumentCoder<RefPtr<WebCore::SecurityOrigin>> {
-    static void encode(Encoder&, const RefPtr<WebCore::SecurityOrigin>&);
-    static std::optional<RefPtr<WebCore::SecurityOrigin>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<Ref<WebCore::SecurityOrigin>> {
-    static void encode(Encoder&, const Ref<WebCore::SecurityOrigin>&);
-    static std::optional<Ref<WebCore::SecurityOrigin>> decode(Decoder&);
-};
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1122,6 +1122,17 @@ enum class WebCore::StoredCredentialsPolicy : uint8_t {
     EphemeralStateless
 };
 
+enum class WebCore::ContentSniffingPolicy : bool;
+enum class WebCore::ContentEncodingSniffingPolicy : bool;
+enum class WebCore::ClientCredentialPolicy : bool;
+enum class WebCore::ShouldRelaxThirdPartyCookieBlocking : bool;
+
+enum class WebCore::PreflightPolicy : uint8_t {
+    Consider,
+    Force,
+    Prevent
+};
+
 enum class WTFLogChannelState : uint8_t {
     Off,
     On,
@@ -2614,4 +2625,51 @@ enum class WebCore::AutocapitalizeType : uint8_t {
     Words,
     Sentences,
     AllCharacters
+};
+
+enum class WebCore::CrossOriginEmbedderPolicyValue : bool
+
+struct WebCore::CrossOriginEmbedderPolicy {
+    WebCore::CrossOriginEmbedderPolicyValue value;
+    String reportingEndpoint;
+    WebCore::CrossOriginEmbedderPolicyValue reportOnlyValue;
+    String reportOnlyReportingEndpoint;
+};
+
+struct WebCore::SameSiteInfo {
+    bool isSameSite;
+    bool isTopSite;
+    bool isSafeHTTPMethod;
+};
+
+[Return=Ref] class WebCore::SecurityOrigin {
+    WebCore::SecurityOriginData m_data;
+    String m_domain;
+    String m_filePath;
+    Markable<WebCore::OpaqueOriginIdentifier, WebCore::OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
+    bool m_universalAccess;
+    bool m_domainWasSetInDOM;
+    bool m_canLoadLocalResources;
+    bool m_enforcesFilePathSeparation;
+    bool m_needsStorageAccessFromFileURLsQuirk;
+    std::optional<bool> m_isPotentiallyTrustworthy;
+    bool m_isLocal;
+}
+
+enum class WebCore::IncludeSecureCookies : bool;
+
+struct WebCore::CookieRequestHeaderFieldProxy {
+    URL firstParty;
+    WebCore::SameSiteInfo sameSiteInfo;
+    URL url;
+    std::optional<WebCore::FrameIdentifier> frameID;
+    std::optional<WebCore::PageIdentifier> pageID;
+    WebCore::IncludeSecureCookies includeSecureCookies;
+};
+
+[Return=Ref] class WebCore::FormData {
+    bool m_alwaysStream;
+    Vector<char> m_boundary;
+    Vector<WebCore::FormDataElement> m_elements;
+    int64_t m_identifier;
 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6058,6 +6058,7 @@
 		84120B2B28258BB5002988E2 /* MacCatalyst.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = MacCatalyst.modulemap; sourceTree = "<group>"; };
 		84477851176FCAC100CDC7BB /* InjectedBundleHitTestResultMediaType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedBundleHitTestResultMediaType.h; sourceTree = "<group>"; };
 		861A646128F5A37300E23C8F /* ShareableBitmap.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ShareableBitmap.serialization.in; sourceTree = "<group>"; };
+		863551D229647AB400C2BE98 /* NetworkResourceLoadParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = NetworkResourceLoadParameters.serialization.in; sourceTree = "<group>"; };
 		8644890A27B47020007A1C66 /* _WKSystemPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferences.h; sourceTree = "<group>"; };
 		8644890C27B47045007A1C66 /* _WKSystemPreferences.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSystemPreferences.mm; sourceTree = "<group>"; };
 		8644890E27B5CB43007A1C66 /* _WKSystemPreferencesInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferencesInternal.h; sourceTree = "<group>"; };
@@ -10963,6 +10964,7 @@
 				51240EBE220B6947005CFC63 /* NetworkResourceLoadMap.h */,
 				5C1426E51C23F80500D41183 /* NetworkResourceLoadParameters.cpp */,
 				5C1426E61C23F80500D41183 /* NetworkResourceLoadParameters.h */,
+				863551D229647AB400C2BE98 /* NetworkResourceLoadParameters.serialization.in */,
 				5C0A10C1235241A30053E2CA /* NetworkSchemeRegistry.cpp */,
 				5CA2F7472350E15400BE5194 /* NetworkSchemeRegistry.h */,
 				532159521DBAE6FC0054AA3C /* NetworkSession.cpp */,


### PR DESCRIPTION
#### db8f4c828416ab5cbe20155367ce24b8d2f987cf
<pre>
Port NetworkResourceLoadParameters to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=250201">https://bugs.webkit.org/show_bug.cgi?id=250201</a>
rdar://103951633

Reviewed by Alex Christensen.

Port NetworkResourceLoadParameters and other related types over to the
new IPC serialization format. This includes:
    * NetworkResourceLoadParameters
    * PreconnectOnly
    * SameSiteInfo
    * SecurityOrigin
    * ContentSniffingPolicy
    * ContentEncodingSniffingPolicy
    * ClientCredentialPolicy
    * ShouldRelaxThirdPartyCookieBlocking
    * PreflightPolicy
    * CrossOriginEmbedderPolicy
    * CrossOriginEmbedderPolicyValue
    * IncludeSecureCookies
    * CookieRequestHeaderFieldProxy

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::fromFormData):
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
(WebCore::CrossOriginEmbedderPolicy::encode const):
(WebCore::CrossOriginEmbedderPolicy::decode):
* Source/WebCore/loader/CrossOriginEmbedderPolicy.h:
(WebCore::CrossOriginEmbedderPolicy::encode const): Deleted.
(WebCore::CrossOriginEmbedderPolicy::decode): Deleted.
* Source/WebCore/loader/NavigationRequester.h:
(WebCore::NavigationRequester::decode):
* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
(WebCore::KeepaliveRequestTracker::tryRegisterRequest):
(WebCore::KeepaliveRequestTracker::registerRequest):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::logMediaDiagnosticMessage const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::create):
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::SecurityOrigin::encode const): Deleted.
(WebCore::SecurityOrigin::decode): Deleted.
* Source/WebCore/platform/network/CookieRequestHeaderFieldProxy.h:
(WebCore::CookieRequestHeaderFieldProxy::encode const): Deleted.
(WebCore::CookieRequestHeaderFieldProxy::decode): Deleted.
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::create):
* Source/WebCore/platform/network/FormData.h:
(WebCore::FormData::encode const): Deleted.
(WebCore::FormData::decode): Deleted.
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::httpBody const):
(WebCore::ResourceRequestBase::hasUpload const):
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/SameSiteInfo.h:
(WebCore::SameSiteInfo::encode const): Deleted.
(WebCore::SameSiteInfo::decode): Deleted.
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::setHTTPBody):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.h:
* Source/WebCore/platform/network/cf/ResourceHandleCFURLConnectionDelegate.cpp:
(WebCore::ResourceHandleCFURLConnectionDelegate::createResourceRequest):
* Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp:
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
(WebCore::CurlFormDataStream::CurlFormDataStream):
* Source/WebCore/platform/network/curl/CurlFormDataStream.h:
* Source/WebCore/platform/network/mac/FormDataStreamMac.h:
* Source/WebCore/platform/network/mac/FormDataStreamMac.mm:
(WebCore::setHTTPBody):
(WebCore::createHTTPBodyNSInputStream):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::willSendRequest):
* Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp:
(WebCore::ResourceRequest::updateSoupMessageBody const):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::createOpaqueWithBlobBodyResponse):
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/FormData.serialization.in: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::resolveBlobReferences):
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
(WebKit::NetworkLoadParameters::NetworkLoadParameters):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
(WebKit::NetworkResourceLoadParameters::parentOrigin const):
(WebKit::NetworkResourceLoadParameters::sandboxExtensionsIfHttpBody const):
(WebKit::NetworkResourceLoadParameters::sandboxExtensionIflocalFile const):
(WebKit::NetworkResourceLoadParameters::encode const): Deleted.
(WebKit::NetworkResourceLoadParameters::decode): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in: Added.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startNetworkLoad):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:needNewBodyStream:]):
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::decode):
* Source/WebKit/Shared/URLSchemeTaskParameters.cpp:
(WebKit::URLSchemeTaskParameters::encode const):
(WebKit::URLSchemeTaskParameters::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;DOMCacheEngine::Record&gt;::encode):
(IPC::ArgumentCoder&lt;DOMCacheEngine::Record&gt;::decode):
(IPC::ArgumentCoder&lt;RefPtr&lt;SecurityOrigin&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;SecurityOrigin&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;Ref&lt;SecurityOrigin&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Ref&lt;SecurityOrigin&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259142@main">https://commits.webkit.org/259142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8390271634f06f705a262e7d7c010e9c7338c9ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104047 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113260 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173567 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4055 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96283 "Reverted pull request changes (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112342 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94012 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96283 "Reverted pull request changes (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25624 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96283 "Reverted pull request changes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3536 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46535 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8434 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3338 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->