### PR TITLE
[GLib] Add WebSetting for media-session support

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3723,6 +3723,7 @@ MediaSessionCoordinatorEnabled:
 MediaSessionEnabled:
   type: bool
   status: stable
+  webcoreOnChange: mediaSessionEnabledChanged
   humanReadableName: "Media Session API"
   humanReadableDescription: "Media Session API"
   condition: ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -53,6 +53,10 @@
 #include "MockRealtimeMediaSourceCenter.h"
 #endif
 
+#if ENABLE(MEDIA_SESSION) && USE(GLIB)
+#include "MediaSessionManagerGLib.h"
+#endif
+
 namespace WebCore {
 
 static void invalidateAfterGenericFamilyChange(Page* page)
@@ -435,6 +439,19 @@ void SettingsBase::layerBasedSVGEngineEnabledChanged()
     }
 }
 
+#endif
+
+#if ENABLE(MEDIA_SESSION)
+void SettingsBase::mediaSessionEnabledChanged()
+{
+#if USE(GLIB)
+    bool enabled = false;
+    if (m_page)
+        enabled = m_page->settings().mediaSessionEnabled();
+    auto& sessionManager = reinterpret_cast<MediaSessionManagerGLib&>(PlatformMediaSessionManager::sharedManager());
+    sessionManager.setDBusNotificationsEnabled(enabled);
+#endif
+}
 #endif
 
 void SettingsBase::userStyleSheetLocationChanged()

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -166,6 +166,9 @@ protected:
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     void layerBasedSVGEngineEnabledChanged();
 #endif
+#if ENABLE(MEDIA_SESSION)
+    void mediaSessionEnabledChanged();
+#endif
 
     Page* m_page;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -530,6 +530,13 @@ WEBKIT_API void
 webkit_settings_set_enable_webrtc                              (WebKitSettings *settings,
                                                                 gboolean enabled);
 
+WEBKIT_API gboolean
+webkit_settings_get_enable_media_session                       (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_media_session                       (WebKitSettings *settings,
+                                                                gboolean        enabled);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -281,6 +281,11 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_enable_webrtc(settings, TRUE);
     g_assert_true(webkit_settings_get_enable_webrtc(settings));
 
+    // By default, MediaSession is disabled
+    g_assert_false(webkit_settings_get_enable_media_session(settings));
+    webkit_settings_set_enable_media_session(settings, TRUE);
+    g_assert_true(webkit_settings_get_enable_media_session(settings));
+
     // By default, SpatialNavigation is disabled
     g_assert_false(webkit_settings_get_enable_spatial_navigation(settings));
     webkit_settings_set_enable_spatial_navigation(settings, TRUE);


### PR DESCRIPTION
#### d9e28adf8b1a015072ab578f96961f1b9df90a8a
<pre>
[GLib] Add WebSetting for media-session support
<a href="https://bugs.webkit.org/show_bug.cgi?id=250269">https://bugs.webkit.org/show_bug.cgi?id=250269</a>

Reviewed by NOBODY (OOPS!).

The MediaSession support (which also exposes media elements over MPRIS) is disabled by default at
runtime because not ready for prime time just yet. See also
<a href="https://bugs.webkit.org/show_bug.cgi?id=247527.">https://bugs.webkit.org/show_bug.cgi?id=247527.</a>

The PlatformMediaSession code is independant from the MEDIA_SESSION support so in order to enable/disable
DBus notifications depending on the MediaSession preference, a `webcoreOnChange` callback was added
for this purpose in SettingsBase.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::mediaSessionEnabledChanged):
* Source/WebCore/page/SettingsBase.h:
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsConstructed):
(webKitSettingsSetProperty):
(webKitSettingsGetProperty):
(webkit_settings_class_init):
(webkit_settings_get_enable_media_session):
(webkit_settings_set_enable_media_session):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9e28adf8b1a015072ab578f96961f1b9df90a8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111826 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172046 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2593 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109535 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37392 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79139 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92802 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25868 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89124 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2829 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5308 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2322 "Found 1 new test failure: webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-3d-rgb8-rgb-unsigned_byte.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29624 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45359 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/92050 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7040 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20625 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->