### PR TITLE
WebKit::WebPageProxy::didSameDocumentNavigationForFrame[ViaJSHistoryAPI]() should take a WebKit::SameDocumentNavigationType

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -531,6 +531,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/LayerTreeContext.serialization.in
     Shared/Model.serialization.in
     Shared/Pasteboard.serialization.in
+    Shared/SameDocumentNavigationType.serialization.in
     Shared/SessionState.serialization.in
     Shared/ShareableBitmap.serialization.in
     Shared/TextFlags.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -181,6 +181,7 @@ $(PROJECT_DIR)/Shared/Notifications/NotificationManagerMessageHandler.messages.i
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerProxy.messages.in
 $(PROJECT_DIR)/Shared/Pasteboard.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
+$(PROJECT_DIR)/Shared/SameDocumentNavigationType.serialization.in
 $(PROJECT_DIR)/Shared/SessionState.serialization.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
 $(PROJECT_DIR)/Shared/Shared/EditorState.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -483,6 +483,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/LayerTreeContext.serialization.in \
 	Shared/Model.serialization.in \
 	Shared/Pasteboard.serialization.in \
+	Shared/SameDocumentNavigationType.serialization.in \
 	Shared/SessionState.serialization.in \
 	Shared/ShareableBitmap.serialization.in \
 	Shared/TextFlags.serialization.in \

--- a/Source/WebKit/Shared/API/Cocoa/_WKSameDocumentNavigationTypeInternal.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKSameDocumentNavigationTypeInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,13 +31,13 @@ namespace WebKit {
 static _WKSameDocumentNavigationType toWKSameDocumentNavigationType(SameDocumentNavigationType navigationType)
 {
     switch (navigationType) {
-    case SameDocumentNavigationAnchorNavigation:
+    case SameDocumentNavigationType::AnchorNavigation:
         return _WKSameDocumentNavigationTypeAnchorNavigation;
-    case SameDocumentNavigationSessionStatePush:
+    case SameDocumentNavigationType::SessionStatePush:
         return _WKSameDocumentNavigationTypeSessionStatePush;
-    case SameDocumentNavigationSessionStateReplace:
+    case SameDocumentNavigationType::SessionStateReplace:
         return _WKSameDocumentNavigationTypeSessionStateReplace;
-    case SameDocumentNavigationSessionStatePop:
+    case SameDocumentNavigationType::SessionStatePop:
         return _WKSameDocumentNavigationTypeSessionStatePop;
     }
 

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -826,112 +826,88 @@ inline OptionSet<FindOptions> toFindOptions(WKFindOptions wkFindOptions)
 
 inline WKFrameNavigationType toAPI(WebCore::NavigationType type)
 {
-    WKFrameNavigationType wkType = kWKFrameNavigationTypeOther;
-
     switch (type) {
     case WebCore::NavigationType::LinkClicked:
-        wkType = kWKFrameNavigationTypeLinkClicked;
-        break;
+        return kWKFrameNavigationTypeLinkClicked;
     case WebCore::NavigationType::FormSubmitted:
-        wkType = kWKFrameNavigationTypeFormSubmitted;
-        break;
+        return kWKFrameNavigationTypeFormSubmitted;
     case WebCore::NavigationType::BackForward:
-        wkType = kWKFrameNavigationTypeBackForward;
-        break;
+        return kWKFrameNavigationTypeBackForward;
     case WebCore::NavigationType::Reload:
-        wkType = kWKFrameNavigationTypeReload;
-        break;
+        return kWKFrameNavigationTypeReload;
     case WebCore::NavigationType::FormResubmitted:
-        wkType = kWKFrameNavigationTypeFormResubmitted;
-        break;
+        return kWKFrameNavigationTypeFormResubmitted;
     case WebCore::NavigationType::Other:
-        wkType = kWKFrameNavigationTypeOther;
-        break;
+        return kWKFrameNavigationTypeOther;
     }
-    
-    return wkType;
+
+    ASSERT_NOT_REACHED();
+    return kWKFrameNavigationTypeOther;
+
 }
 
 inline WKSameDocumentNavigationType toAPI(SameDocumentNavigationType type)
 {
-    WKFrameNavigationType wkType = kWKSameDocumentNavigationAnchorNavigation;
-
     switch (type) {
-    case SameDocumentNavigationAnchorNavigation:
-        wkType = kWKSameDocumentNavigationAnchorNavigation;
-        break;
-    case SameDocumentNavigationSessionStatePush:
-        wkType = kWKSameDocumentNavigationSessionStatePush;
-        break;
-    case SameDocumentNavigationSessionStateReplace:
-        wkType = kWKSameDocumentNavigationSessionStateReplace;
-        break;
-    case SameDocumentNavigationSessionStatePop:
-        wkType = kWKSameDocumentNavigationSessionStatePop;
-        break;
+    case SameDocumentNavigationType::AnchorNavigation:
+        return kWKSameDocumentNavigationAnchorNavigation;
+    case SameDocumentNavigationType::SessionStatePush:
+        return kWKSameDocumentNavigationSessionStatePush;
+    case SameDocumentNavigationType::SessionStateReplace:
+        return kWKSameDocumentNavigationSessionStateReplace;
+    case SameDocumentNavigationType::SessionStatePop:
+        return kWKSameDocumentNavigationSessionStatePop;
     }
-    
-    return wkType;
+
+    ASSERT_NOT_REACHED();
+    return kWKSameDocumentNavigationAnchorNavigation;
 }
 
 inline SameDocumentNavigationType toSameDocumentNavigationType(WKSameDocumentNavigationType wkType)
 {
-    SameDocumentNavigationType type = SameDocumentNavigationAnchorNavigation;
-
     switch (wkType) {
     case kWKSameDocumentNavigationAnchorNavigation:
-        type = SameDocumentNavigationAnchorNavigation;
-        break;
+        return SameDocumentNavigationType::AnchorNavigation;
     case kWKSameDocumentNavigationSessionStatePush:
-        type = SameDocumentNavigationSessionStatePush;
-        break;
+        return SameDocumentNavigationType::SessionStatePush;
     case kWKSameDocumentNavigationSessionStateReplace:
-        type = SameDocumentNavigationSessionStateReplace;
-        break;
+        return SameDocumentNavigationType::SessionStateReplace;
     case kWKSameDocumentNavigationSessionStatePop:
-        type = SameDocumentNavigationSessionStatePop;
-        break;
+        return SameDocumentNavigationType::SessionStatePop;
     }
     
-    return type;
+    ASSERT_NOT_REACHED();
+    return SameDocumentNavigationType::AnchorNavigation;
 }
 
 inline WKDiagnosticLoggingResultType toAPI(WebCore::DiagnosticLoggingResultType type)
 {
-    WKDiagnosticLoggingResultType wkType { };
-
     switch (type) {
     case WebCore::DiagnosticLoggingResultPass:
-        wkType = kWKDiagnosticLoggingResultPass;
-        break;
+        return kWKDiagnosticLoggingResultPass;
     case WebCore::DiagnosticLoggingResultFail:
-        wkType = kWKDiagnosticLoggingResultFail;
-        break;
+        return kWKDiagnosticLoggingResultFail;
     case WebCore::DiagnosticLoggingResultNoop:
-        wkType = kWKDiagnosticLoggingResultNoop;
-        break;
+        return kWKDiagnosticLoggingResultNoop;
     }
 
-    return wkType;
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
 inline WebCore::DiagnosticLoggingResultType toDiagnosticLoggingResultType(WKDiagnosticLoggingResultType wkType)
 {
-    WebCore::DiagnosticLoggingResultType type { };
-
     switch (wkType) {
     case kWKDiagnosticLoggingResultPass:
-        type = WebCore::DiagnosticLoggingResultPass;
-        break;
+        return WebCore::DiagnosticLoggingResultPass;
     case kWKDiagnosticLoggingResultFail:
-        type = WebCore::DiagnosticLoggingResultFail;
-        break;
+        return WebCore::DiagnosticLoggingResultFail;
     case kWKDiagnosticLoggingResultNoop:
-        type = WebCore::DiagnosticLoggingResultNoop;
-        break;
+        return WebCore::DiagnosticLoggingResultNoop;
     }
 
-    return type;
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
 inline WKLayoutMilestones toWKLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)

--- a/Source/WebKit/Shared/SameDocumentNavigationType.h
+++ b/Source/WebKit/Shared/SameDocumentNavigationType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,18 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SameDocumentNavigationType_h
-#define SameDocumentNavigationType_h
+#pragma once
 
 namespace WebKit {
 
-enum SameDocumentNavigationType {
-    SameDocumentNavigationAnchorNavigation,
-    SameDocumentNavigationSessionStatePush,
-    SameDocumentNavigationSessionStateReplace,
-    SameDocumentNavigationSessionStatePop
+enum class SameDocumentNavigationType : uint8_t {
+    AnchorNavigation,
+    SessionStatePush,
+    SessionStateReplace,
+    SessionStatePop
 };
 
 } // namespace WebKit
-
-#endif // SameDocumentNavigationType_h

--- a/Source/WebKit/Shared/SameDocumentNavigationType.serialization.in
+++ b/Source/WebKit/Shared/SameDocumentNavigationType.serialization.in
@@ -1,0 +1,29 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "SameDocumentNavigationType.h"
+enum class WebKit::SameDocumentNavigationType : uint8_t {
+    AnchorNavigation,
+    SessionStatePush,
+    SessionStateReplace,
+    SessionStatePop
+};

--- a/Source/WebKit/UIProcess/API/APILoaderClient.h
+++ b/Source/WebKit/UIProcess/API/APILoaderClient.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "APIData.h"
-#include "SameDocumentNavigationType.h"
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <wtf/Forward.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -24,7 +24,6 @@
  */
 
 #import "PDFPluginIdentifier.h"
-#import "SameDocumentNavigationType.h"
 #import <WebKit/WKShareSheet.h>
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewPrivate.h>

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -242,7 +242,7 @@ void ViewGestureController::didSameDocumentNavigationForMainFrame(SameDocumentNa
     if (!cancelledOutstandingEvent)
         return;
 
-    if (type != SameDocumentNavigationSessionStateReplace && type != SameDocumentNavigationSessionStatePop)
+    if (type != SameDocumentNavigationType::SessionStateReplace && type != SameDocumentNavigationType::SessionStatePop)
         return;
 
     checkForActiveLoads();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -196,6 +196,7 @@
 #include <WebCore/WritingDirection.h>
 #include <stdio.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/EnumTraits.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
@@ -5420,7 +5421,7 @@ void WebPageProxy::didFailLoadForFrame(FrameIdentifier frameID, FrameInfoData&& 
     }
 }
 
-void WebPageProxy::didSameDocumentNavigationForFrame(FrameIdentifier frameID, uint64_t navigationID, uint32_t opaqueSameDocumentNavigationType, URL&& url, const UserData& userData)
+void WebPageProxy::didSameDocumentNavigationForFrame(FrameIdentifier frameID, uint64_t navigationID, SameDocumentNavigationType navigationType, URL&& url, const UserData& userData)
 {
     PageClientProtector protector(pageClient());
 
@@ -5428,7 +5429,7 @@ void WebPageProxy::didSameDocumentNavigationForFrame(FrameIdentifier frameID, ui
     MESSAGE_CHECK(m_process, frame);
     MESSAGE_CHECK_URL(m_process, url);
 
-    WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrame: frameID=%" PRIu64 ", isMainFrame=%d", frameID.object().toUInt64(), frame->isMainFrame());
+    WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrame: frameID=%" PRIu64 ", isMainFrame=%d, type=%u", frameID.object().toUInt64(), frame->isMainFrame(), enumToUnderlyingType(navigationType));
 
     // FIXME: We should message check that navigationID is not zero here, but it's currently zero for some navigations through the back/forward cache.
     RefPtr<API::Navigation> navigation;
@@ -5451,7 +5452,6 @@ void WebPageProxy::didSameDocumentNavigationForFrame(FrameIdentifier frameID, ui
 
     m_pageLoadState.commitChanges();
 
-    SameDocumentNavigationType navigationType = static_cast<SameDocumentNavigationType>(opaqueSameDocumentNavigationType);
     if (isMainFrame)
         m_navigationClient->didSameDocumentNavigation(*this, navigation.get(), navigationType, m_process->transformHandlesToObjects(userData.object()).get());
 
@@ -5459,7 +5459,7 @@ void WebPageProxy::didSameDocumentNavigationForFrame(FrameIdentifier frameID, ui
         pageClient().didSameDocumentNavigationForMainFrame(navigationType);
 }
 
-void WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier frameID, uint32_t opaqueSameDocumentNavigationType, URL url, NavigationActionData&& navigationActionData, const UserData& userData)
+void WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier frameID, SameDocumentNavigationType navigationType, URL url, NavigationActionData&& navigationActionData, const UserData& userData)
 {
     PageClientProtector protector(pageClient());
 
@@ -5467,7 +5467,7 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::Fra
     MESSAGE_CHECK(m_process, frame);
     MESSAGE_CHECK_URL(m_process, url);
 
-    WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrameViaJSHistoryAPI: frameID=%" PRIu64 ", isMainFrame=%d, type=%u", frameID.object().toUInt64(), frame->isMainFrame(), opaqueSameDocumentNavigationType);
+    WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrameViaJSHistoryAPI: frameID=%" PRIu64 ", isMainFrame=%d, type=%u", frameID.object().toUInt64(), frame->isMainFrame(), enumToUnderlyingType(navigationType));
 
     // FIXME: We should message check that navigationID is not zero here, but it's currently zero for some navigations through the back/forward cache.
     RefPtr<API::Navigation> navigation;
@@ -5492,7 +5492,6 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::Fra
 
     m_pageLoadState.commitChanges();
 
-    SameDocumentNavigationType navigationType = static_cast<SameDocumentNavigationType>(opaqueSameDocumentNavigationType);
     if (isMainFrame)
         m_navigationClient->didSameDocumentNavigation(*this, navigation.get(), navigationType, m_process->transformHandlesToObjects(userData.object()).get());
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2257,8 +2257,8 @@ private:
     void didFinishDocumentLoadForFrame(WebCore::FrameIdentifier, uint64_t navigationID, const UserData&);
     void didFinishLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const UserData&);
     void didFailLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const WebCore::ResourceError&, const UserData&);
-    void didSameDocumentNavigationForFrame(WebCore::FrameIdentifier, uint64_t navigationID, uint32_t sameDocumentNavigationType, URL&&, const UserData&);
-    void didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier, uint32_t type, URL, NavigationActionData&&, const UserData&);
+    void didSameDocumentNavigationForFrame(WebCore::FrameIdentifier, uint64_t navigationID, SameDocumentNavigationType, URL&&, const UserData&);
+    void didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier, SameDocumentNavigationType, URL, NavigationActionData&&, const UserData&);
     void didChangeMainDocument(WebCore::FrameIdentifier);
     void didExplicitOpenForFrame(WebCore::FrameIdentifier, URL&&, String&& mimeType);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -130,8 +130,8 @@ messages -> WebPageProxy {
     DidReceiveTitleForFrame(WebCore::FrameIdentifier frameID, String title, WebKit::UserData userData)
     DidDisplayInsecureContentForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)
     DidRunInsecureContentForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)
-    DidSameDocumentNavigationForFrame(WebCore::FrameIdentifier frameID, uint64_t navigationID, uint32_t type, URL url, WebKit::UserData userData)
-    DidSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier frameID, uint32_t type, URL url, struct WebKit::NavigationActionData navigationActionData, WebKit::UserData userData);
+    DidSameDocumentNavigationForFrame(WebCore::FrameIdentifier frameID, uint64_t navigationID, enum:uint8_t WebKit::SameDocumentNavigationType type, URL url, WebKit::UserData userData)
+    DidSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier frameID, enum:uint8_t WebKit::SameDocumentNavigationType type, URL url, struct WebKit::NavigationActionData navigationActionData, WebKit::UserData userData);
     DidChangeMainDocument(WebCore::FrameIdentifier frameID)
     DidExplicitOpenForFrame(WebCore::FrameIdentifier frameID, URL url, String mimeType)
     DidDestroyNavigation(uint64_t navigationID)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4848,6 +4848,7 @@
 		41FFD2DA275A560B00501BBF /* ServiceWorkerDownloadTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDownloadTask.cpp; sourceTree = "<group>"; };
 		41FFD2DB275A560C00501BBF /* ServiceWorkerDownloadTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDownloadTask.h; sourceTree = "<group>"; };
 		41FFD2DC275A6A9400501BBF /* ServiceWorkerDownloadTask.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ServiceWorkerDownloadTask.messages.in; sourceTree = "<group>"; };
+		44122266296A89820057E1A5 /* SameDocumentNavigationType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SameDocumentNavigationType.serialization.in; sourceTree = "<group>"; };
 		4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CacheStoragePolicy.h; sourceTree = "<group>"; };
 		441379602964F0C2003C34C6 /* CacheStoragePolicy.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CacheStoragePolicy.serialization.in; sourceTree = "<group>"; };
 		442E7BE827B4572B00C69AC1 /* RevealItem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RevealItem.mm; sourceTree = "<group>"; };
@@ -8427,6 +8428,7 @@
 				41B28B081F83AD3E00FB52AC /* RTCPacketOptions.h */,
 				41B8D85628C9B8D100E5FA37 /* RTCWebKitEncodedFrameInfo.h */,
 				BC2D021612AC41CB00E732A3 /* SameDocumentNavigationType.h */,
+				44122266296A89820057E1A5 /* SameDocumentNavigationType.serialization.in */,
 				1AAB4A8C1296F0A20023952F /* SandboxExtension.h */,
 				E1E552C316AE065E004ED653 /* SandboxInitializationParameters.h */,
 				2D65D196274B8E84009C4101 /* ScrollingAccelerationCurve.cpp */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -432,10 +432,10 @@ void WebFrameLoaderClient::dispatchDidChangeLocationWithinPage()
     auto navigationID = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().documentLoader()).navigationID();
 
     // Notify the bundle client.
-    webPage->injectedBundleLoaderClient().didSameDocumentNavigationForFrame(*webPage, m_frame, SameDocumentNavigationAnchorNavigation, userData);
+    webPage->injectedBundleLoaderClient().didSameDocumentNavigationForFrame(*webPage, m_frame, SameDocumentNavigationType::AnchorNavigation, userData);
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidSameDocumentNavigationForFrame(m_frame->frameID(), navigationID, SameDocumentNavigationAnchorNavigation, m_frame->coreFrame()->document()->url(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidSameDocumentNavigationForFrame(m_frame->frameID(), navigationID, SameDocumentNavigationType::AnchorNavigation, m_frame->coreFrame()->document()->url(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 }
 
 void WebFrameLoaderClient::dispatchDidChangeMainDocument()
@@ -474,7 +474,7 @@ void WebFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI(Same
     RefPtr<API::Object> userData;
 
     // Notify the bundle client.
-    webPage->injectedBundleLoaderClient().didSameDocumentNavigationForFrame(*webPage, m_frame, SameDocumentNavigationSessionStatePush, userData);
+    webPage->injectedBundleLoaderClient().didSameDocumentNavigationForFrame(*webPage, m_frame, SameDocumentNavigationType::SessionStatePush, userData);
 
     NavigationActionData navigationActionData;
     navigationActionData.userGestureTokenIdentifier = WebProcess::singleton().userGestureTokenIdentifier(UserGestureIndicator::currentUserGesture());
@@ -488,17 +488,17 @@ void WebFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI(Same
 
 void WebFrameLoaderClient::dispatchDidPushStateWithinPage()
 {
-    didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationSessionStatePush);
+    didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationType::SessionStatePush);
 }
 
 void WebFrameLoaderClient::dispatchDidReplaceStateWithinPage()
 {
-    didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationSessionStateReplace);
+    didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationType::SessionStateReplace);
 }
 
 void WebFrameLoaderClient::dispatchDidPopStateWithinPage()
 {
-    didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationSessionStatePop);
+    didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationType::SessionStatePop);
 }
 
 void WebFrameLoaderClient::dispatchWillClose()


### PR DESCRIPTION
#### ab6bfa2b75b51921f2160af4cc66bace51d82849
<pre>
WebKit::WebPageProxy::didSameDocumentNavigationForFrame[ViaJSHistoryAPI]() should take a WebKit::SameDocumentNavigationType
<a href="https://bugs.webkit.org/show_bug.cgi?id=250304">https://bugs.webkit.org/show_bug.cgi?id=250304</a>
&lt;rdar://65495222&gt;

Reviewed by Youenn Fablet.

Update WebPageProxy::didSameDocumentNavigationForFrame() and
WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI()
to use the enum class SameDocumentNavigationType instead of
uint32_t.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
- Update build files to add
  SameDocumentNavigationType.serialization.in.

* Source/WebKit/Shared/API/Cocoa/_WKSameDocumentNavigationTypeInternal.h:
(WebKit::toWKSameDocumentNavigationType):
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toSameDocumentNavigationType):
(WebKit::toDiagnosticLoggingResultType):
- Add ASSERT_NOT_REACHED() after switch statements that should
  never fall through.  Switch to use early return statements.
* Source/WebKit/Shared/SameDocumentNavigationType.h:
- Switch to &quot;#pramga once&quot;.
- Make SameDocumentNavigationType an enum class.
* Source/WebKit/Shared/SameDocumentNavigationType.serialization.in: Add.
- Used for IPC encoding/decoding.
* Source/WebKit/UIProcess/API/APILoaderClient.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
- Remove unneeded header include of
  &quot;SameDocumentNavigationType.h&quot;.
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::didSameDocumentNavigationForMainFrame):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDidChangeLocationWithinPage):
(WebKit::WebFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebFrameLoaderClient::dispatchDidPushStateWithinPage):
(WebKit::WebFrameLoaderClient::dispatchDidReplaceStateWithinPage):
(WebKit::WebFrameLoaderClient::dispatchDidPopStateWithinPage):

Canonical link: <a href="https://commits.webkit.org/258676@main">https://commits.webkit.org/258676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6c0b1fa4cada94330870091c18c9c9b3da3cc66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111899 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2668 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109602 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108408 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37455 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79198 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25937 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2389 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5959 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7108 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->