### PR TITLE
Remove WebSocketEnabled & IsNSURLSessionWebSocketEnabled from DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2994,12 +2994,13 @@ IsNSURLSessionWebSocketEnabled:
   status: developer
   humanReadableName: "NSURLSession WebSocket"
   humanReadableDescription: "Use NSURLSession WebSocket API"
-  webcoreBinding: DeprecatedGlobalSettings
   condition: HAVE(NSURLSESSION_WEBSOCKET)
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
+      default: true
+    WebCore:
       default: true
 
 # FIXME: The 'Is' prefix is inconsistent with most other preferences and should be removed.
@@ -6887,6 +6888,20 @@ WebShareFileAPIEnabled:
       default: false
     WebCore:
       default: false
+
+WebSocketEnabled:
+  type: bool
+  status: embedder
+  defaultValue:
+    WebKitLegacy:
+      "PLATFORM(WATCHOS)": false
+      default: true
+    WebKit:
+      "PLATFORM(WATCHOS)": false
+      default: true
+    WebCore:
+      "PLATFORM(WATCHOS)": false
+      default: true
 
 WebXRAugmentedRealityModuleEnabled:
   type: bool

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -32,7 +32,6 @@
 #include "ThreadableWebSocketChannel.h"
 
 #include "ContentRuleListResults.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "FrameLoader.h"
@@ -56,7 +55,7 @@ Ref<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(Document& doc
 #if USE(CURL) || USE(SOUP)
     bool enabled = true;
 #elif HAVE(NSURLSESSION_WEBSOCKET)
-    bool enabled = DeprecatedGlobalSettings::isNSURLSessionWebSocketEnabled();
+    bool enabled = document.settings().isNSURLSessionWebSocketEnabled();
 #else
     bool enabled = false;
 #endif

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -36,7 +36,6 @@
 #include "CloseEvent.h"
 #include "ContentSecurityPolicy.h"
 #include "DOMWindow.h"
-#include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventListener.h"
@@ -355,7 +354,7 @@ ExceptionOr<void> WebSocket::send(const String& message)
     }
     // FIXME: WebSocketChannel also has a m_bufferedAmount. Remove that one. This one is the correct one accessed by JS.
 #if HAVE(NSURLSESSION_WEBSOCKET)
-    bool shouldSynchronouslyUpdateBufferedAmount = DeprecatedGlobalSettings::isNSURLSessionWebSocketEnabled();
+    bool shouldSynchronouslyUpdateBufferedAmount = scriptExecutionContext()->settingsValues().isNSURLSessionWebSocketEnabled;
 #elif PLATFORM(MAC)
     bool shouldSynchronouslyUpdateBufferedAmount = false;
 #else
@@ -380,7 +379,7 @@ ExceptionOr<void> WebSocket::send(ArrayBuffer& binaryData)
         return { };
     }
 #if HAVE(NSURLSESSION_WEBSOCKET)
-    bool shouldSynchronouslyUpdateBufferedAmount = DeprecatedGlobalSettings::isNSURLSessionWebSocketEnabled();
+    bool shouldSynchronouslyUpdateBufferedAmount = scriptExecutionContext()->settingsValues().isNSURLSessionWebSocketEnabled;
 #elif PLATFORM(MAC)
     bool shouldSynchronouslyUpdateBufferedAmount = false;
 #else
@@ -406,7 +405,7 @@ ExceptionOr<void> WebSocket::send(ArrayBufferView& arrayBufferView)
         return { };
     }
 #if HAVE(NSURLSESSION_WEBSOCKET)
-    bool shouldSynchronouslyUpdateBufferedAmount = DeprecatedGlobalSettings::isNSURLSessionWebSocketEnabled();
+    bool shouldSynchronouslyUpdateBufferedAmount = scriptExecutionContext()->settingsValues().isNSURLSessionWebSocketEnabled;
 #elif PLATFORM(MAC)
     bool shouldSynchronouslyUpdateBufferedAmount = false;
 #else
@@ -431,7 +430,7 @@ ExceptionOr<void> WebSocket::send(Blob& binaryData)
         return { };
     }
 #if HAVE(NSURLSESSION_WEBSOCKET)
-    bool shouldSynchronouslyUpdateBufferedAmount = DeprecatedGlobalSettings::isNSURLSessionWebSocketEnabled();
+    bool shouldSynchronouslyUpdateBufferedAmount = scriptExecutionContext()->settingsValues().isNSURLSessionWebSocketEnabled;
 #elif PLATFORM(MAC)
     bool shouldSynchronouslyUpdateBufferedAmount = false;
 #else

--- a/Source/WebCore/Modules/websockets/WebSocket.idl
+++ b/Source/WebCore/Modules/websockets/WebSocket.idl
@@ -34,7 +34,7 @@
 [
     ActiveDOMObject,
     Exposed=(Window,Worker),
-    EnabledByDeprecatedGlobalSetting=WebSocketEnabled
+    EnabledBySetting=WebSocketEnabled
 ] interface WebSocket : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional sequence<DOMString> protocols = []);
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, DOMString protocol);

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -42,9 +42,6 @@ namespace WebCore {
 
 DeprecatedGlobalSettings::DeprecatedGlobalSettings()
 {
-#if PLATFORM(WATCHOS)
-    m_isWebSocketEnabled = false;
-#endif
 #if USE(AVFOUNDATION)
     m_AVFoundationEnabled = true;
 #endif

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -91,9 +91,6 @@ public:
     static void setCustomPasteboardDataEnabled(bool isEnabled) { shared().m_isCustomPasteboardDataEnabled = isEnabled; }
     static bool customPasteboardDataEnabled() { return shared().m_isCustomPasteboardDataEnabled; }
 
-    static void setWebSocketEnabled(bool isEnabled) { shared().m_isWebSocketEnabled = isEnabled; }
-    static bool webSocketEnabled() { return shared().m_isWebSocketEnabled; }
-
     static bool fetchAPIKeepAliveEnabled() { return shared().m_fetchAPIKeepAliveEnabled; }
     static void setFetchAPIKeepAliveEnabled(bool isEnabled) { shared().m_fetchAPIKeepAliveEnabled = isEnabled; }
 
@@ -151,11 +148,6 @@ public:
     static void setPrivateClickMeasurementDebugModeEnabled(bool isEnabled) { shared().m_privateClickMeasurementDebugModeEnabled = isEnabled; }
     static bool privateClickMeasurementFraudPreventionEnabled() { return shared().m_privateClickMeasurementFraudPreventionEnabled; }
     static void setPrivateClickMeasurementFraudPreventionEnabled(bool isEnabled) { shared().m_privateClickMeasurementFraudPreventionEnabled = isEnabled; }
-
-#if HAVE(NSURLSESSION_WEBSOCKET)
-    static bool isNSURLSessionWebSocketEnabled() { return shared().m_isNSURLSessionWebSocketEnabled; }
-    static void setIsNSURLSessionWebSocketEnabled(bool isEnabled) { shared().m_isNSURLSessionWebSocketEnabled = isEnabled; }
-#endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     static void setIsAccessibilityIsolatedTreeEnabled(bool isEnabled) { shared().m_accessibilityIsolatedTree = isEnabled; }
@@ -241,7 +233,6 @@ private:
     bool m_isPaintTimingEnabled { false };
 
     bool m_isCustomPasteboardDataEnabled { false };
-    bool m_isWebSocketEnabled { true };
     bool m_fetchAPIKeepAliveEnabled { false };
     bool m_itpDebugMode { false };
     bool m_isRestrictedHTTPResponseAccess { true };
@@ -280,10 +271,6 @@ private:
     bool m_privateClickMeasurementFraudPreventionEnabled { true };
 #else
     bool m_privateClickMeasurementFraudPreventionEnabled { false };
-#endif
-
-#if HAVE(NSURLSESSION_WEBSOCKET)
-    bool m_isNSURLSessionWebSocketEnabled { false };
 #endif
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)


### PR DESCRIPTION
#### c3b5f312a71d8598ff1727d406a0782074fbd35f
<pre>
Remove WebSocketEnabled &amp; IsNSURLSessionWebSocketEnabled from DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250244">https://bugs.webkit.org/show_bug.cgi?id=250244</a>
rdar://103973264

Reviewed by Brent Fulgham and Tim Horton.

Use settingsValues and [EnabledBySetting].

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::create):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::send):
* Source/WebCore/Modules/websockets/WebSocket.idl:
* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::DeprecatedGlobalSettings):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setWebSocketEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::webSocketEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::isNSURLSessionWebSocketEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::setIsNSURLSessionWebSocketEnabled): Deleted.

scriptExecutionContext() should always exist given it is passed with the constructor as a reference.

Canonical link: <a href="https://commits.webkit.org/258602@main">https://commits.webkit.org/258602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb4d4e2dc846b375d216b76d663070254c11128e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111746 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2513 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108258 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89047 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2753 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5231 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29596 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45295 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91972 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5908 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20600 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->