### PR TITLE
Do not require whitespace between `of` and selector list in `:nth-child`/`:nth-last-child`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1634,8 +1634,6 @@ webkit.org/b/217904 imported/w3c/web-platform-tests/css/selectors/is-where-visit
 imported/w3c/web-platform-tests/css/selectors/xml-class-selector.xml [ ImageOnlyFailure ]
 webkit.org/b/238822 imported/w3c/web-platform-tests/css/selectors/child-indexed-no-parent.html [ ImageOnlyFailure ]
 webkit.org/b/238822 imported/w3c/web-platform-tests/css/selectors/selector-structural-pseudo-root.html [ ImageOnlyFailure ]
-webkit.org/b/250353 imported/w3c/web-platform-tests/css/selectors/nth-child-of-no-space-after-of.html [ ImageOnlyFailure ]
-webkit.org/b/250353 imported/w3c/web-platform-tests/css/selectors/nth-last-child-of-no-space-after-of.html [ ImageOnlyFailure ]
 
 # This test is bit heavy for debug
 [ Debug ] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html [ Skip ]

--- a/LayoutTests/fast/css/parsing-css-nth-child-of-3-expected.txt
+++ b/LayoutTests/fast/css/parsing-css-nth-child-of-3-expected.txt
@@ -8,15 +8,11 @@ PASS document.querySelector(":nth-child(even of)") threw exception SyntaxError: 
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(even of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(evenof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(odd of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(odd of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(oddof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -24,15 +20,11 @@ PASS document.querySelector(":nth-child(n of)") threw exception SyntaxError: The
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(n of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-n of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-n of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -40,15 +32,11 @@ PASS document.querySelector(":nth-child(3 of)") threw exception SyntaxError: The
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -56,15 +44,11 @@ PASS document.querySelector(":nth-child(n+0 of)") threw exception SyntaxError: T
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(n+0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(n+0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(n-0 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(n-0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(n-0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -72,15 +56,11 @@ PASS document.querySelector(":nth-child(0n of)") threw exception SyntaxError: Th
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(0n of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(0nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3n+5 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -88,23 +68,17 @@ PASS document.querySelector(":nth-child(-3n+5 of)") threw exception SyntaxError:
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-child(-3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0

--- a/LayoutTests/fast/css/parsing-css-nth-child-of-3.html
+++ b/LayoutTests/fast/css/parsing-css-nth-child-of-3.html
@@ -41,7 +41,6 @@ debug("Test invalid selectors:");
 for (var i = 0; i < validNthAnPlusB.length; ++i) {
     testInvalidSelector(validNthAnPlusB[i] + " of");
     testInvalidSelector(validNthAnPlusB[i] + " of    ");
-    testInvalidSelector(validNthAnPlusB[i] + " of.class");
     testInvalidSelector(validNthAnPlusB[i] + "of .class");
 }
 

--- a/LayoutTests/fast/css/parsing-css-nth-last-child-of-3-expected.txt
+++ b/LayoutTests/fast/css/parsing-css-nth-last-child-of-3-expected.txt
@@ -8,15 +8,11 @@ PASS document.querySelector(":nth-last-child(even of)") threw exception SyntaxEr
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(even of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(evenof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(odd of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(odd of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(oddof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -24,15 +20,11 @@ PASS document.querySelector(":nth-last-child(n of)") threw exception SyntaxError
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(n of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-n of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-n of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -40,15 +32,11 @@ PASS document.querySelector(":nth-last-child(3 of)") threw exception SyntaxError
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -56,15 +44,11 @@ PASS document.querySelector(":nth-last-child(n+0 of)") threw exception SyntaxErr
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(n+0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(n+0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(n-0 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(n-0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(n-0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -72,15 +56,11 @@ PASS document.querySelector(":nth-last-child(0n of)") threw exception SyntaxErro
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(0n of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(0nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3n+5 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
@@ -88,23 +68,17 @@ PASS document.querySelector(":nth-last-child(-3n+5 of)") threw exception SyntaxE
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of.class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.querySelector(":nth-last-child(-3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0

--- a/LayoutTests/fast/css/parsing-css-nth-last-child-of-3.html
+++ b/LayoutTests/fast/css/parsing-css-nth-last-child-of-3.html
@@ -41,7 +41,6 @@ debug("Test invalid selectors:");
 for (var i = 0; i < validNthAnPlusB.length; ++i) {
     testInvalidSelector(validNthAnPlusB[i] + " of");
     testInvalidSelector(validNthAnPlusB[i] + " of    ");
-    testInvalidSelector(validNthAnPlusB[i] + " of.class");
     testInvalidSelector(validNthAnPlusB[i] + "of .class");
 }
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -787,8 +787,6 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
                 const CSSParserToken& ident = block.consume();
                 if (!equalLettersIgnoringASCIICase(ident.value(), "of"_s))
                     return nullptr;
-                if (block.peek().type() != WhitespaceToken)
-                    return nullptr;
                 block.consumeWhitespace();
                 auto selectorList = makeUnique<CSSSelectorList>();
                 *selectorList = consumeComplexSelectorList(block);


### PR DESCRIPTION
#### cd7efe660cf49859a3e1738d069acaa103f75d4b
<pre>
Do not require whitespace between `of` and selector list in `:nth-child`/`:nth-last-child`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250353">https://bugs.webkit.org/show_bug.cgi?id=250353</a>
rdar://104058693

Reviewed by Simon Fraser.

As clarified by CSSWG editors in: <a href="https://github.com/w3c/csswg-drafts/issues/8285">https://github.com/w3c/csswg-drafts/issues/8285</a>

Tests:
- LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-of-no-space-after-of.html
- LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-last-child-of-no-space-after-of.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/parsing-css-nth-child-of-3-expected.txt:
* LayoutTests/fast/css/parsing-css-nth-child-of-3.html:
* LayoutTests/fast/css/parsing-css-nth-last-child-of-3-expected.txt:
* LayoutTests/fast/css/parsing-css-nth-last-child-of-3.html:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):

Canonical link: <a href="https://commits.webkit.org/258703@main">https://commits.webkit.org/258703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/984374a4ac8f6be3a6b650e3c7e1f3069f9f3631

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102742 "Failed to checkout and rebase branch from PR 8430") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111998 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/106708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2770 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94995 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108518 "Failed to checkout and rebase branch from PR 8430") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5319 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5468 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11488 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7210 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3178 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->