### PR TITLE
[UI-side compositing] Some scrolling tests time out with UI-side compositing

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -73,7 +73,7 @@ window.UIHelper = class UIHelper {
     static async startMonitoringWheelEvents(...args)
     {
         eventSender.monitorWheelEvents(args);
-        await UIHelper.renderingUpdate();
+        await UIHelper.ensurePresentationUpdate();
     }
 
     static async mouseWheelScrollAt(x, y, beginX, beginY, deltaX, deltaY)
@@ -446,10 +446,8 @@ window.UIHelper = class UIHelper {
 
     static ensurePresentationUpdate()
     {
-        if (!this.isWebKit2()) {
-            testRunner.display();
-            return Promise.resolve();
-        }
+        if (!this.isWebKit2())
+            return UIHelper.renderingUpdate();
 
         return new Promise(resolve => {
             testRunner.runUIScript(`
@@ -461,10 +459,8 @@ window.UIHelper = class UIHelper {
 
     static ensureStablePresentationUpdate()
     {
-        if (!this.isWebKit2()) {
-            testRunner.display();
-            return Promise.resolve();
-        }
+        if (!this.isWebKit2())
+            return UIHelper.renderingUpdate();
 
         return new Promise(resolve => {
             testRunner.runUIScript(`


### PR DESCRIPTION
#### 0b9475d56e4239abc331fd2483e6572dd4ce124a
<pre>
[UI-side compositing] Some scrolling tests time out with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250248">https://bugs.webkit.org/show_bug.cgi?id=250248</a>
rdar://103974484

Reviewed by Tim Horton.

Tests using UIHelper.startMonitoringWheelEvents() still time out after 258483@main and 258549@main
because waiting for a rendering update in the web process before dispatching wheel events is not enough;
we need to wait for the UI process to commit the transaction that enables the wheel event monitor.

So in UIHelper.startMonitoringWheelEvents(), await a presentation update.

For WebKit1, UIHelper.ensurePresentationUpdate() needs to wait for a rendering update,
not just a display, otherwise NSView state may not have been updated yet (indicated by
failures in fast/scrolling/overflow-scroll-past-max.html).

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async startMonitoringWheelEvents):
(window.UIHelper.async ensurePresentationUpdate):
(window.UIHelper.async ensureStablePresentationUpdate):

Canonical link: <a href="https://commits.webkit.org/258670@main">https://commits.webkit.org/258670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b55e14338b5691f8519468965ddbd3ab2fff27f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111813 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172033 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2580 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109523 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37374 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5136 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25855 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2308 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45346 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5957 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7028 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->