### PR TITLE
Fix tests that use `eventSender.mouseScrollBy()` to use UIHelper.statelessMouseWheelScrollAt

### DIFF
--- a/LayoutTests/fast/events/platform-wheelevent-with-delta-zero-crash.html
+++ b/LayoutTests/fast/events/platform-wheelevent-with-delta-zero-crash.html
@@ -1,18 +1,26 @@
 <html>
 <head>
+<script src="../../resources/ui-helper.js"></script>
 <script>
 if (window.testRunner)
     testRunner.dumpAsText();
 
-function runTest()
+async function runTest()
 {
     if (!window.eventSender)
         return;
+
+    testRunner.waitUntilDone();
     var area = document.getElementById('area');
     var x = area.offsetLeft + area.offsetWidth / 2;
     var y = area.offsetTop + area.offsetHeight / 2;
+    
+    // Can't use UIHelper.statelessMouseWheelScrollAt() because the zero deltas don't trigger any scrolling.
+    await UIHelper.ensurePresentationUpdate();
     eventSender.mouseMoveTo(x, y);
     eventSender.mouseScrollBy(0, 0);
+    await UIHelper.delayFor(0);
+    testRunner.notifyDone();
 }
 </script>
 </head>

--- a/LayoutTests/fast/events/remove-child-onscroll.html
+++ b/LayoutTests/fast/events/remove-child-onscroll.html
@@ -1,12 +1,13 @@
 <html>
     <head>
+        <script src="../../resources/ui-helper.js"></script>
         <script>
             if (window.testRunner) {
                 testRunner.dumpAsText();
                 testRunner.waitUntilDone();
             }
 
-            function dispatchScrollEvents()
+            async function dispatchScrollEvents()
             {
                 if (window.eventSender && window.testRunner) {
                     testRunner.waitUntilDone();
@@ -23,8 +24,7 @@
                         },
                         false);
 
-                      eventSender.mouseMoveTo(100, 100);
-                      eventSender.mouseScrollBy(0, -1);
+                    await UIHelper.statelessMouseWheelScrollAt(100, 100, 0, -1);
                 }
             }
         </script>

--- a/LayoutTests/fast/events/scroll-in-scaled-page-with-overflow-hidden.html
+++ b/LayoutTests/fast/events/scroll-in-scaled-page-with-overflow-hidden.html
@@ -3,6 +3,7 @@
         html, body { margin:0; overflow: hidden; }
     </style>
     <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
 </head>
 
 <div>This tests that a usually overflow: hidden viewport should be scrollable when scaled. Otherwise, you can't get to content
@@ -13,7 +14,7 @@
 </div>
 
 <script>
-    window.addEventListener('load', function() {
+    window.addEventListener('load', async () => {
         if (!window.testRunner) {
             debug("This test only works in the test runner.");
             return;
@@ -35,14 +36,12 @@
         // and https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
         shouldBe("window.scrollY", "0");
 
-        document.body.onscroll = function() {
-            shouldBe("window.scrollY", "100");
-            finishJSTest();
-        }
+        await Promise.all([
+            UIHelper.waitForEvent(window, "scroll"),
+            UIHelper.statelessMouseWheelScrollAt(100, 100, 0, -5)
+        ]);
 
-        if (window.eventSender) {
-            eventSender.mouseMoveTo(100, 100);
-            eventSender.mouseScrollBy(0, -5);
-        }
+        shouldBe("window.scrollY", "100");
+        finishJSTest();
     });
 </script>

--- a/LayoutTests/fast/events/wheel/platform-wheelevent-in-scrolling-div.html
+++ b/LayoutTests/fast/events/wheel/platform-wheelevent-in-scrolling-div.html
@@ -23,9 +23,7 @@
                     overflowElement.addEventListener("mousewheel", mousewheelHandler, false);
 
                 eventSender.mouseMoveTo(100, 110);
-                await UIHelper.startMonitoringWheelEvents();
-                eventSender.mouseScrollBy(-expectedScrollLeft, -expectedScrollTop);
-                await UIHelper.waitForScrollCompletion();
+                await UIHelper.statelessMouseWheelScrollAt(100, 110, -expectedScrollLeft, -expectedScrollTop);
                 checkOffsets();
             }
 

--- a/LayoutTests/fast/events/wheel/wheel-event-outside-body.html
+++ b/LayoutTests/fast/events/wheel/wheel-event-outside-body.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <html>
 <head>
     <style>
@@ -25,7 +24,7 @@
             margin-left: 25px;
         }
     </style>
-    
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
         if (window.testRunner) {
             testRunner.dumpAsText();
@@ -44,13 +43,12 @@
                 if (window.testRunner)
                     testRunner.notifyDone();
             }, false)
+
             window.scrollTo(0, 800);
             
-            window.setTimeout(function() {
-                if (window.eventSender) {
-                    eventSender.mouseMoveTo(50, 100);
-                    eventSender.mouseScrollBy(-1, -2);
-                }
+            window.setTimeout(async () => {
+                if (window.eventSender)
+                    await UIHelper.statelessMouseWheelScrollAt(50, 100, -1, -2);
             }, 0);
         }
 

--- a/LayoutTests/fast/events/wheel/wheelevent-basic.html
+++ b/LayoutTests/fast/events/wheel/wheelevent-basic.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <link rel="help" href="http://www.w3.org/TR/DOM-Level-3-Events/#events-WheelEvent">
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
 var eventDeltaX = 0;
@@ -12,7 +13,7 @@ var scrollDeltaY;
 jsTestIsAsync = true;
 
 var testDiv;
-function runTest() {
+async function runTest() {
     // Basic checks.
     shouldBe('WheelEvent.prototype.__proto__', 'MouseEvent.prototype');
     shouldBe('WheelEvent.DOM_DELTA_PIXEL', '0x00');
@@ -24,9 +25,9 @@ function runTest() {
     shouldBeNull('document.onwheel');
     shouldBeNull('testDiv.onwheel');
     testDiv.addEventListener('wheel', wheelHandler);
+
     if (window.eventSender) {
-        eventSender.mouseMoveTo(testDiv.offsetLeft + 5, testDiv.offsetTop + 5);
-        eventSender.mouseScrollBy(-1, -2);
+        await UIHelper.statelessMouseWheelScrollAt(testDiv.offsetLeft + 5, testDiv.offsetTop + 5, -1, -2);        
     } else {
         debug("FAIL: This test requires window.eventSender.");
     }

--- a/LayoutTests/fast/events/wheel/wheelevent-in-text-node.html
+++ b/LayoutTests/fast/events/wheel/wheelevent-in-text-node.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test-pre.js"></script>
     <script>
         window.jsTestIsAsync = true;
 
-        function test() {
+        async function test() {
             var div = document.querySelector('div');
             if (window.eventSender) {
+                await UIHelper.ensurePresentationUpdate();
                 eventSender.mouseMoveTo(div.offsetLeft + 5, div.offsetTop + 5);
                 eventSender.mouseScrollBy(0,120);
             } else {
@@ -24,10 +26,10 @@
             finishJSTest();
         }
 
-        window.onload = function () {
+        window.onload = async function () {
             var div = document.querySelector('div');
             div.addEventListener('mousewheel', wheelHandler);
-            test();
+            await test();
         };
     </script>
     <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/events/wheel/wheelevent-mousewheel-interaction.html
+++ b/LayoutTests/fast/events/wheel/wheelevent-mousewheel-interaction.html
@@ -3,14 +3,14 @@
 <head>
 <link rel="help" href="http://www.w3.org/TR/DOM-Level-3-Events/#events-WheelEvent">
 <script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <script>
-function runTest() {
+async function runTest() {
     var div = document.getElementById('target');
     div.addEventListener('wheel', wheelHandler);
     div.addEventListener('mousewheel', mouseWheelHandler);
     if (window.eventSender) {
-        eventSender.mouseMoveTo(div.offsetLeft + 5, div.offsetTop + 5);
-        eventSender.mouseScrollBy(10, 20);
+        await UIHelper.statelessMouseWheelScrollAt(div.offsetLeft + 5, div.offsetTop + 5, 10, 20);
     } else {
         debug("FAIL: This test requires window.eventSender.");
         finishJSTest();
@@ -23,7 +23,7 @@ function wheelHandler(e) {
     testPassed("Standard wheel event was fired.");
     shouldBe("testEvent.__proto__", "WheelEvent.prototype");
 
-    setTimeout(finishJSTest, 100);
+    setTimeout(finishJSTest, 32);
 }
 
 function mouseWheelHandler(e) {

--- a/LayoutTests/fast/forms/search/search-scroll-hidden-decoration-container-crash.html
+++ b/LayoutTests/fast/forms/search/search-scroll-hidden-decoration-container-crash.html
@@ -10,23 +10,30 @@ input::-webkit-textfield-decoration-container {
 }
 </style>
 <input type="search">
+<script src="../../../resources/ui-helper.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 }
 
-if (window.eventSender) {
+window.addEventListener('load', async () => {
+    if (!window.eventSender)
+        return;
+
     var input = document.querySelector('input');
     var x = input.offsetLeft + input.offsetWidth / 2;
     var y = input.offsetTop + input.offsetHeight / 2;
+
+    // Can't use UIHelper.statelessMouseWheelScrollAt() because the test doesn't trigger any scrolling.
+    await UIHelper.ensurePresentationUpdate();
     eventSender.mouseMoveTo(x, y);
     eventSender.mouseScrollBy(0, 10);
-    
-    setTimeout(function() {
-        document.body.appendChild(document.createTextNode('PASS'));
-        if (window.testRunner)
-            testRunner.notifyDone();
-    }, 100);
-}
+    await UIHelper.delayFor(0);
+
+    document.body.appendChild(document.createTextNode('PASS'));
+    if (window.testRunner)
+        testRunner.notifyDone();    
+}, false);
+
 </script>

--- a/LayoutTests/fast/repaint/overflow-auto-in-overflow-auto-scrolled.html
+++ b/LayoutTests/fast/repaint/overflow-auto-in-overflow-auto-scrolled.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <script src="resources/repaint.js" type="text/javascript"></script>
+    <script src="../../resources/ui-helper.js"></script>
     <script>
     function repaintTest() {
         // Now scroll once in the #innerDiv to the green area.

--- a/LayoutTests/fast/scrolling/mac/horizontal-overflow-trapping-small-deltas.html
+++ b/LayoutTests/fast/scrolling/mac/horizontal-overflow-trapping-small-deltas.html
@@ -54,6 +54,7 @@
             eventSender.mouseScrollByWithWheelAndMomentumPhases(1, -5, "changed", "none");
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
 
+            // FIXME: Use await UIHelper.waitForScrollCompletion();
             return new Promise(resolve => {
                 eventSender.callAfterScrollingCompletes(() => {
                     requestAnimationFrame(resolve);

--- a/LayoutTests/fast/scrolling/mac/rubberband-overflow-in-wheel-region-root-jiggle.html
+++ b/LayoutTests/fast/scrolling/mac/rubberband-overflow-in-wheel-region-root-jiggle.html
@@ -39,7 +39,7 @@
             scroller.scrollTop = 0;
             
             // Wait for scroll events to fire.
-            await UIHelper.renderingUpdate();
+            await UIHelper.ensurePresentationUpdate();
 
             windowScrollEventCount = 0;
             overflowScrollEventCount = 0;

--- a/LayoutTests/fast/scrolling/mac/vertical-scroll-in-horizontal-scroller.html
+++ b/LayoutTests/fast/scrolling/mac/vertical-scroll-in-horizontal-scroller.html
@@ -32,6 +32,8 @@
             await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(x, y);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(deltaX, deltaY, "none", "none");
+
+            // FIXME: Use await UIHelper.waitForScrollCompletion();
             return new Promise(resolve => {
                 eventSender.callAfterScrollingCompletes(() => {
                     requestAnimationFrame(resolve);

--- a/LayoutTests/fast/scrolling/rtl-scrollbars-listbox-scroll.html
+++ b/LayoutTests/fast/scrolling/rtl-scrollbars-listbox-scroll.html
@@ -24,12 +24,16 @@ if (window.internals) {
 <option>November</option>
 <option>December</option>
 </select>
+<script src="../../resources/ui-helper.js"></script>
 <script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+    
 if (window.eventSender) {
-    window.addEventListener('load', function() {
-        eventSender.mouseMoveTo(25, 5);
-        eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -20, "began", "none");
-        eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+    window.addEventListener('load', async () => {
+        await UIHelper.mouseWheelScrollAt(25, 5, 0, -20, 0, 0);
+        if (window.testRunner)
+            testRunner.notifyDone();
     });
 }
 </script>

--- a/LayoutTests/fast/scrolling/scrolling-inside-scrolled-overflowarea.html
+++ b/LayoutTests/fast/scrolling/scrolling-inside-scrolled-overflowarea.html
@@ -8,6 +8,7 @@
             background-image: linear-gradient(white, gray)
         }
   </style>
+  <script src="../../resources/ui-helper.js"></script>
   <script>
        if (window.testRunner) {
            testRunner.dumpAsText();
@@ -30,14 +31,13 @@
             testRunner.notifyDone();
         }
 
-        function scrollTest()
+        async function scrollTest()
         {
             var externalScrollableArea = document.getElementById('externalScrollableArea');
             var externalScrollableAreaBounds = externalScrollableArea.getBoundingClientRect();
 
             logResult('Sending mouse events');
-            eventSender.mouseMoveTo(externalScrollableAreaBounds.left + 60, externalScrollableAreaBounds.bottom - 60);
-            eventSender.mouseScrollBy(0, -10);
+            await UIHelper.statelessMouseWheelScrollAt(externalScrollableAreaBounds.left + 60, externalScrollableAreaBounds.bottom - 60, 0, -10);
         }
 
         function startTest()

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -30,7 +30,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-area-element
 # Some Apple ports don't support RTL scrollbars.
 fast/scrolling/rtl-scrollbars-alternate-body-dir-attr-does-not-update-scrollbar-placement.html [ Pass ]
 fast/scrolling/rtl-scrollbars-iframe-scrolled.html [ Pass ]
-fast/scrolling/rtl-scrollbars-listbox-scroll.html [ Pass ]
 fast/scrolling/rtl-scrollbars-overflow-text-selection-scrolled.html  [ Pass ]
 fast/scrolling/rtl-scrollbars-position-absolute.html  [ Pass ]
 fast/scrolling/rtl-scrollbars-position-fixed.html [ Pass ]
@@ -1490,6 +1489,10 @@ webkit.org/b/159143 fast/dom/horizontal-scrollbar-in-rtl.html [ Failure ]
 
 # Incomplete implementation of eventSender causes this test to fail
 webkit.org/b/42194 fast/scrolling/scroll-select-list.html [ ImageOnlyFailure ]
+
+webkit.org/b/250610 fast/events/wheel/wheelevent-in-text-node.html [ Skip ]
+webkit.org/b/250610 fast/scrolling/rtl-scrollbars-listbox-scroll.html [ Skip ]
+webkit.org/b/250610 scrollbars/scroll-rtl-or-bt-layer.html [ Skip ]
 
 # Missing glyph symbol is not rendered properly.
 webkit.org/b/140252 fast/css/line-height-determined-by-primary-font.html [ Failure ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -101,7 +101,7 @@ window.UIHelper = class UIHelper {
         await UIHelper.startMonitoringWheelEvents();
         eventSender.mouseMoveTo(x, y);
         eventSender.mouseScrollBy(deltaX, deltaY);
-        await UIHelper.waitForScrollCompletion();
+        return UIHelper.waitForScrollCompletion();
     }
 
     static async mouseWheelMayBeginAt(x, y)
@@ -1459,6 +1459,16 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => target.addEventListener(eventName, resolve, { once: true }));
     }
 
+    static waitForEventHandler(target, eventName, handler)
+    {
+        return new Promise((resolve) => {
+            target.addEventListener(eventName, (e) => {
+                handler(e)
+                resolve();
+            }, { once: true });
+        });
+    }
+
     static callFunctionAndWaitForEvent(functionToCall, target, eventName)
     {
         return new Promise(async resolve => {
@@ -1468,7 +1478,7 @@ window.UIHelper = class UIHelper {
                     target.addEventListener(eventName, (e) => {
                         event = e;
                         eventListenerResolve();
-                    }, {once: true});
+                    }, { once: true });
                 }),
                 new Promise(async functionResolve => {
                     await functionToCall();

--- a/LayoutTests/scrollbars/scroll-rtl-or-bt-layer.html
+++ b/LayoutTests/scrollbars/scroll-rtl-or-bt-layer.html
@@ -24,79 +24,81 @@ kkk
 </div>
 
 <div id="console"></div>
-
+<script src="../resources/ui-helper.js"></script>
 <script>
 function log(message)
 {
     document.getElementById("console").innerHTML += message + "<br>";
 }
 
-function centerMouseOn(element)
+function centerOfElement(element)
 {
-    eventSender.mouseMoveTo(element.offsetLeft + element.offsetWidth / 2,
-        element.offsetTop + element.offsetHeight / 2);
+    return { x: element.offsetLeft + element.offsetWidth / 2, y : element.offsetTop + element.offsetHeight / 2 };
 }
 
-function testRTL()
+async function testRTL()
 {
     var rtl = document.getElementById("rtl");
-    centerMouseOn(rtl);
+    var position = centerOfElement(rtl);
     var offsetBefore = rtl.scrollLeft;
 
-    rtl.onscroll = function() {
-        var offsetAfter = rtl.scrollLeft;
-        if (offsetBefore > offsetAfter)
-            log("rtl: PASS");
-        else {
-            log("rtl: FAIL");
-            log("scrollLeft before: " + offsetBefore);
-            log("scrollLeft after: " + offsetAfter);
-        }
-        testBT();
-    }
+    await Promise.all([
+        UIHelper.waitForEvent(rtl, 'scroll'),
+        UIHelper.statelessMouseWheelScrollAt(position.x, position.y, 1, 0)
+    ]);
 
-    eventSender.mouseScrollBy(1, 0);
+    var offsetAfter = rtl.scrollLeft;
+    if (offsetBefore > offsetAfter)
+        log("rtl: PASS");
+    else {
+        log("rtl: FAIL");
+        log("scrollLeft before: " + offsetBefore);
+        log("scrollLeft after: " + offsetAfter);
+    }
 }
 
-function testBT()
+async function testBT()
 {
     var bt = document.getElementById("bt");
-    centerMouseOn(bt);
-    offsetBefore = bt.scrollTop;
-    bt.onscroll = function() {
-        offsetAfter = bt.scrollTop;
-        if (offsetBefore > offsetAfter)
-            log("bt: PASS");
-        else {
-            log("bt: FAIL");
-            log("scrollTop before: " + offsetBefore);
-            log("scrollTop after: " + offsetAfter);
-        }
-
-        document.body.removeChild(document.getElementById("rtl"));
-        document.body.removeChild(document.getElementById("bt"));
-        testRunner.notifyDone();
+    var position = centerOfElement(bt);
+    var offsetBefore = bt.scrollTop;
+    await Promise.all([
+        UIHelper.waitForEvent(bt, 'scroll'),
+        UIHelper.statelessMouseWheelScrollAt(position.x, position.y, 0, 1)
+    ]);
+    
+    var offsetAfter = bt.scrollTop;
+    if (offsetBefore > offsetAfter)
+        log("bt: PASS");
+    else {
+        log("bt: FAIL");
+        log("scrollTop before: " + offsetBefore);
+        log("scrollTop after: " + offsetAfter);
     }
 
-    eventSender.mouseScrollBy(0, 1);
+    document.body.removeChild(document.getElementById("rtl"));
+    document.body.removeChild(document.getElementById("bt"));
 }
 
-function test()
+async function runTest()
 {
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
-    }
-
     if (!window.eventSender || !window.eventSender.mouseScrollBy) {
-        log("This test requires DumpRenderTree with eventSender.mouseScrollBy.");
+        log("This test requires eventSender.mouseScrollBy.");
         return;
     }
 
-    testRTL();
+    await testRTL();
+    await testBT();
+    if (window.testRunner)
+        window.testRunner.notifyDone();
 }
 
-test();
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.addEventListener('load', runTest, false);
 </script>
 
 </body>


### PR DESCRIPTION
#### d5823dca0a47f5a8bf31732ca7c74b4dd9b6a991
<pre>
Fix tests that use `eventSender.mouseScrollBy()` to use UIHelper.statelessMouseWheelScrollAt
<a href="https://bugs.webkit.org/show_bug.cgi?id=250355">https://bugs.webkit.org/show_bug.cgi?id=250355</a>
rdar://104058894

Reviewed by Ryosuke Niwa.

Replace calls to `eventSender.mouseMoveTo(); eventSender.mouseScrollBy()` with a
call to `UIHelper.statelessMouseWheelScrollAt()`, making things async where necessary.

Add `UIHelper.waitForEventHandler()`, which wraps the given function in an event
handler and waits for it to fire.

* LayoutTests/fast/events/platform-wheelevent-with-delta-zero-crash.html:
* LayoutTests/fast/events/remove-child-onscroll.html:
* LayoutTests/fast/events/scroll-in-scaled-page-with-overflow-hidden.html:
* LayoutTests/fast/events/wheel/platform-wheelevent-in-scrolling-div.html:
* LayoutTests/fast/events/wheel/wheel-event-outside-body.html:
* LayoutTests/fast/events/wheel/wheelevent-basic.html:
* LayoutTests/fast/events/wheel/wheelevent-in-text-node.html:
* LayoutTests/fast/events/wheel/wheelevent-mousewheel-interaction.html:
* LayoutTests/fast/forms/search/search-scroll-hidden-decoration-container-crash.html:
* LayoutTests/fast/repaint/overflow-auto-in-overflow-auto-scrolled.html:
* LayoutTests/fast/scrolling/mac/horizontal-overflow-trapping-small-deltas.html:
* LayoutTests/fast/scrolling/mac/rubberband-overflow-in-wheel-region-root-jiggle.html:
* LayoutTests/fast/scrolling/mac/vertical-scroll-in-horizontal-scroller.html:
* LayoutTests/fast/scrolling/rtl-scrollbars-listbox-scroll.html:
* LayoutTests/fast/scrolling/scrolling-inside-scrolled-overflowarea.html:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async statelessMouseWheelScrollAt):
(window.UIHelper.waitForEventHandler):
(window.UIHelper.callFunctionAndWaitForEvent):
* LayoutTests/scrollbars/scroll-rtl-or-bt-layer.html:

Canonical link: <a href="https://commits.webkit.org/259295@main">https://commits.webkit.org/259295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/017887a5a561f075d93550c8234680697d5c21e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113754 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173978 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4475 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112721 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38896 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80565 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6914 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3882 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6408 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8833 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->