### PR TITLE
REGRESSION(258522@main): Ensure the slider style is applied to an <input> element before drawing

### DIFF
--- a/LayoutTests/fast/forms/slider-track-not-input-element-expected.txt
+++ b/LayoutTests/fast/forms/slider-track-not-input-element-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/forms/slider-track-not-input-element.html
+++ b/LayoutTests/fast/forms/slider-track-not-input-element.html
@@ -1,0 +1,12 @@
+<style>
+  html {
+    appearance: slider-vertical;
+  }
+</style>
+<body>
+    <p>This test passes if it does not crash.</p>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+</body>

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -507,18 +507,21 @@ static RefPtr<ControlPart> createSliderTrackPartForRenderer(const RenderObject& 
     if (type != ControlPartType::SliderHorizontal && type != ControlPartType::SliderVertical)
         return nullptr;
 
-    auto& input = downcast<HTMLInputElement>(*renderer.node());
-    if (!input.isRangeControl())
+    auto* input = dynamicDowncast<HTMLInputElement>(*renderer.node());
+    if (!input)
+        return nullptr;
+
+    if (!input->isRangeControl())
         return nullptr;
 
     IntSize thumbSize;
-    if (const auto* thumbRenderer = input.sliderThumbElement()->renderer()) {
+    if (const auto* thumbRenderer = input->sliderThumbElement()->renderer()) {
         const auto& thumbStyle = thumbRenderer->style();
         thumbSize = IntSize { thumbStyle.width().intValue(), thumbStyle.height().intValue() };
     }
 
     IntRect trackBounds;
-    if (const auto* trackRenderer = input.sliderTrackElement()->renderer()) {
+    if (const auto* trackRenderer = input->sliderTrackElement()->renderer()) {
         trackBounds = trackRenderer->absoluteBoundingBoxRectIgnoringTransforms();
         
         // We can ignoring transforms because transform is handled by the graphics context.
@@ -530,12 +533,12 @@ static RefPtr<ControlPart> createSliderTrackPartForRenderer(const RenderObject& 
 
     Vector<double> tickRatios;
 #if ENABLE(DATALIST_ELEMENT)
-    if (auto dataList = input.dataList()) {
-        double minimum = input.minimum();
-        double maximum = input.maximum();
+    if (auto dataList = input->dataList()) {
+        double minimum = input->minimum();
+        double maximum = input->maximum();
 
         for (auto& optionElement : dataList->suggestions()) {
-            auto optionValue = input.listOptionValueAsDouble(optionElement);
+            auto optionValue = input->listOptionValueAsDouble(optionElement);
             if (!optionValue)
                 continue;
             double tickRatio = (*optionValue - minimum) / (maximum - minimum);


### PR DESCRIPTION
#### c14ea6ce8716cee385610874385c04417621068c
<pre>
REGRESSION(258522@main): Ensure the slider style is applied to an &lt;input&gt; element before drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250334">https://bugs.webkit.org/show_bug.cgi?id=250334</a>
rdar://104019874

Reviewed by Aditya Keerthi.

The appearance style can be applied to any non &lt;input&gt; element. In 258522@main,
createSliderTrackPartForRenderer() was refactored from RenderTheme::paintSliderTicks()
which makes an early return &quot;if (!is&lt;HTMLInputElement&gt;(o.node()))&quot;. We need to
port this check to createSliderTrackPartForRenderer().

* LayoutTests/fast/forms/slider-track-not-input-element-expected.txt: Added.
* LayoutTests/fast/forms/slider-track-not-input-element.html: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::createSliderTrackPartForRenderer):

Canonical link: <a href="https://commits.webkit.org/258684@main">https://commits.webkit.org/258684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b131af2487845ebe99c349797d8314a90d119e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11798 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111936 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2704 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108449 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5255 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7145 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->