### PR TITLE
Resync web-platform-tests/custom-elements

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/custom-elements/reactions/HTMLInputElement-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/custom-elements/reactions/HTMLInputElement-expected.txt
@@ -1,5 +1,0 @@
-CONSOLE MESSAGE: TypeError: The HTMLInputElement.capture getter can only be used on instances of HTMLInputElement
-
-Harness Error (FAIL), message = TypeError: The HTMLInputElement.capture getter can only be used on instances of HTMLInputElement
-
-

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/HTMLInputElement-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/HTMLInputElement-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL capture on HTMLInputElement must enqueue an attributeChanged reaction when adding new attribute assert_array_equals: lengths differ, expected array ["constructed"] length 1, got [] length 0
+FAIL capture on HTMLInputElement must enqueue an attributeChanged reaction when replacing an existing attribute assert_array_equals: lengths differ, expected array ["constructed", "attributeChanged"] length 2, got [] length 0
+FAIL capture on HTMLInputElement must enqueue an attributeChanged reaction when adding invalid value default assert_array_equals: lengths differ, expected array ["constructed"] length 1, got [] length 0
+FAIL capture on HTMLInputElement must enqueue an attributeChanged reaction when removing the attribute assert_array_equals: lengths differ, expected array ["constructed", "attributeChanged"] length 2, got [] length 0
+


### PR DESCRIPTION
#### faaa5c24afb07fd69d7a78d4518446e306faaaf1
<pre>
Resync web-platform-tests/custom-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=250362">https://bugs.webkit.org/show_bug.cgi?id=250362</a>

Unreviewed. Rebaseline for iOS.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/custom-elements/reactions/HTMLInputElement-expected.txt: Removed.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/HTMLInputElement-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/258713@main">https://commits.webkit.org/258713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12ef2bdc9a798cb30f3007fffe0cc53496e7ce29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11897 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/35804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12910 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108552 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/35804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/35804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/35804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/5502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/35804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7244 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3182 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->