### PR TITLE
CustomElementReactionQueueItem: don't allocate all arguments for all callback types

### DIFF
--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -102,8 +102,10 @@ public:
 private:
     static void enqueueElementOnAppropriateElementQueue(Element&);
 
+    using Item = CustomElementReactionQueueItem;
+
     Ref<JSCustomElementInterface> m_interface;
-    Vector<CustomElementReactionQueueItem> m_items;
+    Vector<Item> m_items;
     bool m_elementInternalsAttached { false };
 };
 


### PR DESCRIPTION
#### 8c8d35286037ce901078dc15bc2f20172a976889
<pre>
CustomElementReactionQueueItem: don&apos;t allocate all arguments for all callback types
<a href="https://bugs.webkit.org/show_bug.cgi?id=249956">https://bugs.webkit.org/show_bug.cgi?id=249956</a>

Reviewed by Ryosuke Niwa.

This change leverages std::variant to:
  * shrink sizeof(CustomElementReactionQueueItem) from 88 to 56;
  * remove 5 constructors;
  * make correspondence between Item&apos;s type() and payload obvious,
    adding asserts about existence / shape of the latter;
  * refine some types by removing std::optional and using Ref instead of RefPtr.

No new tests, no behavior change.

* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueueItem::CustomElementReactionQueueItem):
(WebCore::CustomElementReactionQueueItem::invoke):
(WebCore::CustomElementReactionQueue::enqueueElementUpgrade):
(WebCore::CustomElementReactionQueue::enqueueConnectedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueDisconnectedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueAdoptedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueAttributeChangedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueFormResetCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueFormDisabledCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueFormStateRestoreCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueuePostUpgradeReactions):
(WebCore::CustomElementReactionQueue::invokeAll):
* Source/WebCore/dom/CustomElementReactionQueue.h:

Canonical link: <a href="https://commits.webkit.org/258696@main">https://commits.webkit.org/258696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/210e4378307e4206231c26f98eeb4058ed637989

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111890 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172113 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2659 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109593 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37445 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25930 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2381 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5977 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7100 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->