### PR TITLE
Local Network Access: Implement the Secure Context Restriction

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -43,6 +43,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/Modules/indexeddb/client"
     "${WEBCORE_DIR}/Modules/indexeddb/server"
     "${WEBCORE_DIR}/Modules/indexeddb/shared"
+    "${WEBCORE_DIR}/Modules/local-network-access"
     "${WEBCORE_DIR}/Modules/mediacapabilities"
     "${WEBCORE_DIR}/Modules/mediacontrols"
     "${WEBCORE_DIR}/Modules/mediarecorder"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -344,6 +344,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/plugins/PluginReplacement.h
     Modules/plugins/YouTubePluginReplacement.h
 
+    Modules/private-network-access/PrivateNetworkAccess.h
+
     Modules/push-api/PushCrypto.h
     Modules/push-api/PushDatabase.h
     Modules/push-api/PushMessageCrypto.h

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -36,6 +36,7 @@
 #include "FetchBodyConsumer.h"
 #include "FetchLoaderClient.h"
 #include "FetchRequest.h"
+#include "LocalNetworkAccess.h"
 #include "ResourceError.h"
 #include "ResourceRequest.h"
 #include "ScriptExecutionContext.h"
@@ -103,6 +104,11 @@ void FetchLoader::start(ScriptExecutionContext& context, const FetchRequest& req
     auto& contentSecurityPolicy = *context.contentSecurityPolicy();
 
     contentSecurityPolicy.upgradeInsecureRequestIfNeeded(fetchRequest, ContentSecurityPolicy::InsecureRequestType::Load);
+
+    if (isLocalNetworkAccessSecureContextRestricted(context, fetchRequest.addressSpace())) {
+        didFail({ errorDomainWebKitInternal, 0, fetchRequest.url(), "Not allowed by Local Network Access"_s, ResourceError::Type::AccessControl });
+        return;
+    }
 
     if (!context.shouldBypassMainWorldContentSecurityPolicy() && !contentSecurityPolicy.allowConnectToSource(fetchRequest.url())) {
         m_client.didFail({ errorDomainWebKitInternal, 0, fetchRequest.url(), "Not allowed by ContentSecurityPolicy"_s, ResourceError::Type::AccessControl });

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -83,6 +83,8 @@ public:
     const String& internalRequestReferrer() const { return m_referrer; }
     const URL& url() const { return m_request.url(); }
 
+    AddressSpace addressSpace() const { return m_request.addressSpace(); }
+
     ResourceRequest resourceRequest() const;
     FetchIdentifier navigationPreloadIdentifier() const { return m_navigationPreloadIdentifier; }
     void setNavigationPreloadIdentifier(FetchIdentifier identifier) { m_navigationPreloadIdentifier = identifier; }

--- a/Source/WebCore/Modules/local-network-access/LocalNetworkAccess.cpp
+++ b/Source/WebCore/Modules/local-network-access/LocalNetworkAccess.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LocalNetworkAccess.h"
+
+#include "SecurityContext.h"
+#include "SecurityOrigin.h"
+
+namespace WebCore {
+
+AddressSpace addressSpaceFromURL(const URL& url)
+{
+    if (SecurityOrigin::isLocalHostOrLoopbackIPAddress(url.host()))
+        return AddressSpace::Local;
+
+    // FIXME (https://webkit.org/b/250339): add support for checking for IPv6 addresses in private address space.
+    if (SecurityOrigin::isLocalNetworkIPv4Address(url.host()))
+        return AddressSpace::Private;
+
+    return AddressSpace::Public;
+}
+
+bool isLocalNetworkAccessSecureContextRestricted(const SecurityContext& securityContext, AddressSpace requestAddressSpace)
+{
+    if (requestAddressSpace == AddressSpace::Public)
+        return false;
+
+    if (securityContext.addressSpace() != AddressSpace::Public)
+        return false;
+
+    // FIXME (https://webkit.org/b/250418): We create documents with a top-level data URL as non-secure
+    // contexts contrary to the HTML spec. The SecurityOrigin::isSecure check exists until that is resolved.
+    if (securityContext.isSecureContext() || SecurityOrigin::isSecure(securityContext.url()))
+        return false;
+
+    if (securityContext.securityOrigin() && securityContext.securityOrigin()->isLocal())
+        return false;
+
+    return true;
+}
+
+}

--- a/Source/WebCore/Modules/local-network-access/LocalNetworkAccess.h
+++ b/Source/WebCore/Modules/local-network-access/LocalNetworkAccess.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class SecurityContext;
+
+enum class AddressSpace : uint8_t {
+    Public,
+    Private,
+    Local
+};
+
+WEBCORE_EXPORT AddressSpace addressSpaceFromURL(const URL&);
+bool isLocalNetworkAccessSecureContextRestricted(const SecurityContext &, AddressSpace);
+
+}
+
+namespace WTF {
+template <> struct EnumTraits<WebCore::AddressSpace> {
+    using values = EnumValues<
+        WebCore::AddressSpace,
+        WebCore::AddressSpace::Public,
+        WebCore::AddressSpace::Private,
+        WebCore::AddressSpace::Local
+    >;
+};
+
+template <> struct EnumTraitsForPersistence<WebCore::AddressSpace> {
+    using values = EnumValues<
+        WebCore::AddressSpace,
+        WebCore::AddressSpace::Public,
+        WebCore::AddressSpace::Private,
+        WebCore::AddressSpace::Local
+    >;
+};
+
+}

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -166,6 +166,7 @@ Modules/indexeddb/shared/IDBResourceIdentifier.cpp
 Modules/indexeddb/shared/IDBResultData.cpp
 Modules/indexeddb/shared/IDBTransactionInfo.cpp
 Modules/indexeddb/shared/IndexKey.cpp
+Modules/local-network-access/LocalNetworkAccess.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
 Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -109,7 +109,6 @@ public:
 
     virtual EventLoopTaskGroup& eventLoop() = 0;
 
-    virtual const URL& url() const = 0;
     enum class ForceUTF8 { No, Yes };
     virtual URL completeURL(const String& url, ForceUTF8 = ForceUTF8::No) const = 0;
 

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -41,6 +41,7 @@ class SecurityOriginPolicy;
 class ContentSecurityPolicy;
 struct CrossOriginOpenerPolicy;
 struct PolicyContainer;
+enum class AddressSpace : uint8_t;
 enum class ReferrerPolicy : uint8_t;
 
 enum SandboxFlag {
@@ -68,6 +69,8 @@ typedef int SandboxFlags;
 
 class SecurityContext {
 public:
+    virtual const URL& url() const = 0;
+
     // https://html.spec.whatwg.org/multipage/origin.html#determining-the-creation-sandboxing-flags
     SandboxFlags creationSandboxFlags() const { return m_creationSandboxFlags; }
 
@@ -101,6 +104,9 @@ public:
 
     virtual ReferrerPolicy referrerPolicy() const { return m_referrerPolicy; }
     void setReferrerPolicy(ReferrerPolicy);
+
+    AddressSpace addressSpace() const { return m_addressSpace; }
+    void setAddressSpace(AddressSpace addressSpace) { m_addressSpace = addressSpace; }
 
     WEBCORE_EXPORT PolicyContainer policyContainer() const;
     virtual void inheritPolicyContainerFrom(const PolicyContainer&);
@@ -153,6 +159,7 @@ private:
     CrossOriginEmbedderPolicy m_crossOriginEmbedderPolicy;
     CrossOriginOpenerPolicy m_crossOriginOpenerPolicy;
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::Default };
+    AddressSpace m_addressSpace;
     SandboxFlags m_creationSandboxFlags { SandboxNone };
     SandboxFlags m_sandboxFlags { SandboxNone };
     OptionSet<MixedContentType> m_mixedContentTypes;

--- a/Source/WebCore/features.json
+++ b/Source/WebCore/features.json
@@ -669,6 +669,16 @@
         "description": "Allows defering loading of images until they are visible in the viewport."
     },
     {
+        "name": "Local Network Access",
+        "status": {
+            "status": "In Development"
+        },
+        "url": "https://wicg.github.io/local-network-access/",
+        "webkit-url": "https://webkit.org/b/250607",
+        "keywords": ["local network", "local network access"],
+        "description": "A mechanism for resources on localhost and local networks to be secured against requests from resources hosted on the public internet."
+    },
+    {
         "name": "Magnetometer",
         "status": {
             "status": "Not Considering"

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -60,6 +60,7 @@
 #include "HTTPHeaderField.h"
 #include "InspectorInstrumentation.h"
 #include "LoaderStrategy.h"
+#include "LocalNetworkAccess.h"
 #include "LocalizedStrings.h"
 #include "Logging.h"
 #include "MemoryCache.h"
@@ -583,6 +584,11 @@ bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url,
         return false;
     }
 
+    if (document() && isLocalNetworkAccessSecureContextRestricted(*document(), addressSpaceFromURL(url))) {
+        LOG(ResourceLoading, "CachedResourceLoader::requestResource URL was not allowed by Local Network Access.");
+        return false;
+    }
+
     if (!allowedByContentSecurityPolicy(type, url, options, ContentSecurityPolicy::RedirectResponseReceived::No))
         return false;
 
@@ -865,6 +871,7 @@ void CachedResourceLoader::prepareFetch(CachedResource::Type type, CachedResourc
         if (auto* activeServiceWorker = document->activeServiceWorker())
             request.setSelectedServiceWorkerRegistrationIdentifierIfNeeded(activeServiceWorker->registrationIdentifier());
 #endif
+        request.setAddressSpace(document->addressSpace());
     }
 
     request.setAcceptHeaderIfNone(type);

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -342,4 +342,9 @@ void CachedResourceRequest::setNavigationServiceWorkerRegistrationData(const std
 }
 #endif
 
+void CachedResourceRequest::setAddressSpace(AddressSpace addressSpace)
+{
+    m_resourceRequest.setAddressSpace(addressSpace);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -116,6 +116,8 @@ public:
     void setNavigationServiceWorkerRegistrationData(const std::optional<ServiceWorkerRegistrationData>&);
 #endif
 
+    void setAddressSpace(AddressSpace);
+
 private:
     ResourceRequest m_resourceRequest;
     String m_charset;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -210,6 +210,7 @@ public:
     void setIsPotentiallyTrustworthy(bool value) { m_isPotentiallyTrustworthy = value; }
 
     WEBCORE_EXPORT static bool isLocalHostOrLoopbackIPAddress(StringView);
+    static bool isLocalNetworkIPv4Address(StringView);
 
     const SecurityOriginData& data() const { return m_data; }
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -125,6 +125,7 @@ void ResourceRequestBase::setURL(const URL& url)
     updateResourceRequest(); 
 
     m_requestData.m_url = url;
+    setAddressSpace(addressSpaceFromURL(url));
     
     m_platformRequestUpdated = false;
 }

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -31,6 +31,7 @@
 #include "FrameLoaderTypes.h"
 #include "HTTPHeaderMap.h"
 #include "IntRect.h"
+#include "LocalNetworkAccess.h"
 #include "ResourceLoadPriority.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
@@ -80,12 +81,14 @@ public:
             , m_priority(priority)
             , m_requester(requester)
             , m_isAppInitiated(isAppInitiated)
+            , m_addressSpace(addressSpaceFromURL(url))
         {
         }
         
         RequestData(const URL& url, ResourceRequestCachePolicy cachePolicy)
             : m_url(url)
             , m_cachePolicy(cachePolicy)
+            , m_addressSpace(addressSpaceFromURL(url))
         {
         }
         
@@ -102,6 +105,7 @@ public:
         ResourceLoadPriority m_priority { ResourceLoadPriority::Low };
         ResourceRequestRequester m_requester { ResourceRequestRequester::Unspecified };
         bool m_isAppInitiated : 1 { true };
+        AddressSpace m_addressSpace { AddressSpace::Public };
     };
 
     ResourceRequestBase(RequestData&& requestData)
@@ -122,6 +126,9 @@ public:
     
     WEBCORE_EXPORT const URL& url() const;
     WEBCORE_EXPORT void setURL(const URL& url);
+
+    AddressSpace addressSpace() const { return m_requestData.m_addressSpace; }
+    void setAddressSpace(AddressSpace addressSpace) { m_requestData.m_addressSpace = addressSpace; }
 
     void redirectAsGETIfNeeded(const ResourceRequestBase &, const ResourceResponse&);
     WEBCORE_EXPORT ResourceRequest redirectedRequest(const ResourceResponse&, bool shouldClearReferrerOnHTTPSToHTTPRedirect) const;

--- a/Tools/TestWebKitAPI/Tests/WTF/StringToIntegerConversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringToIntegerConversion.cpp
@@ -82,4 +82,19 @@ TEST(WTF, ParseIntegerAllowingTrailingJunk)
     EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("65536"_s));
 }
 
+TEST(WTF, ParseIntegerDisallowLeadingAndTrailingSpaces)
+{
+    EXPECT_EQ(std::nullopt, parseIntegerDisallowLeadingAndTrailingSpaces<int>("123 "_s));
+    EXPECT_EQ(std::nullopt, parseIntegerDisallowLeadingAndTrailingSpaces<int>(" 456"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerDisallowLeadingAndTrailingSpaces<int>(" 789 "_s));
+    EXPECT_EQ(0, parseIntegerDisallowLeadingAndTrailingSpaces<int>("0"_s));
+    EXPECT_EQ(1, parseIntegerDisallowLeadingAndTrailingSpaces<int>("1"_s));
+    EXPECT_EQ(3, parseIntegerDisallowLeadingAndTrailingSpaces<int>("3"_s));
+    EXPECT_EQ(-3, parseIntegerDisallowLeadingAndTrailingSpaces<int>("-3"_s));
+    EXPECT_EQ(12345, parseIntegerDisallowLeadingAndTrailingSpaces<int>("12345"_s));
+    EXPECT_EQ(-12345, parseIntegerDisallowLeadingAndTrailingSpaces<int>("-12345"_s));
+    EXPECT_EQ(0U, 0U + *parseIntegerDisallowLeadingAndTrailingSpaces<uint8_t>("0"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerDisallowLeadingAndTrailingSpaces<uint16_t>("-3"_s));
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -27,6 +27,7 @@
 
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringView.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace TestWebKitAPI {
 
@@ -313,6 +314,31 @@ TEST(WTF, StringViewSplitWithConsecutiveSeparators)
     ASSERT_EQ(expected.size(), actual.size());
     for (size_t i = 0; i < actual.size(); ++i)
         EXPECT_STREQ(expected[i].utf8().data(), actual[i].utf8().data()) << "Vectors differ at index " << i;
+}
+
+TEST(WTF, StringViewSplitIP)
+{
+    String referenceHolder;
+    StringView ip = stringViewFromUTF8(referenceHolder, "192.168.0.254");
+    EXPECT_TRUE(ip == "192.168.0.254"_s);
+
+    Vector<String> actual = vectorFromSplitResult(ip.split('.'));
+    Vector<String> expected({ "192"_s, "168"_s, "0"_s, "254"_s });
+    ASSERT_EQ(expected.size(), actual.size());
+    for (size_t i = 0; i < actual.size(); ++i)
+        EXPECT_STREQ(expected[i].utf8().data(), actual[i].utf8().data()) << "Vectors differ at index " << i;
+
+    ip = stringViewFromUTF8(referenceHolder, "172.16.0.10");
+    EXPECT_TRUE(ip == "172.16.0.10"_s);
+
+    actual = vectorFromSplitResult(ip.split('.'));
+    expected = Vector<String>({ "172"_s, "16"_s, "0"_s, "10"_s });
+    ASSERT_EQ(expected.size(), actual.size());
+    for (size_t i = 0; i < actual.size(); ++i)
+        EXPECT_STREQ(expected[i].utf8().data(), actual[i].utf8().data()) << "Vectors differ at index " << i;
+
+    EXPECT_EQ(16, parseInteger<uint8_t>(actual[1]));
+
 }
 
 TEST(WTF, StringViewEqualBasic)


### PR DESCRIPTION
#### 4694c16e36d83d3efd77cc0091d128b0bb319722
<pre>
Local Network Access: Implement the Secure Context Restriction
<a href="https://bugs.webkit.org/show_bug.cgi?id=250330">https://bugs.webkit.org/show_bug.cgi?id=250330</a>
rdar://103142696

Reviewed by NOBODY (OOPS!).

Local Network Access has a Secure Context Restriction [0] which blocks a page in
the public address space that is a non-secure context from accessing resources
in the private or local address spaces. This adds a check and associated helpers
for checking that the request is allowed.

[0]: <a href="https://wicg.github.io/local-network-access/#secure-context-restriction">https://wicg.github.io/local-network-access/#secure-context-restriction</a>

* Source/WTF/wtf/text/StringToIntegerConversion.h:
(WTF::parseInteger):
(WTF::parseIntegerAllowingTrailingJunk):
(WTF::parseIntegerDisallowLeadingAndTrailingSpaces):
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
(WebCore::FetchLoader::start):
* Source/WebCore/Modules/private-network-access/PrivateNetworkAccess.cpp: Added.
(WebCore::isPrivateNetworkAccessSecureContextRestricted):
* Source/WebCore/Modules/private-network-access/PrivateNetworkAccess.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/SecurityContext.h:
(WebCore::SecurityContext::addressSpace const):
(WebCore::SecurityContext::setAddressSpace):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::prepareFetch):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::setAddressSpace):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::isValidIP4Address):
(WebCore::isLoopbackIPAddress):
(WebCore::SecurityOrigin::isPrivateIPv4Address):
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
(WebCore::ResourceRequestBase::addressSpace const):
(WebCore::ResourceRequestBase::setAddressSpace):
* Tools/TestWebKitAPI/Tests/WTF/StringToIntegerConversion.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4694c16e36d83d3efd77cc0091d128b0bb319722

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36773 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113048 "Hash 4694c16e for PR 8407 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173358 "Hash 4694c16e for PR 8407 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3834 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96071 "Hash 4694c16e for PR 8407 does not build (failure)") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112159 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10767 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93842 "Found 1 new API test failure: TestWebKitAPI.NetworkProcess.CORSPreflightCachePartitioned (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96071 "Hash 4694c16e for PR 8407 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92598 "Found 1 new API test failure: TestWebKitAPI.NetworkProcess.CORSPreflightCachePartitioned (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25450 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96071 "Hash 4694c16e for PR 8407 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93935 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6295 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26835 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90391 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4063 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3366 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29846 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46360 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/99000 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8231 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24916 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->