### PR TITLE
[Multicolumn] Guard against zero or negative space shortage

### DIFF
--- a/LayoutTests/fast/multicol/widows-expected.txt
+++ b/LayoutTests/fast/multicol/widows-expected.txt
@@ -1,0 +1,21 @@
+Test column balancer behavior when widows requirements are high, and there's need for an early break to honor widows
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mc.offsetHeight is 250
+PASS first.offsetTop is inFirstColumn.offsetTop
+PASS first.offsetLeft is > inFirstColumn.offsetLeft
+PASS last.offsetLeft is first.offsetLeft
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The 5 lines should all be in the second column.
+
+
+line
+line
+line
+line
+line
+

--- a/LayoutTests/fast/multicol/widows.html
+++ b/LayoutTests/fast/multicol/widows.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<script>
+    description("Test column balancer behavior when widows requirements are high, and there's need for an early break to honor widows");
+</script>
+<p>The 5 lines should all be in the second column.</p>
+<div id="mc" style="-webkit-columns:3; columns:3; -webkit-column-rule:solid; line-height:50px; orphans:1; widows:5;">
+    <span id="inFirstColumn"><br></span>
+    <span id="first">line<br></span>
+    line<br>
+    line<br>
+    line<br>
+    <span id="last">line<br></span>
+</div>
+<script>
+    shouldBe("mc.offsetHeight", "250");
+    shouldBe("first.offsetTop", "inFirstColumn.offsetTop");
+    shouldBeGreaterThan("first.offsetLeft", "inFirstColumn.offsetLeft");
+    shouldBe("last.offsetLeft", "first.offsetLeft");
+</script>

--- a/LayoutTests/fast/multicol/widows2-expected.txt
+++ b/LayoutTests/fast/multicol/widows2-expected.txt
@@ -1,0 +1,28 @@
+Test column balancer behavior when widows requirements are high, and there are so many lines that there's no need for early breaks to honor widows
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mc.offsetHeight is 300
+PASS successfullyParsed is true
+
+TEST COMPLETE
+There should be 6 lines in the first column, 5 in the second and 5 in the last one.
+
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+line
+

--- a/LayoutTests/fast/multicol/widows2.html
+++ b/LayoutTests/fast/multicol/widows2.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<script>
+    description("Test column balancer behavior when widows requirements are high, and there are so many lines that there's no need for early breaks to honor widows");
+</script>
+<p>There should be 6 lines in the first column, 5 in the second and 5 in the last one.</p>
+<div id="mc" style="-webkit-columns:3; columns:3; -webkit-column-rule:solid; line-height:50px;">
+    <div style="orphans:1; widows:5;">
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+        line<br>
+    </div>
+</div>
+<script>
+    shouldBe("mc.offsetHeight", "300");
+</script>

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2012 Apple Inc.  All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,6 +185,13 @@ LayoutUnit RenderMultiColumnFlow::initialLogicalWidth() const
 
 void RenderMultiColumnFlow::setPageBreak(const RenderBlock* block, LayoutUnit offset, LayoutUnit spaceShortage)
 {
+    // Only positive values are interesting (and allowed) here. Zero space shortage may be reported
+    // when we're at the top of a column and the element has zero height. Ignore this, and also
+    // ignore any negative values, which may occur when we set an early break in order to honor
+    // widows in the next column.
+    if (spaceShortage <= 0)
+        return;
+
     if (auto* multicolSet = downcast<RenderMultiColumnSet>(fragmentAtBlockOffset(block, offset)))
         multicolSet->recordSpaceShortage(spaceShortage);
 }


### PR DESCRIPTION
#### 783df4eb909643460092a0df2e44bb5d1fe8fe5d
<pre>
[Multicolumn] Guard against zero or negative space shortage

[Multicolumn] Guard against zero or negative space shortage
<a href="https://bugs.webkit.org/show_bug.cgi?id=250282">https://bugs.webkit.org/show_bug.cgi?id=250282</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=174088

We need positive values in order to get anywhere when stretching columns
in order to balance them, and we may get called with zero or negative
values when there&apos;s zero-height content at column boundaries, so we
set an early break in order to honor widows in the next column.

* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(RenderMultiColumnFlow::initialLogicalWidth): Add early return for &quot;spaceShortage&quot; to get positive values
* LayoutTests/fast/multicol/windows.html: Add Test Case
* LayoutTests/fast/multicol/windows2.html: Ditto
* LayoutTests/fast/multicol/windows-expected.txt: Add Test Case Expectation
* LayoutTests/fast/multicol/windows2-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/258647@main">https://commits.webkit.org/258647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee874b0c41e5f0b50435d2cd6862a806d9420a6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111829 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172049 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2596 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109538 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37391 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79138 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5151 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25871 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2324 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5936 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7043 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->