### PR TITLE
[web-animations] use dynamicDowncast<> when downcast<> is used for DeclarativeAnimation and its subclasses

### DIFF
--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -56,8 +56,8 @@ void AnimationEffect::setAnimation(WebAnimation* animation)
 
 EffectTiming AnimationEffect::getBindingsTiming() const
 {
-    if (is<DeclarativeAnimation>(animation()))
-        downcast<DeclarativeAnimation>(*animation()).flushPendingStyleChanges();
+    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
+        declarativeAnimation->flushPendingStyleChanges();
     return getTiming();
 }
 
@@ -173,8 +173,8 @@ BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<Seconds> startTi
 
 ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
 {
-    if (is<DeclarativeAnimation>(animation()))
-        downcast<DeclarativeAnimation>(*animation()).flushPendingStyleChanges();
+    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
+        declarativeAnimation->flushPendingStyleChanges();
     return getComputedTiming();
 }
 

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -117,9 +117,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
     const auto& blendingKeyframes = keyframeEffect.blendingKeyframes();
     const auto& parsedKeyframes = keyframeEffect.parsedKeyframes();
 
-    if (is<DeclarativeAnimation>(keyframeEffect.animation())) {
-        auto& declarativeAnimation = downcast<DeclarativeAnimation>(*keyframeEffect.animation());
-
+    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(keyframeEffect.animation())) {
         auto* target = keyframeEffect.target();
         auto* renderer = keyframeEffect.renderer();
 
@@ -142,7 +140,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
             if (!timingFunction)
                 timingFunction = blendingKeyframe.timingFunction();
             if (!timingFunction)
-                timingFunction = declarativeAnimation.backingAnimation().timingFunction();
+                timingFunction = declarativeAnimation->backingAnimation().timingFunction();
             if (timingFunction)
                 keyframePayload->setEasing(timingFunction->cssText());
 
@@ -433,10 +431,10 @@ void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, K
                 event->setNodeId(nodeId);
         }
 
-        if (is<CSSAnimation>(animation))
-            event->setAnimationName(downcast<CSSAnimation>(*animation).animationName());
-        else if (is<CSSTransition>(animation))
-            event->setTransitionProperty(downcast<CSSTransition>(*animation).transitionProperty());
+        if (auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation))
+            event->setAnimationName(cssAnimation->animationName());
+        else if (auto* cssTransition = dynamicDowncast<CSSTransition>(animation))
+            event->setTransitionProperty(cssTransition->transitionProperty());
         else
             ASSERT_NOT_REACHED();
     }
@@ -456,8 +454,8 @@ void InspectorAnimationAgent::didChangeWebAnimationName(WebAnimation& animation)
 
 void InspectorAnimationAgent::didSetWebAnimationEffect(WebAnimation& animation)
 {
-    if (is<DeclarativeAnimation>(animation))
-        stopTrackingDeclarativeAnimation(downcast<DeclarativeAnimation>(animation));
+    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation))
+        stopTrackingDeclarativeAnimation(*declarativeAnimation);
 
     didChangeWebAnimationEffectTiming(animation);
     didChangeWebAnimationEffectTarget(animation);
@@ -498,8 +496,8 @@ void InspectorAnimationAgent::didCreateWebAnimation(WebAnimation& animation)
 
 void InspectorAnimationAgent::willDestroyWebAnimation(WebAnimation& animation)
 {
-    if (is<DeclarativeAnimation>(animation))
-        stopTrackingDeclarativeAnimation(downcast<DeclarativeAnimation>(animation));
+    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation))
+        stopTrackingDeclarativeAnimation(*declarativeAnimation);
 
     // The `animationId` may be empty if Animation is tracking but not enabled.
     auto animationId = findAnimationId(animation);
@@ -555,10 +553,10 @@ void InspectorAnimationAgent::bindAnimation(WebAnimation& animation, bool captur
     if (!name.isEmpty())
         animationPayload->setName(name);
 
-    if (is<CSSAnimation>(animation))
-        animationPayload->setCssAnimationName(downcast<CSSAnimation>(animation).animationName());
-    else if (is<CSSTransition>(animation))
-        animationPayload->setCssTransitionProperty(downcast<CSSTransition>(animation).transitionProperty());
+    if (auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation))
+        animationPayload->setCssAnimationName(cssAnimation->animationName());
+    else if (auto* cssTransition = dynamicDowncast<CSSTransition>(animation))
+        animationPayload->setCssTransitionProperty(cssTransition->transitionProperty());
 
     if (auto* effect = animation.effect())
         animationPayload->setEffect(buildObjectForEffect(*effect));

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -221,10 +221,9 @@ void Styleable::removeDeclarativeAnimationFromListsForOwningElement(WebAnimation
 {
     ASSERT(is<DeclarativeAnimation>(animation));
 
-    if (is<CSSTransition>(animation)) {
-        auto& transition = downcast<CSSTransition>(animation);
-        if (!removeCSSTransitionFromMap(transition, ensureRunningTransitionsByProperty()))
-            removeCSSTransitionFromMap(transition, ensureCompletedTransitionsByProperty());
+    if (auto* transition = dynamicDowncast<CSSTransition>(animation)) {
+        if (!removeCSSTransitionFromMap(*transition, ensureRunningTransitionsByProperty()))
+            removeCSSTransitionFromMap(*transition, ensureCompletedTransitionsByProperty());
     }
 }
 
@@ -467,8 +466,8 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
     auto* animation = keyframeEffect ? keyframeEffect->animation() : nullptr;
 
     bool isDeclarative = false;
-    if (is<DeclarativeAnimation>(animation)) {
-        if (auto owningElement = downcast<DeclarativeAnimation>(*animation).owningElement())
+    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation)) {
+        if (auto owningElement = declarativeAnimation->owningElement())
             isDeclarative = *owningElement == styleable;
     }
 


### PR DESCRIPTION
#### 8877afa46f539056d16579515daa83ba97076c29
<pre>
[web-animations] use dynamicDowncast&lt;&gt; when downcast&lt;&gt; is used for DeclarativeAnimation and its subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=250295">https://bugs.webkit.org/show_bug.cgi?id=250295</a>

Reviewed by Tim Nguyen.

* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getBindingsTiming const):
(WebCore::AnimationEffect::getBindingsComputedTiming const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::timingFunctionForBlendingKeyframe const):
(WebCore::KeyframeEffect::backingAnimationForCompositedRenderer const):
(WebCore::KeyframeEffect::progressUntilNextStep const):
(WebCore::KeyframeEffect::bindingsComposite const):
(WebCore::KeyframeEffect::setBindingsComposite):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
(WebCore::InspectorAnimationAgent::didSetWebAnimationEffect):
(WebCore::InspectorAnimationAgent::willDestroyWebAnimation):
(WebCore::InspectorAnimationAgent::bindAnimation):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::removeDeclarativeAnimationFromListsForOwningElement const):
(WebCore::updateCSSTransitionsForStyleableAndProperty):

Canonical link: <a href="https://commits.webkit.org/258636@main">https://commits.webkit.org/258636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4573c36f2859076a60868320a3bade667a72e1f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111828 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172048 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2595 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109537 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9733 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37390 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79137 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25870 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2323 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45361 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7042 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3152 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->