### PR TITLE
Add logs to AutoplayOnVisibilityChange API test timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -873,14 +873,18 @@ TEST(WebKit, AutoplayOnVisibilityChange)
     auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
+    NSLog(@"AutoplayOnVisibilityChange 1\n");
+
     [webView loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
 
+    NSLog(@"AutoplayOnVisibilityChange 2\n");
     done = false;
     auto *hostWindow = [webView hostWindow];
     [hostWindow miniaturize:hostWindow];
     TestWebKitAPI::Util::run(&done);
 
+    NSLog(@"AutoplayOnVisibilityChange 3\n");
     done = false;
     [webView stringByEvaluatingJavaScript:@"capture()"];
     TestWebKitAPI::Util::run(&done);
@@ -888,18 +892,22 @@ TEST(WebKit, AutoplayOnVisibilityChange)
     bool hasSleepDisabler = [webView stringByEvaluatingJavaScript:@"hasSleepDisabler()"].boolValue;
     EXPECT_TRUE(hasSleepDisabler);
 
+    NSLog(@"AutoplayOnVisibilityChange 4\n");
     done = false;
     [hostWindow deminiaturize:hostWindow];
     TestWebKitAPI::Util::run(&done);
 
+    NSLog(@"AutoplayOnVisibilityChange 5\n");
     done = false;
     [webView stringByEvaluatingJavaScript:@"doTest()"];
     TestWebKitAPI::Util::run(&done);
 
+    NSLog(@"AutoplayOnVisibilityChange 6\n");
     done = false;
     [webView stringByEvaluatingJavaScript:@"stop()"];
     TestWebKitAPI::Util::run(&done);
 
+    NSLog(@"AutoplayOnVisibilityChange 7\n");
     hasSleepDisabler = [webView stringByEvaluatingJavaScript:@"hasSleepDisabler()"].boolValue;
     EXPECT_FALSE(hasSleepDisabler);
 }


### PR DESCRIPTION
#### 11366581a6338593ce70d31d8cf7575ac51f4900
<pre>
Add logs to AutoplayOnVisibilityChange API test timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=250368">https://bugs.webkit.org/show_bug.cgi?id=250368</a>
rdar://problem/104066597

Reviewed by Jean-Yves Avenard.

AutoplayOnVisibilityChange is timing out for unobvious reasons on some bots.
Add logging to identify where it actually times out.

* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:

Canonical link: <a href="https://commits.webkit.org/258718@main">https://commits.webkit.org/258718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2c713f35b5931cf5dfe94f13b9eea53ca8a3f7c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112020 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172246 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2793 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109700 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108538 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24624 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5489 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2492 "Found 1 new test failure: webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-3d-rgb8-rgb-unsigned_byte.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45533 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5991 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7231 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->