### PR TITLE
REGRESSION: Horizontal scroll-to-end is very slow (and maybe shouldn't happen at all?)

### DIFF
--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -109,30 +109,32 @@ const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const K
         return { };
 
     // FIXME (bug 227459): This logic does not account for writing-mode.
-    auto granularity = [&] {
-        switch (key.value()) {
-        case KeyboardScrollingKey::LeftArrow:
-        case KeyboardScrollingKey::RightArrow:
-            return event.altKey() ? ScrollGranularity::Page : ScrollGranularity::Line;
-        case KeyboardScrollingKey::UpArrow:
-        case KeyboardScrollingKey::DownArrow:
-            if (event.metaKey())
-                return ScrollGranularity::Document;
-            if (event.altKey())
-                return ScrollGranularity::Page;
-            return ScrollGranularity::Line;
-        case KeyboardScrollingKey::Space:
-        case KeyboardScrollingKey::PageUp:
-        case KeyboardScrollingKey::PageDown:
+    switch (key.value()) {
+    case KeyboardScrollingKey::LeftArrow:
+    case KeyboardScrollingKey::RightArrow:
+        if (event.shiftKey() || event.metaKey())
+            return { };
+        if (event.altKey())
             return ScrollGranularity::Page;
-        case KeyboardScrollingKey::Home:
-        case KeyboardScrollingKey::End:
+        return ScrollGranularity::Line;
+    case KeyboardScrollingKey::UpArrow:
+    case KeyboardScrollingKey::DownArrow:
+        if (event.metaKey())
             return ScrollGranularity::Document;
-        };
-        RELEASE_ASSERT_NOT_REACHED();
-    }();
+        if (event.altKey())
+            return ScrollGranularity::Page;
+        return ScrollGranularity::Line;
+    case KeyboardScrollingKey::Space:
+    case KeyboardScrollingKey::PageUp:
+    case KeyboardScrollingKey::PageDown:
+        return ScrollGranularity::Page;
+    case KeyboardScrollingKey::Home:
+    case KeyboardScrollingKey::End:
+        return ScrollGranularity::Document;
+    };
 
-    return granularity;
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
 }
 
 float KeyboardScrollingAnimator::scrollDistance(ScrollDirection direction, ScrollGranularity granularity) const


### PR DESCRIPTION
#### 410bb5f43c2e76507d7ab0716bb5664b9b420c4d
<pre>
REGRESSION: Horizontal scroll-to-end is very slow (and maybe shouldn&apos;t happen at all?)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250251">https://bugs.webkit.org/show_bug.cgi?id=250251</a>
rdar://103969202

Reviewed by Simon Fraser.

This bug was happening because when modifier keys are applied to a key press,
AppKit sends a `keyDown` event to the UIProcess, but does not send a corresponding
`keyUp` event. This causes scrolling to never stop.

This PR changes this behavior so that no scrolling will happen with `Cmd+Left/Right arrow`,
`Shift+Left/Right arrow`, or `Cmd+Shift+Left/Right arrow`. This behavior is
better because these were never technically valid key combos in the first place,
and simply pressing the left or right arrow accomplishes the desired scrolling.
`Cmd+Left/Right arrow` also sometimes interferes with page back/forward keyboard
shortcuts, so this will avoid that as well.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::scrollGranularityForKeyboardEvent):

Canonical link: <a href="https://commits.webkit.org/258686@main">https://commits.webkit.org/258686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fb2ad9c474bef1bf1b8873d88ad78097d1fb225

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111912 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172135 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2681 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109613 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9805 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37465 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79208 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5231 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2401 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5973 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7121 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->