### PR TITLE
REGRESSION (257171@main): Static media query inside a dynamic media query breaks dynamic evaluation

### DIFF
--- a/LayoutTests/fast/media/mq-nested-non-dynamic-expected.html
+++ b/LayoutTests/fast/media/mq-nested-non-dynamic-expected.html
@@ -1,0 +1,8 @@
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<div></div>

--- a/LayoutTests/fast/media/mq-nested-non-dynamic.html
+++ b/LayoutTests/fast/media/mq-nested-non-dynamic.html
@@ -1,0 +1,12 @@
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+@media screen and (max-width: 10px) {
+    @media screen { }
+    div { background: red; }
+}
+</style>
+<div></div>

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -443,7 +443,7 @@ bool RuleSetBuilder::MediaQueryCollector::pushAndEvaluate(const MQ::MediaQueryLi
 
 void RuleSetBuilder::MediaQueryCollector::pop(const MQ::MediaQueryList& mediaQueries)
 {
-    if (mediaQueries.isEmpty() || dynamicContextStack.isEmpty())
+    if (dynamicContextStack.isEmpty() || &dynamicContextStack.last().queries != &mediaQueries)
         return;
 
     if (!dynamicContextStack.last().affectedRulePositions.isEmpty() || !collectDynamic) {


### PR DESCRIPTION
#### 3e90af4d3b3416f94d82753d2443692300907865
<pre>
REGRESSION (257171@main): Static media query inside a dynamic media query breaks dynamic evaluation
<a href="https://bugs.webkit.org/show_bug.cgi?id=250293">https://bugs.webkit.org/show_bug.cgi?id=250293</a>
rdar://103732686

Reviewed by Simon Fraser.

Dynamic queries end up always matching.

* LayoutTests/fast/media/mq-nested-non-dynamic-expected.html: Added.
* LayoutTests/fast/media/mq-nested-non-dynamic.html: Added.
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::MediaQueryCollector::pop):

Take care we don&apos;t pop a wrong stack frame. Static queries don&apos;t add to the stack.

Canonical link: <a href="https://commits.webkit.org/258732@main">https://commits.webkit.org/258732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a295865724246f5c23c9b014ef9d661e9eca585

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112049 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172271 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2821 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109725 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108566 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24655 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2519 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5997 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7258 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->