### PR TITLE
Web Inspector: Regression [r258503@main] Computed style sections have yellow background

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -252,12 +252,12 @@ body[dir=rtl] .details-section > .header::before {
     margin-inline-start: 5px;
 }
 
-.details-section > .content > .group > .row:has(.warning) {
+.details-section > .content > .group > .row:is(.simple, .font-variation):has(.warning) {
     background-color: var(--warning-background-color-secondary);
     position: relative;
 }
 
-.details-section > .content > .group > .row > .warning {
+.details-section > .content > .group > .row:is(.simple, .font-variation) > .warning {
     position: absolute;
     right: 0;
     align-self: center;


### PR DESCRIPTION
#### 0d3847719a5308c4152846b7eeeaa4fa3d4adf3e
<pre>
Web Inspector: Regression [r258503@main] Computed style sections have yellow background
<a href="https://bugs.webkit.org/show_bug.cgi?id=250204">https://bugs.webkit.org/show_bug.cgi?id=250204</a>

Reviewed by Patrick Angle.

Keep a very specific selector for detail section rows
that have a warning child element to avoid marking
other types of rows with a yellow background color.

* Source/WebInspectorUI/UserInterface/Views/DetailsSection.css:
(.details-section &gt; .content &gt; .group &gt; .row:is(.simple, .font-variation):has(.warning)):
(.details-section &gt; .content &gt; .group &gt; .row:is(.simple, .font-variation) &gt; .warning):
(.details-section &gt; .content &gt; .group &gt; .row:has(.warning)): Deleted.
(.details-section &gt; .content &gt; .group &gt; .row &gt; .warning): Deleted.

Canonical link: <a href="https://commits.webkit.org/258667@main">https://commits.webkit.org/258667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/710c59128db0a3ead62e8312b0b978145a3a1cde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111609 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171797 "The change is no longer eligible for processing.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2358 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94632 "The change is no longer eligible for processing.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109318 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108086 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9526 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92781 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94632 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91394 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24265 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94632 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4955 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25684 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5094 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2122 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11122 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45186 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5950 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6846 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->