### PR TITLE
[css-transition] ensure we fill transition-property values with a custom property when other transition CSS properties are used with a longer list of items

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Using a single "transition-property" value set to a custom property and two "transition-duration" values correctly yields a CSS Transition.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+test(() => {
+    const customProperty = generate_name();
+    CSS.registerProperty({
+      name: customProperty,
+      syntax: "<number>",
+      inherits: false,
+      initialValue: "1"
+    });
+
+    // Create transitions for our custom property with
+    // a longer list of transition-duration values.
+    const target = document.getElementById("target");
+    target.style.transitionProperty = customProperty;
+    target.style.transitionDuration = "100s, 200s";
+
+    // Trigger a style change by getting the custom property
+    // value from the computed style.
+    getComputedStyle(target).getPropertyValue(customProperty);
+
+    // Set a new value for the custom property, which will yield a
+    // transition.
+    target.style.setProperty(customProperty, "2");
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1, "A single transition was generated");
+
+    const transition = animations[0];
+    assert_class_string(transition, "CSSTransition", "A CSSTransition is running");
+    assert_equals(transition.transitionProperty, customProperty);
+}, 'Using a single "transition-property" value set to a custom property and two "transition-duration" values correctly yields a CSS Transition.');
+
+</script>

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -48,6 +48,7 @@ Animation::Animation()
     , m_propertySet(false)
     , m_timingFunctionSet(false)
     , m_compositeOperationSet(false)
+    , m_customOrUnknownPropertySet(false)
     , m_isNone(false)
     , m_delayFilled(false)
     , m_directionFilled(false)
@@ -85,6 +86,7 @@ Animation::Animation(const Animation& o)
     , m_propertySet(o.m_propertySet)
     , m_timingFunctionSet(o.m_timingFunctionSet)
     , m_compositeOperationSet(o.m_compositeOperationSet)
+    , m_customOrUnknownPropertySet(o.m_customOrUnknownPropertySet)
     , m_isNone(o.m_isNone)
     , m_delayFilled(o.m_delayFilled)
     , m_directionFilled(o.m_directionFilled)
@@ -122,6 +124,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_nameSet == other.m_nameSet
         && m_timingFunctionSet == other.m_timingFunctionSet
         && m_compositeOperationSet == other.m_compositeOperationSet
+        && m_customOrUnknownPropertySet == other.m_customOrUnknownPropertySet
         && m_isNone == other.m_isNone;
 
     if (!result)

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -49,6 +49,7 @@ public:
     bool isPropertySet() const { return m_propertySet; }
     bool isTimingFunctionSet() const { return m_timingFunctionSet; }
     bool isCompositeOperationSet() const { return m_compositeOperationSet; }
+    bool isCustomOrUnknownPropertySet() const { return m_customOrUnknownPropertySet; }
 
     // Flags this to be the special "none" animation (animation-name: none)
     bool isNoneAnimation() const { return m_isNone; }
@@ -62,7 +63,7 @@ public:
         return !m_directionSet && !m_durationSet && !m_fillModeSet
             && !m_nameSet && !m_playStateSet && !m_iterationCountSet
             && !m_delaySet && !m_timingFunctionSet && !m_propertySet
-            && !m_isNone && !m_compositeOperationSet;
+            && !m_isNone && !m_compositeOperationSet && !m_customOrUnknownPropertySet;
     }
 
     bool isEmptyOrZeroDuration() const
@@ -80,6 +81,7 @@ public:
     void clearProperty() { m_propertySet = false; m_propertyFilled = false; }
     void clearTimingFunction() { m_timingFunctionSet = false; m_timingFunctionFilled = false; }
     void clearCompositeOperation() { m_compositeOperationSet = false; m_compositeOperationFilled = false; }
+    void clearCustomOrUnknownProperty() { m_customOrUnknownPropertySet = false; }
 
     void clearAll()
     {
@@ -93,6 +95,7 @@ public:
         clearProperty();
         clearTimingFunction();
         clearCompositeOperation();
+        clearCustomOrUnknownProperty();
     }
 
     double delay() const { return m_delay; }
@@ -154,7 +157,7 @@ public:
     }
     void setPlayState(AnimationPlayState d) { m_playState = static_cast<unsigned>(d); m_playStateSet = true; }
     void setProperty(TransitionProperty t) { m_property = t; m_propertySet = true; }
-    void setCustomOrUnknownProperty(const String& property) { m_customOrUnknownProperty = property; }
+    void setCustomOrUnknownProperty(const String& property) { m_customOrUnknownProperty = property; m_customOrUnknownPropertySet = true; }
     void setTimingFunction(RefPtr<TimingFunction>&& function) { m_timingFunction = WTFMove(function); m_timingFunctionSet = true; }
     void setDefaultTimingFunctionForKeyframes(RefPtr<TimingFunction>&& function) { m_defaultTimingFunctionForKeyframes = WTFMove(function); }
 
@@ -169,6 +172,7 @@ public:
     void fillProperty(TransitionProperty property) { setProperty(property); m_propertyFilled = true; }
     void fillTimingFunction(RefPtr<TimingFunction>&& timingFunction) { setTimingFunction(WTFMove(timingFunction)); m_timingFunctionFilled = true; }
     void fillCompositeOperation(CompositeOperation compositeOperation) { setCompositeOperation(compositeOperation); m_compositeOperationFilled = true; }
+    void fillCustomOrUnknownProperty(const String& property) { setCustomOrUnknownProperty(property); }
 
     bool isDelayFilled() const { return m_delayFilled; }
     bool isDirectionFilled() const { return m_directionFilled; }
@@ -226,6 +230,7 @@ private:
     bool m_propertySet : 1;
     bool m_timingFunctionSet : 1;
     bool m_compositeOperationSet : 1;
+    bool m_customOrUnknownPropertySet : 1;
 
     bool m_isNone : 1;
 

--- a/Source/WebCore/platform/animation/AnimationList.cpp
+++ b/Source/WebCore/platform/animation/AnimationList.cpp
@@ -58,6 +58,7 @@ void AnimationList::fillUnsetProperties()
     FILL_UNSET_PROPERTY(isTimingFunctionSet, timingFunction, fillTimingFunction);
     FILL_UNSET_PROPERTY(isPropertySet, property, fillProperty);
     FILL_UNSET_PROPERTY(isCompositeOperationSet, compositeOperation, fillCompositeOperation);
+    FILL_UNSET_PROPERTY(isCustomOrUnknownPropertySet, customOrUnknownProperty, fillCustomOrUnknownProperty);
 }
 
 bool AnimationList::operator==(const AnimationList& other) const


### PR DESCRIPTION
#### 63d1cc8d95c686a9d1684288f16112864aeb9908
<pre>
[css-transition] ensure we fill transition-property values with a custom property when other transition CSS properties are used with a longer list of items
<a href="https://bugs.webkit.org/show_bug.cgi?id=250401">https://bugs.webkit.org/show_bug.cgi?id=250401</a>
rdar://104073160

Reviewed by Dean Jackson.

It&apos;s possible for certain CSS transition properties to specify a longer list of values than the
transition-property property itself. In the case where a custom property is used, we must ensure
to fill in the custom property string for the generated Animation object.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers.html: Added.
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isCustomOrUnknownPropertySet const):
(WebCore::Animation::isEmpty const):
(WebCore::Animation::clearCustomOrUnknownProperty):
(WebCore::Animation::clearAll):
(WebCore::Animation::setCustomOrUnknownProperty):
(WebCore::Animation::fillCustomOrUnknownProperty):
* Source/WebCore/platform/animation/AnimationList.cpp:
(WebCore::AnimationList::fillUnsetProperties):

Canonical link: <a href="https://commits.webkit.org/258770@main">https://commits.webkit.org/258770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ed8b67dcc1b97061b3d2aa9a48a59893b8783a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112084 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172302 "Build was cancelled. Recent messages:Pull request contains relevant changes; Deleted stale build files; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); layout-tests (failure); layout-tests (failure); Reverted pull request changes; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2857 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109754 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9960 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37594 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24681 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79333 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5401 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2559 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45589 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7293 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3209 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->