### PR TITLE
[WPE][GTK] WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD is gone, but still required

### DIFF
--- a/Source/WebKit/Shared/API/APIError.cpp
+++ b/Source/WebKit/Shared/API/APIError.cpp
@@ -60,7 +60,11 @@ const WTF::String& Error::webKitPolicyErrorDomain()
 const WTF::String& Error::webKitPluginErrorDomain()
 {
 #if USE(GLIB)
+#if ENABLE(2022_GLIB_API)
+    static NeverDestroyed<WTF::String> webKitErrorDomainString(MAKE_STATIC_STRING_IMPL("WebKitMediaError"));
+#else
     static NeverDestroyed<WTF::String> webKitErrorDomainString(MAKE_STATIC_STRING_IMPL("WebKitPluginError"));
+#endif
     return webKitErrorDomainString;
 #else
     return webKitErrorDomain();

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.cpp
@@ -120,3 +120,16 @@ GQuark webkit_snapshot_error_quark()
  * Returns: user content filter error domain.
  */
 G_DEFINE_QUARK(WebKitUserContentFilterError, webkit_user_content_filter_error)
+
+#if ENABLE(2022_GLIB_API)
+/**
+ * webkit_media_error_quark:
+ *
+ * Gets the quark for the domain of media errors.
+ *
+ * Returns: media error domin.
+ *
+ * Since: 2.40
+ */
+G_DEFINE_QUARK(WebKitMediaError, webkit_media_error)
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
@@ -41,6 +41,10 @@ G_BEGIN_DECLS
 #define WEBKIT_PRINT_ERROR               webkit_print_error_quark ()
 #endif
 
+#if ENABLE(2022_GLIB_API)
+#define WEBKIT_MEDIA_ERROR               webkit_media_error_quark ()
+#endif
+
 /**
  * WebKitNetworkError:
  * @WEBKIT_NETWORK_ERROR_FAILED: Generic load failure
@@ -163,6 +167,20 @@ typedef enum {
     WEBKIT_USER_CONTENT_FILTER_ERROR_NOT_FOUND,
 } WebKitUserContentFilterError;
 
+#if ENABLE(2022_GLIB_API)
+/**
+ * WebKitMediaError:
+ * @WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD: Preliminary load failure for media content types. A new load will be started to perform the media load. Since: 2.40
+ *
+ * Enum values used to denote the various media errors.
+ *
+ * Since: 2.40
+ */
+typedef enum {
+    WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD = 204
+} WebKitMediaError;
+#endif
+
 WEBKIT_API GQuark
 webkit_network_error_quark             (void);
 
@@ -190,6 +208,11 @@ webkit_snapshot_error_quark            (void);
 
 WEBKIT_API GQuark
 webkit_user_content_filter_error_quark (void);
+
+#if ENABLE(2022_GLIB_API)
+WEBKIT_API GQuark
+webkit_media_error_quark               (void);
+#endif
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
@@ -123,7 +123,11 @@ unsigned toWebKitError(unsigned webCoreError)
         return WEBKIT_PLUGIN_ERROR_JAVA_UNAVAILABLE;
     case API::Error::Plugin::PlugInCancelledConnection:
         return WEBKIT_PLUGIN_ERROR_CONNECTION_CANCELLED;
+#endif
     case API::Error::Plugin::PlugInWillHandleLoad:
+#if ENABLE(2022_GLIB_API)
+        return WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD;
+#else
         return WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD;
 #endif
     case API::Error::Download::Transport:
@@ -170,9 +174,13 @@ unsigned toWebCoreError(unsigned webKitError)
         return API::Error::Plugin::JavaUnavailable;
     case WEBKIT_PLUGIN_ERROR_CONNECTION_CANCELLED:
         return API::Error::Plugin::PlugInCancelledConnection;
-    case WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD:
-        return API::Error::Plugin::PlugInWillHandleLoad;
 #endif
+#if ENABLE(2022_GLIB_API)
+    case WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD:
+#else
+    case WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD:
+#endif
+        return API::Error::Plugin::PlugInWillHandleLoad;
     case WEBKIT_DOWNLOAD_ERROR_NETWORK:
         return API::Error::Download::Transport;
     case WEBKIT_DOWNLOAD_ERROR_CANCELLED_BY_USER:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -506,7 +506,9 @@ WebKitWebResourceLoadManager* WebKitWebViewClient::webResourceLoadManager()
 static gboolean webkitWebViewLoadFail(WebKitWebView* webView, WebKitLoadEvent, const char* failingURI, GError* error)
 {
     if (g_error_matches(error, WEBKIT_NETWORK_ERROR, WEBKIT_NETWORK_ERROR_CANCELLED)
-#if !ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
+        || g_error_matches(error, WEBKIT_MEDIA_ERROR, WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD)
+#else
         || g_error_matches(error, WEBKIT_PLUGIN_ERROR, WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD)
 #endif
         || g_error_matches(error, WEBKIT_POLICY_ERROR, WEBKIT_POLICY_ERROR_FRAME_LOAD_INTERRUPTED_BY_POLICY_CHANGE))


### PR DESCRIPTION
#### cb508f4d82bfa3073355278c7c0a08cc89256468
<pre>
[WPE][GTK] WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD is gone, but still required
<a href="https://bugs.webkit.org/show_bug.cgi?id=250023">https://bugs.webkit.org/show_bug.cgi?id=250023</a>

Reviewed by Michael Catanzaro.

Add new error domain WebKitMediaError and code WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD.

* Source/WebKit/Shared/API/APIError.cpp:
(API::Error::webKitPluginErrorDomain):
* Source/WebKit/UIProcess/API/glib/WebKitError.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitError.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp:
(toWebKitError):
(toWebCoreError):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewLoadFail):

Canonical link: <a href="https://commits.webkit.org/258772@main">https://commits.webkit.org/258772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d95a1438dcbe6ef4b7f2f735ba5b72b697b4965

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112027 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2800 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109707 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37550 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91753 "Found 1 new API test failure: TestIPC.StreamConnectionTest.SendAsyncReplyMessage (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26052 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2499 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45544 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7238 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3210 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->