### PR TITLE
Gamepad.vibrationActuator: Add support for "trigger-rumble" effect type

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
@@ -34,6 +34,8 @@ struct GamepadEffectParameters {
     double startDelay = 0.0;
     double strongMagnitude = 0.0;
     double weakMagnitude = 0.0;
+    double leftTrigger = 0.0;
+    double rightTrigger = 0.0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
@@ -31,4 +31,9 @@
     double startDelay = 0.0;
     double strongMagnitude = 0.0;
     double weakMagnitude = 0.0;
+
+    // Not in the specification but supported by Blink:
+    // https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md
+    double leftTrigger = 0.0;
+    double rightTrigger = 0.0;
 };

--- a/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
@@ -27,5 +27,7 @@
     Conditional=GAMEPAD
 ] enum GamepadHapticEffectType {
     "dual-rumble",
-    "trigger-rumble", // Not in the specification but supported by Blink.
+    // Not in the specification but supported by Blink:
+    // https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md
+    "trigger-rumble",
 };

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -76,6 +76,10 @@ void GameControllerGamepad::setupElements()
             if ([haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityLeftHandle()] && [haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityRightHandle()])
                 m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
         }
+        if (canLoad_GameController_GCHapticsLocalityLeftTrigger() && canLoad_GameController_GCHapticsLocalityRightTrigger()) {
+            if ([haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityLeftTrigger()] && [haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityRightTrigger()])
+                m_supportedEffectTypes.add(GamepadHapticEffectType::TriggerRumble);
+        }
     }
 #endif
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -29,29 +29,31 @@
 
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class GameControllerHapticEngines;
 struct GamepadEffectParameters;
+enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEffect {
+class GameControllerHapticEffect : public CanMakeWeakPtr<GameControllerHapticEffect> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<GameControllerHapticEffect> create(GameControllerHapticEngines&, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&);
+    static std::unique_ptr<GameControllerHapticEffect> create(GameControllerHapticEngines&, GamepadHapticEffectType, const GamepadEffectParameters&);
     ~GameControllerHapticEffect();
 
-    bool start();
+    void start(CompletionHandler<void(bool)>&&);
     void stop();
 
-    void strongEffectFinishedPlaying();
-    void weakEffectFinishedPlaying();
+    void leftEffectFinishedPlaying();
+    void rightEffectFinishedPlaying();
 
 private:
-    GameControllerHapticEffect(RetainPtr<id>&& strongPlayer, RetainPtr<id>&& weakPlayer, CompletionHandler<void(bool)>&&);
+    GameControllerHapticEffect(RetainPtr<id>&& leftlayer, RetainPtr<id>&& rightPlayer);
 
-    RetainPtr<id> m_strongPlayer;
-    RetainPtr<id> m_weakPlayer;
+    RetainPtr<id> m_leftPlayer;
+    RetainPtr<id> m_rightPlayer;
     CompletionHandler<void(bool)> m_completionHandler;
 };
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -30,13 +30,14 @@
 
 #import "GameControllerHapticEngines.h"
 #import "GamepadEffectParameters.h"
+#import "GamepadHapticEffectType.h"
 #import "Logging.h"
 
 #import "CoreHapticsSoftLink.h"
 
 namespace WebCore {
 
-std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, GamepadHapticEffectType type, const GamepadEffectParameters& parameters)
 {
     auto createPlayer = [&](CHHapticEngine *engine, double intensity) -> RetainPtr<id> {
         NSDictionary* hapticDict = @{
@@ -62,20 +63,31 @@ std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(G
 
         return retainPtr([engine createPlayerWithPattern:pattern.get() error:&error]);
     };
-    auto strongPlayer = createPlayer(engines.strongEngine(), parameters.strongMagnitude);
-    auto weakPlayer = createPlayer(engines.weakEngine(), parameters.weakMagnitude);
-    if (!strongPlayer || !weakPlayer) {
+    RetainPtr<id> leftPlayer;
+    RetainPtr<id> rightPlayer;
+    switch (type) {
+    case GamepadHapticEffectType::DualRumble: {
+        leftPlayer = createPlayer(engines.leftHandleEngine(), parameters.strongMagnitude);
+        rightPlayer = createPlayer(engines.rightHandleEngine(), parameters.weakMagnitude);
+        break;
+    }
+    case GamepadHapticEffectType::TriggerRumble: {
+        leftPlayer = createPlayer(engines.leftTriggerEngine(), parameters.leftTrigger);
+        rightPlayer = createPlayer(engines.rightTriggerEngine(), parameters.rightTrigger);
+        break;
+    }
+    }
+
+    if (!leftPlayer || !rightPlayer) {
         RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect: Failed to create the haptic effect players");
-        completionHandler(false);
         return nullptr;
     }
-    return std::unique_ptr<GameControllerHapticEffect>(new GameControllerHapticEffect(WTFMove(strongPlayer), WTFMove(weakPlayer), WTFMove(completionHandler)));
+    return std::unique_ptr<GameControllerHapticEffect>(new GameControllerHapticEffect(WTFMove(leftPlayer), WTFMove(rightPlayer)));
 }
 
-GameControllerHapticEffect::GameControllerHapticEffect(RetainPtr<id>&& strongPlayer, RetainPtr<id>&& weakPlayer, CompletionHandler<void(bool)>&& completionHandler)
-    : m_strongPlayer(WTFMove(strongPlayer))
-    , m_weakPlayer(WTFMove(weakPlayer))
-    , m_completionHandler(WTFMove(completionHandler))
+GameControllerHapticEffect::GameControllerHapticEffect(RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer)
+    : m_leftPlayer(WTFMove(leftPlayer))
+    , m_rightPlayer(WTFMove(rightPlayer))
 {
 }
 
@@ -85,40 +97,43 @@ GameControllerHapticEffect::~GameControllerHapticEffect()
         m_completionHandler(false);
 }
 
-bool GameControllerHapticEffect::start()
+void GameControllerHapticEffect::start(CompletionHandler<void(bool)>&& completionHandler)
 {
+    ASSERT(!m_completionHandler);
+    m_completionHandler = WTFMove(completionHandler);
     NSError *error;
-    if (m_strongPlayer && ![m_strongPlayer startAtTime:0 error:&error]) {
-        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the strong player");
-        m_strongPlayer = nullptr;
+    if (m_leftPlayer && ![m_leftPlayer startAtTime:0 error:&error]) {
+        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the left player");
+        m_leftPlayer = nullptr;
     }
-    if (m_weakPlayer && ![m_weakPlayer startAtTime:0 error:&error]) {
-        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the weak player");
-        m_weakPlayer = nullptr;
+    if (m_rightPlayer && ![m_rightPlayer startAtTime:0 error:&error]) {
+        RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEffect::start: Failed to start the right player");
+        m_rightPlayer = nullptr;
     }
-    return m_strongPlayer || m_weakPlayer;
+    if (!m_leftPlayer && !m_rightPlayer)
+        m_completionHandler(false);
 }
 
 void GameControllerHapticEffect::stop()
 {
     NSError *error;
-    if (auto player = std::exchange(m_strongPlayer, nullptr))
+    if (auto player = std::exchange(m_leftPlayer, nullptr))
         [player stopAtTime:0.0 error:&error];
-    if (auto player = std::exchange(m_weakPlayer, nullptr))
+    if (auto player = std::exchange(m_rightPlayer, nullptr))
         [player stopAtTime:0.0 error:&error];
 }
 
-void GameControllerHapticEffect::strongEffectFinishedPlaying()
+void GameControllerHapticEffect::leftEffectFinishedPlaying()
 {
-    m_strongPlayer = nullptr;
-    if (!m_weakPlayer && m_completionHandler)
+    m_leftPlayer = nullptr;
+    if (!m_rightPlayer && m_completionHandler)
         m_completionHandler(true);
 }
 
-void GameControllerHapticEffect::weakEffectFinishedPlaying()
+void GameControllerHapticEffect::rightEffectFinishedPlaying()
 {
-    m_weakPlayer = nullptr;
-    if (!m_strongPlayer && m_completionHandler)
+    m_rightPlayer = nullptr;
+    if (!m_leftPlayer && m_completionHandler)
         m_completionHandler(true);
 }
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -51,19 +51,27 @@ public:
 
     void stop(CompletionHandler<void()>&&);
 
-    CHHapticEngine *strongEngine() { return m_strongEngine.get(); }
-    CHHapticEngine *weakEngine() { return m_weakEngine.get(); }
+    CHHapticEngine *leftHandleEngine() { return m_leftHandleEngine.get(); }
+    CHHapticEngine *rightHandleEngine() { return m_rightHandleEngine.get(); }
+    CHHapticEngine *leftTriggerEngine() { return m_leftTriggerEngine.get(); }
+    CHHapticEngine *rightTriggerEngine() { return m_rightTriggerEngine.get(); }
 
 private:
     explicit GameControllerHapticEngines(GCController *);
 
-    void ensureStarted(CompletionHandler<void(bool)>&&);
+    void ensureStarted(GamepadHapticEffectType, CompletionHandler<void(bool)>&&);
+    std::unique_ptr<GameControllerHapticEffect>& currentEffectForType(GamepadHapticEffectType);
 
-    RetainPtr<CHHapticEngine> m_strongEngine;
-    RetainPtr<CHHapticEngine> m_weakEngine;
-    bool m_failedToStartStrongEngine { false };
-    bool m_failedToStartWeakEngine { false };
-    std::unique_ptr<GameControllerHapticEffect> m_currentEffect;
+    RetainPtr<CHHapticEngine> m_leftHandleEngine;
+    RetainPtr<CHHapticEngine> m_rightHandleEngine;
+    RetainPtr<CHHapticEngine> m_leftTriggerEngine;
+    RetainPtr<CHHapticEngine> m_rightTriggerEngine;
+    bool m_failedToStartLeftHandleEngine { false };
+    bool m_failedToStartRightHandleEngine { false };
+    bool m_failedToStartLeftTriggerEngine { false };
+    bool m_failedToStartRightTriggerEngine { false };
+    std::unique_ptr<GameControllerHapticEffect> m_currentDualRumbleEffect;
+    std::unique_ptr<GameControllerHapticEffect> m_currentTriggerRumbleEffect;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
@@ -72,6 +72,8 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCControllerDidD
 
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityLeftHandle, NSString *)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityRightHandle, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityLeftTrigger, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityRightTrigger, NSString *)
 
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, GameController, ControllerClassForService, Class, (IOHIDServiceClientRef service), (service))

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
@@ -56,6 +56,8 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCControllerDidD
 
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityLeftHandle, NSString *)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityRightHandle, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityLeftTrigger, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityRightTrigger, NSString *)
 
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, GameController, ControllerClassForService, Class, (IOHIDServiceClientRef service), (service))

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2473,6 +2473,8 @@ struct WebCore::GamepadEffectParameters {
     double startDelay;
     double strongMagnitude;
     double weakMagnitude;
+    double leftTrigger;
+    double rightTrigger;
 };
 
 header: <WebCore/GamepadHapticEffectType.h>


### PR DESCRIPTION
#### b533c39ce86bb895f3833fe662dd3f48d442db4f
<pre>
Gamepad.vibrationActuator: Add support for &quot;trigger-rumble&quot; effect type
<a href="https://bugs.webkit.org/show_bug.cgi?id=250352">https://bugs.webkit.org/show_bug.cgi?id=250352</a>

Reviewed by NOBODY (OOPS!).

Gamepad.vibrationActuator: Add support for &quot;trigger-rumble&quot; effect type:
-  <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md">https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md</a>

It allows vibrating the triggers (which the XBox controller supports), while the
existing &quot;dual-rumble&quot; only makes the handles vibrate.

This isn&apos;t yet part of the specification at:
- <a href="https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticeffecttype">https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticeffecttype</a>

However, it is supported by Blink and used by XBox cloud games.

* Source/WebCore/Modules/gamepad/GamepadEffectParameters.h:
* Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl:
* Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):
(WebCore::GameControllerHapticEffect::GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::start):
(WebCore::GameControllerHapticEffect::stop):
(WebCore::GameControllerHapticEffect::leftEffectFinishedPlaying):
(WebCore::GameControllerHapticEffect::rightEffectFinishedPlaying):
(WebCore::GameControllerHapticEffect::strongEffectFinishedPlaying): Deleted.
(WebCore::GameControllerHapticEffect::weakEffectFinishedPlaying): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
(WebCore::GameControllerHapticEngines::leftHandleEngine):
(WebCore::GameControllerHapticEngines::rightHandleEngine):
(WebCore::GameControllerHapticEngines::leftTriggerEngine):
(WebCore::GameControllerHapticEngines::rightTriggerEngine):
(WebCore::GameControllerHapticEngines::strongEngine): Deleted.
(WebCore::GameControllerHapticEngines::weakEngine): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:
(WebCore::GameControllerHapticEngines::GameControllerHapticEngines):
(WebCore::GameControllerHapticEngines::currentEffectForType):
(WebCore::GameControllerHapticEngines::playEffect):
(WebCore::GameControllerHapticEngines::stopEffects):
(WebCore::GameControllerHapticEngines::ensureStarted):
(WebCore::GameControllerHapticEngines::stop):
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b533c39ce86bb895f3833fe662dd3f48d442db4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111983 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172221 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2755 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109670 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37513 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26006 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2456 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45498 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7196 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->