### PR TITLE
Use an alpha-less pixel format for 32 bit IOSurfaces when RemoteLayerBackingStore::Parameters::isOpaque is true

### DIFF
--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -38,6 +38,7 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
     case PixelFormat::BGRA8:
         return true;
 
+    case PixelFormat::BGRX8:
     case PixelFormat::RGB10:
     case PixelFormat::RGB10A8:
         return false;

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -55,12 +55,13 @@ static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferForm
             else
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
 
+        case PixelFormat::BGRX8:
         case PixelFormat::RGB10:
         case PixelFormat::RGB10A8:
             break;
         }
 
-        // We currently only support 8 bit pixel formats for these conversions.
+        // We currently only support 8 bit pixel formats with alpha for these conversions.
 
         ASSERT_NOT_REACHED();
         return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
@@ -236,7 +237,7 @@ static void convertImagePixelsUnaccelerated(const ConstPixelBufferConversionView
 
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    // We don't currently support converting pixel data with non-8-bit buffers.
+    // We currently only support converting between RGBA8 and BGRA8.
     ASSERT(source.format.pixelFormat == PixelFormat::RGBA8 || source.format.pixelFormat == PixelFormat::BGRA8);
     ASSERT(destination.format.pixelFormat == PixelFormat::RGBA8 || destination.format.pixelFormat == PixelFormat::BGRA8);
 

--- a/Source/WebCore/platform/graphics/PixelFormat.cpp
+++ b/Source/WebCore/platform/graphics/PixelFormat.cpp
@@ -36,6 +36,9 @@ TextStream& operator<<(TextStream& ts, PixelFormat pixelFormat)
     case PixelFormat::RGBA8:
         ts << "RGBA8";
         break;
+    case PixelFormat::BGRX8:
+        ts << "BGRX8";
+        break;
     case PixelFormat::BGRA8:
         ts << "BGRA8";
         break;

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 enum class PixelFormat : uint8_t {
     RGBA8,
+    BGRX8,
     BGRA8,
     RGB10,
     RGB10A8,

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -75,7 +75,7 @@ Ref<IOSurfacePool> IOSurfacePool::create()
 
 static bool surfaceMatchesParameters(IOSurface& surface, IntSize requestedSize, const DestinationColorSpace& colorSpace, IOSurface::Format format)
 {
-    if (format != surface.format())
+    if (!surface.hasFormat(format))
         return false;
     if (colorSpace != surface.colorSpace())
         return false;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -58,6 +58,7 @@ class IOSurface final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Format {
+        BGRX,
         BGRA,
         YUV422,
 #if HAVE(IOSURFACE_RGB10)
@@ -140,11 +141,11 @@ public:
 
     WEBCORE_EXPORT SetNonVolatileResult setVolatile(bool);
 
+    bool hasFormat(Format format) const { return m_format && *m_format == format; }
     IntSize size() const { return m_size; }
     size_t totalBytes() const { return m_totalBytes; }
 
     WEBCORE_EXPORT DestinationColorSpace colorSpace();
-    WEBCORE_EXPORT Format format() const;
     WEBCORE_EXPORT IOSurfaceID surfaceID() const;
     WEBCORE_EXPORT size_t bytesPerRow() const;
 
@@ -181,6 +182,7 @@ private:
 
     BitmapConfiguration bitmapConfiguration() const;
 
+    std::optional<Format> m_format;
     std::optional<DestinationColorSpace> m_colorSpace;
     IntSize m_size;
     size_t m_totalBytes;
@@ -192,10 +194,11 @@ private:
     RetainPtr<IOSurfaceRef> m_surface;
 
     static std::optional<IntSize> s_maximumSize;
+
+    WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const WebCore::IOSurface&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WebCore::IOSurface::Format);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const WebCore::IOSurface&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -180,7 +180,8 @@ static NSDictionary *optionsFor32BitSurface(IntSize size, unsigned pixelFormat)
 }
 
 IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Format format, bool& success)
-    : m_colorSpace(colorSpace)
+    : m_format(format)
+    , m_colorSpace(colorSpace)
     , m_size(size)
 {
     ASSERT(!success);
@@ -189,6 +190,7 @@ IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Form
     NSDictionary *options;
 
     switch (format) {
+    case Format::BGRX:
     case Format::BGRA:
         options = optionsFor32BitSurface(size, 'BGRA');
         break;
@@ -213,8 +215,29 @@ IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Form
         RELEASE_LOG_ERROR(Layers, "IOSurface creation failed for size: (%d %d) and format: (%d)", size.width(), size.height(), format);
 }
 
+static std::optional<IOSurface::Format> formatFromSurface(IOSurfaceRef surface)
+{
+    unsigned pixelFormat = IOSurfaceGetPixelFormat(surface);
+    if (pixelFormat == 'BGRA')
+        return IOSurface::Format::BGRA;
+
+#if HAVE(IOSURFACE_RGB10)
+    if (pixelFormat == 'w30r')
+        return IOSurface::Format::RGB10;
+
+    if (pixelFormat == 'b3a8')
+        return IOSurface::Format::RGB10A8;
+#endif
+
+    if (pixelFormat == '422f')
+        return IOSurface::Format::YUV422;
+
+    return { };
+}
+
 IOSurface::IOSurface(IOSurfaceRef surface, std::optional<DestinationColorSpace>&& colorSpace)
-    : m_colorSpace(WTFMove(colorSpace))
+    : m_format(formatFromSurface(surface))
+    , m_colorSpace(WTFMove(colorSpace))
     , m_surface(surface)
 {
     m_size = IntSize(IOSurfaceGetWidth(surface), IOSurfaceGetHeight(surface));
@@ -329,8 +352,13 @@ IOSurface::BitmapConfiguration IOSurface::bitmapConfiguration() const
     auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
 
     size_t bitsPerComponent = 8;
-    
-    switch (format()) {
+
+    ASSERT(m_format);
+
+    switch (m_format.value_or(Format::BGRA)) {
+    case Format::BGRX:
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
+        break;
     case Format::BGRA:
         break;
 #if HAVE(IOSURFACE_RGB10)
@@ -439,27 +467,6 @@ DestinationColorSpace IOSurface::colorSpace()
     return *m_colorSpace;
 }
 
-IOSurface::Format IOSurface::format() const
-{
-    unsigned pixelFormat = IOSurfaceGetPixelFormat(m_surface.get());
-    if (pixelFormat == 'BGRA')
-        return Format::BGRA;
-
-#if HAVE(IOSURFACE_RGB10)
-    if (pixelFormat == 'w30r')
-        return Format::RGB10;
-
-    if (pixelFormat == 'b3a8')
-        return Format::RGB10A8;
-#endif
-
-    if (pixelFormat == '422f')
-        return Format::YUV422;
-
-    ASSERT_NOT_REACHED();
-    return Format::BGRA;
-}
-
 IOSurfaceID IOSurface::surfaceID() const
 {
 // FIXME: Should be able to do this even without the Apple internal SDK.
@@ -514,7 +521,7 @@ void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&
         CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, kCFRunLoopDefaultMode);
     }
 
-    if (inSurface->format() == format) {
+    if (inSurface->hasFormat(format)) {
         callback(WTFMove(inSurface));
         return;
     }
@@ -605,6 +612,8 @@ IOSurface::Format IOSurface::formatForPixelFormat(PixelFormat format)
     case PixelFormat::RGBA8:
         RELEASE_ASSERT_NOT_REACHED();
         return IOSurface::Format::BGRA;
+    case PixelFormat::BGRX8:
+        return IOSurface::Format::BGRX;
     case PixelFormat::BGRA8:
         return IOSurface::Format::BGRA;
 #if HAVE(IOSURFACE_RGB10)
@@ -627,6 +636,9 @@ IOSurface::Format IOSurface::formatForPixelFormat(PixelFormat format)
 TextStream& operator<<(TextStream& ts, IOSurface::Format format)
 {
     switch (format) {
+    case IOSurface::Format::BGRX:
+        ts << "BGRX";
+        break;
     case IOSurface::Format::BGRA:
         ts << "BGRA";
         break;
@@ -660,7 +672,7 @@ static TextStream& operator<<(TextStream& ts, SetNonVolatileResult state)
 
 TextStream& operator<<(TextStream& ts, const IOSurface& surface)
 {
-    return ts << "IOSurface " << surface.surfaceID() << " size " << surface.size() << " format " << surface.format() << " state " << surface.state();
+    return ts << "IOSurface " << surface.surfaceID() << " size " << surface.size() << " format " << surface.m_format << " state " << surface.state();
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -201,13 +201,14 @@ PixelFormat RemoteLayerBackingStore::pixelFormat() const
     if (usesDeepColorBackingStore())
         return m_parameters.isOpaque ? PixelFormat::RGB10 : PixelFormat::RGB10A8;
 
-    return PixelFormat::BGRA8;
+    return m_parameters.isOpaque ? PixelFormat::BGRX8 : PixelFormat::BGRA8;
 }
 
 unsigned RemoteLayerBackingStore::bytesPerPixel() const
 {
     switch (pixelFormat()) {
     case PixelFormat::RGBA8: return 4;
+    case PixelFormat::BGRX8: return 4;
     case PixelFormat::BGRA8: return 4;
     case PixelFormat::RGB10: return 4;
     case PixelFormat::RGB10A8: return 5;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1582,6 +1582,7 @@ enum class WebCore::AlphaPremultiplication : uint8_t {
 
 enum class WebCore::PixelFormat : uint8_t {
     RGBA8,
+    BGRX8,
     BGRA8,
     RGB10,
     RGB10A8,


### PR DESCRIPTION
#### bd8e9982ce3ea314fbb6c5c132e391dd159b69ab
<pre>
Use an alpha-less pixel format for 32 bit IOSurfaces when RemoteLayerBackingStore::Parameters::isOpaque is true
<a href="https://bugs.webkit.org/show_bug.cgi?id=250100">https://bugs.webkit.org/show_bug.cgi?id=250100</a>
rdar://103885395

Reviewed by Tim Horton.

We use a std::optional&lt;Format&gt; to store the surface format since we
sometimes use IOSurface with video surface types from WebRTC, which
aren&apos;t represented by IOSurface::Format. For such surfaces we never need
to care about the specific format.

* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::supportedPixelFormat):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::makeVImageCGImageFormat):
(WebCore::convertImagePixels):
* Source/WebCore/platform/graphics/PixelFormat.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PixelFormat.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::formatFromSurface):
(WebCore::IOSurface::IOSurface):
(WebCore::IOSurface::bitmapConfiguration const):
(WebCore::IOSurface::formatForPixelFormat):
(WebCore::operator&lt;&lt;):
(WebCore::IOSurface::format const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::pixelFormat const):
(WebKit::RemoteLayerBackingStore::bytesPerPixel const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/258654@main">https://commits.webkit.org/258654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0909cd83c6ef61e9f8e0e2f238c0e2f8a68406d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102613 "Failed to checkout and rebase branch from PR 8386") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111881 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2649 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94889 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108390 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11381 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7091 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3160 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->