### PR TITLE
Page Up/Down scrolling feels too slow

### DIFF
--- a/Source/WebCore/platform/KeyboardScroll.h
+++ b/Source/WebCore/platform/KeyboardScroll.h
@@ -51,19 +51,36 @@ struct KeyboardScroll {
 };
 
 struct KeyboardScrollParameters {
-    float springMass { 1 };
-    float springStiffness { 109 };
-    float springDamping { 20 };
+    const float springMass;
+    const float springStiffness;
+    const float springDamping;
 
-    float maximumVelocityMultiplier { 25 };
-    float timeToMaximumVelocity { 1 };
+    const float maximumVelocityMultiplier;
+    const float timeToMaximumVelocity;
 
-    float rubberBandForce { 5000 };
+    const float rubberBandForce;
 
-    static const KeyboardScrollParameters& parameters()
+    static constexpr KeyboardScrollParameters parameters()
     {
-        static const KeyboardScrollParameters parameters;
-        return parameters;
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        return {
+            .springMass = 1, 
+            .springStiffness = 175, 
+            .springDamping = 20, 
+            .maximumVelocityMultiplier = 25, 
+            .timeToMaximumVelocity = 0.2, 
+            .rubberBandForce = 3000 
+        };
+#else
+        return {
+            .springMass = 1, 
+            .springStiffness = 109, 
+            .springDamping = 20, 
+            .maximumVelocityMultiplier = 25, 
+            .timeToMaximumVelocity = 1.0, 
+            .rubberBandForce = 5000 
+        };
+#endif
     }
 };
 

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
@@ -124,7 +124,7 @@ void ScrollAnimationKeyboard::stopKeyboardScrollAnimation()
     if (!m_currentKeyboardScroll)
         return;
 
-    auto params = KeyboardScrollParameters::parameters();
+    constexpr auto params = KeyboardScrollParameters::parameters();
 
     // Determine the settling position of the spring, conserving the system's current energy.
     // Kinetic = elastic potential
@@ -168,7 +168,7 @@ bool ScrollAnimationKeyboard::animateScroll(MonotonicTime currentTime)
 {
     auto force = FloatSize { };
     auto axesToApplySpring = FloatSize { 1, 1 };
-    KeyboardScrollParameters params = KeyboardScrollParameters::parameters();
+    constexpr auto parameters = KeyboardScrollParameters::parameters();
 
     if (m_currentKeyboardScroll) {
         auto scrollableDirections = scrollableDirectionsFromPosition(m_currentOffset);
@@ -183,7 +183,7 @@ bool ScrollAnimationKeyboard::animateScroll(MonotonicTime currentTime)
             // The scroll view cannot scroll in this direction, and is rubber-banding.
             // Apply a constant and significant force; otherwise, the force for a
             // single-line increment is not strong enough to rubber-band perceptibly.
-            force = unitVectorForScrollDirection(direction).scaled(params.rubberBandForce);
+            force = unitVectorForScrollDirection(direction).scaled(parameters.rubberBandForce);
         }
 
         if (fabs(m_velocity.width()) >= fabs(m_currentKeyboardScroll->maximumVelocity.width()))
@@ -198,13 +198,13 @@ bool ScrollAnimationKeyboard::animateScroll(MonotonicTime currentTime)
     FloatPoint idealPosition = (IntPoint(m_currentKeyboardScroll ? m_currentOffset : m_idealPosition).constrainedBetween(IntPoint(extents.minimumScrollOffset()), IntPoint(extents.maximumScrollOffset())));
     FloatSize displacement = m_currentOffset - idealPosition;
 
-    auto springForce = -displacement.scaled(params.springStiffness) - m_velocity.scaled(params.springDamping);
+    auto springForce = -displacement.scaled(parameters.springStiffness) - m_velocity.scaled(parameters.springDamping);
     force += springForce * axesToApplySpring;
 
     float frameDuration = (currentTime - m_timeAtLastFrame).value();
     m_timeAtLastFrame = currentTime;
 
-    FloatSize acceleration = force.scaled(1. / params.springMass);
+    FloatSize acceleration = force.scaled(1. / parameters.springMass);
     m_velocity += acceleration.scaled(frameDuration);
     m_currentOffset = m_currentOffset + m_velocity.scaled(frameDuration);
 


### PR DESCRIPTION
#### f7ad74a90f6f0f68a2acb9d2b8e5f8e2022aa363
<pre>
Page Up/Down scrolling feels too slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=250224">https://bugs.webkit.org/show_bug.cgi?id=250224</a>
rdar://101651891

Reviewed by Tim Horton.

Adjusts the keyboard scrolling parameters so that it feels faster.

* Source/WebCore/platform/KeyboardScroll.h:

Canonical link: <a href="https://commits.webkit.org/258598@main">https://commits.webkit.org/258598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc6ea639805655a834584cc1c23ecfee7216cc00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111709 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2466 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108201 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24350 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25773 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5906 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6931 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->