### PR TITLE
FileSystemSyncAccessHandle::write should perform quota check

### DIFF
--- a/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-storage-limit.js
+++ b/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-storage-limit.js
@@ -1,0 +1,30 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("This test checks FileSystemSyncAccessHandle returns error when limit is reached");
+
+const quota = 400 * 1024; // Default quota for an origin in TestRunner.
+var accessHandle, fileHandle;
+
+async function test() 
+{
+    try {
+        var rootHandle = await navigator.storage.getDirectory();
+        // Create a new file for this test.
+        await rootHandle.removeEntry("sync-access-handle-storage-limit.txt").then(() => { }, () => { });
+        fileHandle = await rootHandle.getFileHandle("sync-access-handle-storage-limit.txt", { "create" : true  });
+        accessHandle = await fileHandle.createSyncAccessHandle();
+
+        shouldNotThrow("accessHandle.write(new Uint8Array(quota - 1).buffer)");
+        shouldThrow("accessHandle.write(new Uint8Array(2).buffer)");
+        accessHandle.close();
+
+        finishTest();
+    } catch (error) {
+        finishTest(error);
+    }
+}
+
+test();

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker-expected.txt
@@ -1,0 +1,12 @@
+[Worker] This test checks FileSystemSyncAccessHandle returns error when limit is reached
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Starting worker: resources/sync-access-handle-storage-limit.js
+PASS [Worker] accessHandle.write(new Uint8Array(quota - 1).buffer) did not throw exception.
+PASS [Worker] accessHandle.write(new Uint8Array(2).buffer) threw exception QuotaExceededError: The quota has been exceeded..
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.setAllowStorageQuotaIncrease(false);
+worker = startWorker('resources/sync-access-handle-storage-limit.js');</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
@@ -42,6 +42,7 @@ public:
 
     void createSyncAccessHandle(DOMPromiseDeferred<IDLInterface<FileSystemSyncAccessHandle>>&&);
     void closeSyncAccessHandle(FileSystemSyncAccessHandleIdentifier);
+    std::optional<uint64_t> requestNewCapacityForSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity);
     void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, FileSystemSyncAccessHandle&);
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier);
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -46,7 +46,7 @@ public:
         std::optional<unsigned long long> at;
     };
 
-    static Ref<FileSystemSyncAccessHandle> create(ScriptExecutionContext&, FileSystemFileHandle&, FileSystemSyncAccessHandleIdentifier, FileHandle&&);
+    static Ref<FileSystemSyncAccessHandle> create(ScriptExecutionContext&, FileSystemFileHandle&, FileSystemSyncAccessHandleIdentifier, FileHandle&&, uint64_t capacity);
     ~FileSystemSyncAccessHandle();
 
     ExceptionOr<void> truncate(unsigned long long size);
@@ -58,10 +58,11 @@ public:
     void invalidate();
 
 private:
-    FileSystemSyncAccessHandle(ScriptExecutionContext&, FileSystemFileHandle&, FileSystemSyncAccessHandleIdentifier, FileHandle&&);
+    FileSystemSyncAccessHandle(ScriptExecutionContext&, FileSystemFileHandle&, FileSystemSyncAccessHandleIdentifier, FileHandle&&, uint64_t capacity);
     using CloseCallback = CompletionHandler<void(ExceptionOr<void>&&)>;
     enum class ShouldNotifyBackend : bool { No, Yes };
     void closeInternal(ShouldNotifyBackend);
+    bool requestSpaceForWrite(uint64_t writeOffset, uint64_t writeLength);
 
     // ActiveDOMObject
     const char* activeDOMObjectName() const final;
@@ -71,6 +72,7 @@ private:
     FileSystemSyncAccessHandleIdentifier m_identifier;
     FileHandle m_file;
     bool m_isClosed { false };
+    uint64_t m_capacity;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp
@@ -237,7 +237,7 @@ void WorkerFileSystemStorageConnection::completeStringCallback(CallbackIdentifie
         callback(WTFMove(result));
 }
 
-void WorkerFileSystemStorageConnection::didCreateSyncAccessHandle(CallbackIdentifier callbackIdentifier, ExceptionOr<std::pair<FileSystemSyncAccessHandleIdentifier, FileHandle>>&& result)
+void WorkerFileSystemStorageConnection::didCreateSyncAccessHandle(CallbackIdentifier callbackIdentifier, ExceptionOr<FileSystemStorageConnection::SyncAccessHandleInfo>&& result)
 {
     if (auto callback = m_getAccessHandlCallbacks.take(callbackIdentifier))
         callback(WTFMove(result));
@@ -377,6 +377,33 @@ void WorkerFileSystemStorageConnection::move(FileSystemHandleIdentifier identifi
 
         mainThreadConnection->move(identifier, destinationIdentifier, name, WTFMove(mainThreadCallback));
     });
+}
+
+std::optional<uint64_t> WorkerFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier identifier, FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity)
+{
+    if (!m_scope)
+        return std::nullopt;
+
+    if (!m_mainThreadConnection)
+        return std::nullopt;
+
+    BinarySemaphore semaphore;
+    std::optional<uint64_t> grantedCapacity;
+    callOnMainThread([mainThreadConnection = m_mainThreadConnection, identifier, accessHandleIdentifier, newCapacity, &grantedCapacity, &semaphore]() {
+        auto mainThreadCallback = [&grantedCapacity, &semaphore](auto&& result) {
+            grantedCapacity = WTFMove(result);
+            semaphore.signal();
+        };
+        mainThreadConnection->requestNewCapacityForSyncAccessHandle(identifier, accessHandleIdentifier, newCapacity, WTFMove(mainThreadCallback));
+    });
+    semaphore.wait();
+    return grantedCapacity;
+}
+
+void WorkerFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, uint64_t, RequestCapacityCallback&& callback)
+{
+    ASSERT_NOT_REACHED();
+    return callback(std::nullopt);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -48,12 +48,13 @@ public:
     void scopeClosed();
     void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, FileSystemSyncAccessHandle&);
     void closeSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier);
+    std::optional<uint64_t> requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity);
     using CallbackIdentifier = WorkerFileSystemStorageConnectionCallbackIdentifier;
     void didIsSameEntry(CallbackIdentifier, ExceptionOr<bool>&&);
     void didGetHandle(CallbackIdentifier, ExceptionOr<Ref<FileSystemHandleCloseScope>>&&);
     void didResolve(CallbackIdentifier, ExceptionOr<Vector<String>>&&);
     void completeStringCallback(CallbackIdentifier, ExceptionOr<String>&&);
-    void didCreateSyncAccessHandle(CallbackIdentifier, ExceptionOr<std::pair<FileSystemSyncAccessHandleIdentifier, FileHandle>>&&);
+    void didCreateSyncAccessHandle(CallbackIdentifier, ExceptionOr<FileSystemStorageConnection::SyncAccessHandleInfo>&&);
     void completeVoidCallback(CallbackIdentifier, ExceptionOr<void>&& result);
     void didGetHandleNames(CallbackIdentifier, ExceptionOr<Vector<String>>&&);
 
@@ -77,6 +78,7 @@ private:
     void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, ScriptExecutionContextIdentifier) final { };
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
+    void requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, uint64_t, RequestCapacityCallback&&) final;
 
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     RefPtr<FileSystemStorageConnection> m_mainThreadConnection;

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -78,7 +78,7 @@ void FileSystemStorageHandle::close()
         return;
 
     if (m_activeSyncAccessHandle)
-        closeSyncAccessHandle(*m_activeSyncAccessHandle);
+        closeSyncAccessHandle(m_activeSyncAccessHandle->identifier);
     m_manager->closeHandle(*this);
 }
 
@@ -177,7 +177,7 @@ Expected<Vector<String>, FileSystemStorageError> FileSystemStorageHandle::resolv
     return restPath.split(pathSeparator);
 }
 
-Expected<FileSystemStorageHandle::AccessHandleInfo, FileSystemStorageError> FileSystemStorageHandle::createSyncAccessHandle()
+Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError> FileSystemStorageHandle::createSyncAccessHandle()
 {
     if (!m_manager)
         return makeUnexpected(FileSystemStorageError::Unknown);
@@ -197,13 +197,14 @@ Expected<FileSystemStorageHandle::AccessHandleInfo, FileSystemStorageError> File
     }
 
     ASSERT(!m_activeSyncAccessHandle);
-    m_activeSyncAccessHandle = WebCore::FileSystemSyncAccessHandleIdentifier::generateThreadSafe();
-    return std::pair { *m_activeSyncAccessHandle, WTFMove(*ipcHandle) };
+    m_activeSyncAccessHandle = SyncAccessHandleInfo { WebCore::FileSystemSyncAccessHandleIdentifier::generateThreadSafe() };
+    uint64_t initialCapacity = valueOrDefault(FileSystem::fileSize(m_path));
+    return FileSystemSyncAccessHandleInfo { m_activeSyncAccessHandle->identifier, WTFMove(*ipcHandle), initialCapacity };
 }
 
 std::optional<FileSystemStorageError> FileSystemStorageHandle::closeSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
 {
-    if (!m_activeSyncAccessHandle || *m_activeSyncAccessHandle != accessHandleIdentifier)
+    if (!m_activeSyncAccessHandle || m_activeSyncAccessHandle->identifier != accessHandleIdentifier)
         return FileSystemStorageError::Unknown;
 
     if (!m_manager)
@@ -265,6 +266,53 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::move(WebCore::Fil
     m_name = newName;
 
     return std::nullopt;
+}
+
+std::optional<WebCore::FileSystemSyncAccessHandleIdentifier> FileSystemStorageHandle::activeSyncAccessHandle()
+{
+    if (!m_activeSyncAccessHandle)
+        return std::nullopt;
+
+    return m_activeSyncAccessHandle->identifier;
+}
+
+bool FileSystemStorageHandle::isActiveSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
+{
+    return m_activeSyncAccessHandle && m_activeSyncAccessHandle->identifier == accessHandleIdentifier;
+}
+
+uint64_t FileSystemStorageHandle::allocatedUnusedCapacity()
+{
+    if (!m_activeSyncAccessHandle)
+        return 0;
+
+    auto actualSize = valueOrDefault(FileSystem::fileSize(m_path));
+    return actualSize > m_activeSyncAccessHandle->capacity ? 0 : m_activeSyncAccessHandle->capacity - actualSize;
+}
+
+void FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler)
+{
+    if (!isActiveSyncAccessHandle(accessHandleIdentifier))
+        return completionHandler(std::nullopt);
+
+    if (newCapacity <= m_activeSyncAccessHandle->capacity)
+        return completionHandler(m_activeSyncAccessHandle->capacity);
+
+    if (!m_manager)
+        return completionHandler(std::nullopt);
+
+    uint64_t spaceRequested = newCapacity - m_activeSyncAccessHandle->capacity;
+    m_manager->requestSpace(spaceRequested, [this, weakThis = WeakPtr { *this }, accessHandleIdentifier, newCapacity, completionHandler = WTFMove(completionHandler)](bool granted) mutable {
+        if (!weakThis)
+            return completionHandler(std::nullopt);
+
+        if (!isActiveSyncAccessHandle(accessHandleIdentifier))
+            return completionHandler(std::nullopt);
+
+        if (granted)
+            m_activeSyncAccessHandle->capacity = newCapacity;
+        completionHandler(m_activeSyncAccessHandle->capacity);
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -487,7 +487,7 @@ void NetworkStorageManager::getFile(WebCore::FileSystemHandleIdentifier identifi
     completionHandler(handle->path());
 }
 
-void NetworkStorageManager::createSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<AccessHandleInfo, FileSystemStorageError>)>&& completionHandler)
+void NetworkStorageManager::createSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
 
@@ -506,6 +506,17 @@ void NetworkStorageManager::closeSyncAccessHandle(WebCore::FileSystemHandleIdent
         handle->closeSyncAccessHandle(accessHandleIdentifier);
 
     completionHandler();
+}
+
+void NetworkStorageManager::requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler)
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto handle = m_fileSystemStorageHandleRegistry->getHandle(identifier);
+    if (!handle)
+        return completionHandler(std::nullopt);
+
+    handle->requestNewCapacityForSyncAccessHandle(accessHandleIdentifier, newCapacity, WTFMove(completionHandler));
 }
 
 void NetworkStorageManager::getHandleNames(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include "FileSystemStorageError.h"
+#include "FileSystemSyncAccessHandleInfo.h"
 #include "OriginStorageManager.h"
 #include "StorageAreaIdentifier.h"
 #include "StorageAreaImplIdentifier.h"
@@ -142,9 +143,9 @@ private:
     void removeEntry(WebCore::FileSystemHandleIdentifier, const String& name, bool deleteRecursively, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void resolve(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
     void getFile(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&&);
-    using AccessHandleInfo = std::pair<WebCore::FileSystemSyncAccessHandleIdentifier, IPC::SharedFileHandle>;
-    void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<AccessHandleInfo, FileSystemStorageError>)>&&);
+    void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&&);
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);
+    void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&&);
     void getHandleNames(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, FileSystemStorageError>)>&&);
     

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -36,8 +36,9 @@
     Resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     Move(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier destinationIdentifier, String newName) -> (std::optional<WebKit::FileSystemStorageError> result)
     GetFile(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<String, WebKit::FileSystemStorageError> result)
-    CreateSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<std::pair<WebCore::FileSystemSyncAccessHandleIdentifier, IPC::SharedFileHandle>, WebKit::FileSystemStorageError> result)
+    CreateSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<WebKit::FileSystemSyncAccessHandleInfo, WebKit::FileSystemStorageError> result)
     CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier) -> ()
+    RequestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity) -> (std::optional<uint64_t> result)
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, WebKit::FileSystemStorageError> result)
 

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -49,7 +49,7 @@ class StorageAreaRegistry;
 enum class UnifiedOriginStorageLevel : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
-class OriginStorageManager {
+class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static String originFileIdentifier();
@@ -64,6 +64,7 @@ public:
     const String& path() const { return m_path; }
     QuotaManager& quotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);
+    FileSystemStorageManager* existingFileSystemStorageManager();
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);
     LocalStorageManager* existingLocalStorageManager();
     SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
@@ -90,6 +91,7 @@ public:
 #endif
 
 private:
+    Ref<QuotaManager> createQuotaManager();
     enum class StorageBucketMode : bool;
     class StorageBucket;
     StorageBucket& defaultBucket();

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -354,6 +354,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::DisplayListRecorderFlushIdentifier',
         'WebKit::DownloadID',
         'WebKit::FileSystemStorageError',
+        'WebKit::FileSystemSyncAccessHandleInfo',
         'WebKit::ImageBufferBackendHandle',
         'WebKit::LayerHostingContextID',
         'WebKit::LegacyCustomProtocolID',

--- a/Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.h
+++ b/Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SharedFileHandle.h"
+#include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
+
+namespace WebKit {
+
+struct FileSystemSyncAccessHandleInfo {
+    WebCore::FileSystemSyncAccessHandleIdentifier identifier;
+    IPC::SharedFileHandle handle;
+    uint64_t capacity { 0 };
+
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<FileSystemSyncAccessHandleInfo> decode(Decoder&);
+};
+
+template<class Encoder> void FileSystemSyncAccessHandleInfo::encode(Encoder& encoder) const
+{
+    encoder << identifier;
+    encoder << handle;
+    encoder << capacity;
+}
+
+template<class Decoder> std::optional<FileSystemSyncAccessHandleInfo> FileSystemSyncAccessHandleInfo::decode(Decoder& decoder)
+{
+    WebCore::FileSystemSyncAccessHandleIdentifier identifier;
+    if (!decoder.decode(identifier))
+        return std::nullopt;
+
+    IPC::SharedFileHandle handle;
+    if (!decoder.decode(handle))
+        return std::nullopt;
+
+    uint64_t capacity;
+    if (!decoder.decode(capacity))
+        return std::nullopt;
+
+    return FileSystemSyncAccessHandleInfo { identifier, WTFMove(handle), capacity };
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1586,6 +1586,7 @@
 		93AB9B562575A28B0098B10E /* SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93AB9B51257589110098B10E /* SpeechRecognitionRemoteRealtimeMediaSourceManagerMessageReceiver.cpp */; };
 		93AEC161278F8CD30066666F /* StorageAreaMapIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 93AEC160278F8CD20066666F /* StorageAreaMapIdentifier.h */; };
 		93B0A67526D5ADCF00AA21E4 /* WebPermissionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B0A67426D5A72E00AA21E4 /* WebPermissionController.h */; };
+		93B42F2F29834B2600DF1D45 /* FileSystemSyncAccessHandleInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B42F2E29834A4200DF1D45 /* FileSystemSyncAccessHandleInfo.h */; };
 		93B631E527ABA62800443A44 /* IDBStorageConnectionToClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631E427ABA62700443A44 /* IDBStorageConnectionToClient.h */; };
 		93B631E827ABA65D00443A44 /* IDBStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631E627ABA65C00443A44 /* IDBStorageManager.h */; };
 		93B631ED27ABA6B400443A44 /* IDBStorageRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631EB27ABA6B300443A44 /* IDBStorageRegistry.h */; };
@@ -6196,6 +6197,7 @@
 		93AEC160278F8CD20066666F /* StorageAreaMapIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageAreaMapIdentifier.h; sourceTree = "<group>"; };
 		93B0A67326D5A72E00AA21E4 /* WebPermissionController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebPermissionController.cpp; sourceTree = "<group>"; };
 		93B0A67426D5A72E00AA21E4 /* WebPermissionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPermissionController.h; sourceTree = "<group>"; };
+		93B42F2E29834A4200DF1D45 /* FileSystemSyncAccessHandleInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileSystemSyncAccessHandleInfo.h; sourceTree = "<group>"; };
 		93B631E327ABA5F700443A44 /* IDBStorageConnectionToClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IDBStorageConnectionToClient.cpp; sourceTree = "<group>"; };
 		93B631E427ABA62700443A44 /* IDBStorageConnectionToClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IDBStorageConnectionToClient.h; sourceTree = "<group>"; };
 		93B631E627ABA65C00443A44 /* IDBStorageManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IDBStorageManager.h; sourceTree = "<group>"; };
@@ -8367,6 +8369,7 @@
 				8CFECE931490F140002AAA32 /* EditorState.cpp */,
 				1AA41AB412C02EC4002BE67B /* EditorState.h */,
 				5C6CED8E2900598000B5D522 /* EditorState.serialization.in */,
+				93B42F2E29834A4200DF1D45 /* FileSystemSyncAccessHandleInfo.h */,
 				C59C4A5718B81174007BDCB6 /* FocusedElementInformation.h */,
 				86DA60C628EAE9C00044FE4D /* FocusedElementInformation.serialization.in */,
 				BCE81D8A1319F7EF00241910 /* FontInfo.cpp */,
@@ -15070,6 +15073,7 @@
 				9312BAD626F33C2900FDDF5F /* FileSystemStorageHandle.h in Headers */,
 				935B579A26F51933008B48AC /* FileSystemStorageHandleRegistry.h in Headers */,
 				9312BAD526F33C2600FDDF5F /* FileSystemStorageManager.h in Headers */,
+				93B42F2F29834B2600DF1D45 /* FileSystemSyncAccessHandleInfo.h in Headers */,
 				00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */,
 				1A90C1F41264FD71003E44D4 /* FindController.h in Headers */,
 				DD4DB789280F9471001700D4 /* FindNodes.js in Headers */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -149,7 +149,7 @@ void WebFileSystemStorageConnection::createSyncAccessHandle(WebCore::FileSystemH
         if (!result)
             return completionHandler(convertToException(result.error()));
 
-        completionHandler(std::pair { result.value().first, result.value().second.release() });
+        completionHandler(WebCore::FileSystemStorageConnection::SyncAccessHandleInfo { result->identifier, result->handle.release(), result->capacity });
     });
 }
 
@@ -219,6 +219,14 @@ void WebFileSystemStorageConnection::invalidateAccessHandle(WebCore::FileSystemS
                 connection->invalidateAccessHandle(identifier);
         });
     }
+}
+
+void WebFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity, RequestCapacityCallback&& completionHandler)
+{
+    if (!m_connection)
+        return completionHandler(std::nullopt);
+
+    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::RequestNewCapacityForSyncAccessHandle(identifier, accessHandleIdentifier, newCapacity), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -86,6 +86,7 @@ private:
 
     void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemStorageConnection::GetAccessHandleCallback&&) final;
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, VoidCallback&&) final;
+    void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, RequestCapacityCallback&& completionHandler) final;
     void registerSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier) final;
     void unregisterSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;


### PR DESCRIPTION
#### 2706810bb38f1f596337fbdc99fce9db9be53c7b
<pre>
FileSystemSyncAccessHandle::write should perform quota check
<a href="https://bugs.webkit.org/show_bug.cgi?id=250400">https://bugs.webkit.org/show_bug.cgi?id=250400</a>
rdar://93588782

Reviewed by Youenn Fablet.

Implement basic quota check for FileSystemSyncAccessHandle. The general ideas are:
1. Each FileSystemSyncAccessHandle has a capacity intialized to current file size.
2. For write operation on FileSystemSyncAccessHandle, if the new size after write exceeds current capacity, it needs to
send a request to increase capacity.
3. The capacity of FileSystemSyncAccessHandle will be viewed as occupied (even if the real file size is smaller) in
origin quota computation.
4. FileSystem data shares origin quota with IndexedDB and CacheStorage.

* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-storage-limit.js: Added.
(async test):
* LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker-expected.txt: Added.
* LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html: Added.
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp:
(WebCore::FileSystemFileHandle::createSyncAccessHandle):
(WebCore::FileSystemFileHandle::requestNewCapacityForSyncAccessHandle):
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h:
(WebCore::FileSystemStorageConnection::SyncAccessHandleInfo::isolatedCopy):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::create):
(WebCore::FileSystemSyncAccessHandle::FileSystemSyncAccessHandle):
(WebCore::FileSystemSyncAccessHandle::write):
(WebCore::FileSystemSyncAccessHandle::requestSpaceForWrite):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp:
(WebCore::WorkerFileSystemStorageConnection::didCreateSyncAccessHandle):
(WebCore::WorkerFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle):
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::close):
(WebKit::FileSystemStorageHandle::createSyncAccessHandle):
(WebKit::FileSystemStorageHandle::closeSyncAccessHandle):
(WebKit::FileSystemStorageHandle::activeSyncAccessHandle):
(WebKit::FileSystemStorageHandle::isActiveSyncAccessHandle):
(WebKit::FileSystemStorageHandle::allocatedUnusedCapacity):
(WebKit::FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
(WebKit::FileSystemStorageHandle::activeSyncAccessHandle const): Deleted.
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::FileSystemStorageManager):
(WebKit::FileSystemStorageManager::allocatedUnusedCapacity const):
(WebKit::FileSystemStorageManager::requestSpace):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::createSyncAccessHandle):
(WebKit::NetworkStorageManager::requestNewCapacityForSyncAccessHandle):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::existingFileSystemStorageManager):
(WebKit::OriginStorageManager::StorageBucket::fileSystemStorageManager):
(WebKit::OriginStorageManager::createQuotaManager):
(WebKit::OriginStorageManager::quotaManager):
(WebKit::OriginStorageManager::fileSystemStorageManager):
(WebKit::OriginStorageManager::existingFileSystemStorageManager):
(WebKit::createQuotaManager): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/FileSystemSyncAccessHandleInfo.h: Copied from Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h.
(WebKit::FileSystemSyncAccessHandleInfo::encode const):
(WebKit::FileSystemSyncAccessHandleInfo::decode):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::createSyncAccessHandle):
(WebKit::WebFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/259635@main">https://commits.webkit.org/259635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4192aa352c65b7184ec33c44b33e9f9a489630b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114680 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174842 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5432 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114555 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39604 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108869 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81292 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7804 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28093 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4689 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6647 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9718 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->