### PR TITLE
Expose _backgroundWebView, _backgroundContentURL and _backgroundContentIsServiceWorker as _WKWebExtension SPI.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -250,6 +250,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->backgroundContentIsPersistent();
 }
 
+- (BOOL)_backgroundContentIsServiceWorker
+{
+    return _webExtension->backgroundContentIsServiceWorker();
+}
+
 - (BOOL)_backgroundContentUsesModules
 {
     return _webExtension->backgroundContentUsesModules();
@@ -407,6 +412,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 }
 
 - (BOOL)backgroundContentIsPersistent
+{
+    return NO;
+}
+
+- (BOOL)_backgroundContentIsServiceWorker
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -466,6 +466,16 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     _webExtensionContext->setTestingMode(testingMode);
 }
 
+- (WKWebView *)_backgroundWebView
+{
+    return _webExtensionContext->backgroundWebView();
+}
+
+- (NSURL *)_backgroundContentURL
+{
+    return _webExtensionContext->backgroundContentURL();
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -688,6 +698,16 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 
 - (void)_setTestingMode:(BOOL)testingMode
 {
+}
+
+- (WKWebView *)_backgroundWebView
+{
+    return nil;
+}
+
+- (NSURL *)_backgroundContentURL
+{
+    return nil;
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
@@ -35,6 +35,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, getter=_inTestingMode, setter=_setTestingMode:) BOOL _testingMode;
 
+/*! @abstract The extension background view used for the extension, or `nil` if the extension does not have background content or it is currently unloaded. */
+@property (nonatomic, nullable, readonly) WKWebView *_backgroundWebView;
+
+/*! @abstract The extension background content URL for the extension, or `nil` if the extension does not have background content. */
+@property (nonatomic, nullable, readonly) NSURL *_backgroundContentURL;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
@@ -34,6 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
+/*! @abstract A Boolean value indicating whether the extension background content is a service worker. */
+@property (readonly, nonatomic) BOOL _backgroundContentIsServiceWorker;
+
 /*! @abstract A Boolean value indicating whether the extension use modules for the background content. */
 @property (readonly, nonatomic) BOOL _backgroundContentUsesModules;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -196,6 +196,7 @@ bool WebExtensionContext::load(WebExtensionController& controller, String storag
     m_contentScriptWorld = API::ContentWorld::sharedWorldWithName(makeString("WebExtension-", m_uniqueIdentifier));
 
     readStateFromStorage();
+    writeStateToStorage();
 
     // FIXME: <https://webkit.org/b/248430> Move local storage (if base URL changed).
 
@@ -1161,8 +1162,9 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration()
 
 URL WebExtensionContext::backgroundContentURL()
 {
-    ASSERT(extension().hasBackgroundContent());
-    return URL { m_baseURL, extension().backgroundContentPath() };
+    if (!extension().hasBackgroundContent())
+        return { };
+    return { m_baseURL, extension().backgroundContentPath() };
 }
 
 void WebExtensionContext::loadBackgroundWebViewDuringLoad()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -218,6 +218,9 @@ public:
     bool inTestingMode() const { return m_testingMode; }
     void setTestingMode(bool);
 
+    URL backgroundContentURL();
+    WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
+
     bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);
     void didFinishNavigation(WKWebView *, WKNavigation *);
     void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
@@ -253,8 +256,6 @@ private:
     PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, NSString *notificationName = nil);
 
     WKWebViewConfiguration *webViewConfiguration();
-
-    URL backgroundContentURL();
 
     void loadBackgroundWebViewDuringLoad();
     void loadBackgroundWebView();


### PR DESCRIPTION
#### 0a3c1ae261473dc6b99731bdba1f825ae2a27b47
<pre>
Expose _backgroundWebView, _backgroundContentURL and _backgroundContentIsServiceWorker as _WKWebExtension SPI.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250221">https://bugs.webkit.org/show_bug.cgi?id=250221</a>

Reviewed by Brian Weinstein.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension _backgroundContentIsServiceWorker]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext _backgroundWebView]): Added.
(-[_WKWebExtensionContext _backgroundContentURL]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load): Added call to writeStateToStorage() to save the last base URL.
(WebKit::WebExtensionContext::backgroundContentURL): Return a null URL instead of asserting.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::backgroundWebView const): Added.

Canonical link: <a href="https://commits.webkit.org/258554@main">https://commits.webkit.org/258554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63dc388a180d44cfaccc9eb8dfc5dfe0ec5b03a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/102365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/111670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/12502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/108146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/12502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/12502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3103 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->