### PR TITLE
Remove SVGFEMorphologyElement.setRadius(radiusX, radiusY)

### DIFF
--- a/LayoutTests/svg/dynamic-updates/SVGFEMorphologyElement-svgdom-radius-call.html
+++ b/LayoutTests/svg/dynamic-updates/SVGFEMorphologyElement-svgdom-radius-call.html
@@ -53,7 +53,7 @@ shouldBe("morphologyElement.radiusX.baseVal", "6");
 shouldBe("morphologyElement.radiusY.baseVal", "6");
 
 function repaintTest() {
-    morphologyElement.setRadius(4, 4);
+    morphologyElement.setAttribute("radius", "4,4");
     shouldBe("morphologyElement.radiusX.baseVal", "4");
     shouldBe("morphologyElement.radiusY.baseVal", "4");
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -46,13 +47,6 @@ inline SVGFEMorphologyElement::SVGFEMorphologyElement(const QualifiedName& tagNa
 Ref<SVGFEMorphologyElement> SVGFEMorphologyElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGFEMorphologyElement(tagName, document));
-}
-
-void SVGFEMorphologyElement::setRadius(float x, float y)
-{
-    m_radiusX->setBaseValInternal(x);
-    m_radiusY->setBaseValInternal(y);
-    updateSVGRendererForElementChange();
 }
 
 void SVGFEMorphologyElement::parseAttribute(const QualifiedName& name, const AtomString& value)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -58,8 +59,6 @@ class SVGFEMorphologyElement final : public SVGFilterPrimitiveStandardAttributes
     WTF_MAKE_ISO_ALLOCATED(SVGFEMorphologyElement);
 public:
     static Ref<SVGFEMorphologyElement> create(const QualifiedName&, Document&);
-
-    void setRadius(float radiusX, float radiusY);
 
     String in1() const { return m_in1->currentValue(); }
     MorphologyOperatorType svgOperator() const { return m_svgOperator->currentValue<MorphologyOperatorType>(); }

--- a/Source/WebCore/svg/SVGFEMorphologyElement.idl
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.idl
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,9 +38,6 @@
     [ImplementedAs=svgOperator] readonly attribute SVGAnimatedEnumeration operator;
     readonly attribute SVGAnimatedNumber      radiusX;
     readonly attribute SVGAnimatedNumber      radiusY;
-
-    undefined setRadius(optional unrestricted float radiusX = NaN,
-                   optional unrestricted float radiusY = NaN);
 };
 
 SVGFEMorphologyElement includes SVGFilterPrimitiveStandardAttributes;


### PR DESCRIPTION
#### 721874ce3b1a3d49bb3b122019b352b7f8dd89df
<pre>
Remove SVGFEMorphologyElement.setRadius(radiusX, radiusY)

Remove SVGFEMorphologyElement.setRadius(radiusX, radiusY)
<a href="https://bugs.webkit.org/show_bug.cgi?id=249964">https://bugs.webkit.org/show_bug.cgi?id=249964</a>

Reviewed by Simon Fraser.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/feaed7a237ae1fef5303af45d6d44429fa338fb7">https://chromium.googlesource.com/chromium/blink/+/feaed7a237ae1fef5303af45d6d44429fa338fb7</a>

This patch is to remove non-standard &apos;setRadius&apos;, which was only supported by WebKit based browsers
and was dropped by Blink in 2014. Hence, Safari / WebKit is now only browser engine supporting it.

* Source/WebCore/SVGFEMorphologyElement.h: Remove &apos;setRadius&apos;
* Source/WebCore/SVGFEMorphologyElement.cpp: Remove &apos;setRadius&apos; function
* Source/WebCore/SVGFEMorphologyElement.idl: Remove &apos;setRadius&apos; attributes
* LayoutTests/svg/dynamic-updates/SVGFEMorphologyElement-svgdom-radius-call.html: Rebaselined

Canonical link: <a href="https://commits.webkit.org/258733@main">https://commits.webkit.org/258733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/188bad80bbcf442b2e8c007d4972b33988432ca9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112016 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172243 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2789 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109696 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9888 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37540 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79279 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26044 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2486 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45536 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5998 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7227 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->