### PR TITLE
Fix scrollbar thumb drag cancellation in RTL mode

### DIFF
--- a/LayoutTests/fast/overflow/rtl-scrollbar-drag-origin-expected.txt
+++ b/LayoutTests/fast/overflow/rtl-scrollbar-drag-origin-expected.txt
@@ -1,0 +1,7 @@
+PASS container.scrollLeft is 0
+PASS container.scrollLeft is 350
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test verifies scroll position restores correctly when a thumb drag has been cancelled in RTL mode.
+

--- a/LayoutTests/fast/overflow/rtl-scrollbar-drag-origin.html
+++ b/LayoutTests/fast/overflow/rtl-scrollbar-drag-origin.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<style>
+#container {
+	position: absolute;
+	left: 100px;
+	top: 0;
+	width: 300px;
+	height: 200px;
+	direction: rtl;
+	overflow: scroll;
+}
+
+#content {
+	width: 1000px;
+	height: 1px;
+}
+</style>
+<div id="container">
+    <div id="content"></div>
+</div>
+This test verifies scroll position restores correctly when a thumb drag has been cancelled in RTL mode.<br/>
+<script src="../../resources/js-test.js"></script>
+<script>
+    var container = document.getElementById("container");
+    container.scrollLeft = 350;
+
+    if (window.eventSender) {
+        eventSender.dragMode = false;
+        eventSender.mouseMoveTo(250, 195);
+        eventSender.mouseDown();
+
+        eventSender.mouseMoveTo(100, 195);
+        shouldBe("container.scrollLeft" , "0");
+
+        eventSender.mouseMoveTo(0, 195);
+        shouldBe("container.scrollLeft" , "350");
+    }
+</script>

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2004, 2006, 2008, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -308,7 +309,7 @@ bool Scrollbar::mouseMoved(const PlatformMouseEvent& evt)
 {
     if (m_pressedPart == ThumbPart) {
         if (theme().shouldSnapBackToDragOrigin(*this, evt))
-            m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, m_dragOrigin);
+            m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, m_dragOrigin + m_scrollableArea.minimumScrollPosition());
         else {
             moveThumb(m_orientation == ScrollbarOrientation::Horizontal ?
                       convertFromContainingWindow(evt.position()).x() :


### PR DESCRIPTION
<pre>
Fix scrollbar thumb drag cancellation in RTL mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=250207">https://bugs.webkit.org/show_bug.cgi?id=250207</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=175100">https://src.chromium.org/viewvc/blink?view=revision&revision=175100</a>

Scrollbar stores original scroll position in non-negative scroll
coordinates. When sending those coordinates to ScrollableArea, they
should be offsetted with minimumScrollPosition() first.

* Source/WebCore/platform/Scrollbar.cpp:
(Scrollbar::mouseMoved): Update to take "minimumScrollPosition" in consideration while offsetting
* LayoutTests/fast/overflow/rtl-scroll-bar-drag-origin.html: Add Test Case
* LayoutTests/fast/overflow/rtl-scroll-bar-drag-origin-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0aba496bc7a9f5c183a586d33f6163bfa627eac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11924 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35831 "Hash c0aba496 for PR 8355 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112061 "Hash c0aba496 for PR 8355 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172280 "Hash c0aba496 for PR 8355 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12939 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2833 "Hash c0aba496 for PR 8355 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95055 "Hash c0aba496 for PR 8355 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109734 "Hash c0aba496 for PR 8355 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108578 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9941 "Found 1 new test failure: fast/overflow/rtl-scrollbar-drag-origin.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/35831 "Hash c0aba496 for PR 8355 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/95055 "Hash c0aba496 for PR 8355 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91784 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/35831 "Hash c0aba496 for PR 8355 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/95055 "Hash c0aba496 for PR 8355 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5379 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/35831 "Hash c0aba496 for PR 8355 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5527 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/2833 "Hash c0aba496 for PR 8355 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11546 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/35831 "Hash c0aba496 for PR 8355 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7270 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->