### PR TITLE
[web-animations] use dynamicDowncast<> when downcast<KeyframeEffect> is used

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -70,10 +70,10 @@ void AnimationTimeline::removeAnimation(WebAnimation& animation)
 {
     ASSERT(!animation.timeline() || animation.timeline() == this);
     m_animations.remove(animation);
-    if (is<KeyframeEffect>(animation.effect())) {
-        if (auto styleable = downcast<KeyframeEffect>(animation.effect())->targetStyleable()) {
+    if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
+        if (auto styleable = keyframeEffect->targetStyleable()) {
             styleable->animationWasRemoved(animation);
-            styleable->ensureKeyframeEffectStack().removeEffect(*downcast<KeyframeEffect>(animation.effect()));
+            styleable->ensureKeyframeEffectStack().removeEffect(*keyframeEffect);
         }
     }
 }

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -111,8 +111,8 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
         animationEffect->setIterationDuration(Seconds(animation.duration()));
 
     if (!m_overriddenProperties.contains(Property::CompositeOperation)) {
-        if (is<KeyframeEffect>(animationEffect))
-            downcast<KeyframeEffect>(*animationEffect).setComposite(animation.compositeOperation());
+        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animationEffect))
+            keyframeEffect->setComposite(animation.compositeOperation());
     }
 
     animationEffect->updateStaticTimingProperties();

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -187,11 +187,9 @@ ExceptionOr<void> DeclarativeAnimation::bindingsPause()
 
 void DeclarativeAnimation::flushPendingStyleChanges() const
 {
-    if (auto* animationEffect = effect()) {
-        if (is<KeyframeEffect>(animationEffect)) {
-            if (auto* target = downcast<KeyframeEffect>(animationEffect)->target())
-                target->document().updateStyleIfNeeded();
-        }
+    if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(effect())) {
+        if (auto* target = keyframeEffect->target())
+            target->document().updateStyleIfNeeded();
     }
 }
 

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -235,8 +235,8 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
     if (!is<KeyframeEffect>(effect))
         return false;
 
-    auto* keyframeEffect = downcast<KeyframeEffect>(effect);
-    auto target = keyframeEffect->targetStyleable();
+    auto& keyframeEffect = downcast<KeyframeEffect>(*effect);
+    auto target = keyframeEffect.targetStyleable();
     if (!target || !target->element.isDescendantOf(*m_document))
         return false;
 
@@ -253,7 +253,7 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
     };
 
     HashSet<AnimatableProperty> propertiesToMatch;
-    for (auto property : keyframeEffect->animatedProperties())
+    for (auto property : keyframeEffect.animatedProperties())
         propertiesToMatch.add(resolvedProperty(property));
 
     auto protectedAnimations = [&]() -> Vector<RefPtr<WebAnimation>> {
@@ -270,9 +270,7 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
             break;
 
         if (animationWithHigherCompositeOrder && animationWithHigherCompositeOrder->isReplaceable()) {
-            auto* effectWithHigherCompositeOrder = animationWithHigherCompositeOrder->effect();
-            if (is<KeyframeEffect>(effectWithHigherCompositeOrder)) {
-                auto* keyframeEffectWithHigherCompositeOrder = downcast<KeyframeEffect>(effectWithHigherCompositeOrder);
+            if (auto* keyframeEffectWithHigherCompositeOrder = dynamicDowncast<KeyframeEffect>(animationWithHigherCompositeOrder->effect())) {
                 for (auto property : keyframeEffectWithHigherCompositeOrder->animatedProperties()) {
                     if (propertiesToMatch.remove(resolvedProperty(property)) && propertiesToMatch.isEmpty())
                         break;
@@ -326,8 +324,8 @@ void DocumentTimeline::removeReplacedAnimations()
 void DocumentTimeline::transitionDidComplete(Ref<CSSTransition>&& transition)
 {
     removeAnimation(transition.get());
-    if (is<KeyframeEffect>(transition->effect())) {
-        if (auto styleable = downcast<KeyframeEffect>(transition->effect())->targetStyleable()) {
+    if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(transition->effect())) {
+        if (auto styleable = keyframeEffect->targetStyleable()) {
             auto property = transition->property();
             if (styleable->hasRunningTransitionForProperty(property))
                 styleable->ensureCompletedTransitionsByProperty().set(property, WTFMove(transition));
@@ -413,14 +411,11 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 
     bool hasForcedLayout = false;
     for (auto& animation : acceleratedAnimationsPendingRunningStateChange) {
-        auto* effect = animation->effect();
-        if (!is<KeyframeEffect>(effect))
-            continue;
-
-        auto& keyframeEffect = downcast<KeyframeEffect>(*effect);
-        if (!hasForcedLayout)
-            hasForcedLayout |= keyframeEffect.forceLayoutIfNeeded();
-        keyframeEffect.applyPendingAcceleratedActions();
+        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+            if (!hasForcedLayout)
+                hasForcedLayout |= keyframeEffect->forceLayoutIfNeeded();
+            keyframeEffect->applyPendingAcceleratedActions();
+        }
     }
 }
 

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -217,8 +217,8 @@ static Ref<Protocol::Animation::Effect> buildObjectForEffect(AnimationEffect& ef
     if (auto fillMode = protocolValueForFillMode(effect.fill()))
         effectPayload->setFillMode(fillMode.value());
 
-    if (is<KeyframeEffect>(effect))
-        effectPayload->setKeyframes(buildObjectForKeyframes(downcast<KeyframeEffect>(effect)));
+    if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(effect))
+        effectPayload->setKeyframes(buildObjectForKeyframes(*keyframeEffect));
 
     return effectPayload;
 }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -136,11 +136,9 @@ bool Styleable::computeAnimationExtent(LayoutRect& bounds) const
 
     KeyframeEffect* matchingEffect = nullptr;
     for (const auto& animation : *animations) {
-        auto* effect = animation->effect();
-        if (is<KeyframeEffect>(effect)) {
-            auto* keyframeEffect = downcast<KeyframeEffect>(effect);
+        if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
             if (keyframeEffect->animatedProperties().contains(CSSPropertyTransform))
-                matchingEffect = downcast<KeyframeEffect>(effect);
+                matchingEffect = keyframeEffect;
         }
     }
 


### PR DESCRIPTION
#### 600168ef8d8f2825d40b1df5cb3e64b8729098e2
<pre>
[web-animations] use dynamicDowncast&lt;&gt; when downcast&lt;KeyframeEffect&gt; is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=250294">https://bugs.webkit.org/show_bug.cgi?id=250294</a>

Reviewed by Tim Nguyen.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::removeAnimation):
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::flushPendingStyleChanges const):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
(WebCore::DocumentTimeline::transitionDidComplete):
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForEffect):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::computeAnimationExtent const):

Canonical link: <a href="https://commits.webkit.org/258639@main">https://commits.webkit.org/258639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baac4b38c670124eca27e99ad67bf3f3c417218e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111827 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172047 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2594 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109536 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37388 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79136 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25869 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5309 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2320 "Found 1 new test failure: webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-3d-rgb8-rgb-unsigned_byte.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45360 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7041 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3154 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->