### PR TITLE
REGRESSION(258484@main): StreamClientConnection sends destination id in wrong format

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -110,7 +110,7 @@ private:
     bool trySendStream(Span&, T& message, AdditionalData&&...);
     template<typename T>
     std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, Span&);
-    bool trySendDestinationIDIfNeeded(UInt128 destinationID, Timeout);
+    bool trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
     void sendProcessOutOfStreamMessage(Span&&);
 
     std::optional<Span> tryAcquire(Timeout);
@@ -151,7 +151,7 @@ private:
         Connection::Client& m_receiver;
     };
     std::optional<DedicatedConnectionClient> m_dedicatedConnectionClient;
-    UInt128 m_currentDestinationID { 0 };
+    uint64_t m_currentDestinationID { 0 };
     size_t m_clientOffset { 0 };
     StreamConnectionBuffer m_buffer;
     struct Semaphores {
@@ -300,7 +300,7 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
     return result;
 }
 
-inline bool StreamClientConnection::trySendDestinationIDIfNeeded(UInt128 destinationID, Timeout timeout)
+inline bool StreamClientConnection::trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout timeout)
 {
     if (destinationID == m_currentDestinationID)
         return true;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -86,7 +86,7 @@ void StreamServerConnection::invalidate()
     m_connection->invalidate();
 }
 
-void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& receiver, ReceiverName receiverName, UInt128 destinationID)
+void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& receiver, ReceiverName receiverName, uint64_t destinationID)
 {
     {
         auto key = std::make_pair(static_cast<uint8_t>(receiverName), destinationID);
@@ -97,7 +97,7 @@ void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& recei
     m_workQueue.addStreamConnection(*this);
 }
 
-void StreamServerConnection::stopReceivingMessages(ReceiverName receiverName, UInt128 destinationID)
+void StreamServerConnection::stopReceivingMessages(ReceiverName receiverName, uint64_t destinationID)
 {
     m_workQueue.removeStreamConnection(*this);
 
@@ -254,7 +254,7 @@ StreamServerConnection::DispatchResult StreamServerConnection::dispatchStreamMes
 
 bool StreamServerConnection::processSetStreamDestinationID(Decoder&& decoder, RefPtr<StreamMessageReceiver>& currentReceiver)
 {
-    UInt128 destinationID = 0;
+    uint64_t destinationID = 0;
     if (!decoder.decode(destinationID)) {
         m_connection->dispatchDidReceiveInvalidMessage(decoder.messageName());
         return false;
@@ -298,7 +298,7 @@ bool StreamServerConnection::dispatchOutOfStreamMessage(Decoder&& decoder)
 
     RefPtr<StreamMessageReceiver> receiver;
     {
-        auto key = std::make_pair(static_cast<uint8_t>(message->messageReceiverName()), message->destinationID());
+        auto key = std::make_pair(static_cast<uint8_t>(message->messageReceiverName()), static_cast<uint64_t>(message->destinationID()));
         Locker locker { m_receiversLock };
         receiver = m_receivers.get(key);
     }

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -64,9 +64,9 @@ public:
     static Ref<StreamServerConnection> create(Handle&&, StreamConnectionWorkQueue&);
     ~StreamServerConnection() final;
 
-    void startReceivingMessages(StreamMessageReceiver&, ReceiverName, UInt128 destinationID);
+    void startReceivingMessages(StreamMessageReceiver&, ReceiverName, uint64_t destinationID);
     // Stops the message receipt. Note: already received messages might still be delivered.
-    void stopReceivingMessages(ReceiverName, UInt128 destinationID);
+    void stopReceivingMessages(ReceiverName, uint64_t destinationID);
 
     Connection& connection() { return m_connection; }
 
@@ -132,9 +132,9 @@ private:
 
     bool m_isDispatchingStreamMessage { false };
     Lock m_receiversLock;
-    using ReceiversMap = HashMap<std::pair<uint8_t, UInt128>, Ref<StreamMessageReceiver>>;
+    using ReceiversMap = HashMap<std::pair<uint8_t, uint64_t>, Ref<StreamMessageReceiver>>;
     ReceiversMap m_receivers WTF_GUARDED_BY_LOCK(m_receiversLock);
-    UInt128 m_currentDestinationID { 0 };
+    uint64_t m_currentDestinationID { 0 };
 
     friend class StreamConnectionWorkQueue;
 };

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -207,7 +207,7 @@ private:
     static void initialize(JSContextRef, JSObjectRef);
     static void finalize(JSObjectRef);
 
-    static bool prepareToSendOutOfStreamMessage(JSContextRef, size_t argumentCount, const JSValueRef arguments[], JSIPC&, IPC::StreamClientConnection&, IPC::Encoder&, UInt128 destinationID, IPC::Timeout, JSValueRef* exception);
+    static bool prepareToSendOutOfStreamMessage(JSContextRef, size_t argumentCount, const JSValueRef arguments[], JSIPC&, IPC::StreamClientConnection&, IPC::Encoder&, uint64_t destinationID, IPC::Timeout, JSValueRef* exception);
 
     static const JSStaticFunction* staticFunctions();
     static JSValueRef open(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
@@ -501,7 +501,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 namespace {
 
 struct SyncIPCMessageInfo {
-    UInt128 destinationID;
+    uint64_t destinationID; // FIXME: real IPC destinationID is at the moment UInt128, but we cannot decode that from JS.
     IPC::MessageName messageName;
     IPC::Timeout timeout;
 };
@@ -986,7 +986,7 @@ JSValueRef JSIPCStreamClientConnection::setSemaphores(JSContextRef context, JSOb
 }
 
 struct IPCStreamMessageInfo {
-    UInt128 destinationID;
+    uint64_t destinationID;
     IPC::MessageName messageName;
     IPC::Timeout timeout;
 };
@@ -1020,7 +1020,7 @@ static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContext
     return { { *destinationID, static_cast<IPC::MessageName>(*messageID), { timeoutDuration } } };
 }
 
-bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSIPC& jsIPC, IPC::StreamClientConnection& streamConnection, IPC::Encoder& encoder, UInt128 destinationID, IPC::Timeout timeout, JSValueRef* exception)
+bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSIPC& jsIPC, IPC::StreamClientConnection& streamConnection, IPC::Encoder& encoder, uint64_t destinationID, IPC::Timeout timeout, JSValueRef* exception)
 {
     // FIXME: Add support for sending in-stream IPC messages when appropriate.
     if (argumentCount > 3) {


### PR DESCRIPTION
#### ce70a7f574fc549c68b2024f0980f1a1f5878646
<pre>
REGRESSION(258484@main): StreamClientConnection sends destination id in wrong format
<a href="https://bugs.webkit.org/show_bug.cgi?id=250386">https://bugs.webkit.org/show_bug.cgi?id=250386</a>
rdar://104076868

Reviewed by Alex Christensen.

258484@main would change the IPC message destination ID to UInt128.
The commit changed also stream IPC destinations as UInt128.

Stream{Client,Server}Connection public API has only ObjectIdentifier&lt;T&gt; instances
as the destination ID. These are uint64_t. Thus sending UInt128 when the
input is only uint64_t is redundant.

Revert back to uint64_t. The stream IPC memory format expects certain layout and alignment
for messages and their fields. The UInt128 change didn&apos;t contain these.

It is better to make the 128 bit change in isolation, should the need arise. Given
that 64 bits is relatively big id space, try to preserve the perf benefit of using
this smaller space until needed.

* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::startReceivingMessages):
(IPC::StreamServerConnection::stopReceivingMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage):

Canonical link: <a href="https://commits.webkit.org/258782@main">https://commits.webkit.org/258782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec77d5433f95dcfcaf8b54743bb88d456f5631f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112170 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2944 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109825 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108692 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37664 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24757 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5480 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26170 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2618 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45665 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6038 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7380 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->