### PR TITLE
CSS Nesting: handle invalid rules mixed with declarations

### DIFF
--- a/LayoutTests/fast/css/parsing-mixed-at-rules-and-declarations-expected.txt
+++ b/LayoutTests/fast/css/parsing-mixed-at-rules-and-declarations-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't assert or crash

--- a/LayoutTests/fast/css/parsing-mixed-at-rules-and-declarations.html
+++ b/LayoutTests/fast/css/parsing-mixed-at-rules-and-declarations.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<style>
+div {
+    -webkit-animation-name: name1;
+    @unknown {
+        invalid: z;
+    }
+    @font-face {
+        invalid: bar;
+    }
+    @property --foo-name {
+        invalid: lol;
+    }
+    -webkit-animation-duration: 8s;
+    @counter-style {
+        invalid: bar;
+    }
+    @page {
+        margin-top: 4in;
+    }
+    -webkit-animation-timing-function: ease-in ! important;
+    @-webkit-keyframes name1 {
+        invalid {
+                    
+        }
+        from {
+            margin-bottom: auto;
+        }
+        to {
+            margin-bottom: 256in;
+        }
+    }
+};
+</style>
+<body>
+<noscript></noscript>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    setTimeout(() => testRunner.notifyDone(), 50);
+}
+document.body.offsetLeft;
+document.body.innerHTML = "This test passes if it doesn't assert or crash";
+</script>

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -135,7 +135,7 @@ private:
     RefPtr<StyleRuleBase> consumeQualifiedRule(CSSParserTokenRange&, AllowedRulesType);
 
     // This function is used for all the nested group rules (@media, @supports,..etc)
-    Vector<RefPtr<StyleRuleBase>>consumeRegularRuleList(CSSParserTokenRange block);
+    Vector<RefPtr<StyleRuleBase>> consumeRegularRuleList(CSSParserTokenRange block);
 
     static RefPtr<StyleRuleCharset> consumeCharsetRule(CSSParserTokenRange prelude);
     RefPtr<StyleRuleImport> consumeImportRule(CSSParserTokenRange prelude);
@@ -156,9 +156,14 @@ private:
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRule> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    ParsedPropertyVector consumeDeclarationListInNewNestingContext(CSSParserTokenRange, StyleRuleType);
 
+    enum class OnlyDeclarations {
+        Yes,
+        No
+    };
     // FIXME: We should return value for all those functions instead of using class member attributes.
-    void consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange, StyleRuleType);
+    void consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange, StyleRuleType, OnlyDeclarations);
     void consumeDeclarationList(CSSParserTokenRange, StyleRuleType);
     void consumeStyleBlock(CSSParserTokenRange, StyleRuleType);
     void consumeDeclaration(CSSParserTokenRange, StyleRuleType);


### PR DESCRIPTION
#### 36c735247d249cfb7a28aba3f21d3bbb8a96137b
<pre>
CSS Nesting: handle invalid rules mixed with declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250298">https://bugs.webkit.org/show_bug.cgi?id=250298</a>
rdar://104004697

Reviewed by Antti Koivisto.

This patch isolates the parsing of declaration list from one another
(which otherwise could be wrongly mixed when overlapping because of nesting)
by using CSSParserImpl::consumeDeclarationListInNewNestingContext.

* LayoutTests/fast/css/parsing-mixed-at-rules-and-declarations-expected.txt: Added.
* LayoutTests/fast/css/parsing-mixed-at-rules-and-declarations.html: Added.
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::CSSParserImpl::consumeFontFaceRule):
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):
(WebCore::CSSParserImpl::consumePageRule):
(WebCore::CSSParserImpl::consumeCounterStyleRule):
(WebCore::CSSParserImpl::consumePropertyRule):
(WebCore::CSSParserImpl::consumeKeyframeStyleRule):
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):
(WebCore::CSSParserImpl::consumeDeclarationListInNewNestingContext):
(WebCore::CSSParserImpl::consumeDeclarationList):
(WebCore::CSSParserImpl::consumeStyleBlock):
* Source/WebCore/css/parser/CSSParserImpl.h:

Canonical link: <a href="https://commits.webkit.org/258692@main">https://commits.webkit.org/258692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e81fee961a00c45d53d3b251cdce54617274640

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111934 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2702 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109631 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108446 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37480 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24551 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2417 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45459 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5974 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7143 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->