### PR TITLE
Fix build errors for CSSVariableReferenceValue

### DIFF
--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -30,6 +30,8 @@
 #include "config.h"
 #include "CSSVariableReferenceValue.h"
 
+#include "CSSParserToken.h"
+#include "CSSParserTokenRange.h"
 #include "CSSPropertyParser.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSVariableData.h"

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -31,9 +31,11 @@
 
 #include "CSSParserContext.h"
 #include "CSSValue.h"
+#include "CSSValueKeywords.h"
 
 namespace WebCore {
 
+class CSSParserToken;
 class CSSParserTokenRange;
 class CSSVariableData;
 


### PR DESCRIPTION
#### 2a9bdc4807e95ed0ea21ce7bd450b32368188a1a
<pre>
Fix build errors for CSSVariableReferenceValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=250301">https://bugs.webkit.org/show_bug.cgi?id=250301</a>

Reviewed by Tim Nguyen.

* Source/WebCore/css/CSSVariableReferenceValue.cpp:
* Source/WebCore/css/CSSVariableReferenceValue.h:

Canonical link: <a href="https://commits.webkit.org/258637@main">https://commits.webkit.org/258637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd3e01da42113e0ee588e7cac0770ea5c8a8771

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111835 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172056 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2602 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109544 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9738 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37396 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79142 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2328 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45366 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7049 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3151 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->