### PR TITLE
Add support for Web Extensions permissions.request() API.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -23,9 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <wtf/HashSet.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/UUID.h>
 #import <wtf/WallTime.h>
+#import <wtf/text/StringHash.h>
 
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDate;
@@ -77,5 +79,8 @@ NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
 
 NSDate *toAPI(const WallTime&);
 WallTime toImpl(NSDate *);
+
+NSSet *toAPI(HashSet<String>&);
+NSArray *toAPIArray(HashSet<String>&);
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -235,4 +235,22 @@ WallTime toImpl(NSDate *date)
     return WallTime::fromRawSeconds(date.timeIntervalSince1970);
 }
 
+NSSet *toAPI(HashSet<String>& set)
+{
+    NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
+    for (auto& element : set)
+        [result addObject:static_cast<NSString *>(element)];
+
+    return [result copy];
+}
+
+NSArray *toAPIArray(HashSet<String>& set)
+{
+    NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:set.size()];
+    for (auto& element : set)
+        [result addObject:static_cast<NSString *>(element)];
+
+    return [result copy];
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -27,11 +27,57 @@
 
 #import <Foundation/Foundation.h>
 
+#import <WebKit/_WKWebExtensionPermission.h>
+
+@class _WKWebExtensionContext;
+@class _WKWebExtensionMatchPattern;
+@class _WKWebExtensionController;
+@protocol _WKWebExtensionTab;
+
 NS_ASSUME_NONNULL_BEGIN
 
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @protocol _WKWebExtensionControllerDelegate <NSObject>
 @optional
+
+/*!
+ @abstract Called when an extension context requests permissions.
+ @param controller The web extension controller that is managing the extension.
+ @param permissions The set of permissions being requested by the extension.
+ @param tab The tab in which the extension is running, or \c nil if the request are not specific to a tab.
+ @param extensionContext The context in which the web extension is running.
+ @param completionHandler A block to be called with the set of allowed permissions.
+ @discussion This method should be implemented by the app to prompt the user for permission and call the completion block with the
+ set of permissions that were granted. If the completion block is not called within a reasonable amount of time, the request
+ is assumed to have been denied.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissions:in:for:completionHandler:));
+
+/*!
+ @abstract Called when an extension context requests access to a set of URLs.
+ @param controller The web extension controller that is managing the extension.
+ @param urls The set of URLs that the extension is requesting access to.
+ @param tab The tab in which the extension is running, or \c nil if the request is not specific to a tab.
+ @param extensionContext The context in which the web extension is running.
+ @param completionHandler A block to be called with the set of allowed URLs.
+ @discussion This method should be implemented by the app to prompt the user for permission and call the completion block with the
+ set of URLs that were granted access to. If the completion block is not called within a reasonable amount of time, the request
+ is assumed to have been denied.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionToAccessURLs:(NSSet<NSURL *> *)urls inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<NSURL *> *allowedURLs))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionToAccess:in:for:completionHandler:));
+
+/*!
+ @abstract Called when an extension context requests access to a set of match patterns.
+ @param controller The web extension controller that is managing the extension.
+ @param matchPatterns The set of match patterns that the extension is requesting access to.
+ @param tab The tab in which the extension is running, or \c nil if the request is not specific to a tab.
+ @param extensionContext The context in which the web extension is running.
+ @param completionHandler A block to be called with the set of allowed match patterns.
+ @discussion This method should be implemented by the app to prompt the user for permission and call the completion block with the
+ set of match patterns that were granted access to. If the completion block is not called within a reasonable amount of time, the request
+ is assumed to have been denied.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
 
 @end
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -36,7 +36,6 @@
 #import "WebExtensionController.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
-#import "_WKWebExtensionControllerDelegatePrivate.h"
 #import "_WKWebExtensionControllerInternal.h"
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -247,7 +247,7 @@ void WebExtensionController::didStartProvisionalLoadForFrame(WebPageProxyIdentif
         if (!context->hasPermission(targetURL))
             continue;
 
-        context->fireEvents(listenerTypes, [context, pageID, frameID, targetURL] {
+        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
             context->sendToProcessesForEvent(WebExtensionEventListenerType::WebNavigationOnBeforeNavigate, Messages::WebExtensionContextProxy::DispatchWebNavigationOnBeforeNavigateEvent(pageID, frameID, targetURL));
         });
     }
@@ -262,7 +262,7 @@ void WebExtensionController::didCommitLoadForFrame(WebPageProxyIdentifier pageID
         if (!context->hasPermission(frameURL))
             continue;
 
-        context->fireEvents(listenerTypes, [context, pageID, frameID, frameURL] {
+        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
             context->sendToProcessesForEvent(WebExtensionEventListenerType::WebNavigationOnCommitted, Messages::WebExtensionContextProxy::DispatchWebNavigationOnCommittedEvent(pageID, frameID, frameURL));
             context->sendToProcessesForEvent(WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded, Messages::WebExtensionContextProxy::DispatchWebNavigationOnDOMContentLoadedEvent(pageID, frameID, frameURL));
         });
@@ -278,7 +278,7 @@ void WebExtensionController::didFinishLoadForFrame(WebPageProxyIdentifier pageID
         if (!context->hasPermission(frameURL))
             continue;
 
-        context->fireEvents(listenerTypes, [context, pageID, frameID, frameURL] {
+        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
             context->sendToProcessesForEvent(WebExtensionEventListenerType::WebNavigationOnCompleted, Messages::WebExtensionContextProxy::DispatchWebNavigationOnCompletedEvent(pageID, frameID, frameURL));
         });
     }
@@ -293,7 +293,7 @@ void WebExtensionController::didFailLoadForFrame(WebPageProxyIdentifier pageID, 
         if (!context->hasPermission(frameURL))
             continue;
 
-        context->fireEvents(listenerTypes, [context, pageID, frameID, frameURL] {
+        context->wakeUpBackgroundContentIfNecessaryToFireEvents(listenerTypes, [&] {
             context->sendToProcessesForEvent(WebExtensionEventListenerType::WebNavigationOnErrorOccurred, Messages::WebExtensionContextProxy::DispatchWebNavigationOnErrorOccurredEvent(pageID, frameID, frameURL));
         });
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -396,6 +396,37 @@ bool WebExtensionMatchPattern::pathMatches(const WebExtensionMatchPattern& other
     return false;
 }
 
+HashSet<String> toStrings(const MatchPatternSet& matchPatterns)
+{
+    HashSet<String> stringsToReturn;
+    stringsToReturn.reserveInitialCapacity(matchPatterns.size());
+
+    for (auto& pattern : matchPatterns)
+        stringsToReturn.add(pattern.get().string());
+
+    return stringsToReturn;
+}
+
+MatchPatternSet toPatterns(HashSet<String>& domains)
+{
+    MatchPatternSet matchPatterns;
+    matchPatterns.reserveInitialCapacity(domains.size());
+
+    for (auto& domain : domains)
+        matchPatterns.add(*WebExtensionMatchPattern::getOrCreate(domain));
+
+    return matchPatterns;
+}
+
+NSSet *toAPI(MatchPatternSet& set)
+{
+    NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
+    for (auto& element : set)
+        [result addObject:element->wrapper()];
+
+    return [result copy];
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -229,7 +229,7 @@ public:
     void addInjectedContent(WebUserContentControllerProxy&);
     void removeInjectedContent(WebUserContentControllerProxy&);
 
-    void fireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
+    void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
 
     template<typename T>
     void sendToProcessesForEvent(WebExtensionEventListenerType, const T& message);
@@ -298,7 +298,7 @@ private:
     void permissionsContains(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
     void permissionsRequest(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
     void permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
-    void parseMatchPatterns(HashSet<String> origins, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns);
+    void firePermissionsEventListenerIfNecessary(WebExtensionEventListenerType, const PermissionsSet&, const MatchPatternSet&);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -35,6 +35,8 @@
 
 OBJC_CLASS NSArray;
 OBJC_CLASS NSError;
+OBJC_CLASS NSSet;
+OBJC_CLASS NSString;
 OBJC_CLASS _WKWebExtensionMatchPattern;
 
 namespace WebKit {
@@ -65,6 +67,7 @@ public:
     ~WebExtensionMatchPattern() { }
 
     using URLSchemeSet = HashSet<String>;
+    using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
 
     enum class Options : uint8_t {
         IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.
@@ -118,6 +121,12 @@ private:
     bool m_valid { false };
     unsigned m_hash { 0 };
 };
+
+using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
+
+NSSet *toAPI(MatchPatternSet&);
+HashSet<String> toStrings(const MatchPatternSet&);
+MatchPatternSet toPatterns(HashSet<String>&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -54,7 +54,7 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
+void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     RELEASE_LOG(Extensions, "permissions.contains()");
 
@@ -62,11 +62,8 @@ void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensio
     WebExtension::MatchPatternSet matchPatterns;
     parseDetailsDictionary(details, permissions, origins);
 
-    NSString *errorMessage;
-    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"contains()", &errorMessage)) {
-        callback->reportError(errorMessage);
+    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"permissions.contains()", outExceptionString))
         return;
-    }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsContains(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool containsPermissions) {
         callback->call(containsPermissions ? @YES : @NO);
@@ -83,14 +80,21 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
     NSString *errorMessage;
     WebExtension::MatchPatternSet matchPatterns;
 
-    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"request()", &errorMessage)) {
+    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"permissions.request()", &errorMessage)) {
+        // Chrome reports this error as callback error and not an exception, so do the same.
         callback->reportError(errorMessage);
         return;
     }
 
-    // FIXME: <https://webkit.org/b/250135> Check to see if the request is being made from a user gesture.
+    if (!WebCore::UserGestureIndicator::processingUserGesture()) {
+        // Chrome reports this error as callback error and not an exception, so do the same.
+        callback->reportError(@"permissions.request() must be called during a user gesture.");
+        return;
+    }
 
-    if (!verifyRequestedPermissions(permissions, matchPatterns, @"request()", &errorMessage)) {
+    if (!verifyRequestedPermissions(permissions, matchPatterns, @"permissions.request()", &errorMessage)) {
+        // Chrome reports these errors as callback errors and not exceptions, so do the same. Instead of round tripping
+        // to the UI process, we can answer this here and report the error right away.
         callback->reportError(errorMessage);
         return;
     }
@@ -106,6 +110,20 @@ void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionC
 
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);
+
+    NSString *errorMessage;
+    WebExtension::MatchPatternSet matchPatterns;
+    if (!validatePermissionsDetails(permissions, origins, matchPatterns, @"permissions.remove()", &errorMessage)) {
+        // Chrome reports this error as callback error and not an exception, so do the same.
+        callback->reportError(errorMessage);
+        return;
+    }
+
+    if (!verifyRequestedPermissions(permissions, matchPatterns, @"permissions.remove()", &errorMessage)) {
+        // Chrome reports this error as callback error and not an exception, so do the same.
+        callback->reportError(errorMessage);
+        return;
+    }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsRemove(permissions, origins), [protectedThis = Ref { *this }, callback = WTFMove(callback)](bool success) {
         callback->call(success ? @YES : @NO);
@@ -123,32 +141,46 @@ void WebExtensionAPIPermissions::parseDetailsDictionary(NSDictionary *details, H
 
 bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& permissions, HashSet<Ref<WebExtensionMatchPattern>>& matchPatterns, NSString *callingAPIName, NSString **outExceptionString)
 {
-    WebExtension extension = WebExtension(extensionContext().manifest());
-    HashSet<String> allowedPermissions = extension.requestedPermissions();
+    auto extension = WebExtension::create(extensionContext().manifest(), @{ });
+    HashSet<String> allowedPermissions = extension->requestedPermissions();
+    WebExtension::MatchPatternSet allowedHostPermissions = extension->allRequestedMatchPatterns();
 
-    if ([callingAPIName isEqualToString:@"remove()"]) {
-        if (bool requestingToRemoveFunctionalPermissions = permissions.size() && permissions.isSubset(allowedPermissions)) {
+    if ([callingAPIName isEqualToString:@"permissions.remove()"]) {
+        if (bool requestingToRemoveFunctionalPermissions = permissions.size() && permissions.intersectionWith(allowedPermissions).size()) {
             *outExceptionString = @"Required permissions cannot be removed.";
             return false;
         }
+
+        for (auto& requestedPattern : matchPatterns) {
+            for (auto& allowedPattern : allowedHostPermissions) {
+                if (allowedPattern->matchesPattern(requestedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
+                    *outExceptionString = @"Required permissions cannot be removed.";
+                    return false;
+                }
+            }
+        }
     }
 
-    allowedPermissions.add(extension.optionalPermissions().begin(), extension.optionalPermissions().end());
+    allowedPermissions.add(extension->optionalPermissions().begin(), extension->optionalPermissions().end());
+    allowedHostPermissions.add(extension->optionalPermissionMatchPatterns().begin(), extension->optionalPermissionMatchPatterns().end());
 
-    bool requestingPermissionsNotDefinedInManifest = permissions.size() && !permissions.isSubset(allowedPermissions);
+    bool requestingPermissionsNotDeclaredInManifest = (permissions.size() && !permissions.isSubset(allowedPermissions)) || (matchPatterns.size() && !allowedHostPermissions.size());
+    if (requestingPermissionsNotDeclaredInManifest) {
+        *outExceptionString = [callingAPIName isEqualToString:@"permissions.remove()"] ? @"Only permissions specified in the manifest may be removed." : @"Only permissions specified in the manifest may be requested.";
+        return false;
+    }
 
-    WebExtension::MatchPatternSet allowedPatterns = extension.requestedPermissionMatchPatterns();
     for (auto& requestedPattern : matchPatterns) {
-        bool requestingAllowedOrigin = false;
-        for (auto& allowedPattern : allowedPatterns) {
-            if (requestedPattern->matchesPattern(allowedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
-                requestingAllowedOrigin = true;
+        bool matchFound = false;
+        for (auto& allowedPattern : allowedHostPermissions) {
+            if (allowedPattern->matchesPattern(requestedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
+                matchFound = true;
                 break;
             }
         }
 
-        if (!requestingAllowedOrigin || requestingPermissionsNotDefinedInManifest) {
-            *outExceptionString = [callingAPIName isEqualToString:@"remove()"] ? @"Only permissions specified in the manifest may be removed" : @"Only permissions specified in the manifest may be requested.";
+        if (!matchFound) {
+            *outExceptionString = [callingAPIName isEqualToString:@"permissions.remove()"] ? @"Only permissions specified in the manifest may be removed." : @"Only permissions specified in the manifest may be requested.";
             return false;
         }
     }
@@ -182,7 +214,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
 WebExtensionAPIEvent& WebExtensionAPIPermissions::onAdded()
 {
     if (!m_onAdded)
-        m_onAdded = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext());
+        m_onAdded = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PermissionsOnAdded);
 
     return *m_onAdded;
 }
@@ -190,7 +222,7 @@ WebExtensionAPIEvent& WebExtensionAPIPermissions::onAdded()
 WebExtensionAPIEvent& WebExtensionAPIPermissions::onRemoved()
 {
     if (!m_onRemoved)
-        m_onRemoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext());
+        m_onRemoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PermissionsOnRemoved);
 
     return *m_onRemoved;
 }

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -29,6 +29,7 @@
 
 #include "MessageReceiver.h"
 #include "WebExtensionContextParameters.h"
+#include "WebExtensionEventListenerType.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/FrameIdentifier.h>
@@ -39,6 +40,7 @@
 namespace WebKit {
 
 class WebExtensionAPINamespace;
+class WebExtensionMatchPattern;
 class WebFrame;
 
 class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, public IPC::MessageReceiver {
@@ -85,6 +87,9 @@ private:
     void dispatchWebNavigationOnDOMContentLoadedEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
     void dispatchWebNavigationOnCompletedEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
     void dispatchWebNavigationOnErrorOccurredEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+
+    // Permissions support
+    void dispatchPermissionsEvent(const WebKit::WebExtensionEventListenerType&, HashSet<String> permissions, HashSet<String> origins);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -37,6 +37,7 @@ cocoa/TestNavigationDelegate.mm
 cocoa/TestProtocol.mm
 cocoa/TestUIDelegate.mm
 cocoa/TestWKWebView.mm
+cocoa/TestWebExtensionsDelegate.mm
 cocoa/UserMediaCaptureUIDelegate.mm
 
 Tests/WebKitCocoa/AVFoundationPreference.mm
@@ -286,6 +287,7 @@ Tests/WebKitCocoa/WKWebExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
 Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
+Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
 Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
 Tests/WebKitCocoa/WKWebExtensionContext.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3045,6 +3045,9 @@
 		B55AD1D3179F3ABF00AC1494 /* PreventImageLoadWithAutoResizing_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PreventImageLoadWithAutoResizing_Bundle.cpp; path = WebKitObjC/PreventImageLoadWithAutoResizing_Bundle.cpp; sourceTree = "<group>"; };
 		B55F119F1516834F00915916 /* AttributedString.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AttributedString.mm; sourceTree = "<group>"; };
 		B55F11B01517A2C400915916 /* attributedStringCustomFont.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = attributedStringCustomFont.html; sourceTree = "<group>"; };
+		B61EB1642994734A0048DFC0 /* WKWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
+		B63EF53E2995797F00A190A3 /* TestWebExtensionsDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestWebExtensionsDelegate.h; path = cocoa/TestWebExtensionsDelegate.h; sourceTree = "<group>"; };
+		B63EF5462995797F00A190A3 /* TestWebExtensionsDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = TestWebExtensionsDelegate.mm; path = cocoa/TestWebExtensionsDelegate.mm; sourceTree = "<group>"; };
 		B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIEvent.mm; sourceTree = "<group>"; };
 		BC029B161486AD6400817DA9 /* RetainPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RetainPtr.cpp; sourceTree = "<group>"; };
 		BC029B1B1486B25900817DA9 /* RetainPtr.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RetainPtr.mm; path = ns/RetainPtr.mm; sourceTree = "<group>"; };
@@ -3733,6 +3736,8 @@
 				A14FC58E1B8AE36500D107EB /* TestProtocol.mm */,
 				5CBAA7F324327F6B00564A8B /* TestUIDelegate.h */,
 				5CBAA7F424327F6B00564A8B /* TestUIDelegate.mm */,
+				B63EF53E2995797F00A190A3 /* TestWebExtensionsDelegate.h */,
+				B63EF5462995797F00A190A3 /* TestWebExtensionsDelegate.mm */,
 				2EFF06D21D8AEDBB0004BB30 /* TestWKWebView.h */,
 				2EFF06D31D8AEDBB0004BB30 /* TestWKWebView.mm */,
 				41733D7A25DE96DA00A136E5 /* UserMediaCaptureUIDelegate.h */,
@@ -4115,6 +4120,7 @@
 				B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */,
 				1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */,
 				330E135E2943C92000367438 /* WKWebExtensionAPINamespace.mm */,
+				B61EB1642994734A0048DFC0 /* WKWebExtensionAPIPermissions.mm */,
 				1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */,
 				3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */,
 				1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import "TestWKWebView.h"
+#import "TestWebExtensionsDelegate.h"
+#import "WebExtensionUtilities.h"
+#import <WebCore/UserGestureIndicator.h>
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionContextPrivate.h>
+#import <WebKit/_WKWebExtensionControllerDelegate.h>
+
+namespace TestWebKitAPI {
+
+static void runScriptWithUserGesture(const String& script, WKWebView *backgroundWebView)
+{
+    bool callbackComplete = false;
+    RetainPtr<id> evalResult;
+    [backgroundWebView callAsyncJavaScript:script arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:[&] (id result, NSError *error) {
+        evalResult = result;
+        callbackComplete = true;
+        EXPECT_TRUE(!error);
+        if (error)
+            NSLog(@"Encountered error: %@ while evaluating script: %@", error, static_cast<NSString *>(script));
+    }];
+    TestWebKitAPI::Util::run(&callbackComplete);
+}
+
+
+TEST(WKWebExtensionAPIPermissions, PermissionsTest)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"alarms", @"activeTab" ],
+        @"optional_permissions": @[ @"webNavigation", @"cookies" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // contains() should return true for all named permissions and granted match patterns.
+        @"browser.test.assertTrue(await browser.permissions.contains({'permissions': ['alarms', 'activeTab']}))",
+        @"browser.test.assertTrue(await browser.permissions.contains({'origins': ['*://webkit.org/*']}))",
+
+        // contains() should return false for non granted match patterns.
+        @"browser.test.assertFalse(await browser.permissions.contains({'origins': ['*://apple.com/*']}))",
+
+        // Removing optional permissions should pass.
+        @"browser.test.assertTrue(await browser.permissions.remove({'permissions': ['cookies']}))",
+
+        // Removing functional permissions should fail.
+        @"browser.test.assertRejects(browser.permissions.remove({'permissions': ['alarms']}))",
+        @"browser.test.assertRejects(browser.permissions.remove({'permissions': ['alarms', 'activeTab']}))",
+        @"browser.test.assertRejects(browser.permissions.remove({'permissions': ['cookies', 'activeTab']}))",
+        @"browser.test.assertRejects(browser.permissions.remove({'permissions': ['scripting']}))",
+
+        // getALL() should return all named permissions and granted match patterns.
+        @"let permissions = {'origins': ['*://webkit.org/*'], 'permissions': ['alarms', 'activeTab']}",
+        @"const result = await browser.permissions.getAll()",
+        @"browser.test.assertDeepEq(result, permissions)",
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    // Grant "permissions" in the manifest.
+    for (NSString *permission in extension.get().requestedPermissions)
+        [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:permission];
+
+    // Grant extension access to webkit.org.
+    _WKWebExtensionMatchPattern *matchPattern = [_WKWebExtensionMatchPattern matchPatternWithString:@"*://webkit.org/*"];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequestTest)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"alarms", @"activeTab" ],
+        @"optional_permissions": @[ @"webNavigation", @"cookies", @"declarativeNetRequest", @"*://*.apple.com/*" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Finish
+        @"browser.test.yield()",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    NSSet<NSString *> *permissions = [NSSet setWithArray:@[ @"declarativeNetRequest" ]];
+    NSSet<_WKWebExtensionMatchPattern *> *matchPatterns = [NSSet setWithArray:@[ [_WKWebExtensionMatchPattern matchPatternWithString:@"*://*.apple.com/*" ]]];
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Implement the delegate methods that're called when a call to permissions.request() is made.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        EXPECT_EQ(requestedPermissions.count, permissions.count);
+        EXPECT_TRUE([requestedPermissions isEqualToSet:permissions]);
+        callback(requestedPermissions);
+    };
+
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        EXPECT_EQ(requestedMatchPatterns.count, matchPatterns.count);
+        EXPECT_TRUE([requestedMatchPatterns isEqualToSet:matchPatterns]);
+        callback(requestedMatchPatterns);
+        requestComplete = true;
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+    [manager loadAndRun];
+
+    runScriptWithUserGesture("await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequestTest)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"optional_permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Finish
+        @"browser.test.yield()",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Implement the delegate methods, but don't grant the permissions.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        requestComplete = true;
+        callback(nil);
+    };
+
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        ASSERT_NOT_REACHED();
+        callback(nil);
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+    [manager loadAndRun];
+
+    runScriptWithUserGesture("await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequestTest)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"optional_permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Finish
+        @"browser.test.yield()",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Grant the requested permissions.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        callback(requestedPermissions);
+    };
+
+    // Deny the requested match patterns.
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        requestComplete = true;
+        callback(nil);
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+    [manager loadAndRun];
+
+    runScriptWithUserGesture("await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnlyTest)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"optional_permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Finish
+        @"browser.test.yield()",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Grant the requested permissions.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        callback(requestedPermissions);
+    };
+
+    // Grant the requested match patterns.
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        requestComplete = true;
+        callback(requestedMatchPatterns);
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+    [manager loadAndRun];
+
+    runScriptWithUserGesture("await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest']}))"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnlyTest)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"optional_permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Finish
+        @"browser.test.yield()",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get()._webExtensionController = manager.get().controller;
+
+    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    __block bool requestComplete = false;
+
+    // Grant the requested permissions.
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+        callback(requestedPermissions);
+    };
+
+    // Grant the requested match patterns.
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+        requestComplete = true;
+        callback(requestedMatchPatterns);
+    };
+
+    manager.get().controllerDelegate = requestDelegate.get();
+    [manager loadAndRun];
+
+    runScriptWithUserGesture("await browser.test.assertTrue(await browser.permissions.request({'origins': ['*://*.apple.com/*']}))"_s, manager.get().context._backgroundWebView);
+
+    TestWebKitAPI::Util::run(&requestComplete);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,17 +25,18 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-messages -> WebExtensionContextProxy {
-    // Permissions support
-    DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
+#import <WebKit/WebKit.h>
 
-    // webNavigation support
-    DispatchWebNavigationOnBeforeNavigateEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnCommittedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnDOMContentLoadedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnCompletedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnErrorOccurredEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+#import <WebKit/_WKWebExtensionControllerDelegate.h>
+#import <WebKit/_WKWebExtensionMatchPattern.h>
+#import <WebKit/_WKWebExtensionPermission.h>
+#import <WebKit/_WKWebExtensionTab.h>
 
-}
+@interface TestWebExtensionsDelegate : NSObject <_WKWebExtensionControllerDelegate>
+
+@property (nonatomic, copy) void (^promptForPermissions)(id<_WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<_WKWebExtensionPermission> *));
+@property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id<_WKWebExtensionTab>, NSSet<_WKWebExtensionMatchPattern *> *, void (^)(NSSet<_WKWebExtensionMatchPattern *> *));
+
+@end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "config.h"
+#import "TestWebExtensionsDelegate.h"
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-messages -> WebExtensionContextProxy {
-    // Permissions support
-    DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
+#import <WebKit/_WKWebExtensionController.h>
+#import <WebKit/_WKWebExtensionMatchPattern.h>
+#import <WebKit/_WKWebExtensionPermission.h>
 
-    // webNavigation support
-    DispatchWebNavigationOnBeforeNavigateEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnCommittedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnDOMContentLoadedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnCompletedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
-    DispatchWebNavigationOnErrorOccurredEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+@implementation TestWebExtensionsDelegate
 
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler
+{
+    if (_promptForPermissions)
+        _promptForPermissions(tab, permissions, completionHandler);
+    else
+        completionHandler(permissions);
 }
+
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler
+{
+    if (_promptForPermissionMatchPatterns)
+        _promptForPermissionMatchPatterns(tab, matchPatterns, completionHandler);
+    else
+        completionHandler(matchPatterns);
+}
+
+@end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 65e4c3db6cba94a2f2d131433033cf3e15f30c1a
<pre>
Add support for Web Extensions permissions.request() API.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250135">https://bugs.webkit.org/show_bug.cgi?id=250135</a>
Reviewed by Timothy Hatcher.

This patch implements the permissions.request() API. This includes delegating the action of requesting
permissions from the users to the browsers. Once that action has been fulfilled and the user grants
all requested permissions, we add them to the extension&apos;s granted permissions and match pattern sets.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toAPI): Helper method to convert from HashSet&lt;String&gt; to NSSet&lt;String&gt;.
(WebKit::toAPIArray):Helper method to convert from HashSet&lt;String&gt; to NSArray&lt;String&gt;.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
Define the delegate methods used to prompt users to grant permissions.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
Remove unnecessary file import.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsContains):

(WebKit::WebExtensionContext::permissionsRequest):
Call delegate methods to determine if permissions should be granted.

(WebKit::WebExtensionContext::permissionsRemove):

(WebKit::WebExtensionContext::firePermissionsEventListenerIfNecessary):
Fire permissions onAdded or onRemoved events if permissions are granted or removed.

(WebKit::WebExtensionContext::parseMatchPatterns): Deleted.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::postAsyncNotification):
Call firePermissionsEventListenerIfNecessary whenever a notification is posted for a change in an
extension&apos;s permissions.

(WebKit::WebExtensionContext::hasPermissions):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents):
`fireEvents` isn’t an accurate name for this method since it doesn’t actually fire any events.
We should rename this to better describe what’s happening in this method
(WebKit::WebExtensionContext::fireEvents): Deleted.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame):
(WebKit::WebExtensionController::didCommitLoadForFrame):
(WebKit::WebExtensionController::didFinishLoadForFrame):
(WebKit::WebExtensionController::didFailLoadForFrame):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::matchPatternStrings):
(WebKit::WebExtensionMatchPattern::matchPatternsForOrigins):

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
Validate permissions details for these APIs.
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):

(WebKit::WebExtensionAPIPermissions::onAdded):
(WebKit::WebExtensionAPIPermissions::onRemoved):
Pass in the WebExtensionEventListenerType when creating these events.

* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchPermissionsEvent):
Enumerate through the namespace objects and invoke the listeners for the event listener.

* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm: Added.
(TestWebKitAPI::runScriptWithUserGesture):
(TestWebKitAPI::TEST):
Add WebKit tests for Permissions API.

* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
Copied from Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h.

* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
Copied from Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in.
(-[TestWebExtensionsDelegate
webExtensionController:promptForPermissions:inTab:forExtensionContext:completionHandler:]):
(-[TestWebExtensionsDelegate
webExtensionController:promptForPermissionMatchPatterns:inTab:forExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/260370@main">https://commits.webkit.org/260370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be41e1ef323d92a4e3caa09beeb6787273b8d5d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108038 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8408 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100236 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113804 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41861 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28792 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9999 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7041 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49730 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12296 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3900 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->