### PR TITLE
Adopt -presentationSceneBundleIdentifierForPaymentAuthorizationController: as well in WKPaymentAuthorizationControllerDelegate

### DIFF
--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -29,8 +29,9 @@
 #if USE(PASSKIT) && PLATFORM(IOS_FAMILY)
 
 #import "WKPaymentAuthorizationDelegate.h"
-#import <pal/cocoa/PassKitSoftLink.h>
+#import <WebCore/RuntimeApplicationChecks.h>
 #import <wtf/CompletionHandler.h>
+#import <pal/cocoa/PassKitSoftLink.h>
 
 @interface WKPaymentAuthorizationControllerDelegate : WKPaymentAuthorizationDelegate <PKPaymentAuthorizationControllerDelegate, PKPaymentAuthorizationControllerPrivateDelegate>
 
@@ -111,6 +112,11 @@
     if (!_presenter)
         return nil;
     return nsStringNilIfEmpty(_presenter->sceneIdentifier());
+}
+
+- (NSString *)presentationSceneBundleIdentifierForPaymentAuthorizationController:(PKPaymentAuthorizationController *)controller
+{
+    return nsStringNilIfEmpty(WebCore::applicationBundleIdentifier());
 }
 #endif
 


### PR DESCRIPTION
#### 195f8828b1532e7cbf34da602b9346416d1b5c02
<pre>
Adopt -presentationSceneBundleIdentifierForPaymentAuthorizationController: as well in WKPaymentAuthorizationControllerDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=250108">https://bugs.webkit.org/show_bug.cgi?id=250108</a>
rdar://103322056

Reviewed by Tim Horton.

The (sceneID, bundleID) pair uniquely identifies the scene required to present the payment dialog.

* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(-[WKPaymentAuthorizationControllerDelegate presentationSceneBundleIdentifierForPaymentAuthorizationController:]):

Canonical link: <a href="https://commits.webkit.org/258595@main">https://commits.webkit.org/258595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/300ca9244828428057983ab6f2d6506b771d0304

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111717 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2475 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108217 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24357 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25780 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45273 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5899 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->