### PR TITLE
[@property][TypedOM] Reify custom property values with syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Properties declared with @property reify correctly assert_equals: expected " 100px" but got "100px"
-FAIL Re-declaring a property with a different type affects reification assert_equals: expected "CSSUnitValue" but got "CSSUnparsedValue"
+FAIL Re-declaring a property with a different type affects reification assert_equals: expected "number" but got "px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -1,24 +1,24 @@
 
 PASS Computed * is reified as CSSUnparsedValue
-FAIL Computed <angle> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <color> is reified as CSSStyleValue assert_false: expected false got true
-FAIL Computed <custom-ident> is reified as CSSKeywordValue assert_false: expected false got true
+PASS Computed <angle> is reified as CSSUnitValue
+PASS Computed <color> is reified as CSSStyleValue
+PASS Computed <custom-ident> is reified as CSSKeywordValue
 FAIL Computed <image> [url] is reified as CSSImageValue assert_false: expected false got true
-FAIL Computed <integer> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <length-percentage> [%] is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <length-percentage> [px] is reified as CSSUnitValue assert_false: expected false got true
+PASS Computed <integer> is reified as CSSUnitValue
+PASS Computed <length-percentage> [%] is reified as CSSUnitValue
+PASS Computed <length-percentage> [px] is reified as CSSUnitValue
 FAIL Computed <length-percentage> [px + %] is reified as CSSMathSum assert_false: expected false got true
-FAIL Computed <length> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <number> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <percentage> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <resolution> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <time> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <url> is reified as CSSStyleValue assert_false: expected false got true
-FAIL Computed ident is reified as CSSKeywordValue assert_false: expected false got true
-FAIL First computed value correctly reified in space-separated list assert_false: expected false got true
-FAIL First computed value correctly reified in comma-separated list assert_false: expected false got true
-FAIL All computed values correctly reified in space-separated list assert_equals: expected 2 but got 1
-FAIL All computed values correctly reified in comma-separated list assert_equals: expected 2 but got 1
+PASS Computed <length> is reified as CSSUnitValue
+PASS Computed <number> is reified as CSSUnitValue
+PASS Computed <percentage> is reified as CSSUnitValue
+PASS Computed <resolution> is reified as CSSUnitValue
+PASS Computed <time> is reified as CSSUnitValue
+PASS Computed <url> is reified as CSSStyleValue
+PASS Computed ident is reified as CSSKeywordValue
+PASS First computed value correctly reified in space-separated list
+PASS First computed value correctly reified in comma-separated list
+PASS All computed values correctly reified in space-separated list
+PASS All computed values correctly reified in comma-separated list
 PASS Specified * is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified * is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified foo is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSCustomPropertyValue.h"
 #include "CSSImageValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSStyleValue.h"
@@ -47,6 +48,8 @@ public:
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
     static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(const String&);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
+
+    static RefPtr<CSSStyleValue> constructStyleValueForCustomPropertySyntaxValue(const CSSCustomPropertyValue::SyntaxValue&);
 
 protected:
     CSSStyleValueFactory() = delete;


### PR DESCRIPTION
#### 33ede35610f8b0cc50cccd446a1f72384d04beaa
<pre>
[@property][TypedOM] Reify custom property values with syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=250375">https://bugs.webkit.org/show_bug.cgi?id=250375</a>
rdar://104068961

Reviewed by Chris Dumez.

<a href="https://drafts.css-houdini.org/css-properties-values-api/#css-style-value-reification">https://drafts.css-houdini.org/css-properties-values-api/#css-style-value-reification</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):

Reify single values.

(WebCore::CSSStyleValueFactory::constructStyleValueForCustomPropertySyntaxValue):

Add a helper.

* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
(WebCore::StylePropertyMapReadOnly::reifyValueToVector):

Reify list values.

Canonical link: <a href="https://commits.webkit.org/258729@main">https://commits.webkit.org/258729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a03931de031f400aeb676c8c52471b111a0ffe11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112039 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172262 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2810 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109716 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9914 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24638 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26055 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2510 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45547 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5996 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7248 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->