### PR TITLE
Stop returning nullptr for system font keywords on non-font related properties

### DIFF
--- a/LayoutTests/fast/css/css-text-border-menu-expected.txt
+++ b/LayoutTests/fast/css/css-text-border-menu-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/css/css-text-border-menu.html
+++ b/LayoutTests/fast/css/css-text-border-menu.html
@@ -1,0 +1,12 @@
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    const div = document.createElement("div");
+    const elementStyle = div.style;
+    elementStyle.border = "menu";
+    cssText = elementStyle.cssText;
+}
+</script>
+<body onload="test()">
+<p>PASS if no crash</p>

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1139,7 +1139,7 @@ RefPtr<CSSValue> StyleProperties::getPropertyCSSValue(CSSPropertyID propertyID) 
     auto value = property.value();
     // System fonts are represented as CSSPrimitiveValue for various font subproperties, but these must serialize as the empty string.
     // It might be better to implement this as a special CSSValue type instead of turning them into null here.
-    if (property.id() != CSSPropertyFont && CSSPropertyParserHelpers::isSystemFontShorthand(valueID(value)))
+    if (property.shorthandID() == CSSPropertyFont && CSSPropertyParserHelpers::isSystemFontShorthand(valueID(value)))
         return nullptr;
     return value;
 }


### PR DESCRIPTION
#### db5cab0a4aaaf397271d4422ae417a6f39ea18cb
<pre>
Stop returning nullptr for system font keywords on non-font related properties

<a href="https://bugs.webkit.org/show_bug.cgi?id=250245">https://bugs.webkit.org/show_bug.cgi?id=250245</a>
rdar://103916548

Reviewed by Darin Adler and Tim Nguyen.

The code that is handling font: menu shouldn’t apply to non-font
properties.

* LayoutTests/fast/css/css-text-border-menu-expected.txt: Added.
* LayoutTests/fast/css/css-text-border-menu.html: Added.
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::getPropertyCSSValue const):

Canonical link: <a href="https://commits.webkit.org/258742@main">https://commits.webkit.org/258742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6f5b3d5e15a7f65e81e12d41adb3067e14dff9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111945 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172188 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2712 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109638 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9830 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37486 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5263 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2423 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6007 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7154 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->