### PR TITLE
Add exclusive "shouldBeGreaterThan" function to js-test*.js similar to Chromium

### DIFF
--- a/LayoutTests/http/tests/resources/js-test-pre.js
+++ b/LayoutTests/http/tests/resources/js-test-pre.js
@@ -583,6 +583,27 @@ function shouldBeDefined(_a)
         testFailed(_a + " should be defined. Was " + _av);
 }
 
+function shouldBeGreaterThan(_a, _b) {
+    if (typeof _a != "string" || typeof _b != "string")
+        debug("WARN: shouldBeGreaterThan expects string arguments");
+
+    var exception;
+    var _av;
+    try {
+        _av = eval(_a);
+    } catch (e) {
+        exception = e;
+    }
+    var _bv = eval(_b);
+
+    if (exception)
+        testFailed(_a + " should be > " + _b + ". Threw exception " + exception);
+    else if (typeof _av == "undefined" || _av <= _bv)
+        testFailed(_a + " should be > " + _b + ". Was " + _av + " (of type " + typeof _av + ").");
+    else
+        testPassed(_a + " is > " + _b);
+}
+
 function shouldBeGreaterThanOrEqual(_a, _b) {
     if (typeof _a != "string" || typeof _b != "string")
         debug("WARN: shouldBeGreaterThanOrEqual expects string arguments");

--- a/LayoutTests/resources/js-test-pre.js
+++ b/LayoutTests/resources/js-test-pre.js
@@ -583,6 +583,27 @@ function shouldBeDefined(_a)
         testFailed(_a + " should be defined. Was " + _av);
 }
 
+function shouldBeGreaterThan(_a, _b) {
+    if (typeof _a != "string" || typeof _b != "string")
+        debug("WARN: shouldBeGreaterThan expects string arguments");
+
+    var exception;
+    var _av;
+    try {
+        _av = eval(_a);
+    } catch (e) {
+        exception = e;
+    }
+    var _bv = eval(_b);
+
+    if (exception)
+        testFailed(_a + " should be > " + _b + ". Threw exception " + exception);
+    else if (typeof _av == "undefined" || _av <= _bv)
+        testFailed(_a + " should be > " + _b + ". Was " + _av + " (of type " + typeof _av + ").");
+    else
+        testPassed(_a + " is > " + _b);
+}
+
 function shouldBeGreaterThanOrEqual(_a, _b) {
     if (typeof _a != "string" || typeof _b != "string")
         debug("WARN: shouldBeGreaterThanOrEqual expects string arguments");

--- a/LayoutTests/resources/js-test.js
+++ b/LayoutTests/resources/js-test.js
@@ -1,3 +1,6 @@
+// Copyright 2014 Google Inc.  All rights reserved.
+// Copyright 2023 Apple Inc.  All rights reserved.
+
 if (self.testRunner) {
 	// svg/dynamic-updates tests set enablePixelTesting=true, as we want to dump text + pixel results
     if (self.enablePixelTesting)
@@ -605,6 +608,27 @@ function shouldBeDefined(_a)
     testPassed(_a + " is defined.");
   else
     testFailed(_a + " should be defined. Was " + _av);
+}
+
+function shouldBeGreaterThan(_a, _b) {
+    if (typeof _a != "string" || typeof _b != "string")
+        debug("WARN: shouldBeGreaterThan expects string arguments");
+
+    var _exception;
+    var _av;
+    try {
+        _av = eval(_a);
+    } catch (e) {
+        _exception = e;
+    }
+    var _bv = eval(_b);
+
+    if (_exception)
+        testFailed(_a + " should be > " + _b + ". Threw exception " + _exception);
+    else if (typeof _av == "undefined" || _av <= _bv)
+        testFailed(_a + " should be > " + _b + ". Was " + _av + " (of type " + typeof _av + ").");
+    else
+        testPassed(_a + " is > " + _b);
 }
 
 function shouldBeGreaterThanOrEqual(_a, _b) {


### PR DESCRIPTION
#### 24d9e4a1e3d32fa8e0c0a2f81c5160eedf5bf070
<pre>
Add exclusive &quot;shouldBeGreaterThan&quot; function to js-test*.js similar to Chromium

Add exclusive &quot;shouldBeGreaterThan&quot; function to js-test*.js similar to Chromium
<a href="https://bugs.webkit.org/show_bug.cgi?id=250227">https://bugs.webkit.org/show_bug.cgi?id=250227</a>

Reviewed by Ryosuke Niwa and Alexey Proskuryakov.

This patch adds exclusive &quot;shouldBeGreaterThan&quot; function to check values greater than without &quot;equal&quot;
part to testing script and it is pre-requisite for one of SVG SMIL animation test case.

* LayoutTests/resources/js-test.js: Add &quot;shouldBeGreaterThan&quot; function
* LayoutTests/http/tests/resources/js-test-pre.js: Ditto
* LayoutTests/resources/js-test-pre.js: Ditto

Canonical link: <a href="https://commits.webkit.org/258613@main">https://commits.webkit.org/258613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879d5d522d3f620448c0ab0baca29505c2757102

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111725 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171939 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2485 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109442 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37309 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24359 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25782 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2224 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45275 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5920 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6947 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->