### PR TITLE
Make Gamepad.vibrationActuator work with the GameController framework

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-enum class GamepadHapticEffectType : uint8_t { DualRumble };
+enum class GamepadHapticEffectType : uint8_t { DualRumble, TriggerRumble };
 
 using GamepadHapticEffectTypeSet = HashSet<GamepadHapticEffectType, IntHash<GamepadHapticEffectType>, WTF::StrongEnumHashTraits<GamepadHapticEffectType>>;
 

--- a/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
@@ -26,5 +26,6 @@
 [
     Conditional=GAMEPAD
 ] enum GamepadHapticEffectType {
-  "dual-rumble"
+    "dual-rumble",
+    "trigger-rumble", // Not in the specification but supported by Blink.
 };

--- a/Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD) && PLATFORM(COCOA)
+
+#import <CoreHaptics/CoreHaptics.h>
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_HEADER(WebCore, CoreHaptics)
+
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, CHHapticEngine)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, CHHapticPattern)
+
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyEvent, NSString *);
+#define CHHapticPatternKeyEvent WebCore::get_CoreHaptics_CHHapticPatternKeyEvent()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyEventType, NSString *);
+#define CHHapticPatternKeyEventType WebCore::get_CoreHaptics_CHHapticPatternKeyEventType()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticEventTypeHapticTransient, NSString *);
+#define CHHapticEventTypeHapticTransient WebCore::get_CoreHaptics_CHHapticEventTypeHapticTransient()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticEventTypeHapticContinuous, NSString *);
+#define CHHapticEventTypeHapticContinuous WebCore::get_CoreHaptics_CHHapticEventTypeHapticContinuous()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyTime, NSString *);
+#define CHHapticPatternKeyTime WebCore::get_CoreHaptics_CHHapticPatternKeyTime()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyEventParameters, NSString *);
+#define CHHapticPatternKeyEventParameters WebCore::get_CoreHaptics_CHHapticPatternKeyEventParameters()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyParameterID, NSString *);
+#define CHHapticPatternKeyParameterID WebCore::get_CoreHaptics_CHHapticPatternKeyParameterID()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyParameterValue, NSString *);
+#define CHHapticPatternKeyParameterValue WebCore::get_CoreHaptics_CHHapticPatternKeyParameterValue()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticEventParameterIDHapticIntensity, NSString *);
+#define CHHapticEventParameterIDHapticIntensity WebCore::get_CoreHaptics_CHHapticEventParameterIDHapticIntensity()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyEventDuration, NSString *);
+#define CHHapticPatternKeyEventDuration WebCore::get_CoreHaptics_CHHapticPatternKeyEventDuration()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreHaptics, CHHapticPatternKeyPattern, NSString *);
+#define CHHapticPatternKeyPattern WebCore::get_CoreHaptics_CHHapticPatternKeyPattern()
+
+#endif // ENABLE(GAMEPAD) && PLATFORM(COCOA)

--- a/Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.mm
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(GAMEPAD) && PLATFORM(COCOA)
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebCore, CoreHaptics)
+
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, CoreHaptics, CHHapticEngine)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPattern)
+
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyEvent, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyEventType, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticEventTypeHapticTransient, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticEventTypeHapticContinuous, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyTime, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyEventParameters, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticEventParameterIDHapticIntensity, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyEventDuration, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyPattern, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyParameterID, NSString *)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyParameterValue, NSString *)
+
+#endif // ENABLE(GAMEPAD) && PLATFORM(COCOA)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -37,6 +37,8 @@ OBJC_CLASS GCControllerElement;
 
 namespace WebCore {
 
+class GameControllerHapticEngines;
+
 class GameControllerGamepad : public PlatformGamepad {
     WTF_MAKE_NONCOPYABLE(GameControllerGamepad);
 public:
@@ -49,13 +51,17 @@ public:
 
     const char* source() const final { return "GameController"_s; }
 
+    void noLongerHasAnyClient();
+
 private:
     void setupElements();
+    GameControllerHapticEngines& ensureHapticEngines();
 
     RetainPtr<GCController> m_gcController;
 
     Vector<SharedGamepadValue> m_axisValues;
     Vector<SharedGamepadValue> m_buttonValues;
+    std::unique_ptr<GameControllerHapticEngines> m_hapticEngines;
 };
 
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -27,8 +27,8 @@
 
 #if ENABLE(GAMEPAD)
 #import "GameControllerGamepadProvider.h"
+#import "GameControllerHapticEngines.h"
 #import "GamepadConstants.h"
-#import "NotImplemented.h"
 #import <GameController/GCControllerElement.h>
 #import <GameController/GameController.h>
 
@@ -158,18 +158,30 @@ void GameControllerGamepad::setupElements()
     };
 }
 
-void GameControllerGamepad::playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+GameControllerHapticEngines& GameControllerGamepad::ensureHapticEngines()
 {
-    // FIXME(webkit.org/b/250217): Implement support.
-    notImplemented();
-    completionHandler(false);
+    if (!m_hapticEngines)
+        m_hapticEngines = GameControllerHapticEngines::create(m_gcController.get());
+    return *m_hapticEngines;
+}
+
+void GameControllerGamepad::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    ensureHapticEngines().playEffect(type, parameters, WTFMove(completionHandler));
 }
 
 void GameControllerGamepad::stopEffects(CompletionHandler<void()>&& completionHandler)
 {
-    // FIXME(webkit.org/b/250217): Implement support.
-    notImplemented();
+    if (m_hapticEngines)
+        m_hapticEngines->stopEffects();
     completionHandler();
+}
+
+void GameControllerGamepad::noLongerHasAnyClient()
+{
+    // Stop the haptics engine if it is running.
+    if (m_hapticEngines)
+        m_hapticEngines->stop([] { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm
@@ -225,6 +225,9 @@ void GameControllerGamepadProvider::stopMonitoringGamepads(GamepadProviderClient
 
     [[NSNotificationCenter defaultCenter] removeObserver:m_connectObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_disconnectObserver.get()];
+
+    for (auto& gamepad : m_gamepadMap.values())
+        gamepad->noLongerHasAnyClient();
 }
 
 unsigned GameControllerGamepadProvider::indexForNewlyConnectedDevice()

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD)
+
+#import <wtf/CompletionHandler.h>
+#import <wtf/RetainPtr.h>
+
+namespace WebCore {
+
+class GameControllerHapticEngines;
+struct GamepadEffectParameters;
+
+class GameControllerHapticEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static std::unique_ptr<GameControllerHapticEffect> create(GameControllerHapticEngines&, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&);
+    ~GameControllerHapticEffect();
+
+    bool start();
+    void stop();
+
+    void strongEffectFinishedPlaying();
+    void weakEffectFinishedPlaying();
+
+private:
+    GameControllerHapticEffect(RetainPtr<id>&& strongPlayer, RetainPtr<id>&& weakPlayer, CompletionHandler<void(bool)>&&);
+
+    RetainPtr<id> m_strongPlayer;
+    RetainPtr<id> m_weakPlayer;
+    CompletionHandler<void(bool)> m_completionHandler;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(GAMEPAD)
+#import "GameControllerHapticEffect.h"
+
+#import "GameControllerHapticEngines.h"
+#import "GamepadEffectParameters.h"
+#import "Logging.h"
+
+#import "CoreHapticsSoftLink.h"
+
+namespace WebCore {
+
+std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    auto createPlayer = [&](CHHapticEngine *engine, double intensity) -> RetainPtr<id> {
+        NSDictionary* hapticDict = @{
+            CHHapticPatternKeyPattern: @[
+                @{ CHHapticPatternKeyEvent: @{
+                    CHHapticPatternKeyEventType: CHHapticEventTypeHapticContinuous,
+                    CHHapticPatternKeyTime: [NSNumber numberWithDouble:std::max<double>(parameters.startDelay / 1000., 0)],
+                    CHHapticPatternKeyEventDuration: [NSNumber numberWithDouble:std::max<double>(parameters.duration / 1000., 0)],
+                    CHHapticPatternKeyEventParameters: @[ @{
+                        CHHapticPatternKeyParameterID: CHHapticEventParameterIDHapticIntensity,
+                        CHHapticPatternKeyParameterValue: [NSNumber numberWithDouble:std::clamp<double>(intensity, 0, 1)],
+                    } ]
+                }, },
+            ],
+        };
+
+        NSError* error;
+        auto pattern = adoptNS([allocCHHapticPatternInstance() initWithDictionary:hapticDict error:&error]);
+        if (!pattern) {
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect: Failed to create a CHHapticPattern");
+            return nullptr;
+        }
+
+        return retainPtr([engine createPlayerWithPattern:pattern.get() error:&error]);
+    };
+    auto strongPlayer = createPlayer(engines.strongEngine(), parameters.strongMagnitude);
+    auto weakPlayer = createPlayer(engines.weakEngine(), parameters.weakMagnitude);
+    if (!strongPlayer || !weakPlayer) {
+        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect: Failed to create the haptic effect players");
+        completionHandler(false);
+        return nullptr;
+    }
+    return std::unique_ptr<GameControllerHapticEffect>(new GameControllerHapticEffect(WTFMove(strongPlayer), WTFMove(weakPlayer), WTFMove(completionHandler)));
+}
+
+GameControllerHapticEffect::GameControllerHapticEffect(RetainPtr<id>&& strongPlayer, RetainPtr<id>&& weakPlayer, CompletionHandler<void(bool)>&& completionHandler)
+    : m_strongPlayer(WTFMove(strongPlayer))
+    , m_weakPlayer(WTFMove(weakPlayer))
+    , m_completionHandler(WTFMove(completionHandler))
+{
+}
+
+GameControllerHapticEffect::~GameControllerHapticEffect()
+{
+    if (m_completionHandler)
+        m_completionHandler(false);
+}
+
+bool GameControllerHapticEffect::start()
+{
+    NSError *error;
+    if (m_strongPlayer && ![m_strongPlayer startAtTime:0 error:&error]) {
+        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the strong player");
+        m_strongPlayer = nullptr;
+    }
+    if (m_weakPlayer && ![m_weakPlayer startAtTime:0 error:&error]) {
+        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the weak player");
+        m_weakPlayer = nullptr;
+    }
+    return m_strongPlayer || m_weakPlayer;
+}
+
+void GameControllerHapticEffect::stop()
+{
+    NSError *error;
+    if (auto player = std::exchange(m_strongPlayer, nullptr))
+        [player stopAtTime:0.0 error:&error];
+    if (auto player = std::exchange(m_weakPlayer, nullptr))
+        [player stopAtTime:0.0 error:&error];
+}
+
+void GameControllerHapticEffect::strongEffectFinishedPlaying()
+{
+    m_strongPlayer = nullptr;
+    if (!m_weakPlayer && m_completionHandler)
+        m_completionHandler(true);
+}
+
+void GameControllerHapticEffect::weakEffectFinishedPlaying()
+{
+    m_weakPlayer = nullptr;
+    if (!m_strongPlayer && m_completionHandler)
+        m_completionHandler(true);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD)
+
+#include <wtf/Forward.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
+
+OBJC_CLASS CHHapticEngine;
+OBJC_CLASS GCController;
+
+namespace WebCore {
+
+class GameControllerHapticEffect;
+struct GamepadEffectParameters;
+enum class GamepadHapticEffectType : uint8_t;
+
+class GameControllerHapticEngines : public CanMakeWeakPtr<GameControllerHapticEngines> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static std::unique_ptr<GameControllerHapticEngines> create(GCController *);
+    ~GameControllerHapticEngines();
+
+    void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&);
+    void stopEffects();
+
+    void stop(CompletionHandler<void()>&&);
+
+    CHHapticEngine *strongEngine() { return m_strongEngine.get(); }
+    CHHapticEngine *weakEngine() { return m_weakEngine.get(); }
+
+private:
+    explicit GameControllerHapticEngines(GCController *);
+
+    void ensureStarted(CompletionHandler<void(bool)>&&);
+
+    RetainPtr<CHHapticEngine> m_strongEngine;
+    RetainPtr<CHHapticEngine> m_weakEngine;
+    bool m_failedToStartStrongEngine { false };
+    bool m_failedToStartWeakEngine { false };
+    std::unique_ptr<GameControllerHapticEffect> m_currentEffect;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(GAMEPAD)
+#import "GameControllerHapticEngines.h"
+
+#import "GameControllerHapticEffect.h"
+#import "GamepadEffectParameters.h"
+#import "GamepadHapticEffectType.h"
+#import "Logging.h"
+#import <wtf/BlockPtr.h>
+#import <wtf/CallbackAggregator.h>
+#import <wtf/CompletionHandler.h>
+
+#import "GameControllerSoftLink.h"
+#import "CoreHapticsSoftLink.h"
+
+namespace WebCore {
+
+std::unique_ptr<GameControllerHapticEngines> GameControllerHapticEngines::create(GCController *gamepad)
+{
+    return std::unique_ptr<GameControllerHapticEngines>(new GameControllerHapticEngines(gamepad));
+}
+
+GameControllerHapticEngines::GameControllerHapticEngines(GCController *gamepad)
+    : m_strongEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityLeftHandle()])
+    , m_weakEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityRightHandle()])
+{
+}
+
+GameControllerHapticEngines::~GameControllerHapticEngines() = default;
+
+void GameControllerHapticEngines::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    ASSERT_UNUSED(type, type == GamepadHapticEffectType::DualRumble);
+
+    // Trying to create pattern players with a 0 duration will fail. However, Games on XBox seem to use such
+    // requests to stop vibrating.
+    if (!parameters.duration) {
+        if (auto currentEffect = std::exchange(m_currentEffect, nullptr))
+            currentEffect->stop();
+        return completionHandler(true);
+    }
+
+    auto currentEffect = GameControllerHapticEffect::create(*this, parameters, WTFMove(completionHandler));
+    if (!currentEffect)
+        return;
+
+    if (m_currentEffect)
+        m_currentEffect->stop();
+
+    m_currentEffect = WTFMove(currentEffect);
+    ensureStarted([weakThis = WeakPtr { *this }](bool success) mutable {
+        if (!success || !weakThis || !weakThis->m_currentEffect)
+            return;
+
+        if (!weakThis->m_currentEffect->start())
+            weakThis->m_currentEffect = nullptr;
+    });
+}
+
+void GameControllerHapticEngines::stopEffects()
+{
+    if (auto currentEffect = std::exchange(m_currentEffect, nullptr))
+        currentEffect->stop();
+}
+
+void GameControllerHapticEngines::ensureStarted(CompletionHandler<void(bool)>&& completionHandler)
+{
+    auto callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+        completionHandler(weakThis && !weakThis->m_failedToStartStrongEngine && !weakThis->m_failedToStartWeakEngine);
+    });
+    auto startEngine = [weakThis = WeakPtr { *this }](CHHapticEngine *engine, CompletionHandler<void(bool)>&& completionHandler, std::function<void()>&& playersFinished) mutable {
+        [engine startWithCompletionHandler:makeBlockPtr([weakThis = WTFMove(weakThis), engine, completionHandler = WTFMove(completionHandler), playersFinished](NSError* error) mutable {
+            ensureOnMainRunLoop([completionHandler = WTFMove(completionHandler), success = !error]() mutable {
+                completionHandler(success);
+            });
+            if (error)
+                RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::ensureStarted: Failed to start haptic engine");
+            [engine notifyWhenPlayersFinished:makeBlockPtr([playersFinished](NSError *) mutable -> CHHapticEngineFinishedAction {
+                ensureOnMainRunLoop([playersFinished] {
+                    playersFinished();
+                });
+                return CHHapticEngineFinishedActionLeaveEngineRunning;
+            }).get()];
+        }).get()];
+    };
+    startEngine(m_strongEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+        if (weakThis)
+            weakThis->m_failedToStartStrongEngine = !success;
+    }, [weakThis = WeakPtr { *this }] {
+        if (weakThis && weakThis->m_currentEffect)
+            weakThis->m_currentEffect->strongEffectFinishedPlaying();
+    });
+    startEngine(m_weakEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+        if (weakThis)
+            weakThis->m_failedToStartWeakEngine = !success;
+    }, [weakThis = WeakPtr { *this }] {
+        if (weakThis && weakThis->m_currentEffect)
+            weakThis->m_currentEffect->weakEffectFinishedPlaying();
+    });
+}
+
+void GameControllerHapticEngines::stop(CompletionHandler<void()>&& completionHandler)
+{
+    auto callbackAggregator = MainRunLoopCallbackAggregator::create(WTFMove(completionHandler));
+    [m_strongEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
+        if (error)
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the strong haptic engine");
+    }).get()];
+    [m_weakEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
+        if (error)
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the weak haptic engine");
+    }).get()];
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2477,7 +2477,8 @@ struct WebCore::GamepadEffectParameters {
 
 header: <WebCore/GamepadHapticEffectType.h>
 enum class WebCore::GamepadHapticEffectType : uint8_t {
-    DualRumble
+    DualRumble,
+    TriggerRumble
 };
 #endif
 


### PR DESCRIPTION
#### c7f1532632f76bad38f73f3718c79d1363ee7abf
<pre>
Make Gamepad.vibrationActuator work with the GameController framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=250217">https://bugs.webkit.org/show_bug.cgi?id=250217</a>
rdar://problem/103973520

Reviewed by Brady Eidson.

Make Gamepad.vibrationActuator work with the GameController framework, so that
the gamepad now actually vibrates on macOS 13+.

This was tested manually using an XBox controller.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.h: Added.
* Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.mm: Added.
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::ensureHapticEngines):
(WebCore::GameControllerGamepad::playEffect):
(WebCore::GameControllerGamepad::stopEffects):
(WebCore::GameControllerGamepad::noLongerHasAnyClient):
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::stopMonitoringGamepads):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h: Copied from Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm: Added.
(WebCore::GameControllerHapticEffect::create):
(WebCore::GameControllerHapticEffect::GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::~GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::start):
(WebCore::GameControllerHapticEffect::stop):
(WebCore::GameControllerHapticEffect::strongEffectFinishedPlaying):
(WebCore::GameControllerHapticEffect::weakEffectFinishedPlaying):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h: Copied from Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h.
(WebCore::GameControllerHapticEngines::strongEngine):
(WebCore::GameControllerHapticEngines::weakEngine):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm: Added.
(WebCore::GameControllerHapticEngines::create):
(WebCore::GameControllerHapticEngines::GameControllerHapticEngines):
(WebCore::GameControllerHapticEngines::playEffect):
(WebCore::GameControllerHapticEngines::stopEffects):
(WebCore::GameControllerHapticEngines::ensureStarted):
(WebCore::GameControllerHapticEngines::stop):

Canonical link: <a href="https://commits.webkit.org/258674@main">https://commits.webkit.org/258674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aac1aaef657945ecff1414ebf4e5b102608903d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111917 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2686 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94925 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108426 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5236 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45443 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7126 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3165 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->