### PR TITLE
[Forms] Use button instead of push-button appearance for input[type=submit|reset|button]

### DIFF
--- a/LayoutTests/fast/css/button-height-expected.txt
+++ b/LayoutTests/fast/css/button-height-expected.txt
@@ -1,5 +1,4 @@
 This tests that the specified height is honored (*) for <input> and <button> elements.
-(*) The Mac ports ignore the specified height for <input type="button"> elements unless a border and/or background CSS property is also specified (see the fifth button below). Disregarding padding, they render the button with a height equal to the height of the font used for the button label.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -7,7 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS document.getElementById('button1').offsetHeight is document.getElementById('button2').offsetHeight
 PASS document.getElementById('button3').offsetHeight is 40
 PASS document.getElementById('button4').offsetHeight is 40
-PASS document.getElementById('button5').offsetHeight is correct for this platform.
+PASS document.getElementById('button5').offsetHeight is 40
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/css/button-height.html
+++ b/LayoutTests/fast/css/button-height.html
@@ -14,18 +14,12 @@ window.onload = function()
     shouldBe("document.getElementById('button1').offsetHeight", "document.getElementById('button2').offsetHeight");
     shouldEvaluateTo("document.getElementById('button3').offsetHeight", 40);
     shouldEvaluateTo("document.getElementById('button4').offsetHeight", 40);
-
-    // Note, the expected height is the height of button 1 for the Mac ports, and 40 otherwise.
-    var expectedButton5Height = (navigator.platform.indexOf("Mac") !== -1) ? document.getElementById("button1").offsetHeight : 40;
-    if (document.getElementById('button5').offsetHeight == expectedButton5Height)
-        testPassed("document.getElementById('button5').offsetHeight is correct for this platform.");
-    else
-        testFailed("document.getElementById('button5').offsetHeight is incorrect for this platform. Should be the same height as button 1 for the Mac ports and 40 otherwise.");
+    shouldEvaluateTo("document.getElementById('button5').offsetHeight", 40);
 
     if (window.testRunner) {
         var testContainer = document.getElementById("test-container");
         if (testContainer)
-            document.body.removeChild(testContainer);   
+            document.body.removeChild(testContainer);
     }
     debug('<br /><span class="pass">TEST COMPLETE</span>');
 }
@@ -45,10 +39,7 @@ window.onload = function()
 <hr/>
 <div id="console"></div>
 <script>
-    description("This tests that the specified height is honored (*) for &lt;input&gt; and &lt;button&gt; elements.<br/>" +
-                "(*) The Mac ports ignore the specified height for &lt;input type=&quot;button&quot;&gt; elements unless a " +
-                "border and/or background CSS property is also specified (see the fifth button below). Disregarding " +
-                "padding, they render the button with a height equal to the height of the font used for the button label.");
+    description("This tests that the specified height is honored (*) for &lt;input&gt; and &lt;button&gt; elements.");
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/ios/css2.1/20110323/replaced-elements-001-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/20110323/replaced-elements-001-expected.txt
@@ -1,19 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x164
-  RenderBlock {HTML} at (0,0) size 800x164
-    RenderBody {BODY} at (8,16) size 784x132
+layer at (0,0) size 800x156
+  RenderBlock {HTML} at (0,0) size 800x156
+    RenderBody {BODY} at (8,16) size 784x124
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 609x19
           text run at (0,0) width 609: "Below, there should be 2 orange boxes horizontally centered within their respective green bars."
-      RenderBlock {DIV} at (16,36) size 752x40 [bgcolor=#008000]
+      RenderBlock {DIV} at (16,36) size 752x36 [bgcolor=#008000]
         RenderBlock (anonymous) at (0,0) size 752x20
           RenderText {#text} at (0,0) size 36x19
             text run at (0,0) width 36: "         "
-        RenderButton {INPUT} at (364,20) size 24x20 [color=#007AFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]
-      RenderBlock {FORM} at (0,92) size 784x40
-        RenderBlock {DIV} at (16,0) size 752x40 [bgcolor=#008000]
+        RenderButton {INPUT} at (364,20) size 24x16 [color=#007AFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]
+      RenderBlock {FORM} at (0,88) size 784x36
+        RenderBlock {DIV} at (16,0) size 752x36 [bgcolor=#008000]
           RenderBlock (anonymous) at (0,0) size 752x20
             RenderText {#text} at (0,0) size 36x19
               text run at (0,0) width 36: "         "
-          RenderButton {INPUT} at (364,20) size 24x20 [color=#FFFFFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]
+          RenderButton {INPUT} at (364,20) size 24x16 [color=#FFFFFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]

--- a/LayoutTests/platform/ios/css3/flexbox/flexitem-expected.txt
+++ b/LayoutTests/platform/ios/css3/flexbox/flexitem-expected.txt
@@ -15,18 +15,7 @@ PASS .flexbox 13
 PASS .flexbox 14
 PASS .flexbox 15
 PASS .flexbox 16
-FAIL .flexbox 17 assert_equals:
-<div class="flexbox">
-  <input data-expected-display="block" data-expected-width="75" type="checkbox" value="radio">
-  <input data-expected-display="block" data-expected-width="75" type="file" value="file">
-  <input data-expected-display="block" data-expected-width="75" type="image" value="image">
-  <input data-expected-display="block" data-expected-width="75" type="password" value="password">
-  <input data-expected-display="block" data-expected-width="75" type="radio" value="radio">
-  <input data-expected-display="block" data-expected-width="75" type="reset" value="reset">
-  <input data-expected-display="block" data-expected-width="75" type="submit" value="submit">
-  <input data-expected-display="block" data-expected-width="75" type="text" value="text">
-</div>
-width expected 75 but got 69
+PASS .flexbox 17
 FAIL .flexbox 18 assert_equals:
 <div class="flexbox" style="height:200px">
   <button data-expected-display="block" data-expected-width="100" data-expected-height="200">button</button>

--- a/LayoutTests/platform/ios/fast/forms/button-style-color-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/button-style-color-expected.txt
@@ -39,14 +39,14 @@ layer at (0,0) size 800x600
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (525,0) size 5x19
         text run at (525,0) width 5: " "
-      RenderButton {INPUT} at (529,1) size 85x20 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,3) size 61x14
+      RenderButton {INPUT} at (529,3) size 85x16 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (12,1) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (613,0) size 5x19
         text run at (613,0) width 5: " "
-      RenderButton {INPUT} at (617,1) size 85x20 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,3) size 61x14
+      RenderButton {INPUT} at (617,3) size 85x16 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (12,1) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-bigsur/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/fast/css/continuationCrash-expected.txt
@@ -47,19 +47,19 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 205x18
             text run at (0,0) width 205: "2. 3. will not crash Safari either."
         RenderBlock (anonymous) at (40,144) size 744x19
-          RenderButton {INPUT} at (0,1) size 132x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,1) size 132x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 116x13
               RenderText at (0,0) size 116x13
                 text run at (0,0) width 116: "1. Set outline property"
           RenderText {#text} at (132,0) size 4x18
             text run at (132,0) width 4: " "
-          RenderButton {INPUT} at (136,1) size 136x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (136,1) size 136x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 120x13
               RenderText at (0,0) size 120x13
                 text run at (0,0) width 120: "2. Set display property"
           RenderText {#text} at (271,0) size 5x18
             text run at (271,0) width 5: " "
-          RenderButton {INPUT} at (275,1) size 147x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (275,1) size 147x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 131x13
               RenderText at (0,0) size 131x13
                 text run at (0,0) width 131: "3. Replace span-element"

--- a/LayoutTests/platform/mac-bigsur/fast/forms/button-sizes-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/fast/forms/button-sizes-expected.txt
@@ -45,7 +45,7 @@ layer at (0,0) size 800x600
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (452,1) size 5x18
         text run at (452,1) width 5: " "
-      RenderButton {INPUT} at (456,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (456,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"

--- a/LayoutTests/platform/mac-bigsur/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/fast/forms/control-restrict-line-height-expected.txt
@@ -11,18 +11,18 @@ layer at (0,0) size 800x600
           RenderText at (8,2) size 271x13
             text run at (8,2) width 271: "This text should be centered vertically in the button"
       RenderBR {BR} at (302,17) size 0x18
-      RenderButton {INPUT} at (0,36) size 287x18 [color=#000000D8] [bgcolor=#C0C0C0]
-        RenderBlock (anonymous) at (8,2) size 271x13
-          RenderText at (0,0) size 271x13
-            text run at (0,0) width 271: "This text should be centered vertically in the button"
-      RenderBR {BR} at (286,35) size 1x18
-      RenderTextControl {INPUT} at (0,54) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderButton {INPUT} at (0,36) size 287x31 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderBlock (anonymous) at (8,2) size 271x26
+          RenderText at (0,6) size 271x13
+            text run at (0,6) width 271: "This text should be centered vertically in the button"
+      RenderBR {BR} at (286,41) size 1x18
+      RenderTextControl {INPUT} at (0,67) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderFlexibleBox {DIV} at (3,0) size 141x19
           RenderBlock {DIV} at (0,0) size 8x19
           RenderBlock {DIV} at (8,3) size 114x13
           RenderBlock {DIV} at (121,0) size 20x19
       RenderText {#text} at (0,0) size 0x0
-layer at (19,65) size 114x13 scrollWidth 272
+layer at (19,78) size 114x13 scrollWidth 272
   RenderBlock {DIV} at (0,0) size 114x13
     RenderText {#text} at (0,0) size 271x13
       text run at (0,0) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -85,7 +85,7 @@ layer at (0,0) size 785x765
             RenderTextControl {INPUT} at (402,16) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderText {#text} at (548,17) size 17x16
             text run at (548,17) width 17: " "
-          RenderButton {INPUT} at (564,17) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (564,17) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 37x13
               RenderText at (0,0) size 37x13
                 text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug26178-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug26178-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (1,1) size 59x18
                 text run at (1,1) width 59: "First row"
       RenderBlock {FORM} at (0,46) size 784x18
-        RenderButton {INPUT} at (0,0) size 47x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 47x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 31x13
             RenderText at (0,0) size 31x13
               text run at (0,0) width 31: "insert"

--- a/LayoutTests/platform/mac-monterey/fast/forms/button-sizes-expected.txt
+++ b/LayoutTests/platform/mac-monterey/fast/forms/button-sizes-expected.txt
@@ -45,7 +45,7 @@ layer at (0,0) size 800x600
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (452,1) size 5x18
         text run at (452,1) width 5: " "
-      RenderButton {INPUT} at (456,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (456,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"

--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/custom/foreign-object-skew-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/custom/foreign-object-skew-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 580x380
         RenderText {#text} at (0,0) size 68x18
           text run at (0,0) width 68: "and a link."
       RenderBR {xhtml:br} at (67,0) size 1x18
-      RenderButton {xhtml:input} at (0,18) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {xhtml:input} at (0,18) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
       RenderText {#text} at (0,0) size 0x0
 layer at (10,10) size 580x380
   RenderSVGRect {rect} at (10,10) size 580x380 [stroke={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=580.00] [height=380.00]

--- a/LayoutTests/platform/mac-ventura/fast/forms/button-sizes-expected.txt
+++ b/LayoutTests/platform/mac-ventura/fast/forms/button-sizes-expected.txt
@@ -45,7 +45,7 @@ layer at (0,0) size 800x600
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (452,1) size 5x18
         text run at (452,1) width 5: " "
-      RenderButton {INPUT} at (456,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (456,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"

--- a/LayoutTests/platform/mac-ventura/fast/forms/input-button-sizes-expected.txt
+++ b/LayoutTests/platform/mac-ventura/fast/forms/input-button-sizes-expected.txt
@@ -92,14 +92,14 @@ layer at (0,0) size 800x600
             text run at (0,0) width 97: "Test Button"
       RenderText {#text} at (533,30) size 5x18
         text run at (533,30) width 5: " "
-      RenderButton {INPUT} at (537,23) size 116x28 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderButton {INPUT} at (537,23) size 117x28 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 100x23
           RenderText at (0,0) size 100x23
             text run at (0,0) width 100: "Test Button"
-      RenderText {#text} at (653,30) size 4x18
-        text run at (653,30) width 4: " "
+      RenderText {#text} at (653,30) size 5x18
+        text run at (653,30) width 5: " "
       RenderButton {INPUT} at (657,22) size 121x29 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
-        RenderBlock (anonymous) at (8,2) size 105x24
-          RenderText at (0,0) size 105x24
-            text run at (0,0) width 105: "Test Button"
+        RenderBlock (anonymous) at (8,2) size 104x24
+          RenderText at (0,0) size 104x24
+            text run at (0,0) width 104: "Test Button"
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/css3/flexbox/button-expected.txt
+++ b/LayoutTests/platform/mac/css3/flexbox/button-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x243
-  RenderBlock {HTML} at (0,0) size 800x243
-    RenderBody {BODY} at (8,8) size 784x227
+layer at (0,0) size 800x244
+  RenderBlock {HTML} at (0,0) size 800x244
+    RenderBody {BODY} at (8,8) size 784x228
       RenderBlock (anonymous) at (0,0) size 784x36
         RenderText {#text} at (0,0) size 778x36
           text run at (0,0) width 410: "Test for empty buttons, which inherit from RenderFlexibleBox. "
@@ -19,20 +19,20 @@ layer at (0,0) size 800x243
         RenderBR {BR} at (80,0) size 1x18
         RenderButton {BUTTON} at (0,20) size 16x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBR {BR} at (16,18) size 0x18
-        RenderButton {INPUT} at (0,36) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,36) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBR {BR} at (16,37) size 0x18
-      RenderBlock (anonymous) at (0,127) size 784x100
+      RenderBlock (anonymous) at (0,127) size 784x101
         RenderText {#text} at (0,0) size 744x36
           text run at (0,0) width 744: "Empty <button> and <input type=button> with overflow: scroll;. The presence of the scrollbar should not shrink the"
           text run at (0,18) width 45: "button."
         RenderBR {BR} at (44,18) size 1x18
         RenderBR {BR} at (31,36) size 0x18
-        RenderBR {BR} at (31,68) size 0x18
+        RenderBR {BR} at (31,69) size 0x18
 layer at (8,52) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,44) size 784x2 [border: (1px inset #000000)]
 layer at (8,125) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,117) size 784x2 [border: (1px inset #000000)]
 layer at (8,183) size 31x20 clip at (10,183) size 12x5
   RenderButton {BUTTON} at (0,48) size 31x20 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
-layer at (8,215) size 31x18 clip at (8,215) size 16x3
-  RenderButton {INPUT} at (0,80) size 31x18 [color=#000000D8] [bgcolor=#C0C0C0]
+layer at (8,203) size 31x33 clip at (10,203) size 12x18
+  RenderButton {INPUT} at (0,68) size 31x33 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]

--- a/LayoutTests/platform/mac/editing/selection/3690703-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/3690703-2-expected.txt
@@ -83,11 +83,11 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (194,1) size 392x37 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 392x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                   RenderBR {BR} at (391,0) size 1x18
-                  RenderButton {INPUT} at (95,19) size 94x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (95,19) size 94x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 77x13
                       RenderText at (0,0) size 77x13
                         text run at (0,0) width 77: "Google Search"
-                  RenderButton {INPUT} at (188,19) size 108x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (188,19) size 108x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 92x13
                       RenderText at (0,0) size 92x13
                         text run at (0,0) width 92: "I'm Feeling Lucky"

--- a/LayoutTests/platform/mac/editing/selection/3690703-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/3690703-expected.txt
@@ -85,11 +85,11 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (194,1) size 392x37 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 392x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                   RenderBR {BR} at (391,0) size 1x18
-                  RenderButton {INPUT} at (95,19) size 94x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (95,19) size 94x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 77x13
                       RenderText at (0,0) size 77x13
                         text run at (0,0) width 77: "Google Search"
-                  RenderButton {INPUT} at (188,19) size 108x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (188,19) size 108x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 92x13
                       RenderText at (0,0) size 92x13
                         text run at (0,0) width 92: "I'm Feeling Lucky"

--- a/LayoutTests/platform/mac/editing/selection/3690719-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/3690719-expected.txt
@@ -77,11 +77,11 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (194,1) size 392x37 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 392x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                   RenderBR {BR} at (391,0) size 1x18
-                  RenderButton {INPUT} at (95,19) size 94x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (95,19) size 94x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 77x13
                       RenderText at (0,0) size 77x13
                         text run at (0,0) width 77: "Google Search"
-                  RenderButton {INPUT} at (188,19) size 108x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (188,19) size 108x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 92x13
                       RenderText at (0,0) size 92x13
                         text run at (0,0) width 92: "I'm Feeling Lucky"

--- a/LayoutTests/platform/mac/editing/selection/4397952-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/4397952-expected.txt
@@ -13,11 +13,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 271: "This tests caret movement across buttons. "
           text run at (270,0) width 308: "The caret should be just after the second button."
       RenderBlock {DIV} at (0,34) size 784x18
-        RenderButton {INPUT} at (0,0) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 20x13
             RenderText at (0,0) size 20x13
               text run at (0,0) width 20: "Foo"
-        RenderButton {INPUT} at (35,0) size 35x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (35,0) size 35x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 18x13
             RenderText at (0,0) size 18x13
               text run at (0,0) width 18: "Bar"

--- a/LayoutTests/platform/mac/editing/selection/5240265-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/5240265-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
           text run at (475,18) width 298: "The editable region should not be focused, but"
           text run at (0,36) width 246: "the text inside of it should be selected."
       RenderBlock (anonymous) at (0,70) size 784x18
-        RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 62x13
             RenderText at (0,0) size 62x13
               text run at (0,0) width 62: "Click on me"

--- a/LayoutTests/platform/mac/editing/selection/selection-button-text-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/selection-button-text-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x132
           RenderBR {BR} at (49,0) size 1x18
           RenderText {#text} at (0,18) size 61x18
             text run at (0,18) width 61: "with text "
-          RenderButton {INPUT} at (60,19) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (60,19) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 44x13
               RenderText at (0,0) size 44x13
                 text run at (0,0) width 44: "too little"
@@ -22,7 +22,7 @@ layer at (0,0) size 800x132
         RenderBlock {DIV} at (0,37) size 784x19
           RenderText {#text} at (0,0) size 56x18
             text run at (0,0) width 56: "and text "
-          RenderButton {INPUT} at (55,1) size 66x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (55,1) size 66x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 50x13
               RenderText at (0,0) size 50x13
                 text run at (0,0) width 50: "too much"

--- a/LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt
@@ -20,7 +20,7 @@ layer at (0,0) size 785x2342
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
         RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (10,46) size 200x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (10,46) size 200x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 184x13
             RenderText at (86,0) size 12x13
               text run at (86,0) width 12: "Hi"
@@ -37,7 +37,7 @@ layer at (0,0) size 785x2342
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
         RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (110,28) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (110,28) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 84x13
             RenderText at (36,0) size 12x13
               text run at (36,0) width 12: "Hi"
@@ -56,7 +56,7 @@ layer at (0,0) size 785x2342
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
           RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (110,28) size 28x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (110,28) size 28x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 12x13
             RenderText at (0,0) size 12x13
               text run at (0,0) width 12: "Hi"
@@ -75,7 +75,7 @@ layer at (0,0) size 785x2342
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
           RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (110,28) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (110,28) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 84x13
             RenderText at (36,0) size 12x13
               text run at (36,0) width 12: "Hi"

--- a/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
@@ -47,19 +47,19 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 205x18
             text run at (0,0) width 205: "2. 3. will not crash Safari either."
         RenderBlock (anonymous) at (40,144) size 744x19
-          RenderButton {INPUT} at (0,1) size 132x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,1) size 132x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 116x13
               RenderText at (0,0) size 116x13
                 text run at (0,0) width 116: "1. Set outline property"
           RenderText {#text} at (131,0) size 5x18
             text run at (131,0) width 5: " "
-          RenderButton {INPUT} at (135,1) size 136x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (135,1) size 136x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 119x13
               RenderText at (0,0) size 119x13
                 text run at (0,0) width 119: "2. Set display property"
           RenderText {#text} at (270,0) size 5x18
             text run at (270,0) width 5: " "
-          RenderButton {INPUT} at (274,1) size 148x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (274,1) size 148x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 131x13
               RenderText at (0,0) size 131x13
                 text run at (0,0) width 131: "3. Replace span-element"

--- a/LayoutTests/platform/mac/fast/css/input-search-padding-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/input-search-padding-expected.txt
@@ -3,28 +3,26 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTextControl {INPUT} at (2,2) size 538x82 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderFlexibleBox {DIV} at (3,3) size 532x47
-          RenderBlock {DIV} at (0,17) size 10x13
-          RenderBlock {DIV} at (10,0) size 506x47
-          RenderBlock {DIV} at (515,17) size 17x13
-      RenderBR {BR} at (541,44) size 1x0
-      RenderTextControl {INPUT} at (2,88) size 512x82 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-      RenderBR {BR} at (515,130) size 1x0
-      RenderTextControl {INPUT} at (2,172) size 291x25 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderFlexibleBox {DIV} at (6,1) size 279x23
-          RenderBlock {DIV} at (0,5) size 10x13
-          RenderBlock {DIV} at (10,0) size 253x23
-          RenderBlock {DIV} at (262,5) size 17x13
-layer at (23,13) size 506x47
-  RenderBlock {DIV} at (0,0) size 506x47
-    RenderText {#text} at (0,0) size 408x47
-      text run at (0,0) width 408: "value jgq not clipped"
-layer at (13,99) size 506x47
-  RenderBlock {DIV} at (3,3) size 506x47
-    RenderText {#text} at (0,0) size 408x47
-      text run at (0,0) width 408: "value jgq not clipped"
-layer at (26,181) size 253x23
-  RenderBlock {DIV} at (0,0) size 253x23
-    RenderText {#text} at (0,0) size 127x23
-      text run at (0,0) width 127: "Sample Input"
+      RenderTextControl {INPUT} at (0,0) size 500x82 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderFlexibleBox {DIV} at (3,3) size 494x47
+          RenderBlock {DIV} at (0,23) size 0x0
+          RenderBlock {DIV} at (0,0) size 472x47
+          RenderBlock {DIV} at (471,12) size 23x23
+      RenderBR {BR} at (499,28) size 1x18
+      RenderTextControl {INPUT} at (0,82) size 500x82 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBR {BR} at (499,110) size 1x18
+      RenderTextControl {INPUT} at (0,164) size 254x25 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderFlexibleBox {DIV} at (6,1) size 242x23
+          RenderBlock {DIV} at (0,0) size 242x23
+layer at (11,11) size 472x47
+  RenderBlock {DIV} at (0,0) size 472x47
+    RenderText {#text} at (0,0) size 351x47
+      text run at (0,0) width 351: "value jgq not clipped"
+layer at (11,93) size 494x47
+  RenderBlock {DIV} at (3,3) size 494x47
+    RenderText {#text} at (0,0) size 351x47
+      text run at (0,0) width 351: "value jgq not clipped"
+layer at (14,173) size 242x23
+  RenderBlock {DIV} at (0,0) size 242x23
+    RenderText {#text} at (0,0) size 116x23
+      text run at (0,0) width 116: "Sample Input"

--- a/LayoutTests/platform/mac/fast/css/margin-top-bottom-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/margin-top-bottom-dynamic-expected.txt
@@ -35,13 +35,13 @@ layer at (0,0) size 800x600
             text run at (1,1) width 86: "Lorem ipsum"
       RenderBlock (anonymous) at (0,270) size 784x37
         RenderBR {BR} at (0,0) size 0x18
-        RenderButton {INPUT} at (0,19) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 86x13
             RenderText at (0,0) size 86x13
               text run at (0,0) width 86: "Negative margin"
         RenderText {#text} at (101,18) size 5x18
           text run at (101,18) width 5: " "
-        RenderButton {INPUT} at (105,19) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (105,19) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 81x13
             RenderText at (0,0) size 81x13
               text run at (0,0) width 81: "Positive margin"
@@ -58,13 +58,13 @@ layer at (0,0) size 800x600
             text run at (1,1) width 86: "Lorem ipsum"
       RenderBlock (anonymous) at (0,429) size 784x37
         RenderBR {BR} at (0,0) size 0x18
-        RenderButton {INPUT} at (0,19) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 86x13
             RenderText at (0,0) size 86x13
               text run at (0,0) width 86: "Negative margin"
         RenderText {#text} at (101,18) size 5x18
           text run at (101,18) width 5: " "
-        RenderButton {INPUT} at (105,19) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (105,19) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 81x13
             RenderText at (0,0) size 81x13
               text run at (0,0) width 81: "Positive margin"

--- a/LayoutTests/platform/mac/fast/css/rtl-ordering-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/rtl-ordering-expected.txt
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (46,0) size 5x18
           text run at (46,0) width 5: " "
         RenderBR {BR} at (50,0) size 1x18
-        RenderButton {INPUT} at (0,19) size 47x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 47x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 31x13
             RenderText at (0,0) size 31x13
               text run at (0,0) width 31 RTL: "\x{5DB}\x{5E4}\x{5EA}\x{5D5}\x{5E8}"

--- a/LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           text run at (161,18) width 4: " "
         RenderText {#text} at (326,18) size 4x18
           text run at (326,18) width 4: " "
-        RenderButton {INPUT} at (330,19) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (330,19) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 30x13
             RenderText at (0,0) size 30x13
               text run at (0,0) width 30: "Reset"

--- a/LayoutTests/platform/mac/fast/forms/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/001-expected.txt
@@ -34,7 +34,7 @@ layer at (0,0) size 800x600
           RenderTableSection {TBODY} at (2,2) size 780x20
             RenderTableRow {TR} at (0,0) size 780x20
               RenderTableCell {TD} at (0,0) size 38x20 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 20x13
                     RenderText at (0,0) size 20x13
                       text run at (0,0) width 20: "Foo"

--- a/LayoutTests/platform/mac/fast/forms/basic-buttons-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-buttons-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x295
-  RenderBlock {HTML} at (0,0) size 800x295
-    RenderBody {BODY} at (8,8) size 784x279
+layer at (0,0) size 800x307
+  RenderBlock {HTML} at (0,0) size 800x307
+    RenderBody {BODY} at (8,8) size 784x291
       RenderBlock (anonymous) at (0,0) size 784x72
         RenderText {#text} at (0,0) size 543x18
           text run at (0,0) width 543: "Tests for basic button rendering. Creates a table with seven columns and seven rows."
@@ -14,8 +14,8 @@ layer at (0,0) size 800x295
           text run at (0,36) width 656: "with text (\"foo\") and then uses six different paddings to make sure each of the buttons render properly."
         RenderBR {BR} at (656,36) size 0x18
         RenderBR {BR} at (0,54) size 0x18
-      RenderTable {TABLE} at (0,72) size 696x207
-        RenderTableSection {TBODY} at (0,0) size 696x207
+      RenderTable {TABLE} at (0,72) size 696x219
+        RenderTableSection {TBODY} at (0,0) size 696x219
           RenderTableRow {TR} at (0,0) size 696x20
             RenderTableCell {TD} at (0,0) size 170x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 44x18
@@ -44,124 +44,124 @@ layer at (0,0) size 800x295
               RenderText {#text} at (1,0) size 106x20
                 text run at (1,1) width 106: "(18, 26) (18, 22)"
             RenderTableCell {TD} at (391,20) size 135x21 [r=1 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 17x13
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
             RenderTableCell {TD} at (525,20) size 171x21 [r=1 c=4 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
-          RenderTableRow {TR} at (0,41) size 696x21
-            RenderTableCell {TD} at (0,41) size 170x21 [r=2 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,0) size 68x20
+                text run at (1,1) width 106: "(18, 33) (18, 29)"
+          RenderTableRow {TR} at (0,41) size 696x20
+            RenderTableCell {TD} at (0,41) size 170x20 [r=2 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 68x18
                 text run at (1,1) width 68: "padding: 0"
-            RenderTableCell {TD} at (170,41) size 61x21 [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (170,41) size 61x20 [r=2 c=1 rs=1 cs=1]
               RenderButton {BUTTON} at (1,3) size 14x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (2,1) size 10x13
                   RenderImage {IMG} at (0,1) size 10x10
-            RenderTableCell {TD} at (230,41) size 162x21 [r=2 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,0) size 106x20
+            RenderTableCell {TD} at (230,41) size 162x20 [r=2 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 106x18
                 text run at (1,1) width 106: "(15, 14) (15, 10)"
-            RenderTableCell {TD} at (391,41) size 135x21 [r=2 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
-                RenderBlock (anonymous) at (8,2) size 17x13
+            RenderTableCell {TD} at (391,41) size 135x20 [r=2 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,3) size 21x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+                RenderBlock (anonymous) at (2,1) size 17x13
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
-            RenderTableCell {TD} at (525,41) size 171x21 [r=2 c=4 rs=1 cs=1]
-              RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
-          RenderTableRow {TR} at (0,62) size 696x27
-            RenderTableCell {TD} at (0,65) size 170x21 [r=3 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (525,41) size 171x20 [r=2 c=4 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 106x18
+                text run at (1,1) width 106: "(15, 21) (15, 17)"
+          RenderTableRow {TR} at (0,61) size 696x41
+            RenderTableCell {TD} at (0,71) size 170x21 [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (1,0) size 90x20
                 text run at (1,1) width 90: "padding: 10%"
-            RenderTableCell {TD} at (170,62) size 61x27 [r=3 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (170,68) size 61x27 [r=3 c=1 rs=1 cs=1]
               RenderButton {BUTTON} at (1,1) size 26x25 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (7,5) size 11x14
                   RenderImage {IMG} at (0,1) size 10x10
-            RenderTableCell {TD} at (230,65) size 162x21 [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,71) size 162x21 [r=3 c=2 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
                 text run at (1,1) width 106: "(25, 26) (25, 22)"
-            RenderTableCell {TD} at (391,65) size 135x21 [r=3 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
-                RenderBlock (anonymous) at (8,2) size 17x13
+            RenderTableCell {TD} at (391,61) size 135x41 [r=3 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 31x40 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+                RenderBlock (anonymous) at (15,13) size 0x14
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
-            RenderTableCell {TD} at (525,65) size 171x21 [r=3 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (525,71) size 171x21 [r=3 c=4 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
-          RenderTableRow {TR} at (0,89) size 696x21
-            RenderTableCell {TD} at (0,89) size 170x21 [r=4 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,0) size 84x20
+                text run at (1,1) width 106: "(39, 30) (39, 26)"
+          RenderTableRow {TR} at (0,102) size 696x20
+            RenderTableCell {TD} at (0,102) size 170x20 [r=4 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 84x18
                 text run at (1,1) width 84: "padding: 2px"
-            RenderTableCell {TD} at (170,89) size 61x21 [r=4 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (170,102) size 61x20 [r=4 c=1 rs=1 cs=1]
               RenderButton {BUTTON} at (1,2) size 18x17 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (4,2) size 10x13
                   RenderImage {IMG} at (0,1) size 10x10
-            RenderTableCell {TD} at (230,89) size 162x21 [r=4 c=2 rs=1 cs=1]
-              RenderText {#text} at (1,0) size 106x20
+            RenderTableCell {TD} at (230,102) size 162x20 [r=4 c=2 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 106x18
                 text run at (1,1) width 106: "(17, 18) (17, 14)"
-            RenderTableCell {TD} at (391,89) size 135x21 [r=4 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
-                RenderBlock (anonymous) at (8,2) size 17x13
+            RenderTableCell {TD} at (391,102) size 135x20 [r=4 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,2) size 25x17 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+                RenderBlock (anonymous) at (4,2) size 17x13
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
-            RenderTableCell {TD} at (525,89) size 171x21 [r=4 c=4 rs=1 cs=1]
-              RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
-          RenderTableRow {TR} at (0,110) size 696x21
-            RenderTableCell {TD} at (0,110) size 170x21 [r=5 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (525,102) size 171x20 [r=4 c=4 rs=1 cs=1]
+              RenderText {#text} at (1,1) size 106x18
+                text run at (1,1) width 106: "(17, 25) (17, 21)"
+          RenderTableRow {TR} at (0,122) size 696x21
+            RenderTableCell {TD} at (0,122) size 170x21 [r=5 c=0 rs=1 cs=1]
               RenderText {#text} at (1,0) size 168x20
                 text run at (1,1) width 168: "padding: 2px 6px 3px 6px"
-            RenderTableCell {TD} at (170,110) size 61x21 [r=5 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (170,122) size 61x21 [r=5 c=1 rs=1 cs=1]
               RenderButton {BUTTON} at (1,2) size 26x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 10x13
                   RenderImage {IMG} at (0,1) size 10x10
-            RenderTableCell {TD} at (230,110) size 162x21 [r=5 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,122) size 162x21 [r=5 c=2 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
                 text run at (1,1) width 106: "(18, 26) (18, 22)"
-            RenderTableCell {TD} at (391,110) size 135x21 [r=5 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderTableCell {TD} at (391,122) size 135x21 [r=5 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 17x13
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
-            RenderTableCell {TD} at (525,110) size 171x21 [r=5 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (525,122) size 171x21 [r=5 c=4 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
-          RenderTableRow {TR} at (0,131) size 696x21
-            RenderTableCell {TD} at (0,131) size 170x21 [r=6 c=0 rs=1 cs=1]
+                text run at (1,1) width 106: "(18, 33) (18, 29)"
+          RenderTableRow {TR} at (0,143) size 696x21
+            RenderTableCell {TD} at (0,143) size 170x21 [r=6 c=0 rs=1 cs=1]
               RenderText {#text} at (1,0) size 112x20
                 text run at (1,1) width 112: "padding: 3px 7px"
-            RenderTableCell {TD} at (170,131) size 61x21 [r=6 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (170,143) size 61x21 [r=6 c=1 rs=1 cs=1]
               RenderButton {BUTTON} at (1,1) size 28x19 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (9,3) size 10x13
                   RenderImage {IMG} at (0,1) size 10x10
-            RenderTableCell {TD} at (230,131) size 162x21 [r=6 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,143) size 162x21 [r=6 c=2 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
                 text run at (1,1) width 106: "(19, 28) (19, 24)"
-            RenderTableCell {TD} at (391,131) size 135x21 [r=6 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
-                RenderBlock (anonymous) at (8,2) size 17x13
+            RenderTableCell {TD} at (391,143) size 135x21 [r=6 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 35x19 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+                RenderBlock (anonymous) at (9,3) size 17x13
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
-            RenderTableCell {TD} at (525,131) size 171x21 [r=6 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (525,143) size 171x21 [r=6 c=4 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
-          RenderTableRow {TR} at (0,152) size 696x55
-            RenderTableCell {TD} at (0,169) size 170x21 [r=7 c=0 rs=1 cs=1]
+                text run at (1,1) width 106: "(19, 35) (19, 31)"
+          RenderTableRow {TR} at (0,164) size 696x55
+            RenderTableCell {TD} at (0,181) size 170x21 [r=7 c=0 rs=1 cs=1]
               RenderText {#text} at (1,0) size 92x20
                 text run at (1,1) width 92: "padding: 20px"
-            RenderTableCell {TD} at (170,152) size 61x55 [r=7 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (170,164) size 61x55 [r=7 c=1 rs=1 cs=1]
               RenderButton {BUTTON} at (1,1) size 54x53 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (22,20) size 10x13
                   RenderImage {IMG} at (0,1) size 10x10
-            RenderTableCell {TD} at (230,169) size 162x21 [r=7 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (230,181) size 162x21 [r=7 c=2 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
                 text run at (1,1) width 106: "(53, 54) (53, 50)"
-            RenderTableCell {TD} at (391,169) size 135x21 [r=7 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (1,2) size 33x18 [color=#000000D8] [bgcolor=#C0C0C0]
-                RenderBlock (anonymous) at (8,2) size 17x13
+            RenderTableCell {TD} at (391,164) size 135x55 [r=7 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 61x53 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+                RenderBlock (anonymous) at (22,20) size 17x13
                   RenderText at (0,0) size 17x13
                     text run at (0,0) width 17: "foo"
-            RenderTableCell {TD} at (525,169) size 171x21 [r=7 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (525,181) size 171x21 [r=7 c=4 rs=1 cs=1]
               RenderText {#text} at (1,0) size 106x20
-                text run at (1,1) width 106: "(18, 33) (18, 33)"
+                text run at (1,1) width 106: "(53, 61) (53, 57)"

--- a/LayoutTests/platform/mac/fast/forms/blankbuttons-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/blankbuttons-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 37x13
           RenderText at (0,0) size 37x13
             text run at (0,0) width 37: "Submit"
       RenderBR {BR} at (52,-1) size 1x18
-      RenderButton {INPUT} at (0,18) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (0,18) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 30x13
           RenderText at (0,0) size 30x13
             text run at (0,0) width 30: "Reset"

--- a/LayoutTests/platform/mac/fast/forms/box-shadow-override-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/box-shadow-override-expected.txt
@@ -44,31 +44,31 @@ layer at (0,0) size 800x600
         RenderText {#text} at (173,7) size 4x18
           text run at (173,7) width 4: " "
         RenderFileUploadControl {INPUT} at (177,8) size 238x18 "no file selected"
-          RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 62x13
               RenderText at (0,0) size 62x13
                 text run at (0,0) width 62: "Choose File"
         RenderText {#text} at (415,7) size 4x18
           text run at (415,7) width 4: " "
-        RenderButton {INPUT} at (419,6) size 57x21 [color=#000000D8] [bgcolor=#C0C0C0]
-          RenderBlock (anonymous) at (8,2) size 41x16
-            RenderText at (0,0) size 41x16
-              text run at (0,0) width 41: "Button"
-        RenderText {#text} at (475,7) size 5x18
-          text run at (475,7) width 5: " "
-        RenderButton {INPUT} at (479,8) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (419,0) size 75x28 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+          RenderBlock (anonymous) at (8,2) size 59x23
+            RenderText at (0,0) size 59x23
+              text run at (0,0) width 59: "Button"
+        RenderText {#text} at (493,7) size 5x18
+          text run at (493,7) width 5: " "
+        RenderButton {INPUT} at (497,8) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 35x13
             RenderText at (0,0) size 35x13
               text run at (0,0) width 35: "Button"
-        RenderText {#text} at (530,7) size 5x18
-          text run at (530,7) width 5: " "
-        RenderButton {INPUT} at (534,10) size 46x15 [color=#000000D8] [bgcolor=#C0C0C0]
-          RenderBlock (anonymous) at (8,2) size 30x11
-            RenderText at (0,0) size 30x11
-              text run at (0,0) width 30: "Button"
-        RenderText {#text} at (579,7) size 5x18
-          text run at (579,7) width 5: " "
-        RenderButton {BUTTON} at (583,0) size 75x28 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderText {#text} at (548,7) size 5x18
+          text run at (548,7) width 5: " "
+        RenderButton {INPUT} at (552,12) size 34x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+          RenderBlock (anonymous) at (8,4) size 17x6
+            RenderText at (0,0) size 17x6
+              text run at (0,0) width 17: "Button"
+        RenderText {#text} at (585,7) size 5x18
+          text run at (585,7) width 5: " "
+        RenderButton {BUTTON} at (589,0) size 75x28 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 59x23
             RenderText {#text} at (0,0) size 59x23
               text run at (0,0) width 59: "Button"

--- a/LayoutTests/platform/mac/fast/forms/button-positioned-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-positioned-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 149x18
       RenderText {#text} at (0,0) size 133x13
         text run at (0,0) width 133: "This button is positioned."
 layer at (8,8) size 170x18
-  RenderButton {INPUT} at (8,8) size 171x18 [color=#000000D8] [bgcolor=#C0C0C0]
+  RenderButton {INPUT} at (8,8) size 171x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
     RenderBlock (anonymous) at (8,2) size 155x13
       RenderText at (0,0) size 155x13
         text run at (0,0) width 155: "This button is also positioned"

--- a/LayoutTests/platform/mac/fast/forms/button-style-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-style-color-expected.txt
@@ -27,13 +27,13 @@ layer at (0,0) size 800x600
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (316,1) size 5x18
         text run at (316,1) width 5: " "
-      RenderButton {INPUT} at (320,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (320,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (396,1) size 5x18
         text run at (396,1) width 5: " "
-      RenderButton {INPUT} at (400,2) size 78x18 [color=#FF0000] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (400,2) size 78x18 [color=#FF0000] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"

--- a/LayoutTests/platform/mac/fast/forms/button-table-styles-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-table-styles-expected.txt
@@ -7,120 +7,120 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 347x18
           text run at (0,0) width 347: "This tests that buttons don't honor table display styles."
         RenderBR {BR} at (346,0) size 1x18
-      RenderButton {INPUT} at (0,18) size 86x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (0,18) size 86x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 70x13
           RenderText at (0,0) size 70x13
             text run at (0,0) width 70: "display: table"
-      RenderButton {INPUT} at (0,36) size 86x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (0,36) size 86x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 70x13
           RenderText at (0,0) size 70x13
             text run at (0,0) width 70: "display: table"
       RenderBlock (anonymous) at (0,54) size 784x351
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
-        RenderButton {INPUT} at (0,37) size 119x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,37) size 119x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 103x13
             RenderText at (0,0) size 103x13
               text run at (0,0) width 103: "display: inline-table"
         RenderText {#text} at (118,36) size 5x18
           text run at (118,36) width 5: " "
-        RenderButton {INPUT} at (122,37) size 120x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (122,37) size 120x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 103x13
             RenderText at (0,0) size 103x13
               text run at (0,0) width 103: "display: inline-table"
         RenderBR {BR} at (241,36) size 1x18
         RenderBR {BR} at (0,55) size 0x18
-        RenderButton {INPUT} at (0,74) size 146x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,74) size 146x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 130x13
             RenderText at (0,0) size 130x13
               text run at (0,0) width 130: "display: table-row-group"
         RenderText {#text} at (145,73) size 5x18
           text run at (145,73) width 5: " "
-        RenderButton {INPUT} at (149,74) size 147x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (149,74) size 147x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 130x13
             RenderText at (0,0) size 130x13
               text run at (0,0) width 130: "display: table-row-group"
         RenderBR {BR} at (295,73) size 1x18
         RenderBR {BR} at (0,92) size 0x18
-        RenderButton {INPUT} at (0,111) size 163x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,111) size 163x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 147x13
             RenderText at (0,0) size 147x13
               text run at (0,0) width 147: "display: table-header-group"
         RenderText {#text} at (162,110) size 5x18
           text run at (162,110) width 5: " "
-        RenderButton {INPUT} at (166,111) size 164x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (166,111) size 164x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 147x13
             RenderText at (0,0) size 147x13
               text run at (0,0) width 147: "display: table-header-group"
         RenderBR {BR} at (329,110) size 1x18
         RenderBR {BR} at (0,129) size 0x18
-        RenderButton {INPUT} at (0,148) size 158x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,148) size 158x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 142x13
             RenderText at (0,0) size 142x13
               text run at (0,0) width 142: "display: table-footer-group"
         RenderText {#text} at (157,147) size 5x18
           text run at (157,147) width 5: " "
-        RenderButton {INPUT} at (161,148) size 159x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (161,148) size 159x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 142x13
             RenderText at (0,0) size 142x13
               text run at (0,0) width 142: "display: table-footer-group"
         RenderBR {BR} at (319,147) size 1x18
         RenderBR {BR} at (0,166) size 0x18
-        RenderButton {INPUT} at (0,185) size 110x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,185) size 110x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 94x13
             RenderText at (0,0) size 94x13
               text run at (0,0) width 94: "display: table-row"
         RenderText {#text} at (109,184) size 5x18
           text run at (109,184) width 5: " "
-        RenderButton {INPUT} at (113,185) size 111x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (113,185) size 111x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 94x13
             RenderText at (0,0) size 94x13
               text run at (0,0) width 94: "display: table-row"
         RenderBR {BR} at (223,184) size 1x18
         RenderBR {BR} at (0,203) size 0x18
-        RenderButton {INPUT} at (0,222) size 166x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,222) size 166x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 150x13
             RenderText at (0,0) size 150x13
               text run at (0,0) width 150: "display: table-column-group"
         RenderText {#text} at (165,221) size 5x18
           text run at (165,221) width 5: " "
-        RenderButton {INPUT} at (169,222) size 166x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (169,222) size 166x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 150x13
             RenderText at (0,0) size 150x13
               text run at (0,0) width 150: "display: table-column-group"
         RenderBR {BR} at (334,221) size 1x18
         RenderBR {BR} at (0,240) size 0x18
-        RenderButton {INPUT} at (0,259) size 130x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,259) size 130x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 114x13
             RenderText at (0,0) size 114x13
               text run at (0,0) width 114: "display: table-column"
         RenderText {#text} at (129,258) size 5x18
           text run at (129,258) width 5: " "
-        RenderButton {INPUT} at (133,259) size 130x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (133,259) size 130x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 114x13
             RenderText at (0,0) size 114x13
               text run at (0,0) width 114: "display: table-column"
         RenderBR {BR} at (262,258) size 1x18
         RenderBR {BR} at (0,277) size 0x18
-        RenderButton {INPUT} at (0,296) size 110x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,296) size 110x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 94x13
             RenderText at (0,0) size 94x13
               text run at (0,0) width 94: "display: table-cell"
         RenderText {#text} at (109,295) size 5x18
           text run at (109,295) width 5: " "
-        RenderButton {INPUT} at (113,296) size 110x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (113,296) size 110x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 94x13
             RenderText at (0,0) size 94x13
               text run at (0,0) width 94: "display: table-cell"
         RenderBR {BR} at (222,295) size 1x18
         RenderBR {BR} at (0,314) size 0x18
-        RenderButton {INPUT} at (0,333) size 130x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,333) size 130x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 114x13
             RenderText at (0,0) size 114x13
               text run at (0,0) width 114: "display: table-caption"
         RenderText {#text} at (129,332) size 5x18
           text run at (129,332) width 5: " "
-        RenderButton {INPUT} at (133,333) size 131x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (133,333) size 131x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 114x13
             RenderText at (0,0) size 114x13
               text run at (0,0) width 114: "display: table-caption"

--- a/LayoutTests/platform/mac/fast/forms/button-text-transform-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-text-transform-expected.txt
@@ -35,19 +35,19 @@ layer at (0,0) size 800x600
               text run at (0,0) width 52: "Capitalize"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,87) size 784x19
-        RenderButton {INPUT} at (0,1) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,1) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 66x13
             RenderText at (0,0) size 66x13
               text run at (0,0) width 66: "UPPERCASE"
         RenderText {#text} at (81,0) size 5x18
           text run at (81,0) width 5: " "
-        RenderButton {INPUT} at (85,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (85,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 53x13
             RenderText at (0,0) size 53x13
               text run at (0,0) width 53: "lowercase"
         RenderText {#text} at (153,0) size 5x18
           text run at (153,0) width 5: " "
-        RenderButton {INPUT} at (157,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (157,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 52x13
             RenderText at (0,0) size 52x13
               text run at (0,0) width 52: "Capitalize"

--- a/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
@@ -11,18 +11,18 @@ layer at (0,0) size 800x600
           RenderText at (8,2) size 271x13
             text run at (8,2) width 271: "This text should be centered vertically in the button"
       RenderBR {BR} at (302,17) size 0x18
-      RenderButton {INPUT} at (0,36) size 287x18 [color=#000000D8] [bgcolor=#C0C0C0]
-        RenderBlock (anonymous) at (8,2) size 271x13
-          RenderText at (0,0) size 271x13
-            text run at (0,0) width 271: "This text should be centered vertically in the button"
-      RenderBR {BR} at (286,35) size 1x18
-      RenderTextControl {INPUT} at (0,54) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderButton {INPUT} at (0,36) size 287x31 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderBlock (anonymous) at (8,2) size 271x26
+          RenderText at (0,6) size 271x13
+            text run at (0,6) width 271: "This text should be centered vertically in the button"
+      RenderBR {BR} at (286,41) size 1x18
+      RenderTextControl {INPUT} at (0,67) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderFlexibleBox {DIV} at (3,0) size 141x19
           RenderBlock {DIV} at (0,0) size 8x19
           RenderBlock {DIV} at (8,3) size 114x13
           RenderBlock {DIV} at (121,0) size 20x19
       RenderText {#text} at (0,0) size 0x0
-layer at (19,65) size 114x13 scrollWidth 271
+layer at (19,78) size 114x13 scrollWidth 271
   RenderBlock {DIV} at (0,0) size 114x13
     RenderText {#text} at (0,0) size 271x13
       text run at (0,0) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/mac/fast/forms/file/file-input-direction-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/file/file-input-direction-expected.txt
@@ -21,25 +21,25 @@ layer at (0,0) size 800x585
             RenderTableCell {TH} at (2,34) size 86x2 [r=1 c=0 rs=1 cs=1]
             RenderTableCell {TD} at (89,24) size 243x22 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (333,24) size 243x22 [border: (1px solid #000000)] [r=1 c=2 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (577,24) size 243x22 [border: (1px solid #000000)] [r=1 c=3 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (821,24) size 243x22 [border: (1px solid #000000)] [r=1 c=4 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
@@ -49,25 +49,25 @@ layer at (0,0) size 800x585
                 text run at (1,1) width 84: "direction:ltr"
             RenderTableCell {TD} at (89,48) size 243x22 [border: (1px solid #000000)] [r=2 c=1 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (333,48) size 243x22 [border: (1px solid #000000)] [r=2 c=2 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (577,48) size 243x22 [border: (1px solid #000000)] [r=2 c=3 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (821,48) size 243x22 [border: (1px solid #000000)] [r=2 c=4 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
@@ -77,25 +77,25 @@ layer at (0,0) size 800x585
                 text run at (1,1) width 84: "direction:rtl"
             RenderTableCell {TD} at (89,72) size 243x22 [border: (1px solid #000000)] [r=3 c=1 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (333,72) size 243x22 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (577,72) size 243x22 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
             RenderTableCell {TD} at (821,72) size 243x22 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"

--- a/LayoutTests/platform/mac/fast/forms/file/file-input-disabled-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/file/file-input-disabled-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,37) size 89x18
             text run at (0,37) width 89: "  Select File:  "
           RenderFileUploadControl {INPUT} at (88,38) size 239x18 "no file selected"
-            RenderButton {INPUT} at (0,0) size 78x18 [color=#0000003F] [bgcolor=#C0C0C0]
+            RenderButton {INPUT} at (0,0) size 78x18 [color=#0000003F] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,2) size 62x13
                 RenderText at (0,0) size 62x13
                   text run at (0,0) width 62: "Choose File"

--- a/LayoutTests/platform/mac/fast/forms/file/input-file-re-render-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/file/input-file-re-render-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x77
     RenderBody {BODY} at (8,8) size 784x53
       RenderBlock {FORM} at (0,0) size 784x19
         RenderFileUploadControl {INPUT} at (0,1) size 238x18 "2 files"
-          RenderButton {INPUT} at (0,0) size 84x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,0) size 84x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 68x13
               RenderText at (0,0) size 68x13
                 text run at (0,0) width 68: "Choose Files"

--- a/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 785x614
             RenderTableCell {TD} at (2,2) size 57x24 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 55x22 [border: (2px solid #0000FF)]
                 RenderInline {FONT} at (0,0) size 51x28
-                  RenderButton {INPUT} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 35x13
                       RenderText at (0,0) size 35x13
                         text run at (0,0) width 35: "button"
@@ -42,7 +42,7 @@ layer at (0,0) size 785x614
           RenderTableRow {TR} at (0,2) size 169x24
             RenderTableCell {TD} at (2,2) size 57x24 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 55x22 [border: (2px solid #0000FF)]
-                RenderButton {INPUT} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 35x13
                     RenderText at (0,0) size 35x13
                       text run at (0,0) width 35: "button"
@@ -64,7 +64,7 @@ layer at (0,0) size 785x614
             RenderTableCell {TD} at (2,2) size 57x24 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 55x22 [border: (2px solid #0000FF)]
                 RenderInline {FONT} at (0,0) size 51x13
-                  RenderButton {INPUT} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 35x13
                       RenderText at (0,0) size 35x13
                         text run at (0,0) width 35: "button"
@@ -95,7 +95,7 @@ layer at (0,0) size 785x614
             RenderTableCell {TD} at (127,2) size 245x24 [r=0 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 242x22 [border: (2px solid #0000FF)]
                 RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
-                  RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 62x13
                       RenderText at (0,0) size 62x13
                         text run at (0,0) width 62: "Choose File"
@@ -108,7 +108,7 @@ layer at (0,0) size 785x614
         RenderInline {FONT} at (0,0) size 203x28
           RenderText {#text} at (0,0) size 42x28
             text run at (0,0) width 42: "text "
-          RenderButton {INPUT} at (41,9) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (41,9) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 35x13
               RenderText at (0,0) size 35x13
                 text run at (0,0) width 35: "button"
@@ -128,7 +128,7 @@ layer at (0,0) size 785x614
       RenderBlock {DIV} at (0,391) size 769x20
         RenderText {#text} at (0,0) size 28x18
           text run at (0,0) width 28: "text "
-        RenderButton {INPUT} at (27,1) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (27,1) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 35x13
             RenderText at (0,0) size 35x13
               text run at (0,0) width 35: "button"
@@ -149,7 +149,7 @@ layer at (0,0) size 785x614
         RenderInline {FONT} at (0,0) size 168x13
           RenderText {#text} at (0,3) size 18x13
             text run at (0,3) width 18: "text "
-          RenderButton {INPUT} at (17,0) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (17,0) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 35x13
               RenderText at (0,0) size 35x13
                 text run at (0,0) width 35: "button"
@@ -173,7 +173,7 @@ layer at (0,0) size 785x614
         RenderText {#text} at (104,18) size 5x18
           text run at (104,18) width 5: " "
         RenderFileUploadControl {INPUT} at (108,19) size 239x18 "no file selected"
-          RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 62x13
               RenderText at (0,0) size 62x13
                 text run at (0,0) width 62: "Choose File"

--- a/LayoutTests/platform/mac/fast/forms/formmove3-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/formmove3-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
               RenderTableRow {TR} at (0,2) size 63x20
                 RenderTableCell {TD} at (2,11) size 2x2 [r=0 c=0 rs=1 cs=1]
                 RenderTableCell {TD} at (6,2) size 55x20 [r=0 c=1 rs=1 cs=1]
-                  RenderButton {INPUT} at (1,1) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (1,1) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 37x13
                       RenderText at (0,0) size 37x13
                         text run at (0,0) width 37: "Search"

--- a/LayoutTests/platform/mac/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-appearance-height-expected.txt
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,57) size 25x18
           text run at (0,57) width 25: "file "
         RenderFileUploadControl {INPUT} at (24,58) size 239x18 "no file selected"
-          RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 62x13
               RenderText at (0,0) size 62x13
                 text run at (0,0) width 62: "Choose File"
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (176,118) size 1x18
         RenderText {#text} at (0,136) size 35x18
           text run at (0,136) width 35: "reset "
-        RenderButton {INPUT} at (34,137) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (34,137) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 30x13
             RenderText at (0,0) size 30x13
               text run at (0,0) width 30: "Reset"
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (83,136) size 1x18
         RenderText {#text} at (0,155) size 48x18
           text run at (0,155) width 48: "submit "
-        RenderButton {INPUT} at (47,156) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (47,156) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 37x13
             RenderText at (0,0) size 37x13
               text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/fast/forms/input-value-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-value-expected.txt
@@ -81,7 +81,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (1,1) size 228x18
                   text run at (1,1) width 228: "button with value property changed"
               RenderTableCell {TD} at (395,90) size 241x20 [r=4 c=1 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 25x13
                     RenderText at (0,0) size 25x13
                       text run at (0,0) width 25: "after"
@@ -193,7 +193,7 @@ layer at (0,0) size 800x600
                   text run at (1,1) width 208: "file with value property changed"
               RenderTableCell {TD} at (395,291) size 241x20 [r=13 c=1 rs=1 cs=1]
                 RenderFileUploadControl {INPUT} at (1,1) size 238x18 "no file selected"
-                  RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 62x13
                       RenderText at (0,0) size 62x13
                         text run at (0,0) width 62: "Choose File"

--- a/LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {FORM} at (0,0) size 784x18
-        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "form"

--- a/LayoutTests/platform/mac/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-replace-summary-child-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 800x600
               text run at (0,0) width 63: "Details3"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,18) size 784x18
-        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "click"

--- a/LayoutTests/platform/mac/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-replace-text-expected.txt
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
               text run at (0,0) width 63: "Details2"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,36) size 784x18
-        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "click"

--- a/LayoutTests/platform/mac/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt
@@ -12,7 +12,7 @@ layer at (0,-236) size 570x836 backgroundClip at (0,42) size 785x558 clip at (0,
         text run at (0,0) width 571: "This tests that we can scroll to reveal something in a nested positioned block in overflow."
     RenderBlock {DIV} at (0,18) size 571x800
     RenderBlock (anonymous) at (0,818) size 571x18
-      RenderButton {INPUT} at (0,0) size 201x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (0,0) size 201x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 185x13
           RenderText at (0,0) size 185x13
             text run at (0,0) width 185: "If you can see this, test has passed"

--- a/LayoutTests/platform/mac/fast/overflow/scrollRevealButton-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/scrollRevealButton-expected.txt
@@ -30,7 +30,7 @@ layer at (0,0) size 785x1188
               RenderBlock {DIV} at (0,18) size 135x500
               RenderBlock (anonymous) at (0,518) size 135x36
                 RenderBR {BR} at (0,0) size 0x18
-                RenderButton {INPUT} at (0,18) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,18) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 35x13
                     RenderText at (0,0) size 35x13
                       text run at (0,0) width 35: "Button"

--- a/LayoutTests/platform/mac/fast/replaced/replaced-breaking-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/replaced-breaking-expected.txt
@@ -10,11 +10,11 @@ layer at (0,0) size 800x600
         RenderImage {IMG} at (1,39) size 27x27 [border: (1px solid #000000)]
         RenderImage {IMG} at (1,66) size 27x27 [border: (1px solid #000000)]
         RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (1,93) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (1,93) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 27x13
             RenderText at (0,0) size 27x13
               text run at (0,0) width 27: "input"
-        RenderButton {INPUT} at (1,111) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (1,111) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 27x13
             RenderText at (0,0) size 27x13
               text run at (0,0) width 27: "input"

--- a/LayoutTests/platform/mac/fast/replaced/width100percent-button-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/width100percent-button-expected.txt
@@ -10,17 +10,17 @@ layer at (0,0) size 800x600
         RenderTableSection {TBODY} at (0,0) size 784x22
           RenderTableRow {TR} at (0,1) size 784x20
             RenderTableCell {TD} at (1,1) size 66x20 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 48x13
                   RenderText at (0,0) size 48x13
                     text run at (0,0) width 48: "New Mail"
             RenderTableCell {TD} at (67,1) size 48x20 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,1) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 30x13
                   RenderText at (0,0) size 30x13
                     text run at (0,0) width 30: "Reply"
             RenderTableCell {TD} at (115,1) size 65x20 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 46x13
                   RenderText at (0,0) size 46x13
                     text run at (0,0) width 46: "Reply All"
@@ -34,17 +34,17 @@ layer at (0,0) size 800x600
         RenderTableSection {TBODY} at (0,0) size 784x22
           RenderTableRow {TR} at (0,1) size 784x20
             RenderTableCell {TD} at (1,1) size 66x20 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 48x13
                   RenderText at (0,0) size 48x13
                     text run at (0,0) width 48: "New Mail"
             RenderTableCell {TD} at (67,1) size 48x20 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,1) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 30x13
                   RenderText at (0,0) size 30x13
                     text run at (0,0) width 30: "Reply"
             RenderTableCell {TD} at (115,1) size 65x20 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 46x13
                   RenderText at (0,0) size 46x13
                     text run at (0,0) width 46: "Reply All"

--- a/LayoutTests/platform/mac/fast/text/international/hindi-spacing-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/hindi-spacing-expected.txt
@@ -8,20 +8,20 @@ layer at (0,0) size 800x600
         text run at (0,18) width 761: "left for it. Neither the Hindi on the button below nor the same text on two lines below that should be truncated at either"
         text run at (0,36) width 28: "end."
       RenderBR {BR} at (27,36) size 1x18
-      RenderButton {INPUT} at (0,54) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderButton {INPUT} at (0,54) size 100x22 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 84x17
           RenderText at (0,1) size 84x13
             text run at (0,1) width 84: "\x{915}\x{93F}\x{938}\x{940} \x{92D}\x{940} \x{924}\x{930}\x{939} \x{906}\x{917}\x{947} \x{92C}"
       RenderBR {BR} at (99,54) size 1x18
       RenderInline {SPAN} at (0,0) size 114x18
-        RenderText {#text} at (0,76) size 114x18
-          text run at (0,76) width 114: "\x{915}\x{93F}\x{938}\x{940} \x{92D}\x{940} \x{924}\x{930}\x{939} \x{906}\x{917}\x{947} \x{92C}"
-      RenderText {#text} at (113,76) size 25x18
-        text run at (113,76) width 25: "Foo"
-      RenderBR {BR} at (137,76) size 1x18
+        RenderText {#text} at (0,80) size 114x18
+          text run at (0,80) width 114: "\x{915}\x{93F}\x{938}\x{940} \x{92D}\x{940} \x{924}\x{930}\x{939} \x{906}\x{917}\x{947} \x{92C}"
+      RenderText {#text} at (113,80) size 25x18
+        text run at (113,80) width 25: "Foo"
+      RenderBR {BR} at (137,80) size 1x18
       RenderInline {SPAN} at (0,0) size 114x17
-        RenderText {#text} at (0,101) size 114x17
-          text run at (0,101) width 114: "\x{915}\x{93F}\x{938}\x{940} \x{92D}\x{940} \x{924}\x{930}\x{939} \x{906}\x{917}\x{947} \x{92C}"
-      RenderText {#text} at (113,101) size 25x18
-        text run at (113,101) width 25: "Foo"
-      RenderBR {BR} at (137,101) size 1x18
+        RenderText {#text} at (0,105) size 114x17
+          text run at (0,105) width 114: "\x{915}\x{93F}\x{938}\x{940} \x{92D}\x{940} \x{924}\x{930}\x{939} \x{906}\x{917}\x{947} \x{92C}"
+      RenderText {#text} at (113,105) size 25x18
+        text run at (113,105) width 25: "Foo"
+      RenderBR {BR} at (137,105) size 1x18

--- a/LayoutTests/platform/mac/fast/text/textIteratorNilRenderer-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/textIteratorNilRenderer-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
                   RenderTextControl {INPUT} at (0,0) size 287x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                   RenderText {#text} at (0,0) size 0x0
                 RenderTableCell {TD} at (436,0) size 96x19 [r=0 c=2 rs=1 cs=1]
-                  RenderButton {INPUT} at (0,0) size 96x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                  RenderButton {INPUT} at (0,0) size 96x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderBlock (anonymous) at (8,2) size 80x13
                       RenderText at (0,0) size 80x13
                         text run at (0,0) width 80: "Search Froogle"

--- a/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -21,12 +21,12 @@ layer at (0,0) size 800x600
                 RenderBR {BR} at (0,185) size 0x37
                 RenderBR {BR} at (0,222) size 0x37
               RenderBlock {FORM} at (0,293) size 769x412
-                RenderButton {INPUT} at (0,0) size 111x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,0) size 111x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 95x13
                     RenderText at (0,0) size 95x13
                       text run at (0,0) width 95: "Submit with POST"
                 RenderBR {BR} at (110,-16) size 1x37
-                RenderButton {INPUT} at (0,18) size 228x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,18) size 228x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 212x13
                     RenderText at (0,0) size 212x13
                       text run at (0,0) width 212: "Submit with POST followed by a redirect"

--- a/LayoutTests/platform/mac/svg/custom/foreign-object-skew-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/foreign-object-skew-expected.txt
@@ -11,6 +11,6 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 68x18
             text run at (0,0) width 68: "and a link."
         RenderBR {xhtml:br} at (67,0) size 1x18
-        RenderButton {xhtml:input} at (0,18) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {xhtml:input} at (0,18) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderText {#text} at (0,0) size 0x0
     RenderSVGRect {rect} at (9,9) size 582x382 [stroke={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=580.00] [height=380.00]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug1188-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug1188-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
                 RenderTextControl {INPUT} at (266,1) size 218x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (483,0) size 5x20
                   text run at (483,1) width 5: " "
-                RenderButton {INPUT} at (487,2) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (487,2) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 37x13
                     RenderText at (0,0) size 37x13
                       text run at (0,0) width 37: "Search"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug1318-expected.txt
@@ -42,7 +42,7 @@ layer at (0,0) size 800x600
               RenderInline {FONT} at (0,0) size 0x16
                 RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (634,114) size 151x20 [r=3 c=2 rs=1 cs=2]
-              RenderButton {INPUT} at (55,1) size 40x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderButton {INPUT} at (55,1) size 40x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 23x13
                   RenderText at (0,0) size 23x13
                     text run at (0,0) width 23: "vote"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug138725-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug138725-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
                             RenderTableRow {TR} at (0,2) size 133x36
                               RenderTableCell {TD} at (2,2) size 129x36 [r=0 c=0 rs=1 cs=1]
                                 RenderBlock {FORM} at (1,1) size 127x18
-                                  RenderButton {INPUT} at (0,0) size 127x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                                  RenderButton {INPUT} at (0,0) size 127x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                                     RenderBlock (anonymous) at (8,2) size 111x13
                                       RenderText at (0,0) size 111x13
                                         text run at (0,0) width 111: "ApplyForThisPosition"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug18359-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug18359-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (109,2) size 464x21 [r=0 c=1 rs=1 cs=1]
                 RenderTextControl {INPUT} at (1,1) size 462x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
               RenderTableCell {TD} at (574,2) size 85x21 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 38x13
                     RenderText at (0,0) size 38x13
                       text run at (0,0) width 38: "Trigger"
@@ -33,7 +33,7 @@ layer at (0,0) size 800x600
                       text run at (8,2) width 72: "a_abortinstall"
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (574,25) size 85x20 [r=1 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 66x13
                     RenderText at (0,0) size 66x13
                       text run at (0,0) width 66: "Trigger case"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-2-expected.txt
@@ -97,13 +97,13 @@ layer at (0,0) size 800x553
                     RenderTextControl {INPUT} at (0,8) size 119x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
             RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,253) size 568x32
-            RenderButton {INPUT} at (0,9) size 57x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderButton {INPUT} at (0,9) size 57x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,2) size 41x13
                 RenderText at (0,0) size 41x13
                   text run at (0,0) width 41: "Submit!"
             RenderText {#text} at (56,6) size 6x19
               text run at (56,6) width 6: " "
-            RenderButton {INPUT} at (61,9) size 75x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderButton {INPUT} at (61,9) size 75x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,2) size 58x13
                 RenderText at (0,0) size 58x13
                   text run at (0,0) width 58: "Clear Form"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -85,7 +85,7 @@ layer at (0,0) size 785x765
             RenderTextControl {INPUT} at (401,16) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderText {#text} at (547,17) size 17x16
             text run at (547,17) width 17: " "
-          RenderButton {INPUT} at (563,17) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (563,17) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 37x13
               RenderText at (0,0) size 37x13
                 text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -195,7 +195,7 @@ layer at (0,0) size 785x2582
             RenderTextControl {INPUT} at (71,19) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderText {#text} at (218,19) size 5x18
             text run at (218,19) width 5: " "
-          RenderButton {INPUT} at (222,20) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (222,20) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 37x13
               RenderText at (0,0) size 37x13
                 text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug26178-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug26178-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (1,1) size 59x18
                 text run at (1,1) width 59: "First row"
       RenderBlock {FORM} at (0,46) size 784x18
-        RenderButton {INPUT} at (0,0) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 30x13
             RenderText at (0,0) size 30x13
               text run at (0,0) width 30: "insert"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug28928-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug28928-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
                 RenderTextControl {INPUT} at (0,0) size 98x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (97,0) size 5x18
                   text run at (97,0) width 5: " "
-                RenderButton {INPUT} at (101,1) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (101,1) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 22x13
                     RenderText at (0,0) size 22x13
                       text run at (0,0) width 22: " Go "
@@ -35,7 +35,7 @@ layer at (0,0) size 800x600
                 RenderTextControl {INPUT} at (0,0) size 98x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (97,0) size 5x18
                   text run at (97,0) width 5: " "
-                RenderButton {INPUT} at (101,1) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (101,1) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 22x13
                     RenderText at (0,0) size 22x13
                       text run at (0,0) width 22: " Go "

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug33855-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug33855-expected.txt
@@ -8,17 +8,17 @@ layer at (0,0) size 800x600
           RenderTableSection {TBODY} at (0,0) size 784x24
             RenderTableRow {TR} at (0,2) size 784x20 [bgcolor=#FFFFFF]
               RenderTableCell {TD} at (2,2) size 66x20 [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 48x13
                     RenderText at (0,0) size 48x13
                       text run at (0,0) width 48: "Select all"
               RenderTableCell {TD} at (70,2) size 52x20 [r=0 c=1 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 50x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 50x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 34x13
                     RenderText at (0,0) size 34x13
                       text run at (0,0) width 34: "Delete"
               RenderTableCell {TD} at (123,2) size 83x20 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 80x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 80x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 64x13
                     RenderText at (0,0) size 64x13
                       text run at (0,0) width 64: "Empty trash"
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (1,1) size 4x18
                   text run at (1,1) width 4: " "
               RenderTableCell {TD} at (606,2) size 64x20 [r=0 c=4 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 46x13
                     RenderText at (0,0) size 46x13
                       text run at (0,0) width 46: "Move to:"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug39209-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug39209-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
                   RenderTableRow {TR} at (0,2) size 61x38
                     RenderTableCell {TD} at (2,2) size 57x38 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderBlock {FORM} at (2,2) size 53x18
-                        RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                        RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                           RenderBlock (anonymous) at (8,2) size 37x13
                             RenderText at (0,0) size 37x13
                               text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug4429-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug4429-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (2,2) size 22x18
                   text run at (2,2) width 22: "foo"
         RenderBlock (anonymous) at (0,28) size 784x18
-          RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 37x13
               RenderText at (0,0) size 37x13
                 text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug46368-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug46368-1-expected.txt
@@ -33,13 +33,13 @@ layer at (0,0) size 800x600
                 text run at (2,38) width 293: "Architecture, Bidi, Necko/Imglib, and more..."
       RenderBlock (anonymous) at (0,111) size 784x37
         RenderBR {BR} at (0,0) size 0x18
-        RenderButton {INPUT} at (0,19) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 36x13
             RenderText at (0,0) size 36x13
               text run at (0,0) width 36: "Reload"
         RenderText {#text} at (51,18) size 9x18
           text run at (51,18) width 9: "  "
-        RenderButton {INPUT} at (59,19) size 84x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (59,19) size 84x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 67x13
             RenderText at (0,0) size 67x13
               text run at (0,0) width 67: "Change Font"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug46368-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug46368-2-expected.txt
@@ -21,13 +21,13 @@ layer at (0,0) size 800x600
                 text run at (2,2) width 245: "foo bar foo bar foo bar foo bar foo bar"
       RenderBlock (anonymous) at (0,65) size 784x37
         RenderBR {BR} at (0,0) size 0x18
-        RenderButton {INPUT} at (0,19) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 52x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 36x13
             RenderText at (0,0) size 36x13
               text run at (0,0) width 36: "Reload"
         RenderText {#text} at (51,18) size 9x18
           text run at (51,18) width 9: "  "
-        RenderButton {INPUT} at (59,19) size 84x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (59,19) size 84x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 67x13
             RenderText at (0,0) size 67x13
               text run at (0,0) width 67: "Change Font"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug51037-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug51037-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 34: "Top: "
         RenderTextControl {INPUT} at (33,0) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
       RenderBlock {P} at (0,104) size 784x18
-        RenderButton {INPUT} at (0,0) size 45x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 45x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 29x13
             RenderText at (0,0) size 29x13
               text run at (0,0) width 29: "Move"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug51727-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug51727-expected.txt
@@ -4,12 +4,12 @@ layer at (0,0) size 800x80
   RenderBlock {HTML} at (0,0) size 800x80
     RenderBody {BODY} at (8,8) size 784x64
       RenderBlock {FORM} at (0,0) size 784x38
-        RenderButton {INPUT} at (0,1) size 154x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,1) size 154x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 138x13
             RenderText at (0,0) size 138x13
               text run at (0,0) width 138: "(1) Fill cell with long string"
         RenderBR {BR} at (153,0) size 1x18
-        RenderButton {INPUT} at (0,20) size 160x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,20) size 160x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 144x13
             RenderText at (0,0) size 144x13
               text run at (0,0) width 144: "(2) Fill cell with short string"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug52505-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug52505-expected.txt
@@ -4,11 +4,11 @@ layer at (0,0) size 800x106
   RenderBlock {HTML} at (0,0) size 800x106
     RenderBody {BODY} at (8,8) size 784x90
       RenderBlock {FORM} at (0,0) size 784x36
-        RenderButton {INPUT} at (0,0) size 254x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 254x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 238x13
             RenderText at (0,0) size 238x13
               text run at (0,0) width 238: "[Step 1] Set cell width to 60px (nothing seen)"
-        RenderButton {INPUT} at (0,18) size 259x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,18) size 259x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 243x13
             RenderText at (0,0) size 243x13
               text run at (0,0) width 243: "[Step 2] Set cell width to 20px (garbage seen)"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug52506-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug52506-expected.txt
@@ -4,11 +4,11 @@ layer at (0,0) size 800x114
   RenderBlock {HTML} at (0,0) size 800x114
     RenderBody {BODY} at (8,8) size 784x98
       RenderBlock {FORM} at (0,0) size 784x36
-        RenderButton {INPUT} at (0,0) size 179x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,0) size 179x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 163x13
             RenderText at (0,0) size 163x13
               text run at (0,0) width 163: "[Step 1] Set cell height to 60px"
-        RenderButton {INPUT} at (0,18) size 180x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,18) size 180x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 164x13
             RenderText at (0,0) size 164x13
               text run at (0,0) width 164: "[Step 2] Set cell height to 20px"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug60749-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug60749-expected.txt
@@ -13,13 +13,13 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 107x18
                 text run at (2,2) width 107: "   InspectionText"
       RenderBlock {FORM} at (0,28) size 784x19
-        RenderButton {INPUT} at (0,1) size 87x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,1) size 87x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 71x13
             RenderText at (0,0) size 71x13
               text run at (0,0) width 71: "change width"
         RenderText {#text} at (86,0) size 5x18
           text run at (86,0) width 5: " "
-        RenderButton {INPUT} at (90,1) size 177x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (90,1) size 177x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 161x13
             RenderText at (0,0) size 161x13
               text run at (0,0) width 161: "change width with table reflow"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug7342-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug7342-expected.txt
@@ -58,7 +58,7 @@ layer at (0,0) size 800x600
                             RenderText {#text} at (0,0) size 0x0
                           RenderText {#text} at (0,0) size 0x0
                         RenderTableCell {TD} at (356,4) size 96x28 [border: (1px inset #808080)] [r=0 c=3 rs=1 cs=1]
-                          RenderButton {INPUT} at (5,5) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                          RenderButton {INPUT} at (5,5) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                             RenderBlock (anonymous) at (8,2) size 37x13
                               RenderText at (0,0) size 37x13
                                 text run at (0,0) width 37: "Search"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug92647-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug92647-2-expected.txt
@@ -12,5 +12,5 @@ layer at (0,0) size 800x600
                   RenderTableRow {TR} at (0,2) size 36x22
                     RenderTableCell {TD} at (2,11) size 4x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                     RenderTableCell {TD} at (8,2) size 20x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-                      RenderButton {INPUT} at (2,2) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                      RenderButton {INPUT} at (2,2) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                     RenderTableCell {TD} at (30,11) size 4x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
@@ -29,13 +29,13 @@ layer at (0,0) size 800x600
                   RenderText {#text} at (4,4) size 60x18
                     text run at (4,4) width 60: "6:00 a.m."
           RenderBlock {P} at (0,96) size 704x19
-            RenderButton {INPUT} at (289,1) size 63x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderButton {INPUT} at (289,1) size 63x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,2) size 46x13
                 RenderText at (0,0) size 46x13
                   text run at (0,0) width 46: "separate"
             RenderText {#text} at (351,0) size 5x18
               text run at (351,0) width 5: " "
-            RenderButton {INPUT} at (355,1) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderButton {INPUT} at (355,1) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
               RenderBlock (anonymous) at (8,2) size 44x13
                 RenderText at (0,0) size 44x13
                   text run at (0,0) width 44: "collapse"

--- a/LayoutTests/platform/mac/tables/mozilla/dom/tableDom-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/dom/tableDom-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (532,0) size 43x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (574,0) size 21x18
           text run at (574,0) width 21: "     "
-        RenderButton {INPUT} at (594,1) size 42x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (594,1) size 42x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "Do It"

--- a/LayoutTests/platform/mac/tables/mozilla/other/move_row-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/other/move_row-expected.txt
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (18,0) size 14x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (32,0) size 4x18
           text run at (32,0) width 4: " "
-        RenderButton {INPUT} at (36,1) size 30x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (36,1) size 30x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 14x13
             RenderText at (0,0) size 14x13
               text run at (0,0) width 14: "go"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
                 RenderTableSection {TBODY} at (0,0) size 440x24
                   RenderTableRow {TR} at (0,2) size 440x20
                     RenderTableCell {TD} at (2,2) size 217x20 [r=0 c=0 rs=1 cs=1]
-                      RenderButton {INPUT} at (1,1) size 95x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                      RenderButton {INPUT} at (1,1) size 95x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                         RenderBlock (anonymous) at (8,2) size 79x13
                           RenderText at (0,0) size 79x13
                             text run at (0,0) width 79: "Submit Criteria"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -149,7 +149,7 @@ layer at (8,8) size 769x1428
                   RenderTextControl {INPUT} at (71,37) size 148x19 [color=#000000] [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (218,37) size 5x18
                   text run at (218,37) width 5: " "
-                RenderButton {INPUT} at (222,38) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (222,38) size 54x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                   RenderBlock (anonymous) at (8,2) size 37x13
                     RenderText at (0,0) size 37x13
                       text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
@@ -33,13 +33,13 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,2) size 37x18
                 text run at (2,2) width 37: "row 3"
       RenderBlock (anonymous) at (0,240) size 784x19
-        RenderButton {INPUT} at (0,1) size 55x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,1) size 55x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 39x13
             RenderText at (0,0) size 39x13
               text run at (0,0) width 39: "expand"
         RenderText {#text} at (54,0) size 5x18
           text run at (54,0) width 5: " "
-        RenderButton {INPUT} at (58,1) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (58,1) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 27x13
             RenderText at (0,0) size 27x13
               text run at (0,0) width 27: "sizes"

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -373,7 +373,7 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
         auto& input = downcast<HTMLInputElement>(element.get());
 
         if (input.isTextButton() || input.isUploadButton())
-            return StyleAppearance::PushButton;
+            return StyleAppearance::Button;
 
         if (input.isCheckbox())
             return StyleAppearance::Checkbox;


### PR DESCRIPTION
#### 1a0105921defca0770820813cdec1e805036c441
<pre>
[Forms] Use button instead of push-button appearance for input[type=submit|reset|button]
<a href="https://bugs.webkit.org/show_bug.cgi?id=238803">https://bugs.webkit.org/show_bug.cgi?id=238803</a>
rdar://91624840

Reviewed by Aditya Keerthi.

- Fixes bug reported by GOV.UK about font-size not applying on input[type=file]: <a href="https://bugs.webkit.org/show_bug.cgi?id=224746">https://bugs.webkit.org/show_bug.cgi?id=224746</a>
- Fixes input[type=button|reset|submit] not supporting multi-line values: <a href="https://bugs.webkit.org/show_bug.cgi?id=190521">https://bugs.webkit.org/show_bug.cgi?id=190521</a>
- Fixes input[type=button|reset|submit] not honoring font-size/padding/height/etc. properly like other browsers

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):

Use StyleAppearance::Button instead of StyleAppearance::PushButton

* LayoutTests/fast/css/button-height-expected.txt:
* LayoutTests/fast/css/button-height.html:

Adjust test now that input[type=button] honors height on macOS.

* LayoutTests/platform/ios/css2.1/20110323/replaced-elements-001-expected.txt:
* LayoutTests/platform/ios/css3/flexbox/flexitem-expected.txt:
* LayoutTests/platform/ios/fast/forms/button-style-color-expected.txt:
* LayoutTests/platform/mac-bigsur/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/mac-bigsur/fast/forms/button-sizes-expected.txt:
* LayoutTests/platform/mac-bigsur/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug26178-expected.txt:
* LayoutTests/platform/mac-monterey/fast/forms/button-sizes-expected.txt:
* LayoutTests/platform/mac-ventura/fast/forms/button-sizes-expected.txt:
* LayoutTests/platform/mac-ventura/fast/forms/input-button-sizes-expected.txt: Added.
* LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/custom/foreign-object-skew-expected.txt:
* LayoutTests/platform/mac/css3/flexbox/button-expected.txt:
* LayoutTests/platform/mac/editing/selection/3690703-2-expected.txt:
* LayoutTests/platform/mac/editing/selection/3690703-expected.txt:
* LayoutTests/platform/mac/editing/selection/3690719-expected.txt:
* LayoutTests/platform/mac/editing/selection/4397952-expected.txt:
* LayoutTests/platform/mac/editing/selection/5240265-expected.txt:
* LayoutTests/platform/mac/editing/selection/selection-button-text-expected.txt:
* LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt:
* LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/mac/fast/css/input-search-padding-expected.txt:
* LayoutTests/platform/mac/fast/css/margin-top-bottom-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/css/rtl-ordering-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt:
* LayoutTests/platform/mac/fast/forms/001-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-buttons-expected.txt:
* LayoutTests/platform/mac/fast/forms/blankbuttons-expected.txt:
* LayoutTests/platform/mac/fast/forms/box-shadow-override-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-positioned-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-style-color-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-table-styles-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-text-transform-expected.txt:
* LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/file/file-input-direction-expected.txt:
* LayoutTests/platform/mac/fast/forms/file/file-input-disabled-expected.txt:
* LayoutTests/platform/mac/fast/forms/file/input-file-re-render-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt:
* LayoutTests/platform/mac/fast/forms/formmove3-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-button-sizes-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-value-expected.txt:
* LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt:
* LayoutTests/platform/mac/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/mac/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/mac/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt:
* LayoutTests/platform/mac/fast/overflow/scrollRevealButton-expected.txt:
* LayoutTests/platform/mac/fast/replaced/replaced-breaking-expected.txt:
* LayoutTests/platform/mac/fast/replaced/width100percent-button-expected.txt:
* LayoutTests/platform/mac/fast/text/international/hindi-spacing-expected.txt:
* LayoutTests/platform/mac/fast/text/textIteratorNilRenderer-expected.txt:
* LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt:
* LayoutTests/platform/mac/svg/custom/foreign-object-skew-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug1188-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug138725-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug18359-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug26178-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug28928-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug33855-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug39209-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug4429-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug46368-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug46368-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug51037-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug51727-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug52505-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug52506-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug60749-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug7342-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug92647-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/collapsing_borders/bug41262-4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/dom/tableDom-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/other/move_row-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt:

Rebaseline a bunch of tests.

Canonical link: <a href="https://commits.webkit.org/258754@main">https://commits.webkit.org/258754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e46ed4894e74b16706c05c78dca2cedfae49f55a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11966 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35874 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112102 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172322 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2875 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109772 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108622 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35874 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37610 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35874 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5419 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35874 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2573 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11586 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35874 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6017 "Failed to push to pull request branch") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7312 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3201 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->