### PR TITLE
Clean up DeprecatedGlobalSettings

### DIFF
--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -30,8 +30,6 @@
 #include "HTMLMediaElement.h"
 #include "MediaPlayer.h"
 #include "PlatformMediaSessionManager.h"
-#include "PlatformScreen.h"
-#include <JavaScriptCore/Options.h>
 #include <wtf/NeverDestroyed.h>
 
 #if PLATFORM(COCOA)
@@ -39,33 +37,6 @@
 #endif
 
 namespace WebCore {
-
-DeprecatedGlobalSettings::DeprecatedGlobalSettings()
-{
-#if USE(AVFOUNDATION)
-    m_AVFoundationEnabled = true;
-#endif
-
-#if USE(GSTREAMER)
-    m_GStreamerEnabled = true;
-#endif
-#if PLATFORM(WIN)
-    m_shouldUseHighResolutionTimers = true;
-#endif
-#if PLATFORM(IOS_FAMILY)
-    m_networkDataUsageTrackingEnabled = false;
-    m_shouldOptOutOfNetworkStateObservation = false;
-    m_disableScreenSizeOverride = false;
-#endif
-
-    m_mockScrollbarsEnabled = false;
-    m_usesOverlayScrollbars = false;
-    m_lowPowerVideoAudioBufferSizeEnabled = false;
-    m_trackingPreventionEnabled = false;
-    m_allowsAnySSLCertificate = false;
-}
-
-DeprecatedGlobalSettings::~DeprecatedGlobalSettings() = default;
 
 DeprecatedGlobalSettings& DeprecatedGlobalSettings::shared()
 {
@@ -106,7 +77,6 @@ void DeprecatedGlobalSettings::setSampleBufferContentKeySessionSupportEnabled(bo
     MediaSessionManagerCocoa::setSampleBufferContentKeySessionSupportEnabled(enabled);
 }
 #endif
-
 
 #if PLATFORM(WIN)
 void DeprecatedGlobalSettings::setShouldUseHighResolutionTimers(bool shouldUseHighResolutionTimers)
@@ -150,25 +120,10 @@ void DeprecatedGlobalSettings::setMockScrollbarsEnabled(bool flag)
     // FIXME: This should update scroll bars in existing pages.
 }
 
-bool DeprecatedGlobalSettings::mockScrollbarsEnabled()
-{
-    return shared().m_mockScrollbarsEnabled;
-}
-
 void DeprecatedGlobalSettings::setUsesOverlayScrollbars(bool flag)
 {
     shared().m_usesOverlayScrollbars = flag;
     // FIXME: This should update scroll bars in existing pages.
-}
-
-bool DeprecatedGlobalSettings::usesOverlayScrollbars()
-{
-    return shared().m_usesOverlayScrollbars;
-}
-
-void DeprecatedGlobalSettings::setLowPowerVideoAudioBufferSizeEnabled(bool flag)
-{
-    shared().m_lowPowerVideoAudioBufferSizeEnabled = flag;
 }
 
 void DeprecatedGlobalSettings::setTrackingPreventionEnabled(bool flag)
@@ -192,19 +147,9 @@ void DeprecatedGlobalSettings::setNetworkDataUsageTrackingEnabled(bool trackingE
     shared().m_networkDataUsageTrackingEnabled = trackingEnabled;
 }
 
-bool DeprecatedGlobalSettings::networkDataUsageTrackingEnabled()
-{
-    return shared().m_networkDataUsageTrackingEnabled;
-}
-
 void DeprecatedGlobalSettings::setNetworkInterfaceName(const String& networkInterfaceName)
 {
     shared().m_networkInterfaceName = networkInterfaceName;
-}
-
-const String& DeprecatedGlobalSettings::networkInterfaceName()
-{
-    return shared().m_networkInterfaceName;
 }
 #endif
 

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -39,23 +39,23 @@ public:
 #endif
 
 #if USE(AVFOUNDATION)
-    WEBCORE_EXPORT static void setAVFoundationEnabled(bool flag);
+    WEBCORE_EXPORT static void setAVFoundationEnabled(bool);
     static bool isAVFoundationEnabled() { return shared().m_AVFoundationEnabled; }
 #endif
 
 #if USE(GSTREAMER)
-    WEBCORE_EXPORT static void setGStreamerEnabled(bool flag);
+    WEBCORE_EXPORT static void setGStreamerEnabled(bool);
     static bool isGStreamerEnabled() { return shared().m_GStreamerEnabled; }
 #endif
 
-    WEBCORE_EXPORT static void setMockScrollbarsEnabled(bool flag);
-    WEBCORE_EXPORT static bool mockScrollbarsEnabled();
+    WEBCORE_EXPORT static void setMockScrollbarsEnabled(bool);
+    static bool mockScrollbarsEnabled() { return shared().m_mockScrollbarsEnabled; }
 
-    WEBCORE_EXPORT static void setUsesOverlayScrollbars(bool flag);
-    static bool usesOverlayScrollbars();
+    WEBCORE_EXPORT static void setUsesOverlayScrollbars(bool);
+    static bool usesOverlayScrollbars() { return shared().m_usesOverlayScrollbars; }
 
     static bool lowPowerVideoAudioBufferSizeEnabled() { return shared().m_lowPowerVideoAudioBufferSizeEnabled; }
-    WEBCORE_EXPORT static void setLowPowerVideoAudioBufferSizeEnabled(bool);
+    static void setLowPowerVideoAudioBufferSizeEnabled(bool flag) { shared().m_lowPowerVideoAudioBufferSizeEnabled = flag; }
 
     static bool trackingPreventionEnabled() { return shared().m_trackingPreventionEnabled; }
     WEBCORE_EXPORT static void setTrackingPreventionEnabled(bool);
@@ -65,10 +65,10 @@ public:
     static unsigned audioSessionCategoryOverride();
 
     WEBCORE_EXPORT static void setNetworkDataUsageTrackingEnabled(bool);
-    static bool networkDataUsageTrackingEnabled();
+    static bool networkDataUsageTrackingEnabled() { return shared().m_networkDataUsageTrackingEnabled; }
 
     WEBCORE_EXPORT static void setNetworkInterfaceName(const String&);
-    static const String& networkInterfaceName();
+    static const String& networkInterfaceName() { return shared().m_networkInterfaceName; }
 
     static void setDisableScreenSizeOverride(bool flag) { shared().m_disableScreenSizeOverride = flag; }
     static bool disableScreenSizeOverride() { return shared().m_disableScreenSizeOverride; }
@@ -78,7 +78,7 @@ public:
 #endif
 
 #if USE(AUDIO_SESSION)
-    WEBCORE_EXPORT static void setShouldManageAudioSessionCategory(bool flag);
+    WEBCORE_EXPORT static void setShouldManageAudioSessionCategory(bool);
     WEBCORE_EXPORT static bool shouldManageAudioSessionCategory();
 #endif
 
@@ -161,12 +161,12 @@ public:
 #endif
 
 #if ENABLE(VORBIS)
-    WEBCORE_EXPORT static void setVorbisDecoderEnabled(bool isEnabled);
+    WEBCORE_EXPORT static void setVorbisDecoderEnabled(bool);
     static bool vorbisDecoderEnabled() { return shared().m_vorbisDecoderEnabled; }
 #endif
 
 #if ENABLE(OPUS)
-    WEBCORE_EXPORT static void setOpusDecoderEnabled(bool isEnabled);
+    WEBCORE_EXPORT static void setOpusDecoderEnabled(bool);
     static bool opusDecoderEnabled() { return shared().m_opusDecoderEnabled; }
 #endif
 
@@ -176,7 +176,7 @@ public:
 #endif
 
 #if HAVE(AVCONTENTKEYSPECIFIER)
-    WEBCORE_EXPORT static void setSampleBufferContentKeySessionSupportEnabled(bool);
+    static void setSampleBufferContentKeySessionSupportEnabled(bool);
     static bool sampleBufferContentKeySessionSupportEnabled() { return shared().m_sampleBufferContentKeySessionSupportEnabled; }
 #endif
 
@@ -193,35 +193,33 @@ public:
 
 private:
     WEBCORE_EXPORT static DeprecatedGlobalSettings& shared();
-    DeprecatedGlobalSettings();
-    ~DeprecatedGlobalSettings();
+    DeprecatedGlobalSettings() = default;
+    ~DeprecatedGlobalSettings() = default;
 
 #if USE(AVFOUNDATION)
-    bool m_AVFoundationEnabled;
+    bool m_AVFoundationEnabled { true };
 #endif
 
 #if USE(GSTREAMER)
-    bool m_GStreamerEnabled;
+    bool m_GStreamerEnabled { true };
 #endif
 
-    bool m_mockScrollbarsEnabled;
-    bool m_usesOverlayScrollbars;
+    bool m_mockScrollbarsEnabled { false };
+    bool m_usesOverlayScrollbars { false };
 
 #if PLATFORM(WIN)
-    bool m_shouldUseHighResolutionTimers;
+    bool m_shouldUseHighResolutionTimers { true };
 #endif
 #if PLATFORM(IOS_FAMILY)
-    bool m_networkDataUsageTrackingEnabled;
-    bool m_shouldOptOutOfNetworkStateObservation;
-    bool m_disableScreenSizeOverride;
-#endif
-    bool m_manageAudioSession;
-
-    bool m_lowPowerVideoAudioBufferSizeEnabled;
-    bool m_trackingPreventionEnabled;
-    bool m_allowsAnySSLCertificate;
-
+    bool m_networkDataUsageTrackingEnabled { false };
     String m_networkInterfaceName;
+    bool m_shouldOptOutOfNetworkStateObservation { false };
+    bool m_disableScreenSizeOverride { false };
+#endif
+
+    bool m_lowPowerVideoAudioBufferSizeEnabled { false };
+    bool m_trackingPreventionEnabled { false };
+    bool m_allowsAnySSLCertificate { false };
 
     bool m_isPaintTimingEnabled { false };
 
@@ -231,9 +229,7 @@ private:
     bool m_isRestrictedHTTPResponseAccess { true };
     bool m_isServerTimingEnabled { false };
     bool m_attrStyleEnabled { false };
-    bool m_syntheticEditingCommandsEnabled { true };
     bool m_webSQLEnabled { false };
-    bool m_keygenElementEnabled { false };
     bool m_highlightAPIEnabled { false };
 
     bool m_inlineFormattingContextIntegrationEnabled { true };


### PR DESCRIPTION
#### 113459009e442af44e8913a60533c3fb3ee8a5c7
<pre>
Clean up DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250284">https://bugs.webkit.org/show_bug.cgi?id=250284</a>
rdar://103994908

Reviewed by Darin Adler.

- Remove unused fields
- Move m_networkInterfaceName to `#if PLATFORM(IOS_FAMILY)` since it&apos;s only used there
- Remove unused WEBCORE_EXPORT
- Remove constructor and just initialize fields accordingly
- Inline some method definitions

* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::DeprecatedGlobalSettings): Deleted.
(WebCore::DeprecatedGlobalSettings::setNetworkInterfaceName):
(WebCore::DeprecatedGlobalSettings::mockScrollbarsEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::usesOverlayScrollbars): Deleted.
(WebCore::DeprecatedGlobalSettings::setLowPowerVideoAudioBufferSizeEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::networkDataUsageTrackingEnabled): Deleted.
(WebCore::DeprecatedGlobalSettings::networkInterfaceName): Deleted.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::mockScrollbarsEnabled):
(WebCore::DeprecatedGlobalSettings::usesOverlayScrollbars):
(WebCore::DeprecatedGlobalSettings::setLowPowerVideoAudioBufferSizeEnabled):
(WebCore::DeprecatedGlobalSettings::networkDataUsageTrackingEnabled):
(WebCore::DeprecatedGlobalSettings::networkInterfaceName):

Canonical link: <a href="https://commits.webkit.org/258643@main">https://commits.webkit.org/258643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f1505431de2d9c534ccbf57f08ca767b849c727

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111817 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172036 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2584 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109526 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9723 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37377 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79126 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5140 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2311 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5934 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7032 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->