### PR TITLE
[web-animations] consider using Ref<> instead of RefPtr<> in the various types defined in WebAnimationTypes.h

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -47,7 +47,7 @@ void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
 {
     updateGlobalPosition(animation);
 
-    if (m_animations.add(&animation)) {
+    if (m_animations.add(animation)) {
         m_allAnimations.append(animation);
         auto* timeline = animation.timeline();
         if (timeline && timeline != this)
@@ -69,7 +69,7 @@ void AnimationTimeline::updateGlobalPosition(WebAnimation& animation)
 void AnimationTimeline::removeAnimation(WebAnimation& animation)
 {
     ASSERT(!animation.timeline() || animation.timeline() == this);
-    m_animations.remove(&animation);
+    m_animations.remove(animation);
     if (is<KeyframeEffect>(animation.effect())) {
         if (auto styleable = downcast<KeyframeEffect>(animation.effect())->targetStyleable()) {
             styleable->animationWasRemoved(animation);

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -323,15 +323,14 @@ void DocumentTimeline::removeReplacedAnimations()
     }
 }
 
-void DocumentTimeline::transitionDidComplete(RefPtr<CSSTransition> transition)
+void DocumentTimeline::transitionDidComplete(Ref<CSSTransition>&& transition)
 {
-    ASSERT(transition);
-    removeAnimation(*transition);
+    removeAnimation(transition.get());
     if (is<KeyframeEffect>(transition->effect())) {
         if (auto styleable = downcast<KeyframeEffect>(transition->effect())->targetStyleable()) {
             auto property = transition->property();
             if (styleable->hasRunningTransitionForProperty(property))
-                styleable->ensureCompletedTransitionsByProperty().set(property, transition);
+                styleable->ensureCompletedTransitionsByProperty().set(property, WTFMove(transition));
         }
     }
 }

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -58,7 +58,7 @@ public:
 
     void animationTimingDidChange(WebAnimation&) override;
     void removeAnimation(WebAnimation&) override;
-    void transitionDidComplete(RefPtr<CSSTransition>);
+    void transitionDidComplete(Ref<CSSTransition>&&);
 
     void animationAcceleratedRunningStateDidChange(WebAnimation&);
     void detachFromDocument();

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -62,12 +62,12 @@ enum class UseAcceleratedAction : uint8_t { Yes, No };
 
 using MarkableDouble = Markable<double, WebAnimationsMarkableDoubleTraits>;
 
-using AnimationCollection = ListHashSet<RefPtr<WebAnimation>>;
+using AnimationCollection = ListHashSet<Ref<WebAnimation>>;
 using AnimationEvents = Vector<Ref<AnimationEventBase>>;
-using CSSAnimationCollection = ListHashSet<RefPtr<CSSAnimation>>;
+using CSSAnimationCollection = ListHashSet<Ref<CSSAnimation>>;
 
 using AnimatableProperty = std::variant<CSSPropertyID, AtomString>;
-using AnimatablePropertyToTransitionMap = HashMap<AnimatableProperty, RefPtr<CSSTransition>>;
+using AnimatablePropertyToTransitionMap = HashMap<AnimatableProperty, Ref<CSSTransition>>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -89,8 +89,6 @@ static bool isValidSampleLocation(Document& document, const IntPoint& location)
             return false;
         if (auto* animations = styleable.animations()) {
             for (auto& animation : *animations) {
-                if (!animation)
-                    continue;
                 if (animation->playState() == WebAnimation::PlayState::Running)
                     return false;
             }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -204,13 +204,13 @@ bool Styleable::runningAnimationsAreAllAccelerated() const
 
 void Styleable::animationWasAdded(WebAnimation& animation) const
 {
-    ensureAnimations().add(&animation);
+    ensureAnimations().add(animation);
 }
 
 static inline bool removeCSSTransitionFromMap(CSSTransition& transition, AnimatablePropertyToTransitionMap& cssTransitionsByProperty)
 {
     auto transitionIterator = cssTransitionsByProperty.find(transition.property());
-    if (transitionIterator == cssTransitionsByProperty.end() || transitionIterator->value != &transition)
+    if (transitionIterator == cssTransitionsByProperty.end() || transitionIterator->value.ptr() != &transition)
         return false;
 
     cssTransitionsByProperty.remove(transitionIterator);
@@ -230,7 +230,7 @@ void Styleable::removeDeclarativeAnimationFromListsForOwningElement(WebAnimation
 
 void Styleable::animationWasRemoved(WebAnimation& animation) const
 {
-    ensureAnimations().remove(&animation);
+    ensureAnimations().remove(animation);
 
     // Now, if we're dealing with a CSS Transition, we remove it from the m_elementToRunningCSSTransitionByAnimatableProperty map.
     // We don't need to do this for CSS Animations because their timing can be set via CSS to end, which would cause this
@@ -257,8 +257,8 @@ void Styleable::cancelDeclarativeAnimations() const
 {
     if (auto* animations = this->animations()) {
         for (auto& animation : *animations) {
-            if (is<DeclarativeAnimation>(animation))
-                downcast<DeclarativeAnimation>(*animation).cancelFromStyle();
+            if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation.get()))
+                declarativeAnimation->cancelFromStyle();
         }
     }
 


### PR DESCRIPTION
#### 866813ec2e4eb4f8646237cccfe1ad3ad76f46e1
<pre>
[web-animations] consider using Ref&lt;&gt; instead of RefPtr&lt;&gt; in the various types defined in WebAnimationTypes.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=249530">https://bugs.webkit.org/show_bug.cgi?id=249530</a>
rdar://103683475

Reviewed by Darin Adler and Alexey Shvayka.

We switch the AnimationCollection, CSSAnimationCollection and AnimatablePropertyToTransitionMap types
to use Ref&lt;&gt; instead of RefPtr&lt;&gt;.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
(WebCore::AnimationTimeline::removeAnimation):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::transitionDidComplete):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/DocumentTimelinesController.cpp:
(WebCore::DocumentTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::isValidSampleLocation):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::animationWasAdded const):
(WebCore::removeCSSTransitionFromMap):
(WebCore::Styleable::animationWasRemoved const):
(WebCore::Styleable::cancelDeclarativeAnimations const):

Canonical link: <a href="https://commits.webkit.org/258631@main">https://commits.webkit.org/258631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d251b3747d44f034eacc02aa54c932d6dfc4f67c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111824 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172044 "Failed to checkout and rebase branch from PR 8361") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2591 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109533 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5147 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11326 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7039 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3147 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->