### PR TITLE
Unreviewed iOS build fix after 258674@main

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h
@@ -55,13 +55,18 @@ public:
 
 private:
     void setupElements();
+
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     GameControllerHapticEngines& ensureHapticEngines();
+#endif
 
     RetainPtr<GCController> m_gcController;
 
     Vector<SharedGamepadValue> m_axisValues;
     Vector<SharedGamepadValue> m_buttonValues;
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     std::unique_ptr<GameControllerHapticEngines> m_hapticEngines;
+#endif
 };
 
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -70,12 +70,14 @@ void GameControllerGamepad::setupElements()
 
     m_id = makeString(String(m_gcController.get().vendorName), m_gcController.get().extendedGamepad ? " Extended Gamepad"_s : " Gamepad"_s);
 
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     if (auto *haptics = [m_gcController haptics]) {
         if (canLoad_GameController_GCHapticsLocalityLeftHandle() && canLoad_GameController_GCHapticsLocalityRightHandle()) {
             if ([haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityLeftHandle()] && [haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityRightHandle()])
                 m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
         }
     }
+#endif
 
     if (m_gcController.get().extendedGamepad)
         m_mapping = standardGamepadMappingString();
@@ -158,30 +160,42 @@ void GameControllerGamepad::setupElements()
     };
 }
 
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 GameControllerHapticEngines& GameControllerGamepad::ensureHapticEngines()
 {
     if (!m_hapticEngines)
         m_hapticEngines = GameControllerHapticEngines::create(m_gcController.get());
     return *m_hapticEngines;
 }
+#endif
 
 void GameControllerGamepad::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     ensureHapticEngines().playEffect(type, parameters, WTFMove(completionHandler));
+#else
+    UNUSED_PARAM(type);
+    UNUSED_PARAM(parameters);
+    completionHandler(false);
+#endif
 }
 
 void GameControllerGamepad::stopEffects(CompletionHandler<void()>&& completionHandler)
 {
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     if (m_hapticEngines)
         m_hapticEngines->stopEffects();
+#endif
     completionHandler();
 }
 
 void GameControllerGamepad::noLongerHasAnyClient()
 {
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
     // Stop the haptics engine if it is running.
     if (m_hapticEngines)
         m_hapticEngines->stop([] { });
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
@@ -57,4 +57,4 @@ private:
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 #import "GameControllerHapticEffect.h"
 
 #import "GameControllerHapticEngines.h"
@@ -124,4 +124,4 @@ void GameControllerHapticEffect::weakEffectFinishedPlaying()
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
@@ -68,4 +68,4 @@ private:
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 #import "GameControllerHapticEngines.h"
 
 #import "GameControllerHapticEffect.h"
@@ -140,4 +140,4 @@ void GameControllerHapticEngines::stop(CompletionHandler<void()>&& completionHan
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)


### PR DESCRIPTION
#### 78f050afe54e75e081388ad5dfb5ce023053f5a8
<pre>
Unreviewed iOS build fix after 258674@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=250341">https://bugs.webkit.org/show_bug.cgi?id=250341</a>

* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
(WebCore::GameControllerGamepad::playEffect):
(WebCore::GameControllerGamepad::stopEffects):
(WebCore::GameControllerGamepad::noLongerHasAnyClient):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:

Canonical link: <a href="https://commits.webkit.org/258688@main">https://commits.webkit.org/258688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d086909610102ae031040eb138cf7821b7e271fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102693 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111955 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12825 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7164 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3168 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->