### PR TITLE
Move long-shipping features to the new 'shipping' status

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -237,7 +237,7 @@ class Preferences
   end
 
   # Corresponds to WebFeatureStatus enum cases. "developer" and up require human-readable names.
-  STATUSES = %w{ embedder unstable internal developer testable preview stable }
+  STATUSES = %w{ embedder unstable internal developer testable preview stable shipping }
 
   def initializeParsedPreferences(parsedPreferences)
     result = []

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -630,7 +630,7 @@ BackspaceKeyNavigationEnabled:
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 BeaconAPIEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "Beacon API"
   humanReadableDescription: "Beacon API"
   defaultValue:
@@ -2384,7 +2384,7 @@ GraphicsContextFiltersEnabled:
 
 HTTPEquivEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "http-equiv"
   humanReadableDescription: "Enable http-equiv attribute"
   webcoreName: httpEquivEnabled
@@ -3072,7 +3072,7 @@ JavaScriptCanOpenWindowsAutomatically:
 
 JavaScriptEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "JavaScript"
   humanReadableDescription: "Enable JavaScript"
   inspectorOverride: true
@@ -3392,7 +3392,7 @@ LocalFileContentSniffingEnabled:
 
 LocalStorageEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "Local Storage"
   humanReadableDescription: "Enable Local Storage"
   webKitLegacyPreferenceKey: WebKitLocalStorageEnabledPreferenceKey
@@ -3752,7 +3752,7 @@ MediaSessionPlaylistEnabled:
 
 MediaSourceEnabled:
   type: bool
-  status: stable
+  status: embedder
   humanReadableName: "Media Source API"
   humanReadableDescription: "Media Source API"
   defaultValue:
@@ -4839,7 +4839,7 @@ SKAttributionEnabled:
 
 SafeBrowsingEnabled:
   type: bool
-  status: stable
+  status: embedder
   humanReadableName: "Safe Browsing"
   humanReadableDescription: "Enable Safe Browsing"
   webcoreBinding: none
@@ -6530,7 +6530,7 @@ WebGLDraftExtensionsEnabled:
 
 WebGLEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "WebGL"
   humanReadableDescription: "Enable WebGL"
   defaultValue:

--- a/Source/WebKit/UIProcess/API/APIFeatureStatus.h
+++ b/Source/WebKit/UIProcess/API/APIFeatureStatus.h
@@ -40,6 +40,8 @@ enum class FeatureStatus : uint8_t {
     // Enabled by default in Safari Technology Preview, but not considered ready to ship yet.
     Preview,
     // Enabled by default and ready for general use.
-    Stable
+    Stable,
+    // Enabled by default and in general use for more than a year.
+    Shipping
 };
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -67,6 +67,8 @@
         return WebFeatureStatusPreview;
     case API::FeatureStatus::Stable:
         return WebFeatureStatusStable;
+    case API::FeatureStatus::Shipping:
+        return WebFeatureStatusShipping;
     default:
         ASSERT_NOT_REACHED();
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFeature.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFeature.h
@@ -45,7 +45,9 @@ typedef NS_ENUM(NSUInteger, WebFeatureStatus) {
     /// Enabled by default in Safari Technology Preview, but not considered ready to ship yet.
     WebFeatureStatusPreview,
     /// Enabled by default and ready for general use.
-    WebFeatureStatusStable
+    WebFeatureStatusStable,
+    /// Enabled by default and in general use for more than a year.
+    WebFeatureStatusShipping
 };
 
 @interface WebFeature : NSObject


### PR DESCRIPTION
#### 094a38c9acd3d93c930091718a563674166b881a
<pre>
Move long-shipping features to the new &apos;shipping&apos; status
<a href="https://bugs.webkit.org/show_bug.cgi?id=250395">https://bugs.webkit.org/show_bug.cgi?id=250395</a>
&lt;rdar://problem/104081353&gt;

Reviewed by Patrick Angle and Elliott Williams.

Following Bug 247926, we expose &apos;stable&apos; features to the Safari &apos;Develop&apos; menu to
support A/B testing by developers so they can isolate the cause of page regression
to specific features.

This has created an overly-cumbersome UI, and surfaced features that cannot be
disabled on the modern web (and which have been shipping for many years).

This patch updates our Feature flag definitions to use &apos;shipping&apos; for long-shipping
features. These will no longer be displayed in the UI, and the feature toggles will
likely be removed in a future update as they are no longer conditional, but are
foundational to the modern web.

This also corrects MediaSourceEnabled and SafeBrowsing to be &apos;embedder&apos;.

* Source/WTF/Scripts/GeneratePreferences.rb: Add &apos;shipping&apos; as a recognized status.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Scripts/GenerateSettings.rb: Add &apos;shipping&apos; as a recognized status.
* Source/WebKit/UIProcess/API/APIFeatureStatus.h
* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
* Source/WebKitLegacy/mac/WebView/WebFeature.h

Canonical link: https://commits.webkit.org/258753@main
</pre>