### PR TITLE
Revert [258542@main] [ews-build.webkit.org] Use TwistedAdditions in place of Twisted requests

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -33,17 +33,53 @@ from buildbot.util import httpclientservice, service
 from buildbot.www.hooks.github import GitHubEventHandler
 from steps import GitHub
 from twisted.internet import defer
+from twisted.internet import reactor
 from twisted.internet.defer import succeed
 from twisted.python import log
-
-from twisted_additions import TwistedAdditions
+from twisted.web.client import Agent
+from twisted.web.http_headers import Headers
+from twisted.web.iweb import IBodyProducer
+from zope.interface import implementer
 
 custom_suffix = '-uat' if os.getenv('BUILDBOT_UAT') else ''
+
+@implementer(IBodyProducer)
+class JSONProducer(object):
+    """
+    Perform JSON asynchronously as to not lock the buildbot main event loop
+    """
+
+    def __init__(self, data):
+        try:
+            self.body = json.dumps(data, default=self.json_serialize_datetime).encode('utf-8')
+        except TypeError:
+            self.body = ''
+        self.length = len(self.body)
+
+    def startProducing(self, consumer):
+        if self.body:
+            consumer.write(self.body)
+        return succeed(None)
+
+    def pauseProducing(self):
+        pass
+
+    def stopProducing(self):
+        pass
+
+    def json_serialize_datetime(self, obj):
+        """
+        Serializing buildbot dates into UNIX epoch timestamps.
+        """
+        if isinstance(obj, datetime.datetime):
+            return int(calendar.timegm(obj.timetuple()))
+
+        raise TypeError("Type %s not serializable" % type(obj))
 
 
 class Events(service.BuildbotService):
 
-    EVENT_SERVER_ENDPOINT = 'https://ews.webkit{}.org/results/'.format(custom_suffix)
+    EVENT_SERVER_ENDPOINT = 'https://ews.webkit{}.org/results/'.format(custom_suffix).encode()
     MAX_GITHUB_DESCRIPTION = 140
     SHORT_STEPS = (
         'configure-build',
@@ -75,13 +111,10 @@ class Events(service.BuildbotService):
     def sendDataToEWS(self, data):
         if os.getenv('EWS_API_KEY', None):
             data['EWS_API_KEY'] = os.getenv('EWS_API_KEY')
+        agent = Agent(reactor)
+        body = JSONProducer(data)
 
-        TwistedAdditions.request(
-            url=self.EVENT_SERVER_ENDPOINT,
-            type=b'POST',
-            headers={'Content-Type': ['application/json']},
-            json=data,
-        )
+        agent.request(b'POST', self.EVENT_SERVER_ENDPOINT, Headers({'Content-Type': ['application/json']}), body)
 
     def sendDataToGitHub(self, repository, sha, data, user=None):
         username, access_token = GitHub.credentials(user=user)
@@ -92,16 +125,14 @@ class Events(service.BuildbotService):
 
         auth_header = b64encode('{}:{}'.format(username, access_token).encode('utf-8')).decode('utf-8')
 
-        TwistedAdditions.request(
-            url=GitHub.commit_status_url(sha, repository),
-            type=b'POST',
-            headers={
-                'Authorization': ['Basic {}'.format(auth_header)],
-                'User-Agent': ['python-twisted/{}'.format(twisted.__version__)],
-                'Accept': ['application/vnd.github.v3+json'],
-                'Content-Type': ['application/json'],
-            }, json=data,
-        )
+        agent = Agent(reactor)
+        body = JSONProducer(data)
+        d = agent.request(b'POST', GitHub.commit_status_url(sha, repository).encode('utf-8'), Headers({
+            'Authorization': ['Basic {}'.format(auth_header)],
+            'User-Agent': ['python-twisted/{}'.format(twisted.__version__)],
+            'Accept': ['application/vnd.github.v3+json'],
+            'Content-Type': ['application/json'],
+        }), body)
 
     def getBuilderName(self, build):
         if not (build and 'properties' in build):

--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -24,8 +24,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import calendar
-import datetime
 import json
 import os
 import re
@@ -34,7 +32,7 @@ import twisted
 from twisted.internet import defer, error, interfaces, protocol, reactor, task
 from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
-from twisted.web import iweb, http, _newclient
+from twisted.web import http, _newclient
 
 from zope.interface import implementer
 
@@ -184,32 +182,6 @@ class TwistedAdditions(object):
         def json(self):
             return json.loads(self.text)
 
-    @implementer(iweb.IBodyProducer)
-    class JSONProducer(object):
-        @classmethod
-        def serialize(cls, obj):
-            if isinstance(obj, datetime.datetime):
-                return int(calendar.timegm(obj.timetuple()))
-            raise TypeError("Type %s not serializable" % type(obj))
-
-        def __init__(self, data):
-            try:
-                self.body = json.dumps(data, default=self.serialize).encode('utf-8')
-            except TypeError:
-                self.body = ''
-            self.length = len(self.body)
-
-        def startProducing(self, consumer):
-            if self.body:
-                consumer.write(self.body)
-            return succeed(None)
-
-        def pauseProducing(self):
-            pass
-
-        def stopProducing(self):
-            pass
-
     class Printer(protocol.Protocol):
         def __init__(self, finished):
             self.finished = finished
@@ -223,7 +195,7 @@ class TwistedAdditions(object):
 
     @classmethod
     @defer.inlineCallbacks
-    def request(cls, url, type=None, params=None, headers=None, logger=None, timeout=10, json=None):
+    def request(cls, url, type=None, params=None, headers=None, logger=None, timeout=10):
         logger = logger or (lambda _: None)
         typ = type or b'GET'
 
@@ -247,8 +219,7 @@ class TwistedAdditions(object):
             else:
                 agent = Agent(reactor, connectTimeout=timeout)
 
-            body = JSONProducer(json) if json else None
-            response = yield agent.request(typ, url.encode('utf-8'), Headers(headers), body)
+            response = yield agent.request(typ, url.encode('utf-8'), Headers(headers))
             finished = defer.Deferred()
             response.deliverBody(cls.Printer(finished))
             data = yield finished


### PR DESCRIPTION
#### 226b2f3cb9fa175dbf0a8025d882ac3b168b7547
<pre>
Revert [258542@main] [ews-build.webkit.org] Use TwistedAdditions in place of Twisted requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249663">https://bugs.webkit.org/show_bug.cgi?id=249663</a>
rdar://103564994

Unreviewed revert.

EWS isn&apos;t posting results to GitHub after this change, reverting.

* Tools/CISupport/ews-build/events.py:
* Tools/CISupport/ews-build/twisted_additions.py:

Canonical link: <a href="https://commits.webkit.org/258543@main">https://commits.webkit.org/258543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e0eee7157a9d94f7fc00c619ade0353c1d7c38a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/12459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/12459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/12459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | | 
<!--EWS-Status-Bubble-End-->