### PR TITLE
SampleBufferContentKeySessionSupportEnabled is not attached to DeprecatedGlobalSettings

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4853,6 +4853,7 @@ SampleBufferContentKeySessionSupportEnabled:
   status: unstable
   humanReadableName: "ContentKeySession support for SampleBuffer Renderers"
   humanReadableDescription: "ContentKeySession support for SampleBuffer Renderers Enabled"
+  webcoreOnChange: sampleBufferContentKeySessionSupportEnabledChanged
   condition: HAVE(AVCONTENTKEYSPECIFIER)
   defaultValue:
     WebKitLegacy:

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -70,14 +70,6 @@ void DeprecatedGlobalSettings::setMediaSourceInlinePaintingEnabled(bool isEnable
 }
 #endif
 
-#if HAVE(AVCONTENTKEYSPECIFIER)
-void DeprecatedGlobalSettings::setSampleBufferContentKeySessionSupportEnabled(bool enabled)
-{
-    shared().m_sampleBufferContentKeySessionSupportEnabled = enabled;
-    MediaSessionManagerCocoa::setSampleBufferContentKeySessionSupportEnabled(enabled);
-}
-#endif
-
 #if PLATFORM(WIN)
 void DeprecatedGlobalSettings::setShouldUseHighResolutionTimers(bool shouldUseHighResolutionTimers)
 {

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -169,11 +169,6 @@ public:
     static bool mediaSourceInlinePaintingEnabled() { return shared().m_mediaSourceInlinePaintingEnabled; }
 #endif
 
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    static void setSampleBufferContentKeySessionSupportEnabled(bool);
-    static bool sampleBufferContentKeySessionSupportEnabled() { return shared().m_sampleBufferContentKeySessionSupportEnabled; }
-#endif
-
 #if ENABLE(BUILT_IN_NOTIFICATIONS)
     static void setBuiltInNotificationsEnabled(bool isEnabled) { shared().m_builtInNotificationsEnabled = isEnabled; }
     static bool builtInNotificationsEnabled() { return shared().m_builtInNotificationsEnabled; }
@@ -267,10 +262,6 @@ private:
 
 #if ENABLE(MEDIA_SOURCE) && (HAVE(AVSAMPLEBUFFERVIDEOOUTPUT) || USE(GSTREAMER))
     bool m_mediaSourceInlinePaintingEnabled { false };
-#endif
-
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    bool m_sampleBufferContentKeySessionSupportEnabled { false };
 #endif
 
 #if ENABLE(BUILT_IN_NOTIFICATIONS)

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -52,6 +52,9 @@
 #if ENABLE(MEDIA_STREAM)
 #include "MockRealtimeMediaSourceCenter.h"
 #endif
+#if HAVE(AVCONTENTKEYSPECIFIER)
+#include "MediaSessionManagerCocoa.h"
+#endif
 
 namespace WebCore {
 
@@ -495,5 +498,13 @@ void SettingsBase::resourceUsageOverlayVisibleChanged()
         m_page->setResourceUsageOverlayVisible(m_page->settings().resourceUsageOverlayVisible());
 #endif
 }
+
+#if HAVE(AVCONTENTKEYSPECIFIER)
+void SettingsBase::sampleBufferContentKeySessionSupportEnabledChanged()
+{
+    if (m_page)
+        MediaSessionManagerCocoa::setSampleBufferContentKeySessionSupportEnabled(m_page->settings().sampleBufferContentKeySessionSupportEnabled());
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -166,6 +166,9 @@ protected:
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     void layerBasedSVGEngineEnabledChanged();
 #endif
+#if HAVE(AVCONTENTKEYSPECIFIER)
+    void sampleBufferContentKeySessionSupportEnabledChanged();
+#endif
 
     Page* m_page;
 


### PR DESCRIPTION
#### 14816ea69ff90349214ca5f7371d4a21f9244bfc
<pre>
SampleBufferContentKeySessionSupportEnabled is not attached to DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250337">https://bugs.webkit.org/show_bug.cgi?id=250337</a>
&lt;rdar://problem/104044710&gt;

Reviewed by Eric Carlson.

Correct a missing &apos;webcorebindings&apos; field in the new generator file.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Include
missing webcoreOnChange binding.
* Source/WebCore/page/DeprecatedGlobalSettings.cpp: Remove unused method
* Source/WebCore/page/DeprecatedGlobalSettings.h: Remove unused method and
member variable.
* Source/WebCore/page/SettingsBase.cpp: Add handler for KeySessionSupport.
* Source/WebCore/page/SettingsBase.h

Canonical link: <a href="https://commits.webkit.org/258734@main">https://commits.webkit.org/258734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d40271d6ddd28411328304b3f079cf97460f632

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111965 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172206 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2735 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109655 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37509 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79252 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92926 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25993 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89271 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2970 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2440 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29649 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45484 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/92195 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6000 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7177 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20651 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->