### PR TITLE
[iOS] Update sandboxes from telemetry

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -842,7 +842,7 @@
 (when (defined? 'SYS_map_with_linking_np)
     (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
 
-(allow syscall-mach (with telemetry))
+(deny syscall-mach (with telemetry))
 (allow syscall-mach
     (machtrap-number
         MSC__kernelrpc_mach_port_allocate_trap
@@ -862,9 +862,7 @@
         MSC__kernelrpc_mach_vm_deallocate_trap
         MSC__kernelrpc_mach_vm_map_trap
         MSC__kernelrpc_mach_vm_protect_trap
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED < 160000
         MSC__kernelrpc_mach_vm_purgable_control_trap
-#endif
         MSC_host_create_mach_voucher_trap
         MSC_host_self_trap
         MSC_mach_generate_activity_id
@@ -875,6 +873,7 @@
         MSC_mk_timer_arm
         MSC_mk_timer_cancel
         MSC_mk_timer_create
+        MSC_mk_timer_destroy
         MSC_pid_for_task
         MSC_semaphore_signal_trap
         MSC_semaphore_timedwait_trap

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -782,7 +782,7 @@
 (when (defined? 'SYS_map_with_linking_np)
     (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
 
-(allow syscall-mach (with telemetry))
+(deny syscall-mach (with telemetry))
 (allow syscall-mach
     (machtrap-number
         MSC__kernelrpc_mach_port_allocate_trap
@@ -814,10 +814,9 @@
         MSC_mk_timer_create
         MSC_mk_timer_destroy
         MSC_semaphore_signal_trap
+        MSC_semaphore_timedwait_trap
         MSC_semaphore_wait_trap
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED < 160000
         MSC_swtch_pri
-#endif
         MSC_syscall_thread_switch
         MSC_task_self_trap
         MSC_thread_get_special_reply_port))
@@ -825,23 +824,42 @@
 (when (defined? 'MSC_mach_msg2_trap)
     (allow syscall-mach (machtrap-number MSC_mach_msg2_trap)))
 
+(define (kernel-mig-routine-in-use-watchos)
+    (kernel-mig-routine
+        mach_make_memory_entry
+        mach_make_memory_entry_64
+        vm_copy))
+        
 (allow mach-kernel-endpoint
     (apply-message-filter
-        (allow mach-message-send (with report) (with telemetry))
+        (deny mach-message-send (with telemetry))
+#if PLATFORM(WATCHOS)
+        (allow mach-message-send
+            (kernel-mig-routine-in-use-watchos))
+#endif
         (allow mach-message-send
             (kernel-mig-routine
                 _mach_make_memory_entry
                 host_get_clock_service
+                host_get_io_master
                 host_get_special_port
                 host_info
                 host_request_notification
+                io_connect_method
+                io_registry_entry_from_path
+                io_registry_entry_get_property_bin_buf
+                io_server_version
+                io_service_open_extended
+                mach_exception_raise
                 mach_port_extract_right
+                mach_port_get_context_from_user
                 mach_port_get_refs
                 mach_port_is_connection_for_service
                 mach_port_request_notification
                 mach_port_set_attributes
                 mach_vm_copy
                 mach_vm_map_external
+                mach_vm_remap_external
                 semaphore_create
                 semaphore_destroy
                 task_get_special_port_from_user

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1289,7 +1289,6 @@
 (define (syscall-mach-only-in-use-during-launch)
     (machtrap-number
         MSC_mach_timebase_info_trap
-        MSC_swtch_pri
         MSC_task_self_trap))
 
 (define (syscall-mach-in-use-after-launch)
@@ -1313,6 +1312,7 @@
         MSC__kernelrpc_mach_vm_purgable_control_trap
         MSC_host_create_mach_voucher_trap
         MSC_host_self_trap
+        MSC_iokit_user_client_trap
         MSC_mach_generate_activity_id
         MSC_mach_reply_port
         MSC_mk_timer_arm
@@ -1320,6 +1320,7 @@
         MSC_mk_timer_create
         MSC_semaphore_signal_trap
         MSC_semaphore_timedwait_trap
+        MSC_swtch_pri
         MSC_syscall_thread_switch
         MSC_task_name_for_pid
         MSC_thread_get_special_reply_port))
@@ -1337,7 +1338,7 @@
 (deny syscall-mach
     (machtrap-number MSC_mach_wait_until))
 
-(allow syscall-mach (with telemetry))
+(deny syscall-mach (with telemetry))
 (allow syscall-mach
     (syscall-mach-blocked-in-lockdown-mode)
     (syscall-mach-only-in-use-during-launch)
@@ -1351,7 +1352,7 @@
     (allow syscall-mach
         (syscall-mach-only-in-use-during-launch)))
 (with-filter (state-flag "WebContentProcessLaunched")
-    (allow syscall-mach
+    (deny syscall-mach
         (with telemetry)
         (with message "Mach syscall used after launch")
         (syscall-mach-only-in-use-during-launch)))
@@ -1385,9 +1386,11 @@
         io_registry_entry_from_path
         io_registry_entry_get_property_bin_buf
         io_service_get_matching_service_bin
+        mach_memory_entry_ownership
         mach_port_extract_right
         mach_port_get_context_from_user
         mach_port_get_refs
+        mach_port_request_notification
         mach_port_set_attributes
         mach_vm_copy
         mach_vm_map_external
@@ -1421,14 +1424,12 @@
         io_service_close
         io_service_open_extended
         mach_exception_raise
-        mach_port_request_notification
         mach_vm_region
         mach_vm_region_recurse
         task_threads_from_user))
 
 (define (kernel-mig-routine-rarely-used)
     (kernel-mig-routine
-        mach_memory_entry_ownership
         task_set_exc_guard_behavior
         thread_info
         thread_policy
@@ -1436,7 +1437,7 @@
     
 (allow mach-kernel-endpoint
     (apply-message-filter
-        (allow mach-message-send (with telemetry))
+        (deny mach-message-send (with telemetry))
         (allow mach-message-send (with telemetry-backtrace)
             (kernel-mig-routine-rarely-used-need-backtrace))
 
@@ -1458,7 +1459,7 @@
             (allow mach-message-send
                 (kernel-mig-routine-only-in-use-during-launch)))
         (with-filter (state-flag "WebContentProcessLaunched")
-            (allow mach-message-send
+            (deny mach-message-send
                 (with telemetry)
                 (with message "kernel mig routine used after launch")
                 (kernel-mig-routine-only-in-use-during-launch)))


### PR DESCRIPTION
#### 8b0cc0d516bbdf8a4bb8278518915f1c232d6ad6
<pre>
[iOS] Update sandboxes from telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=249709">https://bugs.webkit.org/show_bug.cgi?id=249709</a>
rdar://103742279

Reviewed by Geoffrey Garen.

Update sandboxes after reviewing syscall mach and kernel MIG telemetry on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/258682@main">https://commits.webkit.org/258682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c6988cbe9a9d6c8b00d83296785c55cfd9fab08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111922 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2691 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109621 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9815 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37475 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79218 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25962 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2409 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45451 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5965 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7131 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->