### PR TITLE
[PrettyPatch] XSS vulnerability in file name

### DIFF
--- a/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb
+++ b/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb
@@ -644,10 +644,10 @@ EOF
             for i in 0...lines.length
                 case lines[i]
                 when /^--- /
-                    @from = PrettyPatch.revisionOrDescription(lines[i])
+                    @from = PrettyPatch.revisionOrDescription(CGI.escapeHTML(lines[i]))
                 when /^\+\+\+ /
                     @filename = PrettyPatch.filename_from_diff_header(lines[i].chomp) if @filename.nil?
-                    @to = PrettyPatch.revisionOrDescription(lines[i])
+                    @to = PrettyPatch.revisionOrDescription(CGI.escapeHTML(lines[i]))
                     startOfSections = i + 1
 
                     # Check for 'property' patch, then image data, since svn 1.7 creates a fake patch for property changes.
@@ -746,11 +746,11 @@ EOF
         def to_html
             str = "<div class='FileDiff'>\n"
             if @renameFrom
-                str += "<h1>#{@filename}</h1>"
+                str += "<h1>#{CGI.escapeHTML(@filename)}</h1>"
                 str += "was renamed from"
-                str += "<h1>#{PrettyPatch.linkifyFilename(@renameFrom.to_s)}</h1>"
+                str += "<h1>#{PrettyPatch.linkifyFilename(CGI.escapeHTML(@renameFrom.to_s))}</h1>"
             else
-                str += "<h1>#{PrettyPatch.linkifyFilename(@filename)}</h1>\n"
+                str += "<h1>#{PrettyPatch.linkifyFilename(CGI.escapeHTML(@filename))}</h1>\n"
             end
             if @image then
                 str += self.image_to_html
@@ -774,7 +774,7 @@ EOF
                         str += "<br>"
 
                         if image_url
-                            str += "<img class='image' src='" + image_url + "' />"
+                            str += "<img class='image' src='" + CGI.escapeHTML(image_url) + "' />"
                         else
                             str += ["</p>Added", "</p>Removed"][i]
                         end


### PR DESCRIPTION
#### 2885a1eadc3ced1212d4e9564dda12ee597438e7
<pre>
[PrettyPatch] XSS vulnerability in file name
<a href="https://bugs.webkit.org/show_bug.cgi?id=250222">https://bugs.webkit.org/show_bug.cgi?id=250222</a>
rdar://95708874

Reviewed by Alexey Proskuryakov.

* Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb: Escape file name.

Canonical link: <a href="https://commits.webkit.org/258665@main">https://commits.webkit.org/258665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5010bf5390a415dd4a640f49717a426fd74f269f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111896 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2665 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109599 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9792 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37451 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79195 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25935 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5375 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11396 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7105 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3164 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->