### PR TITLE
[GLIB] Unreviewed, build fix for Ubuntu 22.04 after 258531@main

### DIFF
--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -90,7 +90,9 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , subgridEnabled { document.settings().subgridEnabled() }
     , masonryEnabled { document.settings().masonryEnabled() }
     , cssNestingEnabled { document.settings().cssNestingEnabled() }
+#if ENABLE(CSS_PAINTING_API)
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
+#endif
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }


### PR DESCRIPTION
#### 4f63d0e4724d1eb508056cabc44f27072fd6ffdd
<pre>
[GLIB] Unreviewed, build fix for Ubuntu 22.04 after 258531@main

* Source/WebCore/css/parser/CSSParserContext.cpp: method cssPaintingAPIEnabled()
  is only available if CSS_PAINTING_API property is enabled.

Canonical link: <a href="https://commits.webkit.org/258541@main">https://commits.webkit.org/258541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78f1efb685b2c1cac63851a13fb1252497862345

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11447 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35375 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111622 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106294 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12447 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2371 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108098 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/12447 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/35375 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/12447 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/35375 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/35375 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5106 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/35375 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6858 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3098 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->