### PR TITLE
REGRESSION(257981@main): Form control focus ring is clipped when zooming in

### DIFF
--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -231,14 +231,18 @@ void ControlMac::drawCell(GraphicsContext& context, const FloatRect& rect, float
         return;
     }
 
-    auto imageBufferRect = FloatRect { { 0, 0 }, rect.size() };
+    static constexpr float focusRingOutlineWidth = 3;
+    auto focusRingPadding = FloatSize { focusRingOutlineWidth, focusRingOutlineWidth };
 
-    auto imageBuffer = context.createImageBuffer(rect.size(), deviceScaleFactor);
+    auto cellDrawingRect = FloatRect { toFloatPoint(focusRingPadding), rect.size() };
+    auto imageBufferSize = cellDrawingRect.size() + 2 * focusRingPadding;
+
+    auto imageBuffer = context.createImageBuffer(imageBufferSize, deviceScaleFactor);
     if (!imageBuffer)
         return;
 
-    drawCellOrFocusRing(imageBuffer->context(), imageBufferRect, style, cell, view, drawCell);
-    context.drawConsumingImageBuffer(WTFMove(imageBuffer), rect.location());
+    drawCellOrFocusRing(imageBuffer->context(), cellDrawingRect, style, cell, view, drawCell);
+    context.drawConsumingImageBuffer(WTFMove(imageBuffer), rect.location() - focusRingPadding);
 }
 
 #if ENABLE(DATALIST_ELEMENT)


### PR DESCRIPTION
#### 2d409b2f1e103e048861aed8fc62931fe4a94ae8
<pre>
REGRESSION(257981@main): Form control focus ring is clipped when zooming in
<a href="https://bugs.webkit.org/show_bug.cgi?id=250215">https://bugs.webkit.org/show_bug.cgi?id=250215</a>
rdar://103958015

Reviewed by Aditya Keerthi.

In ControlMac::drawCell(), the drawing will be routed to an ImageBuffer if the
page is zoomed. When the form control is focused, AppKit is asked to draw  a
focus ring around the rectangle of the form control. AppKit bleeds at maximum
three pixels around the drawing rectangle.

Like what ThemeMac::drawCellOrFocusRingWithViewIntoContext() does in this case,
we need to inflate the size of the ImageBuffer by three pixels.

* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawCell):

Canonical link: <a href="https://commits.webkit.org/258553@main">https://commits.webkit.org/258553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b1ba942d863d2aaecdd96bc88d1dd8f1de81b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111649 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2397 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108121 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25720 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5129 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5875 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->