### PR TITLE
[ iOS ] animations/steps-transform-rendering-updates.html is a flaky failure

### DIFF
--- a/LayoutTests/animations/steps-transform-rendering-updates-expected.txt
+++ b/LayoutTests/animations/steps-transform-rendering-updates-expected.txt
@@ -1,5 +1,5 @@
 PASS count is 0
-PASS count <= 9 is true
+PASS count <= 10 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/animations/steps-transform-rendering-updates.html
+++ b/LayoutTests/animations/steps-transform-rendering-updates.html
@@ -36,9 +36,11 @@
                 shouldBe('count', '0');
             }, false);
             box.addEventListener('animationend', () => {
+                // As long as the rendering count remains under 15, which matches 0.25s with
+                // a refresh rate of 60fps, then this test is positive.
                 count = internals.renderingUpdateCount();
-                shouldBeTrue('count <= 9');
-                if (count > 9)
+                shouldBeTrue('count <= 10');
+                if (count > 10)
                     debug(`Saw ${count} updates`);
                 finishJSTest();
             }, false);

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2381,8 +2381,6 @@ webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-stream
 imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.html?101-last [ Failure ]
 imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-last [ Failure ]
 
-webkit.org/b/246547 animations/steps-transform-rendering-updates.html [ Pass Failure ]
-
 # webkit.org/b/246701 Flaky failure only on iOS
 imported/w3c/web-platform-tests/screen-orientation/active-lock.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html [ Pass Failure ]


### PR DESCRIPTION
#### 9ef25b1b639295d3c89b9ad01f5147774d233c67
<pre>
[ iOS ] animations/steps-transform-rendering-updates.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=246547">https://bugs.webkit.org/show_bug.cgi?id=246547</a>
rdar://101190609

Reviewed by Simon Fraser.

Increase the max rendering update count by 1. This yields stable results with the
iOS 16 simulator with local testing regardless of the animation duration.

* LayoutTests/animations/steps-transform-rendering-updates-expected.txt:
* LayoutTests/animations/steps-transform-rendering-updates.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/258723@main">https://commits.webkit.org/258723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ac0e0643de703ab8ce36f54cbfa0af99bf92d67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112055 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2827 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95049 "Failed to checkout and rebase branch from PR 8384") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108572 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/95049 "Failed to checkout and rebase branch from PR 8384") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/95049 "Failed to checkout and rebase branch from PR 8384") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5373 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11540 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7264 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3185 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->