### PR TITLE
font-face src local() doesn't invalidate css-wide keywords

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Check that src: local(inherit), url(foo.ttf) is valid
-PASS Check that src: local("myfont"), local(unset) is valid
+FAIL Check that src: local(inherit), url(foo.ttf) is valid assert_equals: expected true but got false
+FAIL Check that src: local("myfont"), local(unset) is valid assert_equals: expected true but got false
 FAIL Check that src: local(), url(foo.ttf) is valid assert_equals: expected true but got false
 FAIL Check that src: local(12px monospace), url(foo.ttf) is valid assert_equals: expected true but got false
 FAIL Check that src: local("myfont") format(opentype), url(foo.ttf) is valid assert_equals: expected true but got false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local-expected.txt
@@ -3,16 +3,16 @@ PASS Check that src: local(  A  ) is valid
 PASS Check that src: local(A B) is valid
 PASS Check that src: local(A    B) is valid
 PASS Check that src: local(   A  B   ) is valid
-FAIL Check that src: local(default) is invalid assert_equals: expected false but got true
-FAIL Check that src: local(inherit) is invalid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local(revert) is invalid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local(unset) is invalid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local(default A) is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local(inherit A) is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local(revert A) is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local(unset A) is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local("default") is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local("inherit") is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local("revert") is valid assert_equals: testSheet should initially be empty expected 0 but got 1
-FAIL Check that src: local("unset") is valid assert_equals: testSheet should initially be empty expected 0 but got 1
+PASS Check that src: local(default) is invalid
+PASS Check that src: local(inherit) is invalid
+PASS Check that src: local(revert) is invalid
+PASS Check that src: local(unset) is invalid
+PASS Check that src: local(default A) is valid
+PASS Check that src: local(inherit A) is valid
+PASS Check that src: local(revert A) is valid
+PASS Check that src: local(unset A) is valid
+PASS Check that src: local("default") is valid
+PASS Check that src: local("inherit") is valid
+PASS Check that src: local("revert") is valid
+PASS Check that src: local("unset") is valid
 

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -238,7 +238,7 @@ static RefPtr<CSSValue> consumeFontFaceSrcLocal(CSSParserTokenRange& range)
     }
     if (args.peek().type() == IdentToken) {
         AtomString familyName = CSSPropertyParserHelpers::concatenateFamilyName(args);
-        if (!args.atEnd())
+        if (familyName.isNull() || !args.atEnd())
             return nullptr;
         return CSSFontFaceSrcLocalValue::create(WTFMove(familyName));
     }


### PR DESCRIPTION
#### 1940d518c6502f1340ce118692c79ba0b7afa9f1
<pre>
font-face src local() doesn&apos;t invalidate css-wide keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=250321">https://bugs.webkit.org/show_bug.cgi?id=250321</a>
rdar://104028095

Reviewed by Tim Nguyen.

When we parse src for @font-face, CSS-wide keywords are not valid for local(). In case they are the only keywords being input for local, CSSPropertyParserHelpers::concatenateFamilyName will produce a null String, but we won&apos;t invalidate the CSSValue for that case.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt:
This fix exposes a failure on font-face-src-list, which is being tracked by <a href="https://bugs.webkit.org/show_bug.cgi?id=250332.">https://bugs.webkit.org/show_bug.cgi?id=250332.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcLocal):

Canonical link: <a href="https://commits.webkit.org/258695@main">https://commits.webkit.org/258695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef19bac7a573513242aa315f98dc71d6014e1b25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111960 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2727 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109650 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108474 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24569 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5278 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2434 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5976 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7169 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->