### PR TITLE
text-decoration-thickness property doesn't always trigger repaint when changed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="utf-8">
+    <title>text-decoration-thickness invalidation reference</title>
+    <style>
+        :link {
+            text-decoration: underline;
+            text-decoration-thickness: 3px;
+        }
+    </style>
+    <div style="font-size: 28px;">
+        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+    </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="utf-8">
+    <title>text-decoration-thickness invalidation reference</title>
+    <style>
+        :link {
+            text-decoration: underline;
+            text-decoration-thickness: 3px;
+        }
+    </style>
+    <div style="font-size: 28px;">
+        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+    </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <meta charset="utf-8">
+    <title>text-decoration-thickness invalidation</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/selectors/#the-hover-pseudo">
+    <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness-property">
+    <link rel="match" href="text-decoration-thickness-ref.html">
+    <style>
+        :link {
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+        }
+        :link:hover {
+            text-decoration-thickness: 3px;
+        }
+    </style>
+    <div style="font-size: 28px;">
+        <a href="#" id="link">Hover over this link, and check if the text-decoration-thickness increases.</a>
+    </div>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script>
+        window.addEventListener("load", async () => {
+            // Hover the link
+            await new test_driver.Actions().pointerMove(0, 0, { origin: link }).send();
+
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3193,7 +3193,10 @@ webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-
 webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-script-focus-017.tentative.html [ Skip ]
 webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-script-focus-018.html [ Skip ]
 webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/focus-visible-script-focus-019.html [ Skip ]
-webkit.org/b/209734 imported/w3c/web-platform-tests/css/selectors/hover-002.html [ Skip ]
+
+# :hover simulation not working on iOS
+imported/w3c/web-platform-tests/css/selectors/hover-002.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html [ Skip ]
 
 # Certain versions of iOS use different text security characters.
 webkit.org/b/209692 platform/ios/fast/text/text-security-disc-bullet-pua-ios-new.html [ Pass ]

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1242,6 +1242,7 @@ bool RenderStyle::changeRequiresRepaintIfText(const RenderStyle& other, OptionSe
         || m_visualData->textDecorationLine != other.m_visualData->textDecorationLine
         || m_rareNonInheritedData->textDecorationStyle != other.m_rareNonInheritedData->textDecorationStyle
         || m_rareNonInheritedData->textDecorationColor != other.m_rareNonInheritedData->textDecorationColor
+        || m_rareNonInheritedData->textDecorationThickness != other.m_rareNonInheritedData->textDecorationThickness
         || m_rareInheritedData->textDecorationSkipInk != other.m_rareInheritedData->textDecorationSkipInk
         || m_rareInheritedData->textFillColor != other.m_rareInheritedData->textFillColor
         || m_rareInheritedData->textStrokeColor != other.m_rareInheritedData->textStrokeColor


### PR DESCRIPTION
#### 6be98ae1629fb67d7fc6ed7413c6d8e40d251720
<pre>
text-decoration-thickness property doesn&apos;t always trigger repaint when changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=224483">https://bugs.webkit.org/show_bug.cgi?id=224483</a>
rdar://76895249

Reviewed by Darin Adler.

RenderStyle::changeRequiresRepaintIfText() should return true when text-decoration-thickness changes.

GOV.UK bug tracker: <a href="https://github.com/alphagov/reported-bugs/issues/60">https://github.com/alphagov/reported-bugs/issues/60</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresRepaintIfText const):

Canonical link: <a href="https://commits.webkit.org/258641@main">https://commits.webkit.org/258641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42d8bcee6a7036ecb92b4961b16abd70d61ee3d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102584 "Failed to checkout and rebase branch from PR 8372") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111851 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172073 "Failed to checkout and rebase branch from PR 8372") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/106552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2618 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94860 "Failed to checkout and rebase branch from PR 8372") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108363 "Failed to checkout and rebase branch from PR 8372") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11353 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/7065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3156 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->