### PR TITLE
Expose MediaPlayer topDocumentSecurityOrigin

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8827,6 +8827,11 @@ SecurityOriginData HTMLMediaElement::documentSecurityOrigin() const
     return document().securityOrigin().data();
 }
 
+Ref<SecurityOrigin> HTMLMediaElement::topDocumentSecurityOrigin() const
+{
+    return document().topOrigin();
+}
+
 void HTMLMediaElement::setShowPosterFlag(bool flag)
 {
     if (m_showPoster == flag)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -646,6 +646,7 @@ protected:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 
     SecurityOriginData documentSecurityOrigin() const final;
+    Ref<SecurityOrigin> topDocumentSecurityOrigin() const final;
 
     String audioOutputDeviceId() const final { return m_audioOutputPersistentDeviceId; }
     String audioOutputDeviceIdOverride() const final { return m_audioOutputPersistentDeviceId; }

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -215,6 +215,8 @@ private:
     RefPtr<ArrayBuffer> mediaPlayerCachedKeyForKeyId(const String&) const final { return nullptr; }
 #endif
 
+    Ref<SecurityOrigin> topDocumentSecurityOrigin() const { return SecurityOrigin::createOpaque(); }
+
     const std::optional<Vector<String>>& allowedMediaContainerTypes() const final { return nullOptionalStringVector(); }
     const std::optional<Vector<String>>& allowedMediaCodecTypes() const final { return nullOptionalStringVector(); }
     const std::optional<Vector<FourCC>>& allowedMediaVideoCodecIDs() const final { return nullOptionalFourCCVector(); }
@@ -1788,6 +1790,11 @@ void MediaPlayer::remoteEngineFailedToLoad()
 SecurityOriginData MediaPlayer::documentSecurityOrigin() const
 {
     return client().documentSecurityOrigin();
+}
+
+Ref<SecurityOrigin> MediaPlayer::topDocumentSecurityOrigin() const
+{
+    return client().topDocumentSecurityOrigin();
 }
 
 void MediaPlayer::setPreferredDynamicRangeMode(DynamicRangeMode mode)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -36,6 +36,7 @@
 #include "MediaPlayerIdentifier.h"
 #include "PlatformLayer.h"
 #include "PlatformTextTrack.h"
+#include "SecurityOrigin.h"
 #include "SecurityOriginData.h"
 #include "Timer.h"
 #include "VideoFrame.h"
@@ -284,6 +285,7 @@ public:
     virtual void mediaPlayerSeekableTimeRangesChanged() { }
 
     virtual SecurityOriginData documentSecurityOrigin() const { return { }; }
+    virtual Ref<SecurityOrigin> topDocumentSecurityOrigin() const { return SecurityOrigin::createOpaque(); }
 
     virtual String audioOutputDeviceId() const { return { }; }
     virtual String audioOutputDeviceIdOverride() const { return { }; }
@@ -687,6 +689,7 @@ public:
 
     void remoteEngineFailedToLoad();
     SecurityOriginData documentSecurityOrigin() const;
+    Ref<SecurityOrigin> topDocumentSecurityOrigin() const;
 
 #if USE(GSTREAMER)
     void requestInstallMissingPlugins(const String& details, const String& description, MediaPlayerRequestInstallMissingPluginsCallback& callback) { client().requestInstallMissingPlugins(details, description, callback); }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -43,6 +43,7 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/PlatformMediaResourceLoader.h>
+#include <WebCore/SecurityOrigin.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
@@ -281,6 +282,8 @@ private:
     bool mediaPlayerShouldUsePersistentCache() const final;
     const String& mediaPlayerMediaCacheDirectory() const final;
     WebCore::LayoutRect mediaPlayerContentBoxRect() const final;
+
+    Ref<WebCore::SecurityOrigin> topDocumentSecurityOrigin() const { return WebCore::SecurityOrigin::createOpaque(); }
 
     void textTrackRepresentationBoundsChanged(const WebCore::IntRect&) final;
 


### PR DESCRIPTION
#### 610f117c44b48280eb5a83f8e87343a1697d636f
<pre>
Expose MediaPlayer topDocumentSecurityOrigin
<a href="https://bugs.webkit.org/show_bug.cgi?id=250198">https://bugs.webkit.org/show_bug.cgi?id=250198</a>
rdar://problem/103948417

Reviewed by NOBODY (OOPS!).

Expose the associated main document&apos;s SecurityOrigin to media player.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::topDocumentSecurityOrigin const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::NullMediaPlayerClient::topDocumentSecurityOrigin const):
(WebCore::MediaPlayer::topDocumentSecurityOrigin const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/610f117c44b48280eb5a83f8e87343a1697d636f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111643 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171815 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2391 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109352 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37283 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4984 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25721 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2161 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45214 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6875 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->