### PR TITLE
Nullptr crash in effectiveAssignedNodes

### DIFF
--- a/LayoutTests/fast/shadow-dom/manual-slot-gc-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/manual-slot-gc-crash-expected.txt
@@ -1,0 +1,5 @@
+PASS slot.assignedNodes().length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/shadow-dom/manual-slot-gc-crash.html
+++ b/LayoutTests/fast/shadow-dom/manual-slot-gc-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<script>
+const slot = document.createElement('slot');
+slot.assign(document.createElement('div'));
+
+if (window.GCController)
+    GCController.collect();
+
+document.createElement('div').attachShadow({
+    mode: 'open',
+    slotAssignment: 'manual',
+}).append(slot);
+
+shouldBe('slot.assignedNodes().length', '0');
+</script>

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -434,7 +434,7 @@ HTMLSlotElement* ManualSlotAssignment::findAssignedSlot(const Node& node)
 static Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> effectiveAssignedNodes(ShadowRoot& shadowRoot, const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& manuallyAssingedNodes)
 {
     return WTF::compactMap(manuallyAssingedNodes, [&](auto& node) -> std::optional<WeakPtr<Node, WeakPtrImplWithEventTargetData>> {
-        if (node->parentNode() != shadowRoot.host())
+        if (!node || node->parentNode() != shadowRoot.host())
             return std::nullopt;
         return WeakPtr { node.get() };
     });


### PR DESCRIPTION
#### bb2cc188a3a9874b408ef972bd7e0eb8442007f0
<pre>
Nullptr crash in effectiveAssignedNodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250365">https://bugs.webkit.org/show_bug.cgi?id=250365</a>

Reviewed by Alexey Shvayka and Tim Nguyen.

Add a nullptr check in effectiveAssignedNodes.

* LayoutTests/fast/shadow-dom/manual-slot-gc-crash-expected.txt: Added.
* LayoutTests/fast/shadow-dom/manual-slot-gc-crash.html: Added.
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::effectiveAssignedNodes):

Canonical link: <a href="https://commits.webkit.org/258708@main">https://commits.webkit.org/258708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/044d0de4845e97f5abc4120c6fb6d5bd8331003a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112008 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2781 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109689 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108526 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24613 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5327 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26030 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2480 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45522 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7219 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3179 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->