### PR TITLE
Frozen animations still contribute to the sandwich/animation stack

### DIFF
--- a/LayoutTests/svg/animations/animate-to-low-prio-frozen-expected.txt
+++ b/LayoutTests/svg/animations/animate-to-low-prio-frozen-expected.txt
@@ -1,0 +1,6 @@
+PASS rectWidth is > 100
+PASS 200 is >= rectWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/animations/animate-to-low-prio-frozen.html
+++ b/LayoutTests/svg/animations/animate-to-low-prio-frozen.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<svg width="200" height="200" style="display: block">
+  <rect width="0" height="100" fill="green">
+    <animate attributeName="width" begin="0s; 1000s" to="200" dur="25ms" fill="freeze"/>
+    <animate attributeName="width" begin="50ms" to="100" dur="500s" onbegin="runTest()"/>
+  </rect>
+</svg>
+<script>
+window.jsTestIsAsync = true;
+
+var rectWidth;
+
+function runTest() {
+  rect = document.querySelector('rect');
+  rectWidth = rect.width.animVal.valueInSpecifiedUnits;
+  // Width expected to be 100 < x <= 200.
+  shouldBeGreaterThan("rectWidth", "100");
+  shouldBeGreaterThanOrEqual("200", "rectWidth");
+  finishJSTest();
+}
+</script>

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1082,13 +1083,15 @@ bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, 
 
     if (elapsed < m_intervalBegin) {
         ASSERT(m_activeState != Active);
-        if (m_activeState == Frozen) {
+        bool isFrozen = (m_activeState == Frozen);
+        if (isFrozen) {
             if (this == &firstAnimation)
                 startAnimation();
             updateAnimation(m_lastPercent, m_lastRepeat);
         }
         m_nextProgressTime = m_intervalBegin;
-        return false;
+        // If the animation is frozen, it's still contributing.
+        return isFrozen;
     }
 
     m_previousIntervalBegin = m_intervalBegin;


### PR DESCRIPTION
#### 974a0c2ef69617c5465efb1ecd074dc50b6571f9
<pre>
Frozen animations still contribute to the sandwich/animation stack

Frozen animations still contribute to the sandwich/animation stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=250212">https://bugs.webkit.org/show_bug.cgi?id=250212</a>

Reviewed by Simon Fraser.

This patch aligns WebKit to Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/18ca5f05a08ac4da392cfc03dc4ef097f495b5b0">https://chromium.googlesource.com/chromium/blink/+/18ca5f05a08ac4da392cfc03dc4ef097f495b5b0</a>

This patch introduces bool named &apos;isFrozen&apos;, which takes value of frozen state and
return as value rather than false since with (for instance) to-animation, the frozen element will for instance provide the &apos;underlying value&apos; to any following element.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(SVGSMILElement::progress): Add &apos;isFrozen&apos; bool and return it rather than &apos;false&apos;
* LayoutTests/svg/animations/animate-to-low-prio-frozen.html: Add Test Case
* LayoutTests/svg/animations/animate-to-low-prio-frozen-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258630@main">https://commits.webkit.org/258630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31efb30dcd2b2347686ed0569ad7b3e96e54ea23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111776 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171998 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2544 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109490 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37347 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5101 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25828 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2280 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45319 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6994 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->