### PR TITLE
Rebaseline(255215@main): [ macOS arm64 ] 2X imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any(Layout tests) are constant failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -350,6 +350,7 @@ promise_test(async t => {
 
   let errors = 0;
   callbacks.error = e => errors++;
+  callbacks.output = frame => { frame.close(); };
 
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -489,6 +490,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const callbacks = {};
+  callbacks.output = frame => { frame.close(); };
   const decoder = createVideoDecoder(t, callbacks);
 
   // No decodes yet.


### PR DESCRIPTION
#### 639fff79325da94959bfad4e2855a3327e0e9206
<pre>
Rebaseline(255215@main): [ macOS arm64 ] 2X imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any(Layout tests) are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=246278">https://bugs.webkit.org/show_bug.cgi?id=246278</a>
rdar://problem/100981592

Reviewed by Eric Carlson.

Make sure to close explicitly VideoFrame to not trigger console warnings.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js:

Canonical link: <a href="https://commits.webkit.org/258834@main">https://commits.webkit.org/258834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944ac79478c5f9e53534bd3a2862264e5718c6f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112045 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172268 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2816 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109722 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37565 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91772 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24649 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79304 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; 4 api tests failed or timed out; 3 api tests failed or timed out; Reverted pull request changes; Updated gtk dependencies; Compiled WebKit (warnings); run-api-tests-without-change (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2514 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6076 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7254 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->