### PR TITLE
REGRESSION (iOS 16): Incorrect text color used with matching translucent border color

### DIFF
--- a/LayoutTests/fast/css/color-matching-translucent-border-color-expected.html
+++ b/LayoutTests/fast/css/color-matching-translucent-border-color-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .hidden {
+            width: 50px;
+            height: 50px;
+        }
+
+        .red {
+            border-style: solid;
+            border-top-color: rgb(255, 0, 0, 0.1);
+            border-right-color: rgb(255, 0, 0, 0.1);
+            border-left-color: rgb(255, 0, 0, 0.1);
+            color: rgb(255, 0, 0);
+        }
+    </style>
+</head>
+<body>
+    <div class="hidden"></div>
+    <span class="red">This text should be red.</span>
+</body>
+</html>

--- a/LayoutTests/fast/css/color-matching-translucent-border-color.html
+++ b/LayoutTests/fast/css/color-matching-translucent-border-color.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .hidden {
+            color: transparent;
+            width: 50px;
+            height: 50px;
+        }
+
+        .red {
+            border-style: solid;
+            border-top-color: rgb(255, 0, 0, 0.1);
+            border-right-color: rgb(255, 0, 0, 0.1);
+            border-left-color: rgb(255, 0, 0, 0.1);
+            color: rgb(255, 0, 0);
+        }
+    </style>
+</head>
+<body>
+    <div class="hidden">This text should be hidden.</div>
+    <span class="red">This text should be red.</span>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -148,6 +148,8 @@ void BifurcatedGraphicsContext::beginTransparencyLayer(float opacity)
     GraphicsContext::beginTransparencyLayer(opacity);
     m_primaryContext.beginTransparencyLayer(opacity);
     m_secondaryContext.beginTransparencyLayer(opacity);
+
+    GraphicsContext::save();
     m_state.didBeginTransparencyLayer();
 
     VERIFY_STATE_SYNCHRONIZATION();
@@ -158,7 +160,8 @@ void BifurcatedGraphicsContext::endTransparencyLayer()
     GraphicsContext::endTransparencyLayer();
     m_primaryContext.endTransparencyLayer();
     m_secondaryContext.endTransparencyLayer();
-    m_state.didEndTransparencyLayer(m_primaryContext.alpha());
+
+    GraphicsContext::restore();
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -178,16 +178,6 @@ void GraphicsContextState::didBeginTransparencyLayer()
 #endif
 }
 
-void GraphicsContextState::didEndTransparencyLayer(float originalOpacity)
-{
-#if USE(CG)
-    // CGContextBeginTransparencyLayer() sets the CG global alpha to 1. Resore our alpha now.
-    m_alpha = originalOpacity;
-#else
-    UNUSED_PARAM(originalOpacity);
-#endif
-}
-
 static const char* stateChangeName(GraphicsContextState::Change change)
 {
     switch (change) {

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -136,7 +136,6 @@ public:
     void mergeAllChanges(const GraphicsContextState&);
 
     void didBeginTransparencyLayer();
-    void didEndTransparencyLayer(float originalOpacity);
 
     WTF::TextStream& dump(WTF::TextStream&) const;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -324,6 +324,8 @@ void Recorder::beginTransparencyLayer(float opacity)
 
     appendStateChangeItemIfNecessary();
     recordBeginTransparencyLayer(opacity);
+
+    GraphicsContext::save();
     m_stateStack.append(m_stateStack.last().cloneForTransparencyLayer());
     
     m_state.didBeginTransparencyLayer();
@@ -335,9 +337,9 @@ void Recorder::endTransparencyLayer()
 
     appendStateChangeItemIfNecessary();
     recordEndTransparencyLayer();
-    m_stateStack.removeLast();
 
-    m_state.didEndTransparencyLayer(currentState().state.alpha());
+    m_stateStack.removeLast();
+    GraphicsContext::restore();
 }
 
 void Recorder::drawRect(const FloatRect& rect, float borderThickness)


### PR DESCRIPTION
#### cc12988dce62c9150ad502327d8885654c615717
<pre>
REGRESSION (iOS 16): Incorrect text color used with matching translucent border color
<a href="https://bugs.webkit.org/show_bug.cgi?id=247020">https://bugs.webkit.org/show_bug.cgi?id=247020</a>
rdar://101560064

Reviewed by Wenson Hsieh and Said Abou-Hallawa.

Consider the following test case, which should have some green text above red text,
but ends up having only green text:

```
&lt;div style=&quot;color: green;&quot;&gt;Green&lt;/div&gt;
&lt;span style=&quot;color: red; border-style: solid; border-top-color: rgb(255, 0, 0, 0.1); border-right-color: rgb(255, 0, 0, 0.1); border-left-color: rgb(255, 0, 0, 0.1);&quot;&gt;Red&lt;/span&gt;
```

Which issues the following (reduced) set of `GraphicsContext` commands:

```
context.setFillColor(Color::green);
context.drawText(&quot;Green&quot;);
context.beginTransparencyLayer(0.1);
context.setFillColor(Color::red);
// Draw borders
context.endTransparencyLayer();
context.setFillColor(Color::red);
context.drawText(&quot;Red&quot;);
```

When the call to set a green fill color is made, the `GraphicsContext` state
member is updated, as there has been a change in the fill color. Then, the
`DisplayList::Recorder` is informed of the state change via `didUpdateState` and
the appropriate `ChangeFlags`. The recorder has its own `GraphicsContextState`,
which is updated with the latest changes. This ensures the green text is painted
correctly.

The use of a translucent border results in the use of a transparency layer.
`beginTransparencyLayer` and `endTransparencyLayer` push and pop to the recorder&apos;s
state stack respectively. However, the parent class, `GraphicsContext`, maintains
its own state and state stack.

Currently, when beginning a transparency layer, the `GraphicsContext` state stack is
not updated. Consequently, the second call to set a red fill color (for the text
color) is made to the same `GraphicsContextState` as the first call, which
occurred while there was a transparency layer. Since the colors are equal, the recorder
is not informed that a change has been made. However, at this time, the recorder&apos;s
own state has a green fill, following the &quot;pop&quot; from ending the transparency layer.
This green fill color is what is recorded when painting the second line of text,
resulting in an incorrect text color.

To fix, update the `GraphicsContext` state stack is alongside the `DisplayList::Recorder`
state stack when beginning/ending a transparency layer. This ensures that the
`GraphicsContext` state matches the recorder&apos;s state after ending the transparency
layer, and any state updates are not dropped on their way to the recorder.

* LayoutTests/fast/css/color-matching-translucent-border-color-expected.html: Added.
* LayoutTests/fast/css/color-matching-translucent-border-color.html: Added.

Original test case provided by Kevin Muncie, with slight modifications to
support writing a reference test that fails without this change.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:

Make an equivalent change in `BifurcatedGraphicsContext`.

(WebCore::BifurcatedGraphicsContext::beginTransparencyLayer):
(WebCore::BifurcatedGraphicsContext::endTransparencyLayer):
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::didEndTransparencyLayer): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::beginTransparencyLayer):

Push to the `GraphicsContext` state stack by calling parent class method. The
`DisplayList::Recorder::save` is not called to avoid recording an unnecessary
display list item.

(WebCore::DisplayList::Recorder::endTransparencyLayer):

Remove the call to `didEndTransparencyLayer`, as `GraphicsContext` `m_state`
is now correctly restored to the state prior to beginning the transparency
layer.

Canonical link: <a href="https://commits.webkit.org/258762@main">https://commits.webkit.org/258762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ef447a21f8985cc3455428dda0e2d7054584ca8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111966 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172207 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2736 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109656 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37501 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79244 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5287 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2441 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45486 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6025 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7178 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->