### PR TITLE
Remove logging in RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -288,7 +288,6 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
 
 void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    ALWAYS_LOG_WITH_STREAM(stream << "  RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases " << phase << " momentumPhase " << momentumPhase);
     m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase));
 }
 


### PR DESCRIPTION
#### 6445f74177fa4aa8d84001f955825d709e9f5c02
<pre>
Remove logging in RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases
<a href="https://bugs.webkit.org/show_bug.cgi?id=250241">https://bugs.webkit.org/show_bug.cgi?id=250241</a>
rdar://103972584

Unreviewed.

Remove a log that was left in by mistake.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):

Canonical link: <a href="https://commits.webkit.org/258577@main">https://commits.webkit.org/258577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a3269462b415476f578e5c852d9776834f3b145

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/102435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/111716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/12547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/108215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/12547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/12547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3123 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->