### PR TITLE
Invoke ValidatedFormListedElement::parseReadOnlyAttribute() conditionally

### DIFF
--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -183,7 +183,7 @@ void FormAssociatedCustomElement::didUpgrade()
 
     parseFormAttribute(element.attributeWithoutSynchronization(formAttr));
     parseDisabledAttribute(element.attributeWithoutSynchronization(disabledAttr));
-    parseReadonlyAttribute(element.attributeWithoutSynchronization(readonlyAttr));
+    parseReadOnlyAttribute(element.attributeWithoutSynchronization(readonlyAttr));
 
     setDataListAncestorState(TriState::Indeterminate);
     updateWillValidateAndValidity();

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -58,6 +58,8 @@ using namespace HTMLNames;
 ValidatedFormListedElement::ValidatedFormListedElement(HTMLFormElement* form)
     : FormListedElement { form }
 {
+    if (supportsReadOnly())
+        ASSERT(readOnlyBarsFromConstraintValidation());
 }
 
 ValidatedFormListedElement::~ValidatedFormListedElement() = default;
@@ -272,8 +274,8 @@ void ValidatedFormListedElement::parseAttribute(const QualifiedName& name, const
 {
     if (name == disabledAttr && asHTMLElement().canBeActuallyDisabled())
         parseDisabledAttribute(value);
-    else if (name == readonlyAttr)
-        parseReadonlyAttribute(value);
+    else if (name == readonlyAttr && readOnlyBarsFromConstraintValidation())
+        parseReadOnlyAttribute(value);
     else
         FormListedElement::parseAttribute(name, value);
 }
@@ -290,8 +292,10 @@ void ValidatedFormListedElement::parseDisabledAttribute(const AtomString& value)
     }
 }
 
-void ValidatedFormListedElement::parseReadonlyAttribute(const AtomString& value)
+void ValidatedFormListedElement::parseReadOnlyAttribute(const AtomString& value)
 {
+    ASSERT(readOnlyBarsFromConstraintValidation());
+
     bool newHasReadOnlyAttribute = !value.isNull();
     if (m_hasReadOnlyAttribute != newHasReadOnlyAttribute) {
         bool newMatchesReadWrite = supportsReadOnly() && !newHasReadOnlyAttribute;

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -103,7 +103,7 @@ protected:
     void removedFromAncestor(Node::RemovalType, ContainerNode&);
     void parseAttribute(const QualifiedName&, const AtomString&);
     void parseDisabledAttribute(const AtomString&);
-    void parseReadonlyAttribute(const AtomString&);
+    void parseReadOnlyAttribute(const AtomString&);
 
     virtual void disabledAttributeChanged();
     virtual void disabledStateChanged();


### PR DESCRIPTION
#### 05578471c16ebe4939cd5606f9491c0c600187eb
<pre>
Invoke ValidatedFormListedElement::parseReadOnlyAttribute() conditionally
<a href="https://bugs.webkit.org/show_bug.cgi?id=250268">https://bugs.webkit.org/show_bug.cgi?id=250268</a>

Reviewed by Ryosuke Niwa.

Since not all inherently validated form controls care about &quot;readonly&quot; attribute
(namely &lt;button&gt;, &lt;select&gt;, and &lt;fieldset&gt;), this change guards parseReadOnlyAttribute()
with a readOnlyBarsFromConstraintValidation() check.

Also adds an assert that controls which supportsReadOnly() are subset of those who are
barred from constraint validation if &quot;readonly&quot; is present, and renames &quot;parseReadonlyAttribute&quot;
to match case with other methods.

No new tests, no behavior change.

* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::didUpgrade):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::parseAttribute):
(WebCore::ValidatedFormListedElement::parseReadOnlyAttribute):
(WebCore::ValidatedFormListedElement::parseReadonlyAttribute): Deleted.
* Source/WebCore/html/ValidatedFormListedElement.h:

Canonical link: <a href="https://commits.webkit.org/258621@main">https://commits.webkit.org/258621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060870e7c497595e4e5f565f83ba3ad52820cd95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111774 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171983 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2542 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109488 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9696 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37346 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24407 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25825 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2278 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45318 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5925 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6992 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->