### PR TITLE
[css-transitions] css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html is a failure

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-style-resolution-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-style-resolution-expected.txt
@@ -1,7 +1,7 @@
 Text
 
 PASS No style resolution when style is valid.
-PASS No style resolution when parent style is invalid and querying non-inherited property.
-PASS This still works with 'inherit'
+PASS No style resolution when sibling style is invalid.
+PASS No style resolution when ancestor sibling style is invalid.
 PASS Explicit 'inherit' chain triggers style resolution
 

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-style-resolution.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-style-resolution.html
@@ -3,12 +3,17 @@
 <container>
 <subcontainer>
 <target>Text</target>
+<target-sibling></target-sibling>
 </subcontainer>
+<subcontainer-sibling>
+</subcontainer-sibling>
 </container>
 <script>
 var target = document.querySelector("target");
 var container = document.querySelector("container");
 var subcontainer = document.querySelector("subcontainer");
+var subcontainerSibling = document.querySelector("subcontainer-sibling");
+var targetSibling = document.querySelector("target-sibling");
 test(() => {
      target.offsetLeft;
      internals.startTrackingStyleRecalcs();
@@ -19,19 +24,18 @@ test(() => {
 test(() => {
      target.offsetLeft;
      internals.startTrackingStyleRecalcs();
-     container.style.backgroundColor = "blue";
+     targetSibling.style.backgroundColor = "blue";
      assert_equals(getComputedStyle(target).backgroundColor, "rgba(0, 0, 0, 0)", "getComputedStyle color is correct");
      assert_equals(internals.styleRecalcCount(), 0, "getComputedStyle didn't trigger style resolution");
- }, "No style resolution when parent style is invalid and querying non-inherited property.");
+ }, "No style resolution when sibling style is invalid.");
 
- test(() => {
-     target.style.backgroundColor = "inherit";
+test(() => {
      target.offsetLeft;
      internals.startTrackingStyleRecalcs();
-     container.style.backgroundColor = "red";
+     subcontainerSibling.style.backgroundColor = "blue";
      assert_equals(getComputedStyle(target).backgroundColor, "rgba(0, 0, 0, 0)", "getComputedStyle color is correct");
      assert_equals(internals.styleRecalcCount(), 0, "getComputedStyle didn't trigger style resolution");
- }, "This still works with 'inherit'");
+ }, "No style resolution when ancestor sibling style is invalid.");
 
 test(() => {
      target.style.backgroundColor = "inherit";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Running a transition an inherited CSS variable is reflected on a standard property using that variable as a value assert_equals: expected "150px" but got "100px"
+PASS Running a transition an inherited CSS variable is reflected on a standard property using that variable as a value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt
@@ -3,15 +3,15 @@ PASS Testing 'stroke-width' on '#box1'.
 PASS Testing 'stroke-width' on '#box2'.
 PASS Testing 'stroke-width' on '#box3'.
 PASS Testing 'clip' on '#test4'.
-FAIL Testing 'alignment-baseline'. assert_equals: Value Test. expected "baseline" but got "auto"
-FAIL Testing 'baseline-shift'. assert_equals: Value Test. expected "sub" but got "baseline"
+PASS Testing 'alignment-baseline'.
+PASS Testing 'baseline-shift'.
 PASS Testing 'clip-rule'.
 PASS Testing 'color'.
 FAIL Testing 'color-interpolation-filters'. assert_equals: Default value. expected "" but got "linearrgb"
 PASS Testing 'cursor'.
 PASS Testing 'direction'.
-FAIL Testing 'display'. assert_equals: Value Test. expected "block" but got "inline"
-FAIL Testing 'dominant-baseline'. assert_equals: Value Test. expected "use-script" but got "auto"
+PASS Testing 'display'.
+PASS Testing 'dominant-baseline'.
 FAIL Testing 'fill'. assert_equals: Default value. expected "black" but got "rgb(0, 0, 0)"
 PASS Testing 'fill-opacity'.
 PASS Testing 'fill-rule'.
@@ -30,7 +30,7 @@ FAIL Testing 'kerning'. assert_equals: Default value. expected "auto" but got "0
 PASS Testing 'letter-spacing'.
 FAIL Testing 'lighting-color'. assert_equals: Default value. expected "" but got "rgb(255, 255, 255)"
 PASS Testing 'opacity'.
-FAIL Testing 'overflow'. assert_equals: Value Test. expected "hidden" but got "visible"
+PASS Testing 'overflow'.
 FAIL Testing 'pointer-events'. assert_equals: Default value. expected "visiblePainted" but got "auto"
 FAIL Testing 'stop-color'. assert_equals: Default value. expected "" but got "rgb(0, 0, 0)"
 PASS Testing 'stop-opacity'.
@@ -43,7 +43,7 @@ PASS Testing 'stroke-miterlimit'.
 PASS Testing 'stroke-opacity'.
 PASS Testing 'stroke-width'.
 PASS Testing 'text-anchor'.
-FAIL Testing 'text-decoration'. assert_equals: Value Test. expected "underline" but got "none"
+PASS Testing 'text-decoration'.
 PASS Testing 'visibility'.
 PASS Testing 'word-spacing'.
 FAIL Testing 'writing-mode'. assert_equals: Default value. expected "lr-tb" but got "horizontal-tb"


### PR DESCRIPTION
#### e72cc27717779c52c64b8cfffb554584ff431852
<pre>
[css-transitions] css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=249640">https://bugs.webkit.org/show_bug.cgi?id=249640</a>
rdar://103549960

Reviewed by Antoine Quint.

* LayoutTests/fast/css/getComputedStyle/getComputedStyle-style-resolution-expected.txt:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-style-resolution.html:

Change the test to verify that sibling cases don&apos;t trigger recalc.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::hasValidStyleForProperty):

Remove an optimization where we try to avoid style recalc while having a invalid ancestor style. This can&apos;t be done in general case
since there can be complex relationships between properties (via var() and em units for example).

The optimization is narrow and probably not valuable in practice.

(WebCore::isImplicitlyInheritedGridOrFlexProperty): Deleted.
(WebCore::nonInheritedColorPropertyHasValueCurrentColor): Deleted.

Canonical link: <a href="https://commits.webkit.org/258714@main">https://commits.webkit.org/258714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16333a0219460c988145c9338bcc12338e56c7b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111903 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172126 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2672 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109606 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37458 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25941 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2392 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45430 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5953 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7112 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3183 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->