### PR TITLE
Replace use of WTF_ARRAY_LENGTH with std::size()

### DIFF
--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCoreJSBuiltins.h-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCoreJSBuiltins.h-result
@@ -341,7 +341,7 @@ SUPPRESS_ASAN void JSBuiltinInternalFunctions::initialize(JSDOMGlobalObject& glo
 #undef DECLARE_GLOBAL_STATIC
 #endif // ENABLE(TEST_XML_CASTING_TEST_SEPARATE)
     };
-    globalObject.addStaticGlobals(staticGlobals, WTF_ARRAY_LENGTH(staticGlobals));
+    globalObject.addStaticGlobals(staticGlobals, std::size(staticGlobals));
     UNUSED_PARAM(clientData);
 }
 

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_internals_wrapper_implementation.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_internals_wrapper_implementation.py
@@ -138,7 +138,7 @@ class BuiltinsInternalsWrapperImplementationGenerator(BuiltinsGenerator):
         for object in self.internals:
             lines.append(BuiltinsGenerator.wrap_with_guard(object.annotations.get('conditional'), self.property_macro(object)))
         lines.append("    };")
-        lines.append("    globalObject.addStaticGlobals(staticGlobals, WTF_ARRAY_LENGTH(staticGlobals));")
+        lines.append("    globalObject.addStaticGlobals(staticGlobals, std::size(staticGlobals));")
         lines.append("    UNUSED_PARAM(clientData);")
         return '\n'.join(lines)
 

--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -186,7 +186,7 @@ static LLIntOperations llintOperations()
             JSC_WASM_GATE_OPCODES(LLINT_RETURN_LOCATION)
         };
         operations = operationsStorage;
-        numberOfOperations = WTF_ARRAY_LENGTH(operationsStorage);
+        numberOfOperations = std::size(operationsStorage);
     });
     return { operations, numberOfOperations };
 }

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -242,7 +242,7 @@ void BackendDispatcher::sendPendingErrors()
         errorCode = std::get<0>(data);
         errorMessage = std::get<1>(data);
 
-        ASSERT_ARG(errorCode, (unsigned)errorCode < WTF_ARRAY_LENGTH(errorCodes));
+        ASSERT_ARG(errorCode, (unsigned)errorCode < std::size(errorCodes));
         ASSERT_ARG(errorCode, errorCodes[errorCode]);
 
         Ref<JSON::Object> error = JSON::Object::create();

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -849,7 +849,7 @@ static inline bool isASCIIOctalDigitOrSeparator(CharacterType character)
 static inline LChar singleEscape(int c)
 {
     if (c < 128) {
-        ASSERT(static_cast<size_t>(c) < WTF_ARRAY_LENGTH(singleCharacterEscapeValuesForASCII));
+        ASSERT(static_cast<size_t>(c) < std::size(singleCharacterEscapeValuesForASCII));
         return singleCharacterEscapeValuesForASCII[c];
     }
     return 0;

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -132,7 +132,7 @@ void IntlDisplayNames::initializeDisplayNames(JSGlobalObject* globalObject, JSVa
         UDISPCTX_NO_SUBSTITUTE,
     };
     m_localeCString = m_locale.utf8();
-    m_displayNames = std::unique_ptr<ULocaleDisplayNames, ULocaleDisplayNamesDeleter>(uldn_openForContext(m_localeCString.data(), contexts, WTF_ARRAY_LENGTH(contexts), &status));
+    m_displayNames = std::unique_ptr<ULocaleDisplayNames, ULocaleDisplayNamesDeleter>(uldn_openForContext(m_localeCString.data(), contexts, std::size(contexts), &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize DisplayNames"_s);
         return;

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -168,7 +168,7 @@ static unsigned computeCurrencyDigits(const String& currency)
         { "XOF", 0 },
         { "XPF", 0 }
     };
-    auto* currencyMinorUnit = tryBinarySearch<std::pair<const char*, unsigned>>(currencyMinorUnits, WTF_ARRAY_LENGTH(currencyMinorUnits), computeCurrencySortKey(currency), extractCurrencySortKey);
+    auto* currencyMinorUnit = tryBinarySearch<std::pair<const char*, unsigned>>(currencyMinorUnits, std::size(currencyMinorUnits), computeCurrencySortKey(currency), extractCurrencySortKey);
     if (currencyMinorUnit)
         return currencyMinorUnit->second;
     return 2;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -779,7 +779,7 @@ SUPPRESS_ASAN inline void JSGlobalObject::initStaticGlobals(VM& vm)
         GlobalPropertyInfo(vm.propertyNames->builtinNames().assertPrivateName(), JSFunction::create(vm, this, 1, String(), assertCall, ImplementationVisibility::Public), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
 #endif
     };
-    addStaticGlobals(staticGlobals, WTF_ARRAY_LENGTH(staticGlobals));
+    addStaticGlobals(staticGlobals, std::size(staticGlobals));
 }
 
 void JSGlobalObject::init(VM& vm)
@@ -2552,7 +2552,7 @@ SUPPRESS_ASAN void JSGlobalObject::exposeDollarVM(VM& vm)
     GlobalPropertyInfo extraStaticGlobals[] = {
         GlobalPropertyInfo(vm.propertyNames->builtinNames().dollarVMPrivateName(), dollarVM, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
     };
-    addStaticGlobals(extraStaticGlobals, WTF_ARRAY_LENGTH(extraStaticGlobals));
+    addStaticGlobals(extraStaticGlobals, std::size(extraStaticGlobals));
 
     putDirect(vm, Identifier::fromString(vm, "$vm"_s), dollarVM, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -165,14 +165,6 @@ inline size_t bitCount(uint64_t bits)
     return bitCount(static_cast<unsigned>(bits)) + bitCount(static_cast<unsigned>(bits >> 32));
 }
 
-// Macro that returns a compile time constant with the length of an array, but gives an error if passed a non-array.
-template<typename T, size_t Size> char (&ArrayLengthHelperFunction(T (&)[Size]))[Size];
-// GCC needs some help to deduce a 0 length array.
-#if COMPILER(GCC_COMPATIBLE)
-template<typename T> char (&ArrayLengthHelperFunction(T (&)[0]))[0];
-#endif
-#define WTF_ARRAY_LENGTH(array) sizeof(::WTF::ArrayLengthHelperFunction(array))
-
 inline constexpr bool isPowerOfTwo(size_t size) { return !(size & (size - 1)); }
 
 template<typename T> constexpr T mask(T value, uintptr_t mask)

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -234,33 +234,33 @@ public:
 
     UChar lastCharacter() const
     {
-        static_assert(WTF_ARRAY_LENGTH(m_priorContext) == 2, "UBreakIterator unexpected prior context length");
+        static_assert(priorContextCapacity == 2, "UBreakIterator unexpected prior context length");
         return m_priorContext[1];
     }
 
     UChar secondToLastCharacter() const
     {
-        static_assert(WTF_ARRAY_LENGTH(m_priorContext) == 2, "UBreakIterator unexpected prior context length");
+        static_assert(priorContextCapacity == 2, "UBreakIterator unexpected prior context length");
         return m_priorContext[0];
     }
 
     void setPriorContext(UChar last, UChar secondToLast)
     {
-        static_assert(WTF_ARRAY_LENGTH(m_priorContext) == 2, "UBreakIterator unexpected prior context length");
+        static_assert(priorContextCapacity == 2, "UBreakIterator unexpected prior context length");
         m_priorContext[0] = secondToLast;
         m_priorContext[1] = last;
     }
 
     void updatePriorContext(UChar last)
     {
-        static_assert(WTF_ARRAY_LENGTH(m_priorContext) == 2, "UBreakIterator unexpected prior context length");
+        static_assert(priorContextCapacity == 2, "UBreakIterator unexpected prior context length");
         m_priorContext[0] = m_priorContext[1];
         m_priorContext[1] = last;
     }
 
     void resetPriorContext()
     {
-        static_assert(WTF_ARRAY_LENGTH(m_priorContext) == 2, "UBreakIterator unexpected prior context length");
+        static_assert(priorContextCapacity == 2, "UBreakIterator unexpected prior context length");
         m_priorContext[0] = 0;
         m_priorContext[1] = 0;
     }
@@ -268,7 +268,7 @@ public:
     unsigned priorContextLength() const
     {
         unsigned priorContextLength = 0;
-        static_assert(WTF_ARRAY_LENGTH(m_priorContext) == 2, "UBreakIterator unexpected prior context length");
+        static_assert(priorContextCapacity == 2, "UBreakIterator unexpected prior context length");
         if (m_priorContext[1]) {
             ++priorContextLength;
             if (m_priorContext[0])

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -206,8 +206,8 @@ static String cachedStorageDirectory(DWORD pathIdentifier)
 static String generateTemporaryPath(const Function<bool(const String&)>& action)
 {
     wchar_t tempPath[MAX_PATH];
-    int tempPathLength = ::GetTempPathW(WTF_ARRAY_LENGTH(tempPath), tempPath);
-    if (tempPathLength <= 0 || tempPathLength > WTF_ARRAY_LENGTH(tempPath))
+    int tempPathLength = ::GetTempPathW(std::size(tempPath), tempPath);
+    if (tempPathLength <= 0 || tempPathLength > std::size(tempPath))
         return String();
 
     String proposedPath;
@@ -222,7 +222,7 @@ static String generateTemporaryPath(const Function<bool(const String&)>& action)
         for (int i = 0; i < randomPartLength; ++i)
             tempFile[i] = validChars[tempFile[i] % (sizeof(validChars) - 1)];
 
-        ASSERT(wcslen(tempFile) == WTF_ARRAY_LENGTH(tempFile) - 1);
+        ASSERT(wcslen(tempFile) == std::size(tempFile) - 1);
 
         proposedPath = pathByAppendingComponent(String(tempPath), String(tempFile));
         if (proposedPath.isEmpty())

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -69,7 +69,7 @@ String convertEnumerationToString(MediaSourcePrivate::AddStatus enumerationValue
     static_assert(static_cast<size_t>(MediaSourcePrivate::AddStatus::Ok) == 0, "MediaSourcePrivate::AddStatus::Ok is not 0 as expected");
     static_assert(static_cast<size_t>(MediaSourcePrivate::AddStatus::NotSupported) == 1, "MediaSourcePrivate::AddStatus::NotSupported is not 1 as expected");
     static_assert(static_cast<size_t>(MediaSourcePrivate::AddStatus::ReachedIdLimit) == 2, "MediaSourcePrivate::AddStatus::ReachedIdLimit is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -83,7 +83,7 @@ String convertEnumerationToString(MediaSourcePrivate::EndOfStreamStatus enumerat
     static_assert(static_cast<size_t>(MediaSourcePrivate::EndOfStreamStatus::EosNoError) == 0, "MediaSourcePrivate::EndOfStreamStatus::EosNoError is not 0 as expected");
     static_assert(static_cast<size_t>(MediaSourcePrivate::EndOfStreamStatus::EosNetworkError) == 1, "MediaSourcePrivate::EndOfStreamStatus::EosNetworkError is not 1 as expected");
     static_assert(static_cast<size_t>(MediaSourcePrivate::EndOfStreamStatus::EosDecodeError) == 2, "MediaSourcePrivate::EndOfStreamStatus::EosDecodeError is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.cpp
@@ -54,7 +54,7 @@ String convertEnumerationToString(SpeechRecognitionUpdateType enumerationValue)
     static_assert(static_cast<size_t>(SpeechRecognitionUpdateType::NoMatch) == 8, "SpeechRecognitionUpdateType::NoMatch is not 9 as expected");
     static_assert(static_cast<size_t>(SpeechRecognitionUpdateType::Error) == 9, "SpeechRecognitionUpdateType::Error is not 10 as expected");
     static_assert(static_cast<size_t>(SpeechRecognitionUpdateType::End) == 10, "SpeechRecognitionUpdateType::End is not 11 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -94,7 +94,7 @@ String convertEnumerationToString(AudioNode::NodeType enumerationValue)
     static_assert(static_cast<size_t>(AudioNode::NodeTypeIIRFilter) == 19, "AudioNode::NodeTypeIIRFilter is not 19 as expected");
     static_assert(static_cast<size_t>(AudioNode::NodeTypeWorklet) == 20, "AudioNode::NodeTypeWorklet is not 20 as expected");
 
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -165,7 +165,7 @@ SQLTransaction::StateFunction SQLTransaction::stateFunctionFor(SQLTransactionSta
         &SQLTransaction::deliverSuccessCallback           // 12.
     };
 
-    ASSERT(WTF_ARRAY_LENGTH(stateFunctions) == static_cast<int>(SQLTransactionState::NumberOfStates));
+    ASSERT(std::size(stateFunctions) == static_cast<int>(SQLTransactionState::NumberOfStates));
     ASSERT(state < SQLTransactionState::NumberOfStates);
 
     return stateFunctions[static_cast<int>(state)];

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
@@ -417,7 +417,7 @@ SQLTransactionBackend::StateFunction SQLTransactionBackend::stateFunctionFor(SQL
         &SQLTransactionBackend::unreachableState             // 12. deliverSuccessCallback
     };
 
-    ASSERT(WTF_ARRAY_LENGTH(stateFunctions) == static_cast<int>(SQLTransactionState::NumberOfStates));
+    ASSERT(std::size(stateFunctions) == static_cast<int>(SQLTransactionState::NumberOfStates));
     ASSERT(state < SQLTransactionState::NumberOfStates);
 
     return stateFunctions[static_cast<int>(state)];

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -68,7 +68,7 @@ DECLARE_ALIASES(x_mac_centraleurroman, "windows-10029", "x-mac-ce", "macce", "ma
 DECLARE_ALIASES(x_mac_turkish, "windows-10081", "mactr", "x-MacTurkish");
 
 #define DECLARE_ENCODING_NAME(encoding, alias_array) \
-    { encoding, WTF_ARRAY_LENGTH(alias_array##_aliases), alias_array##_aliases }
+    { encoding, std::size(alias_array##_aliases), alias_array##_aliases }
 
 #define DECLARE_ENCODING_NAME_NO_ALIASES(encoding) \
     { encoding, 0, nullptr }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2491,7 +2491,7 @@ static void initializeRoleMap()
 
     gAriaRoleMap = new ARIARoleMap;
     gAriaReverseRoleMap = new ARIAReverseRoleMap;
-    size_t roleLength = WTF_ARRAY_LENGTH(roles);
+    size_t roleLength = std::size(roles);
     for (size_t i = 0; i < roleLength; ++i) {
         gAriaRoleMap->set(roles[i].ariaRole, roles[i].webcoreRole);
         gAriaReverseRoleMap->set(static_cast<int>(roles[i].webcoreRole), roles[i].ariaRole);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -1095,7 +1095,7 @@ static AccessibilitySearchKeyMap* createAccessibilitySearchKeyMap()
     };
     
     AccessibilitySearchKeyMap* searchKeyMap = new AccessibilitySearchKeyMap;
-    for (size_t i = 0; i < WTF_ARRAY_LENGTH(searchKeys); i++)
+    for (size_t i = 0; i < std::size(searchKeys); i++)
         searchKeyMap->set(searchKeys[i].key, searchKeys[i].value);
     
     return searchKeyMap;

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3603,7 +3603,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerMid, &SVGRenderStyle::markerMidResource, &SVGRenderStyle::setMarkerMidResource),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerStart, &SVGRenderStyle::markerStartResource, &SVGRenderStyle::setMarkerStartResource)
     };
-    const unsigned animatableLonghandPropertiesCount = WTF_ARRAY_LENGTH(animatableLonghandPropertyWrappers);
+    const unsigned animatableLonghandPropertiesCount = std::size(animatableLonghandPropertyWrappers);
 
     static const CSSPropertyID animatableShorthandProperties[] = {
         CSSPropertyAll,
@@ -3640,7 +3640,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         CSSPropertyFontSynthesis,
         CSSPropertyContainIntrinsicSize
     };
-    const unsigned animatableShorthandPropertiesCount = WTF_ARRAY_LENGTH(animatableShorthandProperties);
+    const unsigned animatableShorthandPropertiesCount = std::size(animatableShorthandProperties);
 
     // Make sure unused slots have a value
     for (int i = 0; i < numCSSProperties; ++i)

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -283,7 +283,7 @@ SUPPRESS_ASAN void JSDOMGlobalObject::addBuiltinGlobals(VM& vm)
         JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.getInternalWritableStreamPrivateName(), JSFunction::create(vm, this, 1, String(), getInternalWritableStream, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.createWritableStreamFromInternalPrivateName(), JSFunction::create(vm, this, 1, String(), createWritableStreamFromInternal, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
     };
-    addStaticGlobals(staticGlobals, WTF_ARRAY_LENGTH(staticGlobals));
+    addStaticGlobals(staticGlobals, std::size(staticGlobals));
 }
 
 void JSDOMGlobalObject::finishCreation(VM& vm)

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -120,7 +120,7 @@ SUPPRESS_ASAN inline void JSDOMWindowBase::initStaticGlobals(JSC::VM& vm)
         GlobalPropertyInfo(builtinNames.windowPublicName(), m_proxy.get(), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
     };
 
-    addStaticGlobals(staticGlobals, WTF_ARRAY_LENGTH(staticGlobals));
+    addStaticGlobals(staticGlobals, std::size(staticGlobals));
 }
 
 void JSDOMWindowBase::finishCreation(VM& vm, JSWindowProxy* proxy)

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2388,7 +2388,7 @@ sub GenerateEnumerationImplementationContent
         $result .= "    static_assert(static_cast<size_t>(${className}::$enumerationValueName) == $index, \"${className}::$enumerationValueName is not $index as expected\");\n";
         $index++;
     }
-    $result .= "    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));\n";
+    $result .= "    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));\n";
     $result .= "    return values[static_cast<size_t>(enumerationValue)];\n";
     $result .= "}\n\n";
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -59,7 +59,7 @@ String convertEnumerationToString(TestCallbackInterface::Enum enumerationValue)
     };
     static_assert(static_cast<size_t>(TestCallbackInterface::Enum::Value1) == 0, "TestCallbackInterface::Enum::Value1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestCallbackInterface::Enum::Value2) == 1, "TestCallbackInterface::Enum::Value2 is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
@@ -38,7 +38,7 @@ String convertEnumerationToString(TestDefaultToJSONEnum enumerationValue)
     };
     static_assert(static_cast<size_t>(TestDefaultToJSONEnum::EnumValue1) == 0, "TestDefaultToJSONEnum::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestDefaultToJSONEnum::EnumValue2) == 1, "TestDefaultToJSONEnum::EnumValue2 is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -140,7 +140,7 @@ String convertEnumerationToString(TestObj::EnumType enumerationValue)
     static_assert(static_cast<size_t>(TestObj::EnumType::EnumValue1) == 1, "TestObj::EnumType::EnumValue1 is not 1 as expected");
     static_assert(static_cast<size_t>(TestObj::EnumType::EnumValue2) == 2, "TestObj::EnumType::EnumValue2 is not 2 as expected");
     static_assert(static_cast<size_t>(TestObj::EnumType::EnumValue3) == 3, "TestObj::EnumType::EnumValue3 is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -182,7 +182,7 @@ String convertEnumerationToString(TestObj::EnumTrailingComma enumerationValue)
     };
     static_assert(static_cast<size_t>(TestObj::EnumTrailingComma::EnumValue1) == 0, "TestObj::EnumTrailingComma::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestObj::EnumTrailingComma::EnumValue2) == 1, "TestObj::EnumTrailingComma::EnumValue2 is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -225,7 +225,7 @@ String convertEnumerationToString(TestObj::Optional enumerationValue)
     static_assert(static_cast<size_t>(TestObj::Optional::OptionalValue1) == 1, "TestObj::Optional::OptionalValue1 is not 1 as expected");
     static_assert(static_cast<size_t>(TestObj::Optional::OptionalValue2) == 2, "TestObj::Optional::OptionalValue2 is not 2 as expected");
     static_assert(static_cast<size_t>(TestObj::Optional::OptionalValue3) == 3, "TestObj::Optional::OptionalValue3 is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -267,7 +267,7 @@ String convertEnumerationToString(AlternateEnumName enumerationValue)
     };
     static_assert(static_cast<size_t>(AlternateEnumName::EnumValue1) == 0, "AlternateEnumName::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(AlternateEnumName::EnumValue2) == 1, "AlternateEnumName::EnumValue2 is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -306,7 +306,7 @@ String convertEnumerationToString(TestObj::EnumA enumerationValue)
         MAKE_STATIC_STRING_IMPL("A"),
     };
     static_assert(static_cast<size_t>(TestObj::EnumA::A) == 0, "TestObj::EnumA::A is not 0 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -346,7 +346,7 @@ String convertEnumerationToString(TestObj::EnumB enumerationValue)
         MAKE_STATIC_STRING_IMPL("B"),
     };
     static_assert(static_cast<size_t>(TestObj::EnumB::B) == 0, "TestObj::EnumB::B is not 0 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -386,7 +386,7 @@ String convertEnumerationToString(TestObj::EnumC enumerationValue)
         MAKE_STATIC_STRING_IMPL("C"),
     };
     static_assert(static_cast<size_t>(TestObj::EnumC::C) == 0, "TestObj::EnumC::C is not 0 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -426,7 +426,7 @@ String convertEnumerationToString(TestObj::Kind enumerationValue)
     };
     static_assert(static_cast<size_t>(TestObj::Kind::Quick) == 0, "TestObj::Kind::Quick is not 0 as expected");
     static_assert(static_cast<size_t>(TestObj::Kind::Dead) == 1, "TestObj::Kind::Dead is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -465,7 +465,7 @@ String convertEnumerationToString(TestObj::Size enumerationValue)
     };
     static_assert(static_cast<size_t>(TestObj::Size::Small) == 0, "TestObj::Size::Small is not 0 as expected");
     static_assert(static_cast<size_t>(TestObj::Size::MuchMuchLarger) == 1, "TestObj::Size::MuchMuchLarger is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -504,7 +504,7 @@ String convertEnumerationToString(TestObj::Confidence enumerationValue)
     };
     static_assert(static_cast<size_t>(TestObj::Confidence::High) == 0, "TestObj::Confidence::High is not 0 as expected");
     static_assert(static_cast<size_t>(TestObj::Confidence::KindaLow) == 1, "TestObj::Confidence::KindaLow is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -339,7 +339,7 @@ String convertEnumerationToString(TestStandaloneDictionary::EnumInStandaloneDict
     };
     static_assert(static_cast<size_t>(TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1) == 0, "TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue2) == 1, "TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue2 is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -41,7 +41,7 @@ String convertEnumerationToString(TestStandaloneEnumeration enumerationValue)
     };
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue1) == 0, "TestStandaloneEnumeration::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue2) == 1, "TestStandaloneEnumeration::EnumValue2 is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1601,7 +1601,7 @@ void MutableStyleProperties::clear()
     m_propertyVector.clear();
 }
 
-const unsigned numBlockProperties = WTF_ARRAY_LENGTH(blockProperties);
+const unsigned numBlockProperties = std::size(blockProperties);
 
 Ref<MutableStyleProperties> StyleProperties::copyBlockProperties() const
 {

--- a/Source/WebCore/cssjit/RegisterAllocator.h
+++ b/Source/WebCore/cssjit/RegisterAllocator.h
@@ -94,8 +94,8 @@ static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
 #else
 #error RegisterAllocator has no defined registers for the architecture.
 #endif
-static const unsigned calleeSavedRegisterCount = WTF_ARRAY_LENGTH(calleeSavedRegisters);
-static const unsigned maximumRegisterCount = calleeSavedRegisterCount + WTF_ARRAY_LENGTH(callerSavedRegisters);
+static const unsigned calleeSavedRegisterCount = std::size(calleeSavedRegisters);
+static const unsigned maximumRegisterCount = calleeSavedRegisterCount + std::size(callerSavedRegisters);
 
 typedef Vector<JSC::MacroAssembler::RegisterID, maximumRegisterCount> RegisterVector;
 
@@ -157,9 +157,9 @@ public:
     {
 #ifdef NDEBUG
         UNUSED_PARAM(count);
-        unsigned numberToAllocate = WTF_ARRAY_LENGTH(callerSavedRegisters);
+        unsigned numberToAllocate = std::size(callerSavedRegisters);
 #else
-        unsigned numberToAllocate = std::min<unsigned>(WTF_ARRAY_LENGTH(callerSavedRegisters), count);
+        unsigned numberToAllocate = std::min<unsigned>(std::size(callerSavedRegisters), count);
 #endif
         for (unsigned i = 0; i < numberToAllocate; ++i)
             m_registers.append(callerSavedRegisters[i]);
@@ -168,7 +168,7 @@ public:
 
     const Vector<JSC::MacroAssembler::RegisterID, calleeSavedRegisterCount>& reserveCalleeSavedRegisters(unsigned count)
     {
-        RELEASE_ASSERT(count <= WTF_ARRAY_LENGTH(calleeSavedRegisters));
+        RELEASE_ASSERT(count <= std::size(calleeSavedRegisters));
         RELEASE_ASSERT(!m_reservedCalleeSavedRegisters.size());
         for (unsigned i = 0; i < count; ++i) {
             JSC::MacroAssembler::RegisterID registerId = calleeSavedRegisters[i];

--- a/Source/WebCore/dom/DOMException.cpp
+++ b/Source/WebCore/dom/DOMException.cpp
@@ -70,11 +70,11 @@ static const DOMException::Description descriptions[] = {
     { "NotAllowedError"_s, "The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission."_s, 0 }
 };
 static_assert(!IndexSizeError, "This table needs to be kept in sync with DOMException names in ExceptionCode enumeration");
-static_assert(NotAllowedError == WTF_ARRAY_LENGTH(descriptions) - 1, "This table needs to be kept in sync with DOMException names in ExceptionCode enumeration");
+static_assert(NotAllowedError == std::size(descriptions) - 1, "This table needs to be kept in sync with DOMException names in ExceptionCode enumeration");
 
 auto DOMException::description(ExceptionCode ec) -> const Description&
 {
-    if (ec < WTF_ARRAY_LENGTH(descriptions))
+    if (ec < std::size(descriptions))
         return descriptions[ec];
 
     static const Description emptyDescription { { }, { }, 0 };

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -89,9 +89,9 @@ static inline AtomString convertPropertyNameToAttributeName(const StringImpl& na
     Vector<CharacterType, 32> buffer;
 
     unsigned length = name.length();
-    buffer.reserveInitialCapacity(WTF_ARRAY_LENGTH(dataPrefix) + length);
+    buffer.reserveInitialCapacity(std::size(dataPrefix) + length);
 
-    buffer.append(dataPrefix, WTF_ARRAY_LENGTH(dataPrefix));
+    buffer.append(dataPrefix, std::size(dataPrefix));
 
     const CharacterType* characters = name.characters<CharacterType>();
     for (unsigned i = 0; i < length; ++i) {

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -98,7 +98,7 @@ static const CSSPropertyID editingProperties[] = {
     CSSPropertyTextDecorationLine,
 };
 
-const unsigned numAllEditingProperties = WTF_ARRAY_LENGTH(editingProperties);
+const unsigned numAllEditingProperties = std::size(editingProperties);
 const unsigned numInheritableEditingProperties = numAllEditingProperties - 2;
 
 enum EditingPropertiesToInclude { OnlyInheritableEditingProperties, AllEditingProperties };
@@ -820,7 +820,7 @@ TriState EditingStyle::triStateOfStyle(T& styleToCompare, ShouldIgnoreTextOnlyPr
     auto difference = getPropertiesNotIn(*m_mutableStyle, styleToCompare);
 
     if (shouldIgnoreTextOnlyProperties == IgnoreTextOnlyProperties)
-        difference->removePropertiesInSet(textOnlyProperties, WTF_ARRAY_LENGTH(textOnlyProperties));
+        difference->removePropertiesInSet(textOnlyProperties, std::size(textOnlyProperties));
 
     if (difference->isEmpty())
         return TriState::True;

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -164,7 +164,7 @@ static inline void appendCharactersReplacingEntitiesInternal(StringBuilder& resu
     size_t positionAfterLastEntity = 0;
     for (size_t i = 0; i < length; ++i) {
         CharacterType character = text[i];
-        uint8_t substitution = character < WTF_ARRAY_LENGTH(entityMap) ? entityMap[character] : static_cast<uint8_t>(EntitySubstitutionNullIndex);
+        uint8_t substitution = character < std::size(entityMap) ? entityMap[character] : static_cast<uint8_t>(EntitySubstitutionNullIndex);
         if (UNLIKELY(substitution != EntitySubstitutionNullIndex) && entitySubstitutionList[substitution].mask & entityMask) {
             result.appendSubstring(source, offset + positionAfterLastEntity, i - positionAfterLastEntity);
             result.appendCharacters(entitySubstitutionList[substitution].characters, entitySubstitutionList[substitution].length);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -245,7 +245,7 @@ String convertEnumerationToString(HTMLMediaElement::ReadyState enumerationValue)
     static_assert(static_cast<size_t>(HTMLMediaElementEnums::HAVE_CURRENT_DATA) == 2, "HTMLMediaElementEnums::HAVE_CURRENT_DATA is not 2 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElementEnums::HAVE_FUTURE_DATA) == 3, "HTMLMediaElementEnums::HAVE_FUTURE_DATA is not 3 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElementEnums::HAVE_ENOUGH_DATA) == 4, "HTMLMediaElementEnums::HAVE_ENOUGH_DATA is not 4 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -261,7 +261,7 @@ String convertEnumerationToString(HTMLMediaElement::NetworkState enumerationValu
     static_assert(static_cast<size_t>(HTMLMediaElementEnums::NETWORK_IDLE) == 1, "HTMLMediaElementEnums::NETWORK_IDLE is not 1 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElementEnums::NETWORK_LOADING) == 2, "HTMLMediaElementEnums::NETWORK_LOADING is not 2 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElementEnums::NETWORK_NO_SOURCE) == 3, "HTMLMediaElementEnums::NETWORK_NO_SOURCE is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -277,7 +277,7 @@ String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState e
     static_assert(static_cast<size_t>(HTMLMediaElement::AutoplayEventPlaybackState::PreventedAutoplay) == 1, "AutoplayEventPlaybackState::PreventedAutoplay is not 1 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElement::AutoplayEventPlaybackState::StartedWithUserGesture) == 2, "AutoplayEventPlaybackState::StartedWithUserGesture is not 2 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElement::AutoplayEventPlaybackState::StartedWithoutUserGesture) == 3, "AutoplayEventPlaybackState::StartedWithoutUserGesture is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -289,7 +289,7 @@ String convertEnumerationToString(HTMLMediaElement::TextTrackVisibilityCheckType
     };
     static_assert(static_cast<size_t>(HTMLMediaElement::TextTrackVisibilityCheckType::CheckTextTrackVisibility) == 0, "TextTrackVisibilityCheckType::CheckTextTrackVisibility is not 0 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElement::TextTrackVisibilityCheckType::AssumeTextTrackVisibilityChanged) == 1, "TextTrackVisibilityCheckType::AssumeTextTrackVisibilityChanged is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -305,7 +305,7 @@ String convertEnumerationToString(HTMLMediaElement::SpeechSynthesisState enumera
     static_assert(static_cast<size_t>(HTMLMediaElement::SpeechSynthesisState::Speaking) == 1, "SpeechSynthesisState::Speaking is not 1 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElement::SpeechSynthesisState::CompletingExtendedDescription) == 2, "SpeechSynthesisState::CompletingExtendedDescription is not 2 as expected");
     static_assert(static_cast<size_t>(HTMLMediaElement::SpeechSynthesisState::Paused) == 3, "SpeechSynthesisState::Paused is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1311,7 +1311,7 @@ String convertEnumerationToString(const MediaPlaybackDenialReason enumerationVal
     static_assert(static_cast<size_t>(MediaPlaybackDenialReason::FullscreenRequired) == 1, "MediaPlaybackDenialReason::FullscreenRequired is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlaybackDenialReason::PageConsentRequired) == 2, "MediaPlaybackDenialReason::PageConsentRequired is not 2 as expected");
     static_assert(static_cast<size_t>(MediaPlaybackDenialReason::InvalidState) == 3, "MediaPlaybackDenialReason::InvalidState is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -356,7 +356,7 @@ private:
 };
 
 #define ADD_VALUES_TO_SET(set, arr) \
-    set.add(arr, arr + WTF_ARRAY_LENGTH(arr))
+    set.add(arr, arr + std::size(arr))
 
 InspectorScopedShaderProgramHighlight::InspectorScopedShaderProgramHighlight(WebGLRenderingContextBase& context, WebGLProgram* program)
     : m_context(context)

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -74,12 +74,12 @@ constexpr double DEFAULTCAPTIONFONTSIZEPERCENTAGE = 5;
 static const CSSValueID displayWritingModeMap[] = {
     CSSValueHorizontalTb, CSSValueVerticalRl, CSSValueVerticalLr
 };
-static_assert(WTF_ARRAY_LENGTH(displayWritingModeMap) == VTTCue::NumberOfWritingDirections, "displayWritingModeMap has wrong size");
+static_assert(std::size(displayWritingModeMap) == VTTCue::NumberOfWritingDirections, "displayWritingModeMap has wrong size");
 
 static const CSSValueID displayAlignmentMap[] = {
     CSSValueStart, CSSValueCenter, CSSValueEnd, CSSValueLeft, CSSValueRight
 };
-static_assert(WTF_ARRAY_LENGTH(displayAlignmentMap) == VTTCue::NumberOfAlignments, "displayAlignmentMap has wrong size");
+static_assert(std::size(displayAlignmentMap) == VTTCue::NumberOfAlignments, "displayAlignmentMap has wrong size");
 
 static const String& startKeyword()
 {

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -81,7 +81,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
   {
     static const char *month_names = "JanFebMarAprMayJunJulAugSepOctNovDec";
     const char *tokens[16]; /* 16 is more than enough */
-    unsigned int toklen[WTF_ARRAY_LENGTH(tokens)];
+    unsigned int toklen[std::size(tokens)];
     unsigned int linelen_sans_wsp;  // line length sans whitespace
     unsigned int numtoks = 0;
     unsigned int tokmarker = 0; /* extra info for lstyle handler */
@@ -97,7 +97,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
     }
 
     unsigned int pos = 0;
-    while (pos < linelen && numtoks < WTF_ARRAY_LENGTH(tokens))
+    while (pos < linelen && numtoks < std::size(tokens))
     {
       while (pos < linelen && 
             (line[pos] == ' ' || line[pos] == '\t' || line[pos] == '\r'))
@@ -120,7 +120,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
       return ParsingFailed(state);
 
     linelen_sans_wsp = &(tokens[numtoks-1][toklen[numtoks-1]]) - tokens[0];
-    if (numtoks == WTF_ARRAY_LENGTH(tokens))
+    if (numtoks == std::size(tokens))
     {
       pos = linelen;
       while (pos > 0 && (line[pos-1] == ' ' || line[pos-1] == '\t'))

--- a/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
@@ -1153,7 +1153,7 @@ std::optional<Property> MathMLOperatorDictionary::search(UChar32 character, Form
 
 bool MathMLOperatorDictionary::isVertical(UChar32 textContent)
 {
-    return !tryBinarySearch<const UChar32, UChar32>(horizontalOperators, WTF_ARRAY_LENGTH(horizontalOperators), textContent, ExtractKeyHorizontal);
+    return !tryBinarySearch<const UChar32, UChar32>(horizontalOperators, std::size(horizontalOperators), textContent, ExtractKeyHorizontal);
 }
 
 }

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -272,7 +272,7 @@ static void showText(CGContextRef context, float x, float y, CGColorRef color, c
     auto font = adoptCF(CTFontCreateWithName(fontName, fontSize, &matrix));
     CFTypeRef keys[] = { kCTFontAttributeName, kCTForegroundColorFromContextAttributeName };
     CFTypeRef values[] = { font.get(), kCFBooleanTrue };
-    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CString cstr = text.ascii();
     auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, cstr.dataAsUInt8Ptr(), cstr.length(), kCFStringEncodingASCII, false, kCFAllocatorNull));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -309,7 +309,7 @@ Node* Frame::qualifyingNodeAtViewportLocation(const FloatPoint& viewportLocation
         };
 
         Node* originalApproximateNode = approximateNode;
-        for (unsigned n = 0; n < WTF_ARRAY_LENGTH(testOffsets); n += 2) {
+        for (unsigned n = 0; n < std::size(testOffsets); n += 2) {
             IntSize testOffset(testOffsets[n] * searchRadius, testOffsets[n + 1] * searchRadius);
             IntPoint testPoint = testCenter + testOffset;
 
@@ -352,7 +352,7 @@ Node* Frame::qualifyingNodeAtViewportLocation(const FloatPoint& viewportLocation
         IntRect testRect(testCenter, IntSize());
         testRect.inflate(searchRadius);
         int currentTestRadius = 0;
-        for (unsigned n = 0; n < WTF_ARRAY_LENGTH(testOffsets); n += 2) {
+        for (unsigned n = 0; n < std::size(testOffsets); n += 2) {
             IntSize testOffset(testOffsets[n] * searchRadius, testOffsets[n + 1] * searchRadius);
             IntPoint testPoint = testCenter + testOffset;
             int testRadius = std::max(abs(testOffset.width()), abs(testOffset.height()));

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -265,7 +265,7 @@ String convertEnumerationToString(RouteSharingPolicy enumerationValue)
     static_assert(static_cast<size_t>(RouteSharingPolicy::LongFormAudio) == 1, "RouteSharingPolicy::LongFormAudio is not 1 as expected");
     static_assert(static_cast<size_t>(RouteSharingPolicy::Independent) == 2, "RouteSharingPolicy::Independent is not 2 as expected");
     static_assert(static_cast<size_t>(RouteSharingPolicy::LongFormVideo) == 3, "RouteSharingPolicy::LongFormVideo is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -287,7 +287,7 @@ String convertEnumerationToString(AudioSession::CategoryType enumerationValue)
     static_assert(static_cast<size_t>(AudioSession::CategoryType::RecordAudio) == 4, "AudioSession::CategoryType::RecordAudio is not 4 as expected");
     static_assert(static_cast<size_t>(AudioSession::CategoryType::PlayAndRecord) == 5, "AudioSession::CategoryType::PlayAndRecord is not 5 as expected");
     static_assert(static_cast<size_t>(AudioSession::CategoryType::AudioProcessing) == 6, "AudioSession::CategoryType::AudioProcessing is not 6 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -301,7 +301,7 @@ String convertEnumerationToString(AudioSessionRoutingArbitrationClient::RoutingA
     static_assert(!static_cast<size_t>(AudioSessionRoutingArbitrationClient::RoutingArbitrationError::None), "AudioSessionRoutingArbitrationClient::RoutingArbitrationError::None is not 0 as expected");
     static_assert(static_cast<size_t>(AudioSessionRoutingArbitrationClient::RoutingArbitrationError::Failed), "AudioSessionRoutingArbitrationClient::RoutingArbitrationError::Failed is not 1 as expected");
     static_assert(static_cast<size_t>(AudioSessionRoutingArbitrationClient::RoutingArbitrationError::Cancelled), "AudioSessionRoutingArbitrationClient::RoutingArbitrationError::Cancelled is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -313,7 +313,7 @@ String convertEnumerationToString(AudioSessionRoutingArbitrationClient::DefaultR
     };
     static_assert(!static_cast<bool>(AudioSessionRoutingArbitrationClient::DefaultRouteChanged::No), "AudioSessionRoutingArbitrationClient::DefaultRouteChanged::No is not false as expected");
     static_assert(static_cast<bool>(AudioSessionRoutingArbitrationClient::DefaultRouteChanged::Yes), "AudioSessionRoutingArbitrationClient::DefaultRouteChanged::Yes is not true as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -52,7 +52,7 @@ String convertEnumerationToString(PlatformMediaSession::State state)
     static_assert(static_cast<size_t>(PlatformMediaSession::Playing) == 2, "PlatformMediaSession::Playing is not 2 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::Paused) == 3, "PlatformMediaSession::Paused is not 3 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::Interrupted) == 4, "PlatformMediaSession::Interrupted is not 4 as expected");
-    ASSERT(static_cast<size_t>(state) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(state) < std::size(values));
     return values[static_cast<size_t>(state)];
 }
 
@@ -76,7 +76,7 @@ String convertEnumerationToString(PlatformMediaSession::InterruptionType type)
     static_assert(static_cast<size_t>(PlatformMediaSession::InvisibleAutoplay) == 5, "PlatformMediaSession::InvisibleAutoplay is not 5 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::ProcessInactive) == 6, "PlatformMediaSession::ProcessInactive is not 6 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::PlaybackSuspended) == 7, "PlatformMediaSession::PlaybackSuspended is not 7 as expected");
-    ASSERT(static_cast<size_t>(type) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(type) < std::size(values));
     return values[static_cast<size_t>(type)];
 }
 
@@ -117,7 +117,7 @@ String convertEnumerationToString(PlatformMediaSession::RemoteControlCommandType
     static_assert(static_cast<size_t>(PlatformMediaSession::BeginScrubbingCommand) == 14, "PlatformMediaSession::BeginScrubbingCommand is not 14 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::EndScrubbingCommand) == 15, "PlatformMediaSession::EndScrubbingCommand is not 15 as expected");
 
-    ASSERT(static_cast<size_t>(command) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(command) < std::size(values));
     return values[static_cast<size_t>(command)];
 }
 

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -301,7 +301,7 @@ static std::optional<size_t> codePointSupportIndex(UChar32 codePoint)
         zeroWidthNoBreakSpace
     };
     bool found = false;
-    for (size_t i = 0; i < WTF_ARRAY_LENGTH(codePointOrder); ++i) {
+    for (size_t i = 0; i < std::size(codePointOrder); ++i) {
         if (codePointOrder[i] == codePoint) {
             ASSERT(i == result);
             found = true;

--- a/Source/WebCore/platform/graphics/GraphicsTypes.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.cpp
@@ -72,8 +72,8 @@ static constexpr ASCIILiteral blendOperatorNames[] = {
     "plus-darker"_s,
     "plus-lighter"_s
 };
-const uint8_t numCompositeOperatorNames = WTF_ARRAY_LENGTH(compositeOperatorNames);
-const uint8_t numBlendOperatorNames = WTF_ARRAY_LENGTH(blendOperatorNames);
+const uint8_t numCompositeOperatorNames = std::size(compositeOperatorNames);
+const uint8_t numBlendOperatorNames = std::size(blendOperatorNames);
 
 bool parseBlendMode(const String& s, BlendMode& blendMode)
 {

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1897,7 +1897,7 @@ String convertEnumerationToString(MediaPlayer::ReadyState enumerationValue)
     static_assert(static_cast<size_t>(MediaPlayer::ReadyState::HaveCurrentData) == 2, "MediaPlayer::ReadyState::HaveCurrentData is not 2 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::ReadyState::HaveFutureData) == 3, "MediaPlayer::ReadyState::HaveFutureData is not 3 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::ReadyState::HaveEnoughData) == 4, "MediaPlayer::ReadyState::HaveEnoughData is not 4 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -1919,7 +1919,7 @@ String convertEnumerationToString(MediaPlayer::NetworkState enumerationValue)
     static_assert(static_cast<size_t>(MediaPlayer::NetworkState::FormatError) == 4, "MediaPlayer::NetworkState::FormatError is not 4 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::NetworkState::NetworkError) == 5, "MediaPlayer::NetworkError is not 5 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::NetworkState::DecodeError) == 6, "MediaPlayer::NetworkState::DecodeError is not 6 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -1933,7 +1933,7 @@ String convertEnumerationToString(MediaPlayer::Preload enumerationValue)
     static_assert(!static_cast<size_t>(MediaPlayer::Preload::None), "MediaPlayer::Preload::None is not 0 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::Preload::MetaData) == 1, "MediaPlayer::Preload::MetaData is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::Preload::Auto) == 2, "MediaPlayer::Preload::Auto is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -1947,7 +1947,7 @@ String convertEnumerationToString(MediaPlayer::SupportsType enumerationValue)
     static_assert(!static_cast<size_t>(MediaPlayer::SupportsType::IsNotSupported), "MediaPlayer::SupportsType::IsNotSupported is not 0 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::SupportsType::IsSupported) == 1, "MediaPlayer::SupportsType::IsSupported is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::SupportsType::MayBeSupported) == 2, "MediaPlayer::SupportsType::MayBeSupported is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -1963,7 +1963,7 @@ String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::LimitReadAhead) == 1, "MediaPlayer::LimitReadAhead is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::MakeResourcesPurgeable) == 2, "MediaPlayer::MakeResourcesPurgeable is not 2 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::PurgeResources) == 3, "MediaPlayer::PurgeResources is not 3 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp
@@ -45,7 +45,7 @@ String convertEnumerationToString(SourceBufferPrivateClient::ReceiveResult enume
     static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::ClientDisconnected) == 2, "ReceiveResult::ClientDisconnected is not 2 as expected");
     static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::BufferRemoved) == 3, "ReceiveResult::BufferRemoved is not 3 as expected");
     static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::IPCError) == 4, "ReceiveResult::IPCError is not 4 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -1154,7 +1154,7 @@ String convertEnumerationToString(MediaPlayerPrivateAVFoundation::MediaRendering
     static_assert(static_cast<size_t>(MediaPlayerPrivateAVFoundation::MediaRenderingMode::MediaRenderingNone) == 0, "MediaRenderingMode::MediaRenderingNone is not 0 as expected");
     static_assert(static_cast<size_t>(MediaPlayerPrivateAVFoundation::MediaRenderingMode::MediaRenderingToContext) == 1, "MediaRenderingMode::MediaRenderingToContext is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayerPrivateAVFoundation::MediaRenderingMode::MediaRenderingToLayer) == 2, "MediaRenderingMode::MediaRenderingToLayer is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.cpp
@@ -1599,7 +1599,7 @@ static RetainPtr<CFArrayRef> createLegibleOutputSubtypes()
     int webVTTInt = 'wvtt'; // kCMSubtitleFormatType_WebVTT;
     RetainPtr<CFNumberRef> webVTTNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &webVTTInt));
     CFTypeRef formatTypes[] = { webVTTNumber.get() };
-    return adoptCF(CFArrayCreate(0, formatTypes, WTF_ARRAY_LENGTH(formatTypes), &kCFTypeArrayCallBacks));
+    return adoptCF(CFArrayCreate(0, formatTypes, std::size(formatTypes), &kCFTypeArrayCallBacks));
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -221,7 +221,7 @@ static String convertEnumerationToString(AVPlayerTimeControlStatus enumerationVa
     static_assert(!static_cast<size_t>(AVPlayerTimeControlStatusPaused), "AVPlayerTimeControlStatusPaused is not 0 as expected");
     static_assert(static_cast<size_t>(AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate) == 1, "AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate is not 1 as expected");
     static_assert(static_cast<size_t>(AVPlayerTimeControlStatusPlaying) == 2, "AVPlayerTimeControlStatusPlaying is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -82,7 +82,7 @@ String convertEnumerationToString(MediaPlayerPrivateMediaSourceAVFObjC::SeekStat
     static_assert(static_cast<size_t>(MediaPlayerPrivateMediaSourceAVFObjC::SeekState::Seeking) == 0, "MediaPlayerPrivateMediaSourceAVFObjC::SeekState::Seeking is not 0 as expected");
     static_assert(static_cast<size_t>(MediaPlayerPrivateMediaSourceAVFObjC::SeekState::WaitingForAvailableFame) == 1, "MediaPlayerPrivateMediaSourceAVFObjC::SeekState::WaitingForAvailableFame is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayerPrivateMediaSourceAVFObjC::SeekState::SeekCompleted) == 2, "MediaPlayerPrivateMediaSourceAVFObjC::SeekState::SeekCompleted is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.cpp
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.cpp
@@ -160,7 +160,7 @@ void PlatformCALayer::drawTextAtPoint(CGContextRef context, CGFloat x, CGFloat y
         strokeCGColor.get(),
     };
 
-    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(text), length, kCFStringEncodingUTF8, false, kCFAllocatorNull));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -442,7 +442,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
     auto gradientInterpolatesPremultipliedOptionsDictionary = [] () -> CFDictionaryRef {
         static CFTypeRef keys[] = { kCGGradientInterpolatesPremultiplied };
         static CFTypeRef values[] = { kCFBooleanTrue };
-        static CFDictionaryRef options = CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        static CFDictionaryRef options = CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 
         return options;
     };

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -163,7 +163,7 @@ RetainPtr<CMFormatDescriptionRef> createFormatDescriptionFromTrackInfo(const Tra
     ASSERT(videoInfo.codecName == 'vp09' || videoInfo.codecName == 'vp08');
     CFTypeRef configurationKeys[] = { CFSTR("vpcC") };
     CFTypeRef configurationValues[] = { data.get() };
-    auto configurationDict = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, configurationKeys, configurationValues, WTF_ARRAY_LENGTH(configurationKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto configurationDict = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, configurationKeys, configurationValues, std::size(configurationKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 
     Vector<CFTypeRef> extensionsKeys { PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms };
     Vector<CFTypeRef> extensionsValues = { configurationDict.get() };

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -59,7 +59,7 @@ static inline void appendTrueTypeFeature(CFMutableArrayRef features, int type, i
     auto selectorNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &selector));
     CFTypeRef featureKeys[] = { kCTFontFeatureTypeIdentifierKey, kCTFontFeatureSelectorIdentifierKey };
     CFTypeRef featureValues[] = { typeNumber.get(), selectorNumber.get() };
-    auto feature = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, featureKeys, featureValues, WTF_ARRAY_LENGTH(featureKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto feature = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, featureKeys, featureValues, std::size(featureKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFArrayAppendValue(features, feature.get());
 }
 
@@ -75,7 +75,7 @@ static inline void appendOpenTypeFeature(CFMutableArrayRef features, const FontF
     auto featureValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawFeatureValue));
     CFTypeRef featureDictionaryKeys[] = { kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue };
     CFTypeRef featureDictionaryValues[] = { featureKey.get(), featureValue.get() };
-    auto featureDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, featureDictionaryKeys, featureDictionaryValues, WTF_ARRAY_LENGTH(featureDictionaryValues), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto featureDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, featureDictionaryKeys, featureDictionaryValues, std::size(featureDictionaryValues), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFArrayAppendValue(features, featureDictionary.get());
 }
 
@@ -166,13 +166,13 @@ static struct {
     { 0.56, 860 },
     { 0.62, 1000 },
 };
-static_assert(WTF_ARRAY_LENGTH(keyframes) > 0);
+static_assert(std::size(keyframes) > 0);
 
 float normalizeCTWeight(float value)
 {
     if (value < keyframes[0].ctWeight)
         return keyframes[0].cssWeight;
-    for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyframes) - 1; ++i) {
+    for (size_t i = 0; i < std::size(keyframes) - 1; ++i) {
         auto& before = keyframes[i];
         auto& after = keyframes[i + 1];
         if (value >= before.ctWeight && value <= after.ctWeight) {
@@ -180,7 +180,7 @@ float normalizeCTWeight(float value)
             return ratio * (after.cssWeight - before.cssWeight) + before.cssWeight;
         }
     }
-    return keyframes[WTF_ARRAY_LENGTH(keyframes) - 1].cssWeight;
+    return keyframes[std::size(keyframes) - 1].cssWeight;
 }
 
 static inline float normalizeSlope(float value)
@@ -197,7 +197,7 @@ float denormalizeCTWeight(float value)
 {
     if (value < keyframes[0].cssWeight)
         return keyframes[0].ctWeight;
-    for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyframes) - 1; ++i) {
+    for (size_t i = 0; i < std::size(keyframes) - 1; ++i) {
         auto& before = keyframes[i];
         auto& after = keyframes[i + 1];
         if (value >= before.cssWeight && value <= after.cssWeight) {
@@ -205,7 +205,7 @@ float denormalizeCTWeight(float value)
             return ratio * (after.ctWeight - before.ctWeight) + before.ctWeight;
         }
     }
-    return keyframes[WTF_ARRAY_LENGTH(keyframes) - 1].ctWeight;
+    return keyframes[std::size(keyframes) - 1].ctWeight;
 }
 
 static inline float denormalizeSlope(float value)
@@ -1093,7 +1093,7 @@ static void autoActivateFont(const String& name, CGFloat size)
     auto fontName = name.createCFString();
     CFTypeRef keys[] = { kCTFontNameAttribute, kCTFontEnabledAttribute };
     CFTypeRef values[] = { fontName.get(), kCFBooleanTrue };
-    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto descriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
     auto newFont = adoptCF(CTFontCreateWithFontDescriptor(descriptor.get(), size, nullptr));
 }
@@ -1201,7 +1201,7 @@ static RetainPtr<CTFontRef> lookupFallbackFont(CTFontRef font, FontSelectionValu
             CFStringRef newFamilyName = isFontWeightBold(fontWeight) ? CFSTR("GeezaPro-Bold") : CFSTR("GeezaPro");
             CFTypeRef keys[] = { kCTFontNameAttribute };
             CFTypeRef values[] = { newFamilyName };
-            auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+            auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
             auto modification = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
             result = adoptCF(CTFontCreateCopyWithAttributes(result.get(), CTFontGetSize(result.get()), nullptr, modification.get()));
         }
@@ -1352,7 +1352,7 @@ RetainPtr<CFSetRef> installedFontMandatoryAttributes(AllowUserInstalledFonts all
 {
     if (allowUserInstalledFonts == AllowUserInstalledFonts::No) {
         CFTypeRef mandatoryAttributesValues[] = { kCTFontFamilyNameAttribute, kCTFontPostScriptNameAttribute, kCTFontEnabledAttribute, kCTFontUserInstalledAttribute, kCTFontFallbackOptionAttribute };
-        return adoptCF(CFSetCreate(kCFAllocatorDefault, mandatoryAttributesValues, WTF_ARRAY_LENGTH(mandatoryAttributesValues), &kCFTypeSetCallBacks));
+        return adoptCF(CFSetCreate(kCFAllocatorDefault, mandatoryAttributesValues, std::size(mandatoryAttributesValues), &kCFTypeSetCallBacks));
     }
     return nullptr;
 }

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -152,7 +152,7 @@ RetainPtr<CTFontRef> SystemFontDatabaseCoreText::createFontByApplyingWeightWidth
     auto italicsNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &italicsRawNumber));
     CFTypeRef traitsKeys[] = { kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait, kCTFontUIFontDesignTrait };
     CFTypeRef traitsValues[] = { weightNumber.get(), widthNumber.get(), italicsNumber.get(), design ? static_cast<CFTypeRef>(design) : static_cast<CFTypeRef>(kCTFontUIFontDesignDefault) };
-    auto traitsDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, traitsKeys, traitsValues, WTF_ARRAY_LENGTH(traitsKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto traitsDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, traitsKeys, traitsValues, std::size(traitsKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto attributes = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CFDictionaryAddValue(attributes.get(), kCTFontTraitsAttribute, traitsDictionary.get());
     addAttributesForInstalledFonts(attributes.get(), allowUserInstalledFonts);
@@ -167,7 +167,7 @@ RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::removeCascadeList(CTF
     auto emptyArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks));
     CFTypeRef fallbackDictionaryKeys[] = { kCTFontCascadeListAttribute };
     CFTypeRef fallbackDictionaryValues[] = { emptyArray.get() };
-    auto fallbackDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, fallbackDictionaryKeys, fallbackDictionaryValues, WTF_ARRAY_LENGTH(fallbackDictionaryKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto fallbackDictionary = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, fallbackDictionaryKeys, fallbackDictionaryValues, std::size(fallbackDictionaryKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto modifiedFontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(fontDescriptor, fallbackDictionary.get()));
     return modifiedFontDescriptor;
 }
@@ -175,7 +175,7 @@ RetainPtr<CTFontDescriptorRef> SystemFontDatabaseCoreText::removeCascadeList(CTF
 Vector<RetainPtr<CTFontDescriptorRef>> SystemFontDatabaseCoreText::computeCascadeList(CTFontRef font, CFStringRef locale)
 {
     CFTypeRef arrayValues[] = { locale };
-    auto localeArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, arrayValues, WTF_ARRAY_LENGTH(arrayValues), &kCFTypeArrayCallBacks));
+    auto localeArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, arrayValues, std::size(arrayValues), &kCFTypeArrayCallBacks));
     auto cascadeList = adoptCF(CTFontCopyDefaultCascadeListForLanguages(font, localeArray.get()));
     Vector<RetainPtr<CTFontDescriptorRef>> result;
     // WebKit handles the cascade list, and WebKit 2's IPC code doesn't know how to serialize Core Text's cascade list.

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -307,7 +307,7 @@ static RetainPtr<CFDictionaryRef> smallCapsOpenTypeDictionary(CFStringRef key, i
     RetainPtr<CFNumberRef> value = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawValue));
     CFTypeRef keys[] = { kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue };
     CFTypeRef values[] = { key, value.get() };
-    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }
 
 static RetainPtr<CFDictionaryRef> smallCapsTrueTypeDictionary(int rawKey, int rawValue)
@@ -316,7 +316,7 @@ static RetainPtr<CFDictionaryRef> smallCapsTrueTypeDictionary(int rawKey, int ra
     RetainPtr<CFNumberRef> value = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawValue));
     CFTypeRef keys[] = { kCTFontFeatureTypeIdentifierKey, kCTFontFeatureSelectorIdentifierKey };
     CFTypeRef values[] = { key.get(), value.get() };
-    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }
 
 static void unionBitVectors(BitVector& result, CFBitVectorRef source)
@@ -538,7 +538,7 @@ static RetainPtr<CTFontRef> createCTFontWithoutSynthesizableFeatures(CTFontRef f
     }
     CFTypeRef keys[] = { kCTFontFeatureSettingsAttribute };
     CFTypeRef values[] = { newFeatures.get() };
-    RetainPtr<CFDictionaryRef> attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr<CFDictionaryRef> attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     RetainPtr<CTFontDescriptorRef> newDescriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
     return adoptCF(CTFontCreateCopyWithAttributes(font, CTFontGetSize(font), nullptr, newDescriptor.get()));
 }

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -100,11 +100,11 @@ static RetainPtr<CFDictionaryRef> cascadeToLastResortAttributesDictionary()
     auto lastResort = adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR("LastResort"), 0));
 
     CFTypeRef descriptors[] = { lastResort.get() };
-    RetainPtr<CFArrayRef> array = adoptCF(CFArrayCreate(kCFAllocatorDefault, descriptors, WTF_ARRAY_LENGTH(descriptors), &kCFTypeArrayCallBacks));
+    RetainPtr<CFArrayRef> array = adoptCF(CFArrayCreate(kCFAllocatorDefault, descriptors, std::size(descriptors), &kCFTypeArrayCallBacks));
 
     CFTypeRef keys[] = { kCTFontCascadeListAttribute };
     CFTypeRef values[] = { array.get() };
-    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }
 
 static CTFontDescriptorRef cascadeToLastResortAndVariationsFontDescriptor()

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -106,7 +106,7 @@ FEComponentTransferSoftwareApplier::LookupTable FEComponentTransferSoftwareAppli
         computeGammaTable       // FECOMPONENTTRANSFER_TYPE_GAMMA
     };
 
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(static_cast<size_t>(function.type) < WTF_ARRAY_LENGTH(callEffect));
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(static_cast<size_t>(function.type) < std::size(callEffect));
     callEffect[function.type](table, function);
 
     return table;

--- a/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
@@ -55,7 +55,7 @@ GBMDevice::GBMDevice()
         drmDevicePtr devices[64];
         memset(devices, 0, sizeof(devices));
 
-        int numDevices = drmGetDevices2(0, devices, WTF_ARRAY_LENGTH(devices));
+        int numDevices = drmGetDevices2(0, devices, std::size(devices));
         if (numDevices <= 0)
             return;
 

--- a/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
@@ -143,7 +143,7 @@ static CFDictionaryRef typesetterOptions()
         short embeddingLevelValue = isLTR ? 0 : 1;
         const void* optionKeys[] = { kCTTypesetterOptionForcedEmbeddingLevel };
         const void* optionValues[] = { CFNumberCreate(kCFAllocatorDefault, kCFNumberShortType, &embeddingLevelValue) };
-        options.construct(adoptCF(CFDictionaryCreate(kCFAllocatorDefault, optionKeys, optionValues, WTF_ARRAY_LENGTH(optionKeys), &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)));
+        options.construct(adoptCF(CFDictionaryCreate(kCFAllocatorDefault, optionKeys, optionValues, std::size(optionKeys), &kCFCopyStringDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)));
     });
     return options.get().get();
 }

--- a/Source/WebCore/platform/graphics/mac/SimpleFontDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/mac/SimpleFontDataCoreText.cpp
@@ -90,7 +90,7 @@ RetainPtr<CFDictionaryRef> Font::getCFStringAttributes(bool enableKerning, FontO
         ++count;
     }
 
-    ASSERT(count <= WTF_ARRAY_LENGTH(keys));
+    ASSERT(count <= std::size(keys));
 
     return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
@@ -353,7 +353,7 @@ void OpenTypeMathData::getMathVariants(Glyph glyph, bool isVertical, Vector<Glyp
 
     sizeVariants.clear();
     hb_ot_math_glyph_variant_t variants[10];
-    unsigned variantsSize = WTF_ARRAY_LENGTH(variants);
+    unsigned variantsSize = std::size(variants);
     unsigned count;
     unsigned offset = 0;
     do {
@@ -366,7 +366,7 @@ void OpenTypeMathData::getMathVariants(Glyph glyph, bool isVertical, Vector<Glyp
 
     assemblyParts.clear();
     hb_ot_math_glyph_part_t parts[10];
-    unsigned partsSize = WTF_ARRAY_LENGTH(parts);
+    unsigned partsSize = std::size(parts);
     offset = 0;
     do {
         count = partsSize;

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -384,7 +384,7 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
             "Lucida Sans Unicode"_str,
             "Arial"_str
         };
-        for (size_t i = 0; i < WTF_ARRAY_LENGTH(fallbackFonts); ++i) {
+        for (size_t i = 0; i < std::size(fallbackFonts); ++i) {
             if (fontForFamily(fontDescription, fallbackFonts[i])) {
                 fallbackFontName.get() = fallbackFonts[i];
                 return;

--- a/Source/WebCore/platform/graphics/win/GraphicsContextCGWin.cpp
+++ b/Source/WebCore/platform/graphics/win/GraphicsContextCGWin.cpp
@@ -192,17 +192,17 @@ void GraphicsContextCG::drawDotsForDocumentMarker(const FloatRect& rect, Documen
     const float lowerOpacity = 0.88f;
 
     //Top line
-    CGContextSetLineDash(context, edge_offset, edge_dash_lengths, WTF_ARRAY_LENGTH(edge_dash_lengths));
+    CGContextSetLineDash(context, edge_offset, edge_dash_lengths, std::size(edge_dash_lengths));
     CGContextSetAlpha(context, upperOpacity);
     CGContextStrokeLineSegments(context, upperPoints, 2);
  
     // Middle line
-    CGContextSetLineDash(context, middle_offset, middle_dash_lengths, WTF_ARRAY_LENGTH(middle_dash_lengths));
+    CGContextSetLineDash(context, middle_offset, middle_dash_lengths, std::size(middle_dash_lengths));
     CGContextSetAlpha(context, middleOpacity);
     CGContextStrokeLineSegments(context, middlePoints, 2);
     
     // Bottom line
-    CGContextSetLineDash(context, edge_offset, edge_dash_lengths, WTF_ARRAY_LENGTH(edge_dash_lengths));
+    CGContextSetLineDash(context, edge_offset, edge_dash_lengths, std::size(edge_dash_lengths));
     CGContextSetAlpha(context, lowerOpacity);
     CGContextStrokeLineSegments(context, lowerPoints, 2);
 

--- a/Source/WebCore/platform/graphics/win/IconWin.cpp
+++ b/Source/WebCore/platform/graphics/win/IconWin.cpp
@@ -60,7 +60,7 @@ RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& filenames)
     }
 
     WCHAR buffer[MAX_PATH];
-    UINT length = ::GetSystemDirectoryW(buffer, WTF_ARRAY_LENGTH(buffer));
+    UINT length = ::GetSystemDirectoryW(buffer, std::size(buffer));
     if (!length)
         return nullptr;
 

--- a/Source/WebCore/platform/ios/KeyEventIOS.mm
+++ b/Source/WebCore/platform/ios/KeyEventIOS.mm
@@ -194,7 +194,7 @@ int windowsKeyCodeForKeyCode(uint16_t keyCode)
         return VK_APPS;
     }
     // Otherwise check all other known keys.
-    if (keyCode < WTF_ARRAY_LENGTH(windowsKeyCode))
+    if (keyCode < std::size(windowsKeyCode))
         return windowsKeyCode[keyCode];
     return 0; // Unknown key
 }

--- a/Source/WebCore/platform/ios/LegacyTileCache.mm
+++ b/Source/WebCore/platform/ios/LegacyTileCache.mm
@@ -585,7 +585,7 @@ void LegacyTileCache::drawLayer(LegacyTileLayer* layer, CGContextRef context, Dr
         auto font = adoptCF(CTFontCreateWithName(CFSTR("Helvetica"), 25, &matrix));
         CFTypeRef keys[] = { kCTFontAttributeName, kCTForegroundColorFromContextAttributeName };
         CFTypeRef values[] = { font.get(), kCFBooleanTrue };
-        auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
         auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(text), strlen(text), kCFStringEncodingUTF8, false, kCFAllocatorNull));
         auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
         auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));

--- a/Source/WebCore/platform/mac/KeyEventMac.mm
+++ b/Source/WebCore/platform/mac/KeyEventMac.mm
@@ -167,7 +167,7 @@ int windowsKeyCodeForKeyCode(uint16_t keyCode)
         /* 0x7D */ VK_DOWN, // Down Arrow
         /* 0x7E */ VK_UP, // Up Arrow
     };
-    if (keyCode < WTF_ARRAY_LENGTH(windowsKeyCode))
+    if (keyCode < std::size(windowsKeyCode))
         return windowsKeyCode[keyCode];
     return 0;
 }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1200,7 +1200,7 @@ String convertEnumerationToString(RealtimeMediaSource::Type enumerationValue)
     };
     static_assert(static_cast<size_t>(RealtimeMediaSource::Type::Audio) == 0, "RealtimeMediaSource::Type::Audio is not 0 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSource::Type::Video) == 1, "RealtimeMediaSource::Type::Video is not 1 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -52,7 +52,7 @@ String RealtimeMediaSourceSettings::facingMode(RealtimeMediaSourceSettings::Vide
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Environment) == 2, "RealtimeMediaSourceSettings::VideoFacingMode::Environment is not 2 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Left) == 3, "RealtimeMediaSourceSettings::VideoFacingMode::Left is not 3 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Right) == 4, "RealtimeMediaSourceSettings::VideoFacingMode::Right is not 4 as expected");
-    ASSERT(static_cast<size_t>(mode) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(mode) < std::size(values));
     return values[static_cast<size_t>(mode)];
 }
 
@@ -179,7 +179,7 @@ String convertEnumerationToString(RealtimeMediaSourceSettings::VideoFacingMode e
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Environment) == 2, "RealtimeMediaSourceSettings::VideoFacingMode::Environment is not 2 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Left) == 3, "RealtimeMediaSourceSettings::VideoFacingMode::Left is not 3 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::VideoFacingMode::Right) == 4, "RealtimeMediaSourceSettings::VideoFacingMode::Right is not 4 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 
@@ -198,7 +198,7 @@ String RealtimeMediaSourceSettings::displaySurface(RealtimeMediaSourceSettings::
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Application) == 2, "RealtimeMediaSourceSettings::DisplaySurface::Application is not 0 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Browser) == 3, "RealtimeMediaSourceSettings::DisplaySurface::Browser is not 1 as expected");
     static_assert(static_cast<size_t>(RealtimeMediaSourceSettings::DisplaySurfaceType::Invalid) == 4, "RealtimeMediaSourceSettings::DisplaySurface::Invalid is not 0 as expected");
-    ASSERT(static_cast<size_t>(surface) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(surface) < std::size(values));
     return values[static_cast<size_t>(surface)];
 }
 

--- a/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp
@@ -348,7 +348,7 @@ void SocketStreamHandleImpl::createStreams()
         // But SOCKS5 credentials don't work at the time of this writing anyway, see <rdar://6776698>.
         const void* proxyKeys[] = { kCFStreamPropertySOCKSProxyHost, kCFStreamPropertySOCKSProxyPort };
         const void* proxyValues[] = { m_proxyHost.get(), m_proxyPort.get() };
-        RetainPtr<CFDictionaryRef> connectDictionary = adoptCF(CFDictionaryCreate(0, proxyKeys, proxyValues, WTF_ARRAY_LENGTH(proxyKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        RetainPtr<CFDictionaryRef> connectDictionary = adoptCF(CFDictionaryCreate(0, proxyKeys, proxyValues, std::size(proxyKeys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
         CFReadStreamSetProperty(m_readStream.get(), kCFStreamPropertySOCKSProxy, connectDictionary.get());
         break;
         }
@@ -374,7 +374,7 @@ void SocketStreamHandleImpl::createStreams()
 #endif
             validateCertificateChain
         };
-        RetainPtr<CFDictionaryRef> settings = adoptCF(CFDictionaryCreate(0, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        RetainPtr<CFDictionaryRef> settings = adoptCF(CFDictionaryCreate(0, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
         CFReadStreamSetProperty(m_readStream.get(), kCFStreamPropertySSLSettings, settings.get());
         CFWriteStreamSetProperty(m_writeStream.get(), kCFStreamPropertySSLSettings, settings.get());
     }

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -142,7 +142,7 @@ UDateFormat* LocaleICU::openDateFormat(UDateFormatStyle timeStyle, UDateFormatSt
 {
     const UChar gmtTimezone[3] = {'G', 'M', 'T'};
     UErrorCode status = U_ZERO_ERROR;
-    return udat_open(timeStyle, dateStyle, m_locale.data(), gmtTimezone, WTF_ARRAY_LENGTH(gmtTimezone), 0, -1, &status);
+    return udat_open(timeStyle, dateStyle, m_locale.data(), gmtTimezone, std::size(gmtTimezone), 0, -1, &status);
 }
 
 static String getDateFormatPattern(const UDateFormat* dateFormat)
@@ -280,7 +280,7 @@ String LocaleICU::monthFormat()
     // Gets a format for "MMMM" because Windows API always provides formats for
     // "MMMM" in some locales.
     const UChar skeleton[] = { 'y', 'y', 'y', 'y', 'M', 'M', 'M', 'M' };
-    m_monthFormat = getFormatForSkeleton(m_locale.data(), skeleton, WTF_ARRAY_LENGTH(skeleton));
+    m_monthFormat = getFormatForSkeleton(m_locale.data(), skeleton, std::size(skeleton));
     return m_monthFormat;
 }
 
@@ -289,7 +289,7 @@ String LocaleICU::shortMonthFormat()
     if (!m_shortMonthFormat.isNull())
         return m_shortMonthFormat;
     const UChar skeleton[] = { 'y', 'y', 'y', 'y', 'M', 'M', 'M' };
-    m_shortMonthFormat = getFormatForSkeleton(m_locale.data(), skeleton, WTF_ARRAY_LENGTH(skeleton));
+    m_shortMonthFormat = getFormatForSkeleton(m_locale.data(), skeleton, std::size(skeleton));
     return m_shortMonthFormat;
 }
 
@@ -327,8 +327,8 @@ const Vector<String>& LocaleICU::shortMonthLabels()
             return m_shortMonthLabels;
         }
     }
-    m_shortMonthLabels.reserveCapacity(WTF_ARRAY_LENGTH(WTF::monthName));
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(WTF::monthName); ++i)
+    m_shortMonthLabels.reserveCapacity(std::size(WTF::monthName));
+    for (unsigned i = 0; i < std::size(WTF::monthName); ++i)
         m_shortMonthLabels.append(WTF::monthName[i]);
     return m_shortMonthLabels;
 }

--- a/Source/WebCore/platform/text/LocaleNone.cpp
+++ b/Source/WebCore/platform/text/LocaleNone.cpp
@@ -71,8 +71,8 @@ const Vector<String>& LocaleNone::monthLabels()
 {
     if (!m_monthLabels.isEmpty())
         return m_monthLabels;
-    m_monthLabels.reserveCapacity(WTF_ARRAY_LENGTH(WTF::monthFullName));
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(WTF::monthFullName); ++i)
+    m_monthLabels.reserveCapacity(std::size(WTF::monthFullName));
+    for (unsigned i = 0; i < std::size(WTF::monthFullName); ++i)
         m_monthLabels.uncheckedAppend(WTF::monthFullName[i]);
     return m_monthLabels;
 }

--- a/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
+++ b/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
@@ -156,7 +156,7 @@ static HashMap<AtomString, Vector<String>>& availableLocales()
     static HashMap<AtomString, Vector<String>> availableLocales;
 
     if (!scannedLocales) {
-        for (size_t i = 0; i < WTF_ARRAY_LENGTH(gDictionaryDirectories); i++)
+        for (size_t i = 0; i < std::size(gDictionaryDirectories); i++)
             scanDirectoryForDictionaries(gDictionaryDirectories[i], availableLocales);
 
 #if ENABLE(DEVELOPER_MODE)

--- a/Source/WebCore/platform/text/win/LocaleWin.cpp
+++ b/Source/WebCore/platform/text/win/LocaleWin.cpp
@@ -124,13 +124,13 @@ void LocaleWin::ensureShortMonthLabels()
         LOCALE_SABBREVMONTHNAME11,
         LOCALE_SABBREVMONTHNAME12,
     };
-    m_shortMonthLabels.reserveCapacity(WTF_ARRAY_LENGTH(types));
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(types); ++i) {
+    m_shortMonthLabels.reserveCapacity(std::size(types));
+    for (unsigned i = 0; i < std::size(types); ++i) {
         m_shortMonthLabels.append(getLocaleInfoString(types[i]));
         if (m_shortMonthLabels.last().isEmpty()) {
             m_shortMonthLabels.shrink(0);
-            m_shortMonthLabels.reserveCapacity(WTF_ARRAY_LENGTH(WTF::monthName));
-            for (unsigned m = 0; m < WTF_ARRAY_LENGTH(WTF::monthName); ++m)
+            m_shortMonthLabels.reserveCapacity(std::size(WTF::monthName));
+            for (unsigned m = 0; m < std::size(WTF::monthName); ++m)
                 m_shortMonthLabels.append(WTF::monthName[m]);
             return;
         }
@@ -259,13 +259,13 @@ void LocaleWin::ensureMonthLabels()
         LOCALE_SMONTHNAME11,
         LOCALE_SMONTHNAME12,
     };
-    m_monthLabels.reserveCapacity(WTF_ARRAY_LENGTH(types));
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(types); ++i) {
+    m_monthLabels.reserveCapacity(std::size(types));
+    for (unsigned i = 0; i < std::size(types); ++i) {
         m_monthLabels.append(getLocaleInfoString(types[i]));
         if (m_monthLabels.last().isEmpty()) {
             m_monthLabels.shrink(0);
-            m_monthLabels.reserveCapacity(WTF_ARRAY_LENGTH(WTF::monthFullName));
-            for (unsigned m = 0; m < WTF_ARRAY_LENGTH(WTF::monthFullName); ++m)
+            m_monthLabels.reserveCapacity(std::size(WTF::monthFullName));
+            for (unsigned m = 0; m < std::size(WTF::monthFullName); ++m)
                 m_monthLabels.append(WTF::monthFullName[m]);
             return;
         }

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -72,13 +72,13 @@ static bool getWebLocData(IDataObject* dataObject, String& url, String* title)
     if (!hdrop)
         return false;
 
-    if (!DragQueryFileW(hdrop, 0, filename, WTF_ARRAY_LENGTH(filename)))
+    if (!DragQueryFileW(hdrop, 0, filename, std::size(filename)))
         goto exit;
 
     if (_wcsicmp(PathFindExtensionW(filename), L".url"))
         goto exit;    
     
-    if (!GetPrivateProfileStringW(L"InternetShortcut", L"url", 0, urlBuffer, WTF_ARRAY_LENGTH(urlBuffer), filename))
+    if (!GetPrivateProfileStringW(L"InternetShortcut", L"url", 0, urlBuffer, std::size(urlBuffer), filename))
         goto exit;
     
     if (title) {
@@ -108,7 +108,7 @@ static bool getWebLocData(const DragDataMap* dataObject, String& url, String* ti
     if (_wcsicmp(PathFindExtensionW(filename), L".url"))
         return false;    
 
-    if (!GetPrivateProfileStringW(L"InternetShortcut", L"url", 0, urlBuffer, WTF_ARRAY_LENGTH(urlBuffer), filename))
+    if (!GetPrivateProfileStringW(L"InternetShortcut", L"url", 0, urlBuffer, std::size(urlBuffer), filename))
         return false;
 
     if (title) {
@@ -417,7 +417,7 @@ void setFileDescriptorData(IDataObject* dataObject, int size, const String& pass
     fgd->fgd[0].dwFlags = FD_FILESIZE;
     fgd->fgd[0].nFileSizeLow = size;
 
-    int maxSize = std::min<int>(pathname.length(), WTF_ARRAY_LENGTH(fgd->fgd[0].cFileName));
+    int maxSize = std::min<int>(pathname.length(), std::size(fgd->fgd[0].cFileName));
     CopyMemory(fgd->fgd[0].cFileName, pathname.charactersWithNullTermination().data(), maxSize * sizeof(UChar));
     GlobalUnlock(medium.hGlobal);
 
@@ -718,7 +718,7 @@ void getHDropData(IDataObject* data, FORMATETC* format, Vector<String>& dataStri
     WCHAR filename[MAX_PATH];
     UINT fileCount = DragQueryFileW(hdrop, 0xFFFFFFFF, 0, 0);
     for (UINT i = 0; i < fileCount; i++) {
-        if (!DragQueryFileW(hdrop, i, filename, WTF_ARRAY_LENGTH(filename)))
+        if (!DragQueryFileW(hdrop, i, filename, std::size(filename)))
             continue;
         dataStrings.append(filename);
     }

--- a/Source/WebCore/platform/win/DragDataWin.cpp
+++ b/Source/WebCore/platform/win/DragDataWin.cpp
@@ -146,7 +146,7 @@ Vector<String> DragData::asFilenames() const
 
         const unsigned numFiles = DragQueryFileW(hdrop, 0xFFFFFFFF, 0, 0);
         for (unsigned i = 0; i < numFiles; i++) {
-            if (!DragQueryFileW(hdrop, i, filename, WTF_ARRAY_LENGTH(filename)))
+            if (!DragQueryFileW(hdrop, i, filename, std::size(filename)))
                 continue;
             result.append(filename);
         }

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -383,7 +383,7 @@ void Pasteboard::read(PasteboardFileReader& reader, std::optional<size_t>)
         WCHAR filename[MAX_PATH];
         UINT fileCount = DragQueryFileW(hdrop, 0xFFFFFFFF, 0, 0);
         for (UINT i = 0; i < fileCount; i++) {
-            if (!DragQueryFileW(hdrop, i, filename, WTF_ARRAY_LENGTH(filename)))
+            if (!DragQueryFileW(hdrop, i, filename, std::size(filename)))
                 continue;
             reader.readFilename(filename);
         }
@@ -720,7 +720,7 @@ void Pasteboard::writeURLToDataObject(const URL& kurl, const String& titleStr)
     fgd->fgd[0].dwFlags = FD_FILESIZE;
     fgd->fgd[0].nFileSizeLow = content.length();
 
-    unsigned maxSize = std::min<unsigned>(fsPath.length(), WTF_ARRAY_LENGTH(fgd->fgd[0].cFileName));
+    unsigned maxSize = std::min<unsigned>(fsPath.length(), std::size(fgd->fgd[0].cFileName));
     StringView(fsPath).left(maxSize).getCharacters(ucharFrom(fgd->fgd[0].cFileName));
     GlobalUnlock(urlFileDescriptor);
 
@@ -958,7 +958,7 @@ static HGLOBAL createGlobalImageFileDescriptor(const String& url, const String& 
         return 0;
     }
 
-    int maxSize = std::min<int>(fsPath.length(), WTF_ARRAY_LENGTH(fgd->fgd[0].cFileName));
+    int maxSize = std::min<int>(fsPath.length(), std::size(fgd->fgd[0].cFileName));
     StringView(fsPath).left(maxSize).getCharacters(ucharFrom(fgd->fgd[0].cFileName));
     GlobalUnlock(memObj);
 
@@ -1005,7 +1005,7 @@ static HGLOBAL createGlobalHDropContent(const URL& url, String& fileName, Fragme
     } else {
         WCHAR tempPath[MAX_PATH];
         WCHAR extension[MAX_PATH];
-        if (!::GetTempPath(WTF_ARRAY_LENGTH(tempPath), tempPath))
+        if (!::GetTempPath(std::size(tempPath), tempPath))
             return 0;
         if (!::PathAppend(tempPath, fileName.wideCharacters().data()))
             return 0;

--- a/Source/WebCore/platform/win/WebCoreBundleWin.cpp
+++ b/Source/WebCore/platform/win/WebCoreBundleWin.cpp
@@ -48,9 +48,9 @@ static RetainPtr<CFBundleRef> createWebKitBundle()
         return existingBundle;
 
     wchar_t dllPathBuffer[MAX_PATH];
-    DWORD length = ::GetModuleFileNameW(WebCore::instanceHandle(), dllPathBuffer, WTF_ARRAY_LENGTH(dllPathBuffer));
+    DWORD length = ::GetModuleFileNameW(WebCore::instanceHandle(), dllPathBuffer, std::size(dllPathBuffer));
     ASSERT(length);
-    ASSERT(length < WTF_ARRAY_LENGTH(dllPathBuffer));
+    ASSERT(length < std::size(dllPathBuffer));
 
     RetainPtr<CFStringRef> dllPath = adoptCF(CFStringCreateWithCharactersNoCopy(0, reinterpret_cast<const UniChar*>(dllPathBuffer), length, kCFAllocatorNull));
     RetainPtr<CFURLRef> dllURL = adoptCF(CFURLCreateWithFileSystemPath(0, dllPath.get(), kCFURLWindowsPathStyle, false));

--- a/Source/WebCore/platform/win/WindowsKeyNames.cpp
+++ b/Source/WebCore/platform/win/WindowsKeyNames.cpp
@@ -505,13 +505,13 @@ void WindowsKeyNames::updateLayout()
         for (unsigned virtualKey = 0; virtualKey <= 0xFF; ++virtualKey) {
             wchar_t translatedChars[5];
             int rv = ToUnicodeEx(virtualKey, 0, keyboardState, translatedChars,
-                WTF_ARRAY_LENGTH(translatedChars), 0, m_keyboardLayout);
+                std::size(translatedChars), 0, m_keyboardLayout);
 
             if (rv == -1) {
                 // Dead key, injecting VK_SPACE to get character representation.
                 BYTE emptyState[256] = { };
                 rv = ToUnicodeEx(VK_SPACE, 0, emptyState, translatedChars,
-                    WTF_ARRAY_LENGTH(translatedChars), 0, m_keyboardLayout);
+                    std::size(translatedChars), 0, m_keyboardLayout);
                 // Expecting a dead key character (not followed by a space).
                 if (rv == 1)
                     m_printableKeyCodeToKey.set(std::make_pair(virtualKey, modifiers), "Dead"_s);

--- a/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
@@ -70,7 +70,7 @@ Instance::Impl::Impl()
         createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
         createInfo.applicationInfo.applicationVersion = s_applicationVersion;
         createInfo.enabledApiLayerCount = 0;
-        createInfo.enabledExtensionCount = WTF_ARRAY_LENGTH(enabledExtensions);
+        createInfo.enabledExtensionCount = std::size(enabledExtensions);
         createInfo.enabledExtensionNames = enabledExtensions;
 
         XrResult result = xrCreateInstance(&createInfo, &m_instance);

--- a/Source/WebCore/rendering/BreakLines.cpp
+++ b/Source/WebCore/rendering/BreakLines.cpp
@@ -95,6 +95,6 @@ const unsigned char lineBreakTable[][lineBreakTableColumnCount] = {
 #undef DI
 #undef AL
 
-static_assert(WTF_ARRAY_LENGTH(lineBreakTable) == lineBreakTableLastCharacter - lineBreakTableFirstCharacter + 1, "Test LineBreakTable consistency");
+static_assert(std::size(lineBreakTable) == lineBreakTableLastCharacter - lineBreakTableFirstCharacter + 1, "Test LineBreakTable consistency");
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -367,7 +367,7 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
         checkNumberOfDistinctQuoteCharacters(quotationMark);
         checkNumberOfDistinctQuoteCharacters(apostrophe);
 
-        for (unsigned i = 0; i < WTF_ARRAY_LENGTH(quoteTable); ++i) {
+        for (unsigned i = 0; i < std::size(quoteTable); ++i) {
             if (i)
                 ASSERT(strcmp(quoteTable[i - 1].language, quoteTable[i].language) < 0);
 
@@ -398,7 +398,7 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
     QuotesForLanguage languageKey = { languageKeyBuffer.data(), 0, 0, 0, 0, 0 };
 
     return static_cast<const QuotesForLanguage*>(bsearch(&languageKey,
-        quoteTable, WTF_ARRAY_LENGTH(quoteTable), sizeof(quoteTable[0]), quoteTableLanguageComparisonFunction));
+        quoteTable, std::size(quoteTable), sizeof(quoteTable[0]), quoteTableLanguageComparisonFunction));
 }
 
 static StringImpl* stringForQuoteCharacter(UChar character)

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -237,7 +237,7 @@ static inline FontSelectionValue cssWeightOfSystemFont(CTFontRef font)
     CFNumberGetValue(resultRef.get(), kCFNumberFloatType, &result);
     // These numbers were experimentally gathered from weights of the system font.
     static constexpr float weightThresholds[] = { -0.6, -0.365, -0.115, 0.130, 0.235, 0.350, 0.5, 0.7 };
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(weightThresholds); ++i) {
+    for (unsigned i = 0; i < std::size(weightThresholds); ++i) {
         if (result < weightThresholds[i])
             return FontSelectionValue((static_cast<int>(i) + 1) * 100);
     }

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -206,7 +206,7 @@ static const UChar32 characterFallback[][maxFallbackPerCharacter] = {
     { 0x02C6, 0x0302, 0 }, // MODIFIER LETTER CIRCUMFLEX ACCENT
     { 0x02C7, 0x030C, 0 } // CARON
 };
-const unsigned characterFallbackSize = WTF_ARRAY_LENGTH(characterFallback);
+const unsigned characterFallbackSize = std::size(characterFallback);
 
 void MathOperator::getMathVariantsWithFallback(const RenderStyle& style, bool isVertical, Vector<Glyph>& sizeVariants, Vector<OpenTypeMathData::AssemblyPart>& assemblyParts)
 {
@@ -406,7 +406,7 @@ void MathOperator::calculateStretchyData(const RenderStyle& style, bool calculat
 
         // If the font does not have a MATH table, we fallback to the Unicode-only constructions.
         const StretchyCharacter* stretchyCharacter = nullptr;
-        const unsigned maxIndex = WTF_ARRAY_LENGTH(stretchyCharacters);
+        const unsigned maxIndex = std::size(stretchyCharacters);
         for (unsigned index = 0; index < maxIndex; ++index) {
             if (stretchyCharacters[index].character == m_baseCharacter) {
                 stretchyCharacter = &stretchyCharacters[index];

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -455,23 +455,23 @@ static UChar32 mathVariant(UChar32 codePoint, MathMLElement::MathVariant mathvar
         switch (mathvariant) {
         case MathMLElement::MathVariant::Initial:
             mapTable = arabicInitialMapTable;
-            tableLength = WTF_ARRAY_LENGTH(arabicInitialMapTable);
+            tableLength = std::size(arabicInitialMapTable);
             break;
         case MathMLElement::MathVariant::Tailed:
             mapTable = arabicTailedMapTable;
-            tableLength = WTF_ARRAY_LENGTH(arabicTailedMapTable);
+            tableLength = std::size(arabicTailedMapTable);
             break;
         case MathMLElement::MathVariant::Stretched:
             mapTable = arabicStretchedMapTable;
-            tableLength = WTF_ARRAY_LENGTH(arabicStretchedMapTable);
+            tableLength = std::size(arabicStretchedMapTable);
             break;
         case MathMLElement::MathVariant::Looped:
             mapTable = arabicLoopedMapTable;
-            tableLength = WTF_ARRAY_LENGTH(arabicLoopedMapTable);
+            tableLength = std::size(arabicLoopedMapTable);
             break;
         case MathMLElement::MathVariant::DoubleStruck:
             mapTable = arabicDoubleMapTable;
-            tableLength = WTF_ARRAY_LENGTH(arabicDoubleMapTable);
+            tableLength = std::size(arabicDoubleMapTable);
             break;
         default:
             return codePoint; // No valid transformations exist.
@@ -486,7 +486,7 @@ static UChar32 mathVariant(UChar32 codePoint, MathMLElement::MathVariant mathvar
         // See the Number case for an explanation of the following calculation
         tempChar = baseChar + mathBoldUpperA + multiplier * (mathItalicUpperA - mathBoldUpperA);
         // There are roughly twenty characters that are located outside of the mathematical block, so the spaces where they ought to be are used as keys for a lookup table containing the correct character mappings.
-        newChar = MathVariantMappingSearch(tempChar, latinExceptionMapTable, WTF_ARRAY_LENGTH(latinExceptionMapTable));
+        newChar = MathVariantMappingSearch(tempChar, latinExceptionMapTable, std::size(latinExceptionMapTable));
     }
 
     if (newChar)

--- a/Source/WebCore/rendering/style/TextSizeAdjustment.cpp
+++ b/Source/WebCore/rendering/style/TextSizeAdjustment.cpp
@@ -142,8 +142,8 @@ float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
     if (specifiedSize <= 0)
         return 0;
 
-    float result = scalePoint(points[WTF_ARRAY_LENGTH(points) - 1]).y();
-    for (size_t i = 1; i < WTF_ARRAY_LENGTH(points); ++i) {
+    float result = scalePoint(points[std::size(points) - 1]).y();
+    for (size_t i = 1; i < std::size(points); ++i) {
         if (points[i].x() < specifiedSize)
             continue;
         auto leftPoint = scalePoint(points[i - 1]);

--- a/Source/WebCore/testing/LegacyMockCDM.cpp
+++ b/Source/WebCore/testing/LegacyMockCDM.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<LegacyCDMSession> LegacyMockCDM::createSession(LegacyCDMSessionC
 static Uint8Array* initDataPrefix()
 {
     const unsigned char prefixData[] = { 'm', 'o', 'c', 'k' };
-    static Uint8Array& prefix { Uint8Array::create(prefixData, WTF_ARRAY_LENGTH(prefixData)).leakRef() };
+    static Uint8Array& prefix { Uint8Array::create(prefixData, std::size(prefixData)).leakRef() };
 
     return &prefix;
 }
@@ -88,7 +88,7 @@ static Uint8Array* initDataPrefix()
 static Uint8Array* keyPrefix()
 {
     static const unsigned char prefixData[] = {'k', 'e', 'y'};
-    static Uint8Array& prefix { Uint8Array::create(prefixData, WTF_ARRAY_LENGTH(prefixData)).leakRef() };
+    static Uint8Array& prefix { Uint8Array::create(prefixData, std::size(prefixData)).leakRef() };
 
     return &prefix;
 }
@@ -96,7 +96,7 @@ static Uint8Array* keyPrefix()
 static Uint8Array* keyRequest()
 {
     static const unsigned char requestData[] = {'r', 'e', 'q', 'u', 'e', 's', 't'};
-    static Uint8Array& request { Uint8Array::create(requestData, WTF_ARRAY_LENGTH(requestData)).leakRef() };
+    static Uint8Array& request { Uint8Array::create(requestData, std::size(requestData)).leakRef() };
 
     return &request;
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1207,7 +1207,7 @@ static xmlEntityPtr getXHTMLEntity(const xmlChar* name)
     if (!numberOfCodeUnits)
         return 0;
 
-    constexpr size_t kSharedXhtmlEntityResultLength = WTF_ARRAY_LENGTH(sharedXHTMLEntityResult);
+    constexpr size_t kSharedXhtmlEntityResultLength = std::size(sharedXHTMLEntityResult);
     size_t entityLengthInUTF8;
     // Unlike HTML parser, XML parser parses the content of named
     // entities. So we need to escape '&' and '<'.

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -236,7 +236,7 @@ std::optional<WebDriverService::HTTPMethod> WebDriverService::toCommandHTTPMetho
 
 bool WebDriverService::findCommand(HTTPMethod method, const String& path, CommandHandler* handler, HashMap<String, String>& parameters)
 {
-    size_t length = WTF_ARRAY_LENGTH(s_commands);
+    size_t length = std::size(s_commands);
     for (size_t i = 0; i < length; ++i) {
         if (s_commands[i].method != method)
             continue;

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -63,7 +63,7 @@ static auto sizeOfEntries(const WGPUBindGroupDescriptor& descriptor, BindGroupLa
         bool samplerIsPresent = WebGPU::samplerIsPresent(entry);
         bool textureViewIsPresent = WebGPU::textureViewIsPresent(entry);
 
-        for (size_t currentStage = 0; currentStage < WTF_ARRAY_LENGTH(shaderStage); ++currentStage) {
+        for (size_t currentStage = 0; currentStage < std::size(shaderStage); ++currentStage) {
             WGPUShaderStage renderStage = shaderStage[currentStage];
             if (!(stages & renderStage))
                 continue;
@@ -91,7 +91,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
         auto bindGroupLayout = descriptor.layout ? &WebGPU::fromAPI(descriptor.layout) : nullptr;
         auto bufferSizes = sizeOfEntries(descriptor, bindGroupLayout);
         constexpr WGPUShaderStage shaderStage[] = { WGPUShaderStage_Vertex, WGPUShaderStage_Fragment, WGPUShaderStage_Compute };
-        constexpr auto shaderStageLength = WTF_ARRAY_LENGTH(shaderStage);
+        constexpr auto shaderStageLength = std::size(shaderStage);
         id<MTLBuffer> argumentBuffer[shaderStageLength];
         for (size_t i = 0; i < shaderStageLength; ++i)
             argumentBuffer[i] = bufferSizes[i] ? safeCreateBuffer(bufferSizes[i], MTLStorageModeShared) : nil;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -57,7 +57,7 @@ static const ThroughputInterval throughputIntervals[] = {
 
 static Seconds timeUntilNextInterval(size_t currentInterval)
 {
-    RELEASE_ASSERT(currentInterval + 1 < WTF_ARRAY_LENGTH(throughputIntervals));
+    RELEASE_ASSERT(currentInterval + 1 < std::size(throughputIntervals));
     return throughputIntervals[currentInterval + 1].time - throughputIntervals[currentInterval].time;
 }
 
@@ -114,11 +114,11 @@ void DownloadMonitor::timerFired()
 {
     downloadReceivedBytes(0);
 
-    RELEASE_ASSERT(m_interval < WTF_ARRAY_LENGTH(throughputIntervals));
+    RELEASE_ASSERT(m_interval < std::size(throughputIntervals));
     if (measuredThroughputRate() < throughputIntervals[m_interval].bytesPerSecond) {
         DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: cancelling download (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
         m_download.cancel([](auto&) { }, Download::IgnoreDidFailCallback::No);
-    } else if (m_interval + 1 < WTF_ARRAY_LENGTH(throughputIntervals)) {
+    } else if (m_interval + 1 < std::size(throughputIntervals)) {
         DOWNLOAD_MONITOR_RELEASE_LOG("timerFired: sufficient throughput rate (id = %" PRIu64 ")", m_download.downloadID().toUInt64());
         m_timer.startOneShot(timeUntilNextInterval(m_interval++) / testSpeedMultiplier());
     } else

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -180,13 +180,13 @@ std::optional<SHA1::Digest> ArgumentCoder<SHA1::Digest>::decode(Decoder& decoder
 
 void ArgumentCoder<audit_token_t>::encode(Encoder& encoder, const audit_token_t& auditToken)
 {
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(auditToken.val); i++)
+    for (unsigned i = 0; i < std::size(auditToken.val); i++)
         encoder << auditToken.val[i];
 }
 
 WARN_UNUSED_RETURN bool ArgumentCoder<audit_token_t>::decode(Decoder& decoder, audit_token_t& auditToken)
 {
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(auditToken.val); i++) {
+    for (unsigned i = 0; i < std::size(auditToken.val); i++) {
         if (!decoder.decode(auditToken.val[i]))
             return false;
     }

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -208,7 +208,7 @@ static std::optional<Vector<char>> fileContents(const String& path, bool shouldL
         return std::nullopt;
 
     char chunk[4096];
-    constexpr size_t chunkSize = WTF_ARRAY_LENGTH(chunk);
+    constexpr size_t chunkSize = std::size(chunk);
     size_t contentSize = 0;
     Vector<char> contents;
     contents.reserveInitialCapacity(chunkSize);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -377,7 +377,7 @@ bool AuxiliaryProcessProxy::platformIsBeingDebugged() const
     struct kinfo_proc info;
     int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, processIdentifier() };
     size_t size = sizeof(info);
-    if (sysctl(mib, WTF_ARRAY_LENGTH(mib), &info, &size, nullptr, 0) == -1)
+    if (sysctl(mib, std::size(mib), &info, &size, nullptr, 0) == -1)
         return false;
 
     return info.kp_proc.p_flag & P_TRACED;

--- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
+++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
@@ -70,7 +70,7 @@ void ProcessLauncher::launchProcess()
         return;
 
     WCHAR pathStr[MAX_PATH];
-    if (!::GetModuleFileName(webKitModule, pathStr, WTF_ARRAY_LENGTH(pathStr)))
+    if (!::GetModuleFileName(webKitModule, pathStr, std::size(pathStr)))
         return;
 
     ::PathRemoveFileSpec(pathStr);

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -1012,7 +1012,7 @@ String convertEnumerationToString(UserMediaPermissionRequestManagerProxy::Reques
     static_assert(static_cast<size_t>(UserMediaPermissionRequestManagerProxy::RequestAction::Deny) == 0, "UserMediaPermissionRequestManagerProxy::RequestAction::Deny is not 0 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestManagerProxy::RequestAction::Grant) == 1, "UserMediaPermissionRequestManagerProxy::RequestAction::Grant is not 1 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestManagerProxy::RequestAction::Prompt) == 2, "UserMediaPermissionRequestManagerProxy::RequestAction::Prompt is not 2 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
@@ -143,7 +143,7 @@ String convertEnumerationToString(UserMediaPermissionRequestProxy::UserMediaAcce
     static_assert(static_cast<size_t>(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::HardwareError) == 4, "UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::HardwareError is not 4 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied) == 5, "UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied is not 5 as expected");
     static_assert(static_cast<size_t>(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::OtherFailure) == 6, "UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::OtherFailure is not 6 as expected");
-    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
 

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -753,7 +753,7 @@ bool WebView::shouldInitializeTrackPointHack()
         L"Software\\Synaptics\\SynTPEnh\\UltraNavPS2"
     };
 
-    for (size_t i = 0; i < WTF_ARRAY_LENGTH(trackPointKeys); ++i) {
+    for (size_t i = 0; i < std::size(trackPointKeys); ++i) {
         HKEY trackPointKey;
         int readKeyResult = ::RegOpenKeyExW(HKEY_CURRENT_USER, trackPointKeys[i], 0, KEY_READ, &trackPointKey);
         ::RegCloseKey(trackPointKey);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -276,7 +276,7 @@ JSObjectRef WebAutomationSessionProxy::scriptObjectForFrame(WebFrame& frame)
     JSObjectRef createUUIDFunction = JSObjectMakeFunctionWithCallback(context, nullptr, createUUID);
     JSObjectRef isValidNodeIdentifierFunction = JSObjectMakeFunctionWithCallback(context, nullptr, isValidNodeIdentifier);
     JSValueRef arguments[] = { sessionIdentifier, evaluateFunction, createUUIDFunction, isValidNodeIdentifierFunction };
-    JSObjectRef scriptObject = const_cast<JSObjectRef>(JSObjectCallAsFunction(context, scriptObjectFunction, nullptr, WTF_ARRAY_LENGTH(arguments), arguments, &exception));
+    JSObjectRef scriptObject = const_cast<JSObjectRef>(JSObjectCallAsFunction(context, scriptObjectFunction, nullptr, std::size(arguments), arguments, &exception));
     ASSERT(JSValueIsObject(context, scriptObject));
 
     setScriptObject(context, scriptObject);
@@ -297,7 +297,7 @@ WebCore::Element* WebAutomationSessionProxy::elementForNodeHandle(WebFrame& fram
         toJSValue(context, nodeHandle)
     };
 
-    JSValueRef result = callPropertyFunction(context, scriptObject, "nodeForIdentifier"_s, WTF_ARRAY_LENGTH(functionArguments), functionArguments, nullptr);
+    JSValueRef result = callPropertyFunction(context, scriptObject, "nodeForIdentifier"_s, std::size(functionArguments), functionArguments, nullptr);
     JSObjectRef element = JSValueToObject(context, result, nullptr);
     if (!element)
         return nullptr;
@@ -425,7 +425,7 @@ void WebAutomationSessionProxy::evaluateJavaScriptFunction(WebCore::PageIdentifi
 
     {
         WebCore::UserGestureIndicator gestureIndicator(WebCore::ProcessingUserGesture, frame->coreFrame()->document());
-        callPropertyFunction(context, scriptObject, "evaluateJavaScriptFunction"_s, WTF_ARRAY_LENGTH(functionArguments), functionArguments, &exception);
+        callPropertyFunction(context, scriptObject, "evaluateJavaScriptFunction"_s, std::size(functionArguments), functionArguments, &exception);
     }
 
     if (!exception)

--- a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
@@ -142,9 +142,9 @@ static const char* interpretKeyEvent(const KeyboardEvent& event)
     static NeverDestroyed<HashMap<int, const char*>> keyPressCommandsMap;
 
     if (keyDownCommandsMap.get().isEmpty()) {
-        for (unsigned i = 0; i < WTF_ARRAY_LENGTH(keyDownEntries); i++)
+        for (unsigned i = 0; i < std::size(keyDownEntries); i++)
             keyDownCommandsMap.get().set(keyDownEntries[i].modifiers << 16 | keyDownEntries[i].virtualKey, keyDownEntries[i].name);
-        for (unsigned i = 0; i < WTF_ARRAY_LENGTH(keyPressEntries); i++)
+        for (unsigned i = 0; i < std::size(keyPressEntries); i++)
             keyPressCommandsMap.get().set(keyPressEntries[i].modifiers << 16 | keyPressEntries[i].charCode, keyPressEntries[i].name);
     }
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2864,7 +2864,7 @@ void JSMessageListener::willSendMessage(const IPC::Encoder& encoder, OptionSet<I
     auto* description = jsDescriptionFromDecoder(globalObject, *decoder);
 
     JSValueRef arguments[] = { description ? toRef(globalObject, description) : JSValueMakeUndefined(m_context) };
-    JSObjectCallAsFunction(m_context, m_callback, m_callback, WTF_ARRAY_LENGTH(arguments), arguments, nullptr);
+    JSObjectCallAsFunction(m_context, m_callback, m_callback, std::size(arguments), arguments, nullptr);
 }
 
 JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* globalObject, IPC::Decoder& decoder)

--- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
+++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
@@ -195,10 +195,10 @@ const char* WebPage::interpretKeyEvent(const WebCore::KeyboardEvent* evt)
         keyDownCommandsMap = new HashMap<int, const char*>;
         keyPressCommandsMap = new HashMap<int, const char*>;
 
-        for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyDownEntries); ++i)
+        for (size_t i = 0; i < std::size(keyDownEntries); ++i)
             keyDownCommandsMap->set(keyDownEntries[i].modifiers << 16 | keyDownEntries[i].virtualKey, keyDownEntries[i].name);
 
-        for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyPressEntries); ++i)
+        for (size_t i = 0; i < std::size(keyPressEntries); ++i)
             keyPressCommandsMap->set(keyPressEntries[i].modifiers << 16 | keyPressEntries[i].charCode, keyPressEntries[i].name);
     }
 

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebChromeClient.cpp
@@ -594,7 +594,7 @@ void WebChromeClient::exceededDatabaseQuota(Frame& frame, const String& database
             HMODULE safariHandle = GetModuleHandleW(L"Safari.exe");
             if (!safariHandle)
                 return;
-            if (!::GetModuleFileName(safariHandle, path, WTF_ARRAY_LENGTH(path)))
+            if (!::GetModuleFileName(safariHandle, path, std::size(path)))
                 return;
             DWORD handle = 0;
             DWORD versionSize = GetFileVersionInfoSize(path, &handle);

--- a/Source/WebKitLegacy/win/WebKitDLL.cpp
+++ b/Source/WebKitLegacy/win/WebKitDLL.cpp
@@ -111,7 +111,7 @@ _Check_return_
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID* ppv)
 {
     bool found = false;
-    for (size_t i = 0; i < WTF_ARRAY_LENGTH(gRegCLSIDs); ++i) {
+    for (size_t i = 0; i < std::size(gRegCLSIDs); ++i) {
         if (IsEqualGUID(rclsid, gRegCLSIDs[i])) {
             found = true;
             break;

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -1910,9 +1910,9 @@ bool WebView::mouseWheel(WPARAM wParam, LPARAM lParam, bool isMouseHWheel)
         WCHAR className[256];
 
         // Make sure truncation won't affect the comparison.
-        ASSERT(WTF_ARRAY_LENGTH(className) > wcslen(PopupMenuWin::popupClassName()));
+        ASSERT(std::size(className) > wcslen(PopupMenuWin::popupClassName()));
 
-        if (GetClassNameW(focusedWindow, className, WTF_ARRAY_LENGTH(className)) && !wcscmp(className, PopupMenuWin::popupClassName())) {
+        if (GetClassNameW(focusedWindow, className, std::size(className)) && !wcscmp(className, PopupMenuWin::popupClassName())) {
             // We don't let the WebView scroll here for two reasons - 1) To match Firefox behavior, 2) If we do scroll, we lose the
             // focus ring around the select menu.
             SetFocus(m_viewWindow);
@@ -2109,10 +2109,10 @@ const char* WebView::interpretKeyEvent(const KeyboardEvent* evt)
         keyDownCommandsMap = new HashMap<int, const char*>;
         keyPressCommandsMap = new HashMap<int, const char*>;
 
-        for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyDownEntries); ++i)
+        for (size_t i = 0; i < std::size(keyDownEntries); ++i)
             keyDownCommandsMap->set(keyDownEntries[i].modifiers << 16 | keyDownEntries[i].virtualKey, keyDownEntries[i].name);
 
-        for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyPressEntries); ++i)
+        for (size_t i = 0; i < std::size(keyPressEntries); ++i)
             keyPressCommandsMap->set(keyPressEntries[i].modifiers << 16 | keyPressEntries[i].charCode, keyPressEntries[i].name);
     }
 

--- a/Tools/TestRunnerShared/cocoa/ModifierKeys.mm
+++ b/Tools/TestRunnerShared/cocoa/ModifierKeys.mm
@@ -220,7 +220,7 @@ struct KeyMappingEntry {
         { 0x1C, 0x5B, '8', nil },
         { 0x19, 0x5C, '9', nil },
     };
-    for (unsigned i = 0; i < WTF_ARRAY_LENGTH(table); ++i) {
+    for (unsigned i = 0; i < std::size(table); ++i) {
         NSString* currentCharacterString = [NSString stringWithCharacters:&table[i].character length:1];
         if ([character isEqualToString:currentCharacterString] || [character isEqualToString:table[i].characterName]) {
             if (keyLocation == 0x03 /*DOM_KEY_LOCATION_NUMPAD*/)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -102,7 +102,7 @@ TEST(StringBuilderTest, Append)
     builderForUChar32Append.appendCharacter(static_cast<UChar32>('A'));
     EXPECT_EQ(3U, builderForUChar32Append.length());
     const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), 'A' };
-    expectBuilderContent(String(resultArray, WTF_ARRAY_LENGTH(resultArray)), builderForUChar32Append);
+    expectBuilderContent(String(resultArray, std::size(resultArray)), builderForUChar32Append);
     {
         StringBuilder builder;
         StringBuilder builder2;
@@ -116,7 +116,7 @@ TEST(StringBuilderTest, Append)
         builder.appendCharacters(data, 2);
         EXPECT_EQ(4U, builder.length());
         const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
-        expectBuilderContent(String(resultArray, WTF_ARRAY_LENGTH(resultArray)), builder);
+        expectBuilderContent(String(resultArray, std::size(resultArray)), builder);
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -59,7 +59,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
     FloatSize initialAdvance = FloatSize(-15.15625, 18.046875);
 
     UChar characters[] = { 0x644, 0x637, 0x641, 0x627, 0x64b, 0x20 };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength));
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(21.875, 0) }, { FloatPoint() }, { 5 }, { 5 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 5, 6, false);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
@@ -105,7 +105,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
     FloatSize initialAdvance = FloatSize(-15.15625, 18.046875);
 
     UChar characters[] = { 0x644, 0x637, 0x641, 0x627, 0x64b };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength));
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -150,7 +150,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
     FloatSize initialAdvance = FloatSize(28.144531, 0);
 
     UChar characters[] = { 0x20, 0x61, 0x20e3 };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength));
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(spaceWidth, 0) }, { FloatPoint() }, { 5 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, true);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 1, 2 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 1, 3, true);
@@ -192,7 +192,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
     FloatSize initialAdvance = FloatSize(28.144531, 0);
 
     UChar characters[] = { 0x61, 0x20e3 };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength));
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 0, 1 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 2, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -226,7 +226,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
     FloatSize initialAdvance = FloatSize(4.33996383363472, 12.368896925859);
 
     UChar characters[] = { 0x633, 0x20, 0x627, 0x650 };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength));
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(-4.33996383363472, -12.368896925859), FloatSize(14.0397830018083, 0) }, { }, { 884, 240 }, { 3, 2 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 2, 4, false);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(12.0, 0) }, { }, { 3 }, { 1 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 1, 2, false);
@@ -270,7 +270,7 @@ TEST_F(ComplexTextControllerTest, LeftExpansion)
     font.update();
 
     UChar characters[] = { 'a' };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength), 0, 100, ExpansionBehavior::forceLeftOnly());
     auto run = ComplexTextController::ComplexTextRun::create({ FloatSize(24, 0) }, { }, { 16 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -300,7 +300,7 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
     font.update();
 
     UChar characters[] = { 'a', 'b', 'c', 'd' };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength));
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 1), FloatSize(0, 2) }, { FloatPoint(0, 4), FloatPoint(0, 8) }, { 16, 17 }, { 0, 1 }, FloatSize(0, 16), font.primaryFont(), characters, 0, charactersLength, 0, 2, true);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 32), FloatSize(0, 64) }, { FloatPoint(0, 128), FloatPoint(0, 256) }, { 18, 19 }, { 2, 3 }, FloatSize(0, 512), font.primaryFont(), characters, 0, charactersLength, 2, 4, true);
@@ -349,7 +349,7 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
     FloatSize initialAdvance = FloatSize();
 
     UChar characters[] = { 0x644, ' ', 0x644, ' ', 0x644 };
-    size_t charactersLength = WTF_ARRAY_LENGTH(characters);
+    size_t charactersLength = std::size(characters);
     TextRun textRun(StringView(characters, charactersLength), 0, 14, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 5, 6, 7, 8, 9 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;

--- a/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
@@ -44,7 +44,7 @@ static bool checkDecodedBytes(const uint8_t* original, size_t originalSize, cons
 TEST(KeyedCoding, SetAndGetBytes)
 {
     const uint8_t data[] = { 0x00, 0x01, 0x02, 0x03, 0xde, 0xad, 0xbe, 0xef };
-    const size_t dataLength = WTF_ARRAY_LENGTH(data);
+    const size_t dataLength = std::size(data);
     const size_t dataLengthOne = 1;
     const size_t dataLengthZero = 0;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
@@ -51,7 +51,7 @@ TEST(WebKit, TextWidth)
     // Use CFAttributedString so we don't have to deal with NSFont / UIFont and have this code be platform-dependent.
     CFTypeRef keys[] = { kCTFontAttributeName };
     CFTypeRef values[] = { font.get() };
-    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, WTF_ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("This is a test string"), attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(attributedString)));
     double coreTextWidth = CTLineGetTypographicBounds(line.get(), nullptr, nullptr, nullptr);


### PR DESCRIPTION
#### ea3f1c213913d1420007fdeb707e4b051f4f332c
<pre>
Replace use of WTF_ARRAY_LENGTH with std::size()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250261">https://bugs.webkit.org/show_bug.cgi?id=250261</a>
rdar://103982450

Reviewed by Yusuke Suzuki.

This was mechanically produced by:
% find . -type f &quot;(&quot; -name &quot;*.h&quot; -or -name &quot;*.cpp&quot; -or -name &quot;*.m&quot; -or -name &quot;*.mm&quot; &quot;)&quot; -exec sed -i &quot;&quot; &apos;s/WTF_ARRAY_LENGTH/std::size/&apos; &quot;{}&quot; \;
(... And then fixed up a bit afterward.)

FTPDirectoryParser.cpp appears to use a style guide that&apos;s totally different than our own,
and I didn&apos;t want to rewrite the whole file, so this patch only swaps out the WTF_ARRAY_LENGTH()s
in it. I&apos;ll rewrite that file to pass our style guide in another patch.

* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCoreJSBuiltins.h-result:
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_internals_wrapper_implementation.py:
(BuiltinsInternalsWrapperImplementationGenerator._generate_initialize_static_globals):
* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::sendPendingErrors):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::singleEscape):
* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::initializeDisplayNames):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::computeCurrencyDigits):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::initStaticGlobals):
(JSC::JSGlobalObject::exposeDollarVM):
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::LazyLineBreakIterator::lastCharacter const):
(WTF::LazyLineBreakIterator::secondToLastCharacter const):
(WTF::LazyLineBreakIterator::setPriorContext):
(WTF::LazyLineBreakIterator::updatePriorContext):
(WTF::LazyLineBreakIterator::resetPriorContext):
(WTF::LazyLineBreakIterator::priorContextLength const):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::generateTemporaryPath):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/Modules/speech/SpeechRecognitionUpdate.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
(WebCore::SQLTransaction::stateFunctionFor):
* Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp:
(WebCore::SQLTransactionBackend::stateFunctionFor):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::initializeRoleMap):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(createAccessibilitySearchKeyMap):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::addBuiltinGlobals):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::initStaticGlobals):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateEnumerationImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/css/StyleProperties.cpp:
* Source/WebCore/cssjit/RegisterAllocator.h:
(WebCore::RegisterAllocator::reserveCallerSavedRegisters):
(WebCore::RegisterAllocator::reserveCalleeSavedRegisters):
* Source/WebCore/dom/DOMException.cpp:
(WebCore::DOMException::description const):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::convertPropertyNameToAttributeName):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::triStateOfStyle const):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::appendCharactersReplacingEntitiesInternal):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
* Source/WebCore/html/track/VTTCue.cpp:
* Source/WebCore/loader/FTPDirectoryParser.cpp:
(WebCore::parseOneFTPLine):
* Source/WebCore/mathml/MathMLOperatorDictionary.cpp:
(WebCore::MathMLOperatorDictionary::isVertical):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::showText):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::Frame::qualifyingNodeAtViewportLocation):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::codePointSupportIndex):
* Source/WebCore/platform/graphics/GraphicsTypes.cpp:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.cpp:
(WebCore::createLegibleOutputSubtypes):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.cpp:
(WebCore::PlatformCALayer::drawTextAtPoint const):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::makeGradient const):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::createFormatDescriptionFromTrackInfo):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::appendTrueTypeFeature):
(WebCore::appendOpenTypeFeature):
(WebCore::normalizeCTWeight):
(WebCore::denormalizeCTWeight):
(WebCore::autoActivateFont):
(WebCore::lookupFallbackFont):
(WebCore::installedFontMandatoryAttributes):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
(WebCore::SystemFontDatabaseCoreText::createFontByApplyingWeightWidthItalicsAndFallbackBehavior):
(WebCore::SystemFontDatabaseCoreText::removeCascadeList):
(WebCore::SystemFontDatabaseCoreText::computeCascadeList):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::smallCapsOpenTypeDictionary):
(WebCore::smallCapsTrueTypeDictionary):
(WebCore::createCTFontWithoutSynthesizableFeatures):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::cascadeToLastResortAttributesDictionary):
* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp:
(WebCore::FEComponentTransferSoftwareApplier::computeLookupTable):
* Source/WebCore/platform/graphics/gbm/GBMDevice.cpp:
(WebCore::GBMDevice::GBMDevice):
* Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm:
(WebCore::typesetterOptions):
* Source/WebCore/platform/graphics/mac/SimpleFontDataCoreText.cpp:
(WebCore::Font::getCFStringAttributes const):
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::FontCache::lastResortFallbackFont):
* Source/WebCore/platform/graphics/win/GraphicsContextCGWin.cpp:
(WebCore::GraphicsContextCG::drawDotsForDocumentMarker):
* Source/WebCore/platform/graphics/win/IconWin.cpp:
(WebCore::Icon::createIconForFiles):
* Source/WebCore/platform/ios/KeyEventIOS.mm:
(WebCore::windowsKeyCodeForKeyCode):
* Source/WebCore/platform/ios/LegacyTileCache.mm:
(WebCore::LegacyTileCache::drawLayer):
* Source/WebCore/platform/mac/KeyEventMac.mm:
(WebCore::windowsKeyCodeForKeyCode):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::facingMode):
(WebCore::convertEnumerationToString):
(WebCore::RealtimeMediaSourceSettings::displaySurface):
* Source/WebCore/platform/network/cf/SocketStreamHandleImplCFNet.cpp:
(WebCore::SocketStreamHandleImpl::createStreams):
* Source/WebCore/platform/text/LocaleICU.cpp:
(WebCore::LocaleICU::openDateFormat const):
(WebCore::LocaleICU::monthFormat):
(WebCore::LocaleICU::shortMonthFormat):
(WebCore::LocaleICU::shortMonthLabels):
* Source/WebCore/platform/text/LocaleNone.cpp:
(WebCore::LocaleNone::monthLabels):
* Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp:
(WebCore::availableLocales):
* Source/WebCore/platform/text/win/LocaleWin.cpp:
(WebCore::LocaleWin::ensureShortMonthLabels):
(WebCore::LocaleWin::ensureMonthLabels):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::getWebLocData):
(WebCore::setFileDescriptorData):
(WebCore::getHDropData):
* Source/WebCore/platform/win/DragDataWin.cpp:
(WebCore::DragData::asFilenames const):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::writeURLToDataObject):
(WebCore::createGlobalImageFileDescriptor):
(WebCore::createGlobalHDropContent):
* Source/WebCore/platform/win/WebCoreBundleWin.cpp:
(WebCore::createWebKitBundle):
* Source/WebCore/platform/win/WindowsKeyNames.cpp:
(WebCore::WindowsKeyNames::updateLayout):
* Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp:
(PlatformXR::Instance::Impl::Impl):
* Source/WebCore/rendering/BreakLines.cpp:
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::quotesForLanguage):
* Source/WebCore/rendering/RenderThemeCocoa.mm:
(WebCore::cssWeightOfSystemFont):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::calculateStretchyData):
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::mathVariant):
* Source/WebCore/rendering/style/TextSizeAdjustment.cpp:
(WebCore::AutosizeStatus::idempotentTextSize):
* Source/WebCore/testing/LegacyMockCDM.cpp:
(WebCore::initDataPrefix):
(WebCore::keyPrefix):
(WebCore::keyRequest):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::getXHTMLEntity):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::findCommand):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::sizeOfEntries):
(WebGPU::Device::createBindGroup):
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
(WebKit::timeUntilNextInterval):
(WebKit::DownloadMonitor::timerFired):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;audit_token_t&gt;::encode):
(IPC::ArgumentCoder&lt;audit_token_t&gt;::decode):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::platformIsBeingDebugged const):
* Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::convertEnumerationToString):
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp:
(WebKit::convertEnumerationToString):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::shouldInitializeTrackPointHack):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::scriptObjectForFrame):
(WebKit::WebAutomationSessionProxy::elementForNodeHandle):
(WebKit::WebAutomationSessionProxy::evaluateJavaScriptFunction):
* Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp:
(WebKit::interpretKeyEvent):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::willSendMessage):
* Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp:
(WebKit::WebPage::interpretKeyEvent):
* Source/WebKitLegacy/win/WebCoreSupport/WebChromeClient.cpp:
(WebChromeClient::exceededDatabaseQuota):
* Source/WebKitLegacy/win/WebKitDLL.cpp:
(DllGetClassObject):
* Source/WebKitLegacy/win/WebView.cpp:
(WebView::mouseWheel):
* Tools/TestRunnerShared/cocoa/ModifierKeys.mm:
(+[ModifierKeys modifierKeysWithKey:modifiers:keyLocation:]):
* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/258619@main">https://commits.webkit.org/258619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ec1f0590feebd616538fb5c426205dfd283584

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102498 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111765 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171975 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2533 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109481 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9682 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37336 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24396 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25817 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89068 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2773 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2264 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29606 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45310 "Passed tests") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91992 "Failed to checkout and rebase branch from PR 8349") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5923 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6983 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/91992 "Failed to checkout and rebase branch from PR 8349") | 
| | | | | 
<!--EWS-Status-Bubble-End-->