### PR TITLE
Add options to run-api-tests to enable GPU process DOM rendering and UI side compositing

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -956,6 +956,14 @@ void WebPageProxy::replaceImageForRemoveBackground(const ElementContext& element
 
 #endif
 
+bool WebPageProxy::useGPUProcessForDOMRenderingEnabled() const
+{
+    if (id useGPUProcessForDOMRendering = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"])
+        return [useGPUProcessForDOMRendering boolValue];
+
+    return preferences().useGPUProcessForDOMRenderingEnabled();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK_COMPLETION

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8619,6 +8619,13 @@ static Span<const ASCIILiteral> gpuMachServices()
 
 #endif // PLATFORM(COCOA)
 
+#if !PLATFORM(COCOA)
+bool WebPageProxy::useGPUProcessForDOMRenderingEnabled() const
+{
+    return preferences().useGPUProcessForDOMRenderingEnabled();
+}
+#endif
+
 WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& process, DrawingAreaProxy& drawingArea, RefPtr<API::WebsitePolicies>&& websitePolicies)
 {
     WebPageCreationParameters parameters;
@@ -8797,7 +8804,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
     parameters.shouldRenderCanvasInGPUProcess = preferences().useGPUProcessForCanvasRenderingEnabled();
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
-    parameters.shouldRenderDOMInGPUProcess = preferences().useGPUProcessForDOMRenderingEnabled();
+    parameters.shouldRenderDOMInGPUProcess = useGPUProcessForDOMRenderingEnabled();
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
     parameters.shouldPlayMediaInGPUProcess = preferences().useGPUProcessForMediaEnabled();
 #if ENABLE(WEBGL)
@@ -11840,7 +11847,7 @@ bool WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock() const
         return true;
 
 #if ENABLE(GPU_PROCESS)
-    if (m_preferences->useGPUProcessForDOMRenderingEnabled()) {
+    if (useGPUProcessForDOMRenderingEnabled()) {
         auto* gpuProcess = GPUProcessProxy::singletonIfCreated();
         if (!gpuProcess || !gpuProcess->hasConnection()) {
             // It's possible that the GPU process hasn't been initialized yet; in this case, we might end up in a deadlock

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2775,6 +2775,8 @@ private:
     void fullscreenVideoTextRecognitionTimerFired();
 #endif
 
+    bool useGPUProcessForDOMRenderingEnabled() const;
+
     const Identifier m_identifier;
     WebCore::PageIdentifier m_webPageID;
     WeakPtr<PageClient> m_pageClient;

--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -144,6 +144,11 @@ def parse_args(args):
                              help='Run all tests, even DISABLED tests'),
         optparse.make_option('--additional-env-var', type='string', action='append', default=[],
                              help='Passes that environment variable to the tests (--additional-env-var=NAME=VALUE)'),
+
+        optparse.make_option('--remote-layer-tree', action='store_true', default=False,
+                             help='Use the remote layer tree drawing model (macOS non-WebKitLegacy only)'),
+        optparse.make_option('--use-gpu-process', action='store_true', default=False,
+                             help='Enable GPU process DOM rendering'),
     ]))
     option_group_definitions.append(('Upload Options', upload_options()))
 

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -88,6 +88,10 @@ class Runner(object):
     def command_for_port(port, args):
         if (port.get_option('force')):
             args.append('--gtest_also_run_disabled_tests=1')
+        if (port.get_option('remote_layer_tree')):
+            args.append('--remote-layer-tree')
+        if (port.get_option('use_gpu_process')):
+            args.append('--use-gpu-process')
         if getattr(port, 'DEVICE_MANAGER', None):
             assert port.DEVICE_MANAGER.INITIALIZED_DEVICES
             return ['/usr/bin/xcrun', 'simctl', 'spawn', port.DEVICE_MANAGER.INITIALIZED_DEVICES[0].udid] + args


### PR DESCRIPTION
#### bb0600277dfc92a32c5889b282bee303368e51d1
<pre>
Add options to run-api-tests to enable GPU process DOM rendering and UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250358">https://bugs.webkit.org/show_bug.cgi?id=250358</a>
rdar://104060036

Reviewed by Simon Fraser.

We&apos;ll use these new options for the GPU process DOM rendering enabled
test bot.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/Scripts/run-api-tests:
* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.command_for_port):
* Tools/TestWebKitAPI/mac/mainMac.mm:
(main):

Canonical link: <a href="https://commits.webkit.org/258740@main">https://commits.webkit.org/258740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ed51455c61175219e7fb4471fbe00c9ce74b4db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/102847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/11965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/106810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/12982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/108621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/12982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/106360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/12982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/7311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3193 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->