### PR TITLE
Add WASM opcode counter

### DIFF
--- a/JSTests/stress/atob-btoa.js
+++ b/JSTests/stress/atob-btoa.js
@@ -1,0 +1,38 @@
+function assert(b) {
+    if (!b)
+        throw new Error("Bad assertion");
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+let strs = [
+    "",
+    "3OBQwMDuz29xSLpfDZ3BZpoSmOp5uqpC1AvdUeO4Mj",
+    "U5qFQTeWHPtyLAfFpf0DzgNiCXr17LsZxEHRlRoE3S",
+    "97tJorct1Pc1IhFuMNCb2XWQ01cVbZF6dQCzcH3QRn",
+    "zIom9GE2x1xr6VS6kM8iRoco34an8FVfZ6EvT2kd5EHZ2YxkL91hLhjsmRRsmT6GiOdkSFhOdGJF4GEC42gUosLLNxBmspVl",
+    "G8YxPonzURIHs5SOURZnYeASifuSbifqyFoWPexDuxTN3x84Uti00fCUS9DgbqKMIySK4wt9TCeecyr2rD55QDzIlOgmiPUC",
+    "rcivMmo7ECcfITpH3uB2FXHfOJH5ILdXoXHbZ4FuzFiPBcTUUfcpSFZlaopWtGSa7YP4Gb9embV2cBsS5vFV6mo7HqCyGAyG",
+];
+
+for (let str in strs)
+    assert(atob(btoa(str)) === str);
+
+assert(atob(btoa(null)) === "null");
+assert(atob(btoa(undefined)) === "undefined");
+
+shouldThrow(() => { btoa("嗨"); }, "Error: Invalid argument for btoa.");
+shouldThrow(() => { atob(undefined); }, "Error: Invalid argument for atob.");

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1136,6 +1136,7 @@ wasm/WasmOperations.cpp
 wasm/WasmPlan.cpp
 wasm/WasmSectionParser.cpp
 wasm/WasmTypeDefinition.cpp
+wasm/WasmOpcodeCounter.cpp
 wasm/WasmSlowPaths.cpp
 wasm/WasmStreamingCompiler.cpp
 wasm/WasmStreamingParser.cpp

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -540,6 +540,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
     v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
+    v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
     \
     /* Feature Flags */\
     \

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "WasmOpcodeCounter.h"
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(B3_JIT)
+#include "WasmTypeDefinition.h"
+#include <wtf/Atomics.h>
+#include <wtf/DataLog.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Vector.h>
+
+#if PLATFORM(COCOA)
+#include <notify.h>
+#include <unistd.h>
+#endif
+
+namespace JSC {
+namespace Wasm {
+
+WasmOpcodeCounter& WasmOpcodeCounter::singleton()
+{
+    static LazyNeverDestroyed<WasmOpcodeCounter> counter;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        counter.construct();
+    });
+    return counter;
+}
+
+
+template<typename OpcodeType, typename OpcodeTypeDump, typename IsRegisteredOpcodeFunctor>
+void WasmOpcodeCounter::dump(Atomic<uint64_t>* counter, NumberOfRegisteredOpcodes numberOfRegisteredOpcode, CounterSize counterSize, const IsRegisteredOpcodeFunctor& isRegisteredOpcodeFunctor, const char* prefix, const char* suffix)
+{
+    struct Pair {
+        OpcodeType opcode;
+        uint64_t count;
+    };
+
+    Vector<Pair> vector;
+    uint64_t usedOpcode = 0;
+    for (size_t i = 0; i < counterSize; i++) {
+        if (!isRegisteredOpcodeFunctor((OpcodeType)i))
+            continue;
+
+        uint64_t count = counter[i].loadFullyFenced();
+        if (count)
+            usedOpcode++;
+        vector.append({ (OpcodeType)i, count });
+    }
+
+    std::sort(vector.begin(), vector.end(), [](Pair& a, Pair& b) {
+        return b.count < a.count;
+    });
+
+    int pid = 0;
+#if PLATFORM(COCOA)
+    pid = getpid();
+#endif
+    float coverage = usedOpcode * 1.0 / numberOfRegisteredOpcode * 100;
+    dataLogF("%s<%d> %s use coverage %.2f%%.\n", prefix, pid, suffix, coverage);
+    for (Pair& pair : vector)
+        dataLogLn(prefix, "<", pid, ">    ", OpcodeTypeDump(pair.opcode), ": ", pair.count);
+}
+
+void WasmOpcodeCounter::dump()
+{
+    dump<ExtSIMDOpType, ExtSIMDOpTypeDump>(m_extendedSIMDOpcodeCounter, m_extendedSIMDOpcodeInfo.first, m_extendedSIMDOpcodeInfo.second, isRegisteredWasmExtendedSIMDOpcode, "<WASM.EXT.SIMD.OP.STAT>", "wasm extended SIMD opcode");
+
+    dump<ExtAtomicOpType, ExtAtomicOpTypeDump>(m_extendedAtomicOpcodeCounter, m_extendedAtomicOpcodeInfo.first, m_extendedAtomicOpcodeInfo.second, isRegisteredExtenedAtomicOpcode, "<WASM.EXT.ATOMIC.OP.STAT>", "wasm extended atomic opcode");
+
+    dump<GCOpType, GCOpTypeDump>(m_GCOpcodeCounter, m_GCOpcodeInfo.first, m_GCOpcodeInfo.second, isRegisteredGCOpcode, "<WASM.GC.OP.STAT>", "wasm GC opcode");
+
+    dump<OpType, OpTypeDump>(m_baseOpcodeCounter, m_baseOpcodeInfo.first, m_baseOpcodeInfo.second, isRegisteredBaseOpcode, "<WASM.BASE.OP.STAT>", "wasm base opcode");
+}
+
+void WasmOpcodeCounter::registerDispatch()
+{
+#if PLATFORM(COCOA)
+    static std::once_flag registerFlag;
+    std::call_once(registerFlag, [&]() {
+        int pid = getpid();
+        const char* key = "com.apple.WebKit.wasm.op.stat";
+        dataLogF("<WASM.OP.STAT><%d> Registering callback for wasm opcode statistics.\n", pid);
+        dataLogF("<WASM.OP.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, key);
+
+        int token;
+        notify_register_dispatch(key, &token, dispatch_get_main_queue(), ^(int) {
+            WasmOpcodeCounter::singleton().dump();
+        });
+    });
+#endif
+}
+
+void WasmOpcodeCounter::increment(ExtSIMDOpType op)
+{
+    registerDispatch();
+    m_extendedSIMDOpcodeCounter[(uint8_t)op].exchangeAdd(1);
+}
+
+void WasmOpcodeCounter::increment(ExtAtomicOpType op)
+{
+    registerDispatch();
+    m_extendedAtomicOpcodeCounter[(uint8_t)op].exchangeAdd(1);
+}
+
+void WasmOpcodeCounter::increment(GCOpType op)
+{
+    registerDispatch();
+    m_GCOpcodeCounter[(uint8_t)op].exchangeAdd(1);
+}
+
+void WasmOpcodeCounter::increment(OpType op)
+{
+    registerDispatch();
+    m_baseOpcodeCounter[(uint8_t)op].exchangeAdd(1);
+}
+
+} // namespace JSC
+} // namespace JSC::Wasm
+
+#endif // ENABLE(WEBASSEMBLY) && && ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(B3_JIT)
+
+#include "WasmTypeDefinition.h"
+#include <wtf/Atomics.h>
+
+namespace JSC {
+namespace Wasm {
+
+class WasmOpcodeCounter {
+    WTF_MAKE_FAST_ALLOCATED;
+    using NumberOfRegisteredOpcodes = size_t;
+    using CounterSize = size_t;
+
+public:
+    static WasmOpcodeCounter& singleton();
+
+    void registerDispatch();
+
+    void increment(ExtSIMDOpType);
+    void increment(ExtAtomicOpType);
+    void increment(GCOpType);
+    void increment(OpType);
+
+    void dump();
+    template<typename OpcodeType, typename OpcodeTypeDump, typename IsRegisteredOpcodeFunctor>
+    void dump(Atomic<uint64_t>* counter, NumberOfRegisteredOpcodes, CounterSize, const IsRegisteredOpcodeFunctor&, const char* prefix, const char* suffix);
+
+private:
+    constexpr static std::pair<NumberOfRegisteredOpcodes, CounterSize> m_extendedSIMDOpcodeInfo = countNumberOfWasmExtendedSIMDOpcodes();
+    Atomic<uint64_t> m_extendedSIMDOpcodeCounter[m_extendedSIMDOpcodeInfo.second];
+
+    constexpr static std::pair<NumberOfRegisteredOpcodes, CounterSize> m_extendedAtomicOpcodeInfo = countNumberOfWasmExtendedAtomicOpcodes();
+    Atomic<uint64_t> m_extendedAtomicOpcodeCounter[m_extendedAtomicOpcodeInfo.second];
+
+    constexpr static std::pair<NumberOfRegisteredOpcodes, CounterSize> m_GCOpcodeInfo = countNumberOfWasmGCOpcodes();
+    Atomic<uint64_t> m_GCOpcodeCounter[m_GCOpcodeInfo.second];
+
+    constexpr static std::pair<NumberOfRegisteredOpcodes, CounterSize> m_baseOpcodeInfo = countNumberOfWasmBaseOpcodes();
+    Atomic<uint64_t> m_baseOpcodeCounter[m_baseOpcodeInfo.second];
+};
+
+} // namespace JSC
+} // namespace JSC::Wasm
+
+#endif // ENABLE(WEBASSEMBLY) && && ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -59,6 +59,163 @@ enum class ExtSIMDOpType : uint8_t {
 };
 #undef CREATE_ENUM_VALUE
 
+constexpr std::pair<size_t, size_t> countNumberOfWasmExtendedSIMDOpcodes()
+{
+    uint8_t numberOfOpcodes = 0;
+    uint8_t mapSize = 0;
+#define COUNT_EXT_SIMD_OPERATION(name, id, ...) \
+    numberOfOpcodes++; \
+    mapSize = std::max<size_t>(mapSize, (size_t)id);
+    FOR_EACH_WASM_EXT_SIMD_OP(COUNT_EXT_SIMD_OPERATION)
+#undef COUNT_EXT_SIMD_OPERATION
+    return { numberOfOpcodes, mapSize + 1 };
+}
+
+constexpr bool isRegisteredWasmExtendedSIMDOpcode(ExtSIMDOpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case ExtSIMDOpType::name:
+    FOR_EACH_WASM_EXT_SIMD_OP(CREATE_CASE)
+#undef CREATE_CASE
+        return true;
+    default:
+        return false;
+    }
+}
+
+constexpr void dumpExtSIMDOpType(PrintStream& out, ExtSIMDOpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case ExtSIMDOpType::name: out.print(#name); break;
+    FOR_EACH_WASM_EXT_SIMD_OP(CREATE_CASE)
+#undef CREATE_CASE
+    default:
+        return;
+    }
+}
+
+MAKE_PRINT_ADAPTOR(ExtSIMDOpTypeDump, ExtSIMDOpType, dumpExtSIMDOpType);
+
+constexpr std::pair<size_t, size_t> countNumberOfWasmExtendedAtomicOpcodes()
+{
+    uint8_t numberOfOpcodes = 0;
+    uint8_t mapSize = 0;
+#define COUNT_WASM_EXT_ATOMIC_OP(name, id, ...) \
+    numberOfOpcodes++;                      \
+    mapSize = std::max<size_t>(mapSize, (size_t)id);
+    FOR_EACH_WASM_EXT_ATOMIC_LOAD_OP(COUNT_WASM_EXT_ATOMIC_OP);
+    FOR_EACH_WASM_EXT_ATOMIC_STORE_OP(COUNT_WASM_EXT_ATOMIC_OP);
+    FOR_EACH_WASM_EXT_ATOMIC_BINARY_RMW_OP(COUNT_WASM_EXT_ATOMIC_OP);
+    FOR_EACH_WASM_EXT_ATOMIC_OTHER_OP(COUNT_WASM_EXT_ATOMIC_OP);
+#undef COUNT_WASM_EXT_ATOMIC_OP
+    return { numberOfOpcodes, mapSize + 1 };
+}
+
+constexpr bool isRegisteredExtenedAtomicOpcode(ExtAtomicOpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case ExtAtomicOpType::name:
+    FOR_EACH_WASM_EXT_ATOMIC_LOAD_OP(CREATE_CASE)
+    FOR_EACH_WASM_EXT_ATOMIC_STORE_OP(CREATE_CASE)
+    FOR_EACH_WASM_EXT_ATOMIC_BINARY_RMW_OP(CREATE_CASE)
+    FOR_EACH_WASM_EXT_ATOMIC_OTHER_OP(CREATE_CASE)
+#undef CREATE_CASE
+        return true;
+    default:
+        return false;
+    }
+}
+
+constexpr void dumpExtAtomicOpType(PrintStream& out, ExtAtomicOpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case ExtAtomicOpType::name: out.print(#name); break;
+    FOR_EACH_WASM_EXT_ATOMIC_LOAD_OP(CREATE_CASE)
+    FOR_EACH_WASM_EXT_ATOMIC_STORE_OP(CREATE_CASE)
+    FOR_EACH_WASM_EXT_ATOMIC_BINARY_RMW_OP(CREATE_CASE)
+    FOR_EACH_WASM_EXT_ATOMIC_OTHER_OP(CREATE_CASE)
+#undef CREATE_CASE
+    default:
+        return;
+    }
+}
+
+MAKE_PRINT_ADAPTOR(ExtAtomicOpTypeDump, ExtAtomicOpType, dumpExtAtomicOpType);
+
+constexpr std::pair<size_t, size_t> countNumberOfWasmGCOpcodes()
+{
+    uint8_t numberOfOpcodes = 0;
+    uint8_t mapSize = 0;
+#define COUNT_WASM_GC_OP(name, id, ...) \
+    numberOfOpcodes++;                  \
+    mapSize = std::max<size_t>(mapSize, (size_t)id);
+    FOR_EACH_WASM_GC_OP(COUNT_WASM_GC_OP);
+#undef COUNT_WASM_GC_OP
+    return { numberOfOpcodes, mapSize + 1 };
+}
+
+constexpr bool isRegisteredGCOpcode(GCOpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case GCOpType::name:
+    FOR_EACH_WASM_GC_OP(CREATE_CASE)
+#undef CREATE_CASE
+        return true;
+    default:
+        return false;
+    }
+}
+
+constexpr void dumpGCOpType(PrintStream& out, GCOpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case GCOpType::name: out.print(#name); break;
+    FOR_EACH_WASM_GC_OP(CREATE_CASE)
+#undef CREATE_CASE
+    default:
+        return;
+    }
+}
+
+MAKE_PRINT_ADAPTOR(GCOpTypeDump, GCOpType, dumpGCOpType);
+
+constexpr std::pair<size_t, size_t> countNumberOfWasmBaseOpcodes()
+{
+    uint8_t numberOfOpcodes = 0;
+    uint8_t mapSize = 0;
+#define COUNT_WASM_OP(name, id, ...) \
+    numberOfOpcodes++;               \
+    mapSize = std::max<size_t>(mapSize, (size_t)id);
+    FOR_EACH_WASM_OP(COUNT_WASM_OP);
+#undef COUNT_WASM_OP
+    return { numberOfOpcodes, mapSize + 1 };
+}
+
+constexpr bool isRegisteredBaseOpcode(OpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case OpType::name:
+    FOR_EACH_WASM_OP(CREATE_CASE)
+#undef CREATE_CASE
+        return true;
+    default:
+        return false;
+    }
+}
+
+constexpr void dumpOpType(PrintStream& out, OpType op)
+{
+    switch (op) {
+#define CREATE_CASE(name, id, ...) case OpType::name: out.print(#name); break;
+    FOR_EACH_WASM_OP(CREATE_CASE)
+#undef CREATE_CASE
+    default:
+        return;
+    }
+}
+
+MAKE_PRINT_ADAPTOR(OpTypeDump, OpType, dumpOpType);
+
 constexpr Type simdScalarType(SIMDLane lane)
 {
     switch (lane) {


### PR DESCRIPTION
#### 70ccbd9daaa2db326dfed9a1d84f7be4ffdddaa7
<pre>
Add WASM opcode counter
<a href="https://bugs.webkit.org/show_bug.cgi?id=250213">https://bugs.webkit.org/show_bug.cgi?id=250213</a>
rdar://103956646

Reviewed by Justin Michaud.

This patch includes three things:

a) Added `atob` and `btoa` to jsc shell as helpers for loading tfjs pre-trained models.

b) Skipped JetStream3 tests UniPoker and bigint-paillier, since UniPoker
   fails on browser with error messages and bigint-paillier hangs with
   `deterministicRandom` is true.

c) Added a WASM opcode counter. Use `dumpWasmOpcodeStatistics=1` to enable
   opcode collection. And use `notifyutil -v -p com.apple.WebKit.wasm.op.stat`
   to dump statistics sorted by counts in descending order for all WASM opcodes.
   An example of dumped statistics:

      &lt;WASM.OP.STAT&gt;&lt;92428&gt; Registering callback for wasm opcode statistics.
      &lt;WASM.OP.STAT&gt;&lt;92428&gt; Use `notifyutil -v -p com.apple.WebKit.wasm.op.stat` to dump statistics.
      &lt;WASM.EXT.SIMD.OP.STAT&gt;&lt;92428&gt; wasm extended SIMD opcode use coverage 32.63%.
      &lt;WASM.EXT.SIMD.OP.STAT&gt;&lt;92428&gt;    V128Load: 4588
      &lt;WASM.EXT.SIMD.OP.STAT&gt;&lt;92428&gt;    F32x4Add: 2522
      ...
      &lt;WASM.EXT.ATOMIC.OP.STAT&gt;&lt;92428&gt; wasm extended atomic opcode use coverage 0.00%.
      &lt;WASM.EXT.ATOMIC.OP.STAT&gt;&lt;92428&gt;    MemoryAtomicNotify: 0
      &lt;WASM.EXT.ATOMIC.OP.STAT&gt;&lt;92428&gt;    MemoryAtomicWait32: 0
      ...
      &lt;WASM.GC.OP.STAT&gt;&lt;92428&gt; wasm GC opcode use coverage 0.00%.
      &lt;WASM.GC.OP.STAT&gt;&lt;92428&gt;    StructNewCanon: 0
      &lt;WASM.GC.OP.STAT&gt;&lt;92428&gt;    StructGet: 0
      ...
      &lt;WASM.BASE.OP.STAT&gt;&lt;92428&gt; wasm base opcode use coverage 74.49%.
      &lt;WASM.BASE.OP.STAT&gt;&lt;92428&gt;    GetLocal: 80967
      &lt;WASM.BASE.OP.STAT&gt;&lt;92428&gt;    I32Const: 28805
      ...

* JSTests/stress/atob-btoa.js: Added.
(assert):
(shouldThrow):
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp: Added.
(JSC::Wasm::WasmOpcodeCounter::singleton):
(JSC::Wasm::WasmOpcodeCounter::dump):
(JSC::Wasm::WasmOpcodeCounter::registerDispatch):
(JSC::Wasm::WasmOpcodeCounter::increment):
* Source/JavaScriptCore/wasm/WasmOpcodeCounter.h: Added.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::countNumberOfWasmExtendedSIMDOpcodes):
(JSC::Wasm::isRegisteredWasmExtendedSIMDOpcode):
(JSC::Wasm::dumpExtSIMDOpType):
(JSC::Wasm::countNumberOfWasmExtendedAtomicOpcodes):
(JSC::Wasm::isRegisteredExtenedAtomicOpcode):
(JSC::Wasm::dumpExtAtomicOpType):
(JSC::Wasm::countNumberOfWasmGCOpcodes):
(JSC::Wasm::isRegisteredGCOpcode):
(JSC::Wasm::dumpGCOpType):
(JSC::Wasm::countNumberOfWasmBaseOpcodes):
(JSC::Wasm::isRegisteredBaseOpcode):
(JSC::Wasm::dumpOpType):

Canonical link: <a href="https://commits.webkit.org/258678@main">https://commits.webkit.org/258678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8f19533a3d875846b41cd86e8e9b44c4824e54c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102607 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111876 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172098 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2643 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109579 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37429 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79174 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92846 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25914 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89169 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2872 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2366 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29629 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45403 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/92094 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5961 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7086 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20631 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->