### PR TITLE
REGRESSION(253727@main): [ macOS wk2 ] inspector/css/setLayoutContextTypeChangedMode.html is a flaky failure

### DIFF
--- a/LayoutTests/inspector/css/setLayoutContextTypeChangedMode.html
+++ b/LayoutTests/inspector/css/setLayoutContextTypeChangedMode.html
@@ -27,6 +27,19 @@ function test()
         return Array.from(WI.domManager.attachedNodes({filter: (node) => node.layoutContextType === type}));
     }
 
+    function awaitDomNodeWithIdLayoutFlagsChanged(id)
+    {
+        return new Promise((resolve, reject) => {
+            WI.DOMNode.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, function listener(event) {
+                if (event.target.escapedIdSelector !== id)
+                    return;
+
+                WI.DOMNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, listener);
+                resolve();
+            });
+        });
+    }
+
     suite.addTestCase({
         name: "CSS.setLayoutContextTypeChangedMode.queryGrid",
         description: "Test that the expected number of grids are instrumented without chagning the LayoutContextTypeChangedMode.",
@@ -92,14 +105,14 @@ function test()
 
             InspectorTest.log("Changing `#normalGrid` to `display: block;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                awaitDomNodeWithIdLayoutFlagsChanged("#normalGrid"),
                 changeElementDisplayValue("normalGrid", "block"),
             ]);
             InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 1, "1 grid node should be instrumented.");
 
             InspectorTest.log("Changing `#normalGrid` to `display: grid;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                awaitDomNodeWithIdLayoutFlagsChanged("#normalGrid"),
                 changeElementDisplayValue("normalGrid", "grid"),
             ]);
             InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
@@ -131,14 +144,14 @@ function test()
             // Changing a node to a grid after enabling `All` mode will increase the count.
             InspectorTest.log("Changing `#normalNonGrid` to `display: grid;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                awaitDomNodeWithIdLayoutFlagsChanged("#normalNonGrid"),
                 changeElementDisplayValue("normalNonGrid", "grid"),
             ]);
             InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 3, "3 grid nodes should be instrumented.");
 
             InspectorTest.log("Changing `#normalNonGrid` to `display: block;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                awaitDomNodeWithIdLayoutFlagsChanged("#normalNonGrid"),
                 changeElementDisplayValue("normalNonGrid", "block"),
             ]);
             InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1359,8 +1359,6 @@ webkit.org/b/223462 [ Debug arm64 ] imported/w3c/web-platform-tests/mediacapture
 
 webkit.org/b/223486 [ arm64 ] inspector/css/modify-inline-style.html [ Pass Failure ]
 
-webkit.org/b/244846 inspector/css/setLayoutContextTypeChangedMode.html [ Pass Failure ]
-
 # webkit.org/b/223488 The following three tests are flakey failing only on Apple Silicon.
 [ arm64 ] http/wpt/beacon/cors/cors-preflight-blob-failure.html [ Pass Failure ]
 [ arm64 ] http/wpt/beacon/cors/cors-preflight-blob-success.html [ Pass Failure ]

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1122,15 +1122,18 @@ void InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired()
             continue;
 
         auto nodeId = domAgent->boundNodeId(&node);
+        auto nodeWasPushedToFrontend = false;
         if (!nodeId && m_layoutContextTypeChangedMode == Protocol::CSS::LayoutContextTypeChangedMode::All && layoutFlagsContainLayoutContextType(layoutFlags)) {
             // FIXME: <https://webkit.org/b/189687> Preserve DOM.NodeId if a node is removed and re-added
             nodeId = domAgent->identifierForNode(node);
+            nodeWasPushedToFrontend = nodeId;
         }
         if (!nodeId)
             continue;
 
         m_lastLayoutFlagsForNode.set(node, layoutFlags);
-        m_frontendDispatcher->nodeLayoutFlagsChanged(nodeId, toProtocol(layoutFlags));
+        if (!nodeWasPushedToFrontend)
+            m_frontendDispatcher->nodeLayoutFlagsChanged(nodeId, toProtocol(layoutFlags));
     }
 }
 


### PR DESCRIPTION
#### 33d4b1c48279e35925acc9a0351e480975499feb
<pre>
REGRESSION(253727@main): [ macOS wk2 ] inspector/css/setLayoutContextTypeChangedMode.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244846">https://bugs.webkit.org/show_bug.cgi?id=244846</a>
rdar://99599308

Reviewed by Devin Rousso.

Two issues exist making this test flakey. The first was that we incorrectly would send a layout information twice for
previously unobserved nodes, once with the new node and then again. This meant the test would wait for the first
&quot;change&quot; when the node was added, and the next await for a change could sometimes happen quickly enough that it would be
satisfied by the errant second notifcation of changed layout context.

The second issue is the result of other new flags causing all nodes to have a layout flags, including the output element
for the test. We can&apos;t explicitly add an event listener to the node we want to observe though because that would cause
the node to be sent to the frontend, which is the behavior we are trying to test. To combat this, we now use a special
observer that looks at the ID of elements with layout flag changes to ensure we are observing the change for the node we
actually care about.

* LayoutTests/inspector/css/setLayoutContextTypeChangedMode.html:
- Ensure we observe flags changing only for the node we care about, even if we can&apos;t yet know if we have a WI.DOMNode.

* LayoutTests/platform/mac-wk2/TestExpectations:

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired):
- If we get a nodeId back for a node that didn&apos;t previously have a nodeId, we know that the latest layout flags have
just been sent to the frontend.

Canonical link: <a href="https://commits.webkit.org/258858@main">https://commits.webkit.org/258858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f89ef21a7bfb47d981ae92e714ef6bbd0a41b9ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112238 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172449 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3013 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110334 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37713 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79441 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26224 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2676 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45724 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6088 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7446 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->