### PR TITLE
Disallow MSE with mp4 should AVStreamDataParser be non-functional

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -208,6 +208,10 @@ private:
 
 MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported(const ContentType& type)
 {
+    // Check that AVStreamDataParser is in a functional state.
+    if (!PAL::getAVStreamDataParserClass() || ![adoptNS(PAL::allocAVStreamDataParserInstance()) init])
+        return MediaPlayerEnums::SupportsType::IsNotSupported;
+
     String extendedType = type.raw();
     String outputCodecs = type.parameter(ContentType::codecsParameter());
     if (!outputCodecs.isEmpty() && [PAL::getAVStreamDataParserClass() respondsToSelector:@selector(outputMIMECodecParameterForInputMIMECodecParameter:)]) {


### PR DESCRIPTION
#### 1f860580a5b3d46064f0bae485fa060c68e5c655
<pre>
Disallow MSE with mp4 should AVStreamDataParser be non-functional
<a href="https://bugs.webkit.org/show_bug.cgi?id=250367">https://bugs.webkit.org/show_bug.cgi?id=250367</a>
rdar://104065947

Reviewed by Youenn Fablet.

On iPhone, MSE is disabled by default.
It can be enabled using an experimental setting, however it is mostly non-functional
as the SourceBufferParserAVFObjC relies on AVStreamDataParser class which itself is non-functional.
So testing for the availability of this class isn&apos;t sufficient,
we need to test that the init method itself doesn&apos;t return nil.

No test, as currently all MSE tests are disabled on iOS, and enabling those is out of scope for this change.i
On other platforms, covered by existing tests.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::isContentTypeSupported):

Canonical link: <a href="https://commits.webkit.org/258716@main">https://commits.webkit.org/258716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e5eecd0b3d9eb0da4f5043d64bc83a73d38f1e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112041 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2812 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95035 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108558 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24641 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26058 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5507 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5987 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7250 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->