### PR TITLE
queryCommandValue("stylewithcss") should always return an empty string

### DIFF
--- a/LayoutTests/editing/editability/empty-document-stylewithcss.html
+++ b/LayoutTests/editing/editability/empty-document-stylewithcss.html
@@ -10,17 +10,17 @@ function runTest() {
     document.open();
     window.getSelection().addRange(document.createRange());
 
-    var initialValue = document.queryCommandValue('StyleWithCSS');
+    var initialValue = document.queryCommandState('StyleWithCSS');
     document.execCommand("StyleWithCSS", false, !eval(initialValue));
     document.writeln('hello');
 
     document.open();
     window.getSelection().addRange(document.createRange());
-    var valueAfterFirstNegation = document.queryCommandValue('StyleWithCSS');
+    var valueAfterFirstNegation = document.queryCommandState('StyleWithCSS');
 
     document.execCommand("StyleWithCSS", false, !eval(valueAfterFirstNegation));
     document.writeln('world');
-    var valueAfterSecondNegation = document.queryCommandValue('StyleWithCSS');
+    var valueAfterSecondNegation = document.queryCommandState('StyleWithCSS');
 
     document.open();
     document.writeln('This test ensures WebKit executes StyleWithCSS properly even in an empty document.<br>');

--- a/LayoutTests/editing/execCommand/reset-values-after-navigation-expected.txt
+++ b/LayoutTests/editing/execCommand/reset-values-after-navigation-expected.txt
@@ -1,5 +1,5 @@
 PASS queryCommandValues["DefaultParagraphSeparator"] is "div"
-PASS queryCommandValues["StyleWithCSS"] is "false"
+PASS queryCommandValues["StyleWithCSS"] is ""
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/execCommand/reset-values-after-navigation.html
+++ b/LayoutTests/editing/execCommand/reset-values-after-navigation.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script>
     window.jsTestIsAsync = true;
     window.onmessage = function (e) {
         if (e.origin == location.protocol + "//" + location.host) {
             queryCommandValues = JSON.parse(e.data);
             shouldBeEqualToString('queryCommandValues["DefaultParagraphSeparator"]', "div");
-            shouldBeEqualToString('queryCommandValues["StyleWithCSS"]', "false");
+            shouldBeEqualToString('queryCommandValues["StyleWithCSS"]', "");
             finishJSTest();
         }
     }
@@ -16,6 +16,5 @@
 </head>
 <body>
 <iframe style="display: none" src="resources/reset-default-values-helper-1.html"></iframe>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/editing/execCommand/style-with-css-expected.txt
+++ b/LayoutTests/editing/execCommand/style-with-css-expected.txt
@@ -9,9 +9,9 @@ PASS styleWithCSS changed the state successfully
 PASS styleWithCSS changed the state successfully
 PASS styleWithCSS changed the state successfully
 PASS queryCommandState('styleWithCSS') returns true
-PASS queryCommandValue('styleWithCSS') returns 'true'
+PASS queryCommandValue('styleWithCSS') returns ''
 PASS queryCommandState('styleWithCSS') returns false
-PASS queryCommandValue('styleWithCSS') returns 'false'
+PASS queryCommandValue('styleWithCSS') returns ''
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/execCommand/style-with-css.html
+++ b/LayoutTests/editing/execCommand/style-with-css.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -30,10 +30,10 @@ if (document.queryCommandState('styleWithCSS') === true)
 else
     testFailed("queryCommandState('styleWithCSS') should return boolean true");
 
-if (document.queryCommandValue('styleWithCSS') === 'true')
-    testPassed("queryCommandValue('styleWithCSS') returns 'true'");
+if (document.queryCommandValue('styleWithCSS') === '')
+    testPassed("queryCommandValue('styleWithCSS') returns ''");
 else
-    testFailed("queryCommandValue('styleWithCSS') should return 'true'");
+    testFailed("queryCommandValue('styleWithCSS') should return ''");
 
 document.execCommand('styleWithCSS', false, false);
 if (document.queryCommandState('styleWithCSS') === false)
@@ -41,12 +41,11 @@ if (document.queryCommandState('styleWithCSS') === false)
 else
     testFailed("queryCommandState('styleWithCSS') should return boolean false");
 
-if (document.queryCommandValue('styleWithCSS') === 'false')
-    testPassed("queryCommandValue('styleWithCSS') returns 'false'");
+if (document.queryCommandValue('styleWithCSS') === '')
+    testPassed("queryCommandValue('styleWithCSS') returns ''");
 else
-    testFailed("queryCommandValue('styleWithCSS') should return 'false'");
+    testFailed("queryCommandValue('styleWithCSS') should return ''");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2008, 2014, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2009 Igalia S.L.
  *
@@ -1558,6 +1559,14 @@ static String valueNull(Frame&, Event*)
     return String();
 }
 
+// The command has no value.
+// https://w3c.github.io/editing/execCommand.html#querycommandvalue()
+// > ... or has no value, return the empty string.
+static String valueAsEmptyString(Frame&, Event*)
+{
+    return emptyString();
+}
+
 static String valueBackColor(Frame& frame, Event*)
 {
     return valueStyle(frame, CSSPropertyBackgroundColor);
@@ -1776,7 +1785,7 @@ static const CommandMap& createCommandMap()
         { "SelectWord"_s, { executeSelectWord, supportedFromMenuOrKeyBinding, enabledVisibleSelection, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "SetMark"_s, { executeSetMark, supportedFromMenuOrKeyBinding, enabledVisibleSelection, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "Strikethrough"_s, { executeStrikethrough, supported, enabledInRichlyEditableText, stateStrikethrough, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
-        { "StyleWithCSS"_s, { executeStyleWithCSS, supported, enabled, stateStyleWithCSS, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
+        { "StyleWithCSS"_s, { executeStyleWithCSS, supported, enabled, stateStyleWithCSS, valueAsEmptyString, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "Subscript"_s, { executeSubscript, supported, enabledInRichlyEditableText, stateSubscript, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "Superscript"_s, { executeSuperscript, supported, enabledInRichlyEditableText, stateSuperscript, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "SwapWithMark"_s, { executeSwapWithMark, supportedFromMenuOrKeyBinding, enabledVisibleSelectionAndMark, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },


### PR DESCRIPTION
#### 547de625ee39cf066893b8dafd70fa534f132791
<pre>
queryCommandValue(&quot;stylewithcss&quot;) should always return an empty string

queryCommandValue(&quot;stylewithcss&quot;) should always return an empty string
<a href="https://bugs.webkit.org/show_bug.cgi?id=250397">https://bugs.webkit.org/show_bug.cgi?id=250397</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/57c2207020be6758153102c90902b4b49781744e">https://chromium.googlesource.com/chromium/src.git/+/57c2207020be6758153102c90902b4b49781744e</a>

This patch introduces a new function, which returns emptyString and then use in the CommandMap
for the default value of &quot;StyleWithCSS&quot;, which is aligned with web-specification.

This change does not have any dedicated test since the change already has WPT coverage.

* Source/WebCore/editing/EditorCommand.cpp:
(valueAsEmptyString): New function
(CommandMaps): Update default from &quot;valueNull&quot; to &quot;valueAsEmptyString&quot;
* LayoutTests/editing/editability/empty-document-stylewithcss.html: Rebaselined
* LayoutTests/editing/execCommand/reset-values-after-navigation-expected.txt: Ditto
* LayoutTests/editing/execCommand/reset-values-after-navigation.html: Ditto
* LayoutTests/editing/execCommand/style-with-css-expected.txt: Ditto
* LayoutTests/editing/execCommand/style-with-css.html: Ditto

Canonical link: <a href="https://commits.webkit.org/258777@main">https://commits.webkit.org/258777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d39ae8d444ad2994500ae94c7d729a487a8ae12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112093 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172313 "An unexpected error occured. Recent messages:Pull request contains relevant changes; validate-change running; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2866 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109763 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37606 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79340 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26114 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2567 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45604 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6035 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7303 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->