### PR TITLE
Don't attempt to de-reference node in createSliderTrackPartForRenderer

### DIFF
--- a/LayoutTests/fast/forms/slider-appearance-on-pseudo-element-expected.txt
+++ b/LayoutTests/fast/forms/slider-appearance-on-pseudo-element-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/forms/slider-appearance-on-pseudo-element.html
+++ b/LayoutTests/fast/forms/slider-appearance-on-pseudo-element.html
@@ -1,0 +1,18 @@
+<style>
+    dialog::backdrop {
+        content: "";
+        display: inline-block;
+        appearance: slider-vertical;
+        width: 16px;
+        height: 100px;
+    }
+</style>
+<body>
+    <dialog id="dialog"></dialog>
+    <p>This test passes if it does not crash.</p>
+    <script>
+        dialog.showModal();
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+</body>

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -507,11 +507,8 @@ static RefPtr<ControlPart> createSliderTrackPartForRenderer(const RenderObject& 
     if (type != StyleAppearance::SliderHorizontal && type != StyleAppearance::SliderVertical)
         return nullptr;
 
-    auto* input = dynamicDowncast<HTMLInputElement>(*renderer.node());
-    if (!input)
-        return nullptr;
-
-    if (!input->isRangeControl())
+    auto* input = dynamicDowncast<HTMLInputElement>(renderer.node());
+    if (!input || !input->isRangeControl())
         return nullptr;
 
     IntSize thumbSize;
@@ -523,10 +520,10 @@ static RefPtr<ControlPart> createSliderTrackPartForRenderer(const RenderObject& 
     IntRect trackBounds;
     if (const auto* trackRenderer = input->sliderTrackElement()->renderer()) {
         trackBounds = trackRenderer->absoluteBoundingBoxRectIgnoringTransforms();
-        
+
         // We can ignoring transforms because transform is handled by the graphics context.
         auto sliderBounds = renderer.absoluteBoundingBoxRectIgnoringTransforms();
-        
+
         // Make position relative to the transformed ancestor element.
         trackBounds.moveBy(-sliderBounds.location());
     }


### PR DESCRIPTION
#### fc1f99b860a5e09e532fb557a0fa4857531e35a1
<pre>
Don&apos;t attempt to de-reference node in createSliderTrackPartForRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=250378">https://bugs.webkit.org/show_bug.cgi?id=250378</a>
rdar://104072805

Reviewed by Aditya Keerthi.

The node may be null in case the renderer is associated to some pseudo-elements.

Happens on all pseudo-elements that support appearance (excludes ::marker), and that are not
backed by PseudoElement (excludes ::before/::after). So ::backdrop or ::-webkit-scrollbar both have null nodes.

The dereferencing is pretty unnecessary here, since dynamicDowncast returns a pointer anyway.

* LayoutTests/fast/forms/slider-appearance-on-pseudo-element-expected.txt: Added.
* LayoutTests/fast/forms/slider-appearance-on-pseudo-element.html: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::createSliderTrackPartForRenderer):

Canonical link: <a href="https://commits.webkit.org/258739@main">https://commits.webkit.org/258739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82eface85aee4a56529ccfafa5f86a50f372aff0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112051 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172273 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2823 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109727 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37569 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24652 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2521 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45561 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7260 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3192 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->