### PR TITLE
Instantiate a RemoteFrameView when switching from a Frame to a RemoteFrame

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1860,6 +1860,7 @@ page/ProcessWarming.cpp
 page/Quirks.cpp
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
+page/RemoteFrameView.cpp
 page/RenderingUpdateScheduler.cpp
 page/ResizeObservation.cpp
 page/ResizeObserver.cpp

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -39,8 +39,6 @@ public:
 
     DOMTokenList& sandbox();
 
-    RenderIFrame* renderer() const;
-
     void setReferrerPolicyForBindings(const AtomString&);
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -102,6 +102,7 @@ public:
     void setFrameRect(const IntRect&) final;
     FrameViewType viewType() const final { return FrameViewType::Local; }
 
+    // FIXME: This should return Frame. If it were a RemoteFrame, we would have a RemoteFrameView.
     AbstractFrame& frame() const { return m_frame; }
 
     WEBCORE_EXPORT RenderView* renderView() const;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -69,4 +69,9 @@ AbstractFrameView* RemoteFrame::virtualView() const
     return m_view.get();
 }
 
+void RemoteFrame::setView(RefPtr<RemoteFrameView>&& view)
+{
+    m_view = WTFMove(view);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -56,6 +56,7 @@ public:
     RemoteFrameClient& client() { return m_client.get(); }
 
     RemoteFrameView* view() const { return m_view.get(); }
+    WEBCORE_EXPORT void setView(RefPtr<RemoteFrameView>&&);
 
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, FrameIdentifier, HTMLFrameOwnerElement*, UniqueRef<RemoteFrameClient>&&);

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteFrameView.h"
+
+#include "RemoteFrame.h"
+
+namespace WebCore {
+
+RemoteFrameView::RemoteFrameView(RemoteFrame& frame)
+    : m_frame(frame)
+{
+}
+
+// FIXME: Implement all the stubs below.
+
+void RemoteFrameView::invalidateRect(const IntRect&)
+{
+}
+
+bool RemoteFrameView::isActive() const
+{
+    return false;
+}
+
+bool RemoteFrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
+{
+    return false;
+}
+
+ScrollableArea* RemoteFrameView::enclosingScrollableArea() const
+{
+    return nullptr;
+}
+
+bool RemoteFrameView::isScrollableOrRubberbandable()
+{
+    return false;
+}
+
+bool RemoteFrameView::hasScrollableOrRubberbandableAncestor()
+{
+    return false;
+}
+
+IntRect RemoteFrameView::scrollableAreaBoundingBox(bool*) const
+{
+    return { };
+}
+
+bool RemoteFrameView::shouldPlaceVerticalScrollbarOnLeft() const
+{
+    return false;
+}
+
+void RemoteFrameView::invalidateScrollbarRect(Scrollbar&, const IntRect&)
+{
+}
+
+HostWindow* RemoteFrameView::hostWindow() const
+{
+    return nullptr;
+}
+
+IntRect RemoteFrameView::windowClipRect() const
+{
+    return { };
+}
+
+void RemoteFrameView::paintContents(GraphicsContext&, const IntRect&, SecurityOriginPaintPolicy, EventRegionContext*)
+{
+}
+
+void RemoteFrameView::addedOrRemovedScrollbar()
+{
+}
+
+void RemoteFrameView::delegatedScrollingModeDidChange()
+{
+}
+
+void RemoteFrameView::updateScrollCorner()
+{
+}
+
+bool RemoteFrameView::scrollContentsFastPath(const IntSize&, const IntRect&, const IntRect&)
+{
+    return false;
+}
+
+bool RemoteFrameView::isVerticalDocument() const
+{
+    return false;
+}
+
+bool RemoteFrameView::isFlippedDocument() const
+{
+    return false;
+}
+
+bool RemoteFrameView::shouldDeferScrollUpdateAfterContentSizeChange()
+{
+    return false;
+}
+
+void RemoteFrameView::scrollOffsetChangedViaPlatformWidgetImpl(const ScrollOffset&, const ScrollOffset&)
+{
+}
+
+void RemoteFrameView::unobscuredContentSizeChanged()
+{
+}
+
+void RemoteFrameView::didFinishProhibitingScrollingWhenChangingContentSize()
+{
+}
+
+void RemoteFrameView::updateLayerPositionsAfterScrolling()
+{
+}
+
+void RemoteFrameView::updateCompositingLayersAfterScrolling()
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -29,8 +29,42 @@
 
 namespace WebCore {
 
-class RemoteFrameView : public AbstractFrameView {
+class RemoteFrame;
+
+class RemoteFrameView final : public AbstractFrameView {
+public:
+    static Ref<RemoteFrameView> create(RemoteFrame& frame) { return adoptRef(*new RemoteFrameView(frame)); }
+
     FrameViewType viewType() const final { return FrameViewType::Remote; }
+private:
+    WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
+
+    void invalidateRect(const IntRect&) final;
+    bool isActive() const final;
+    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
+    ScrollableArea* enclosingScrollableArea() const final;
+    bool isScrollableOrRubberbandable() final;
+    bool hasScrollableOrRubberbandableAncestor() final;
+    IntRect scrollableAreaBoundingBox(bool*) const final;
+    bool shouldPlaceVerticalScrollbarOnLeft() const final;
+    void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
+    HostWindow* hostWindow() const final;
+    IntRect windowClipRect() const final;
+    void paintContents(GraphicsContext&, const IntRect& damageRect, SecurityOriginPaintPolicy, EventRegionContext*) final;
+    void addedOrRemovedScrollbar() final;
+    void delegatedScrollingModeDidChange() final;
+    void updateScrollCorner() final;
+    bool scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect) final;
+    bool isVerticalDocument() const final;
+    bool isFlippedDocument() const final;
+    bool shouldDeferScrollUpdateAfterContentSizeChange() final;
+    void scrollOffsetChangedViaPlatformWidgetImpl(const ScrollOffset&, const ScrollOffset&) final;
+    void unobscuredContentSizeChanged() final;
+    void didFinishProhibitingScrollingWhenChangingContentSize() final;
+    void updateLayerPositionsAfterScrolling() final;
+    void updateCompositingLayersAfterScrolling() final;
+
+    const Ref<RemoteFrame> m_frame;
 };
 
 }


### PR DESCRIPTION
#### d94f936fea418cd56776173969983e81cd874284
<pre>
Instantiate a RemoteFrameView when switching from a Frame to a RemoteFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=250343">https://bugs.webkit.org/show_bug.cgi?id=250343</a>
rdar://104049967

Reviewed by Chris Dumez.

This is a step towards drawing remote frame content.
Things still aren&apos;t quite hooked up right, but they&apos;re getting closer.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::setView):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameView.cpp: Added.
(WebCore::RemoteFrameView::RemoteFrameView):
(WebCore::RemoteFrameView::invalidateRect):
(WebCore::RemoteFrameView::isActive const):
(WebCore::RemoteFrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const):
(WebCore::RemoteFrameView::enclosingScrollableArea const):
(WebCore::RemoteFrameView::isScrollableOrRubberbandable):
(WebCore::RemoteFrameView::hasScrollableOrRubberbandableAncestor):
(WebCore::RemoteFrameView::scrollableAreaBoundingBox const):
(WebCore::RemoteFrameView::shouldPlaceVerticalScrollbarOnLeft const):
(WebCore::RemoteFrameView::invalidateScrollbarRect):
(WebCore::RemoteFrameView::hostWindow const):
(WebCore::RemoteFrameView::windowClipRect const):
(WebCore::RemoteFrameView::paintContents):
(WebCore::RemoteFrameView::addedOrRemovedScrollbar):
(WebCore::RemoteFrameView::delegatedScrollingModeDidChange):
(WebCore::RemoteFrameView::updateScrollCorner):
(WebCore::RemoteFrameView::scrollContentsFastPath):
(WebCore::RemoteFrameView::isVerticalDocument const):
(WebCore::RemoteFrameView::isFlippedDocument const):
(WebCore::RemoteFrameView::shouldDeferScrollUpdateAfterContentSizeChange):
(WebCore::RemoteFrameView::scrollOffsetChangedViaPlatformWidgetImpl):
(WebCore::RemoteFrameView::unobscuredContentSizeChanged):
(WebCore::RemoteFrameView::didFinishProhibitingScrollingWhenChangingContentSize):
(WebCore::RemoteFrameView::updateLayerPositionsAfterScrolling):
(WebCore::RemoteFrameView::updateCompositingLayersAfterScrolling):
* Source/WebCore/page/RemoteFrameView.h:
(WebCore::RemoteFrameView::create):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didCommitLoadInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/258731@main">https://commits.webkit.org/258731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16a1a3ba10c33f248aac3a66f3df4c9b00723a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112069 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2841 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95063 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108586 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5387 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5535 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11554 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7278 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3190 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->