### PR TITLE
Augment a WTF::URL helper function to return a list of query parameters

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1307,15 +1307,15 @@ bool isEqualIgnoringQueryAndFragments(const URL& a, const URL& b)
     return substringIgnoringQueryAndFragments(a) == substringIgnoringQueryAndFragments(b);
 }
 
-void removeQueryParameters(URL& url, const HashSet<String>& keysToRemove)
+Vector<String> removeQueryParameters(URL& url, const HashSet<String>& keysToRemove)
 {
     if (keysToRemove.isEmpty())
-        return;
+        return { };
 
     if (!url.hasQuery())
-        return;
+        return { };
 
-    bool removedAnyKey = false;
+    Vector<String> removedParameters;
     StringBuilder queryWithoutRemovalKeys;
     for (auto bytes : url.query().split('&')) {
         auto nameAndValue = URLParser::parseQueryNameAndValue(bytes);
@@ -1327,15 +1327,17 @@ void removeQueryParameters(URL& url, const HashSet<String>& keysToRemove)
             continue;
 
         if (keysToRemove.contains(key)) {
-            removedAnyKey = true;
+            removedParameters.append(key);
             continue;
         }
 
         queryWithoutRemovalKeys.append(queryWithoutRemovalKeys.isEmpty() ? "" : "&", bytes);
     }
 
-    if (removedAnyKey)
+    if (!removedParameters.isEmpty())
         url.setQuery(queryWithoutRemovalKeys);
+
+    return removedParameters;
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -259,7 +259,9 @@ WTF_EXPORT_PRIVATE bool protocolHostAndPortAreEqual(const URL&, const URL&);
 WTF_EXPORT_PRIVATE Vector<KeyValuePair<String, String>> differingQueryParameters(const URL&, const URL&);
 WTF_EXPORT_PRIVATE Vector<KeyValuePair<String, String>> queryParameters(const URL&);
 WTF_EXPORT_PRIVATE bool isEqualIgnoringQueryAndFragments(const URL&, const URL&);
-WTF_EXPORT_PRIVATE void removeQueryParameters(URL&, const HashSet<String>&);
+
+// Returns the parameters that were removed (including duplicates), in the order that they appear in the URL.
+WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const HashSet<String>&);
 
 WTF_EXPORT_PRIVATE const URL& aboutBlankURL();
 WTF_EXPORT_PRIVATE const URL& aboutSrcDocURL();

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -32,6 +32,7 @@
 #include <wtf/StringPrintStream.h>
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>
+#include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
 
 namespace TestWebKitAPI {
@@ -540,39 +541,66 @@ TEST_F(WTF_URL, URLRemoveQueryParameters)
     HashSet<String> keyRemovalSet3 { "key2"_s };
     HashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
 
-    removeQueryParameters(url1, keyRemovalSet2);
+    auto checkRemovedParameters = [](int lineNumber, const Vector<String>& removedParameters, std::initializer_list<String>&& expected) {
+        Vector<String> expectedParameters { WTFMove(expected) };
+        bool areEqual = removedParameters == expectedParameters;
+        EXPECT_TRUE(areEqual);
+        if (areEqual)
+            return;
+
+        WTFLogAlways("Test failed at %s:%d", __FILE__, lineNumber);
+        WTFLogAlways("- Got %zu parameter(s)", removedParameters.size());
+        for (auto& parameter : removedParameters)
+            WTFLogAlways("    %s", parameter.utf8().data());
+        WTFLogAlways("- Expected %zu parameter(s)", expectedParameters.size());
+        for (auto& parameter : expectedParameters)
+            WTFLogAlways("    %s", parameter.utf8().data());
+    };
+
+    auto removedParameters1 = removeQueryParameters(url1, keyRemovalSet2);
     EXPECT_EQ(url1.string(), url.string());
+    checkRemovedParameters(__LINE__, removedParameters1, { "key1"_s });
 
     const auto originalURL2 = url2;
-    removeQueryParameters(url2, keyRemovalSet1);
+    auto removedParameters2 = removeQueryParameters(url2, keyRemovalSet1);
     EXPECT_EQ(url2.string(), originalURL2.string());
+    checkRemovedParameters(__LINE__, removedParameters2, { });
 
-    removeQueryParameters(url3, keyRemovalSet1);
+    auto removedParameters3 = removeQueryParameters(url3, keyRemovalSet1);
     EXPECT_EQ(url3.string(), url6.string());
+    checkRemovedParameters(__LINE__, removedParameters3, { "key"_s });
 
-    removeQueryParameters(url4, keyRemovalSet1);
+    auto removedParameters4 = removeQueryParameters(url4, keyRemovalSet1);
     EXPECT_EQ(url4.string(), url6.string());
+    checkRemovedParameters(__LINE__, removedParameters4, { "key"_s, "key"_s });
 
-    removeQueryParameters(url5, keyRemovalSet1);
+    auto removedParameters5 = removeQueryParameters(url5, keyRemovalSet1);
     EXPECT_EQ(url5.string(), url6.string());
+    checkRemovedParameters(__LINE__, removedParameters5, { "key"_s, "key"_s });
 
-    removeQueryParameters(url6, keyRemovalSet1);
+    auto removedParameters6 = removeQueryParameters(url6, keyRemovalSet1);
     EXPECT_EQ(url6.string(), url9.string());
+    checkRemovedParameters(__LINE__, removedParameters6, { });
 
-    removeQueryParameters(url7, keyRemovalSet2);
+    auto removedParameters7 = removeQueryParameters(url7, keyRemovalSet2);
     EXPECT_EQ(url7.string(), url10.string());
+    checkRemovedParameters(__LINE__, removedParameters7, { });
 
-    removeQueryParameters(url11, keyRemovalSet3);
+    auto removedParameters11 = removeQueryParameters(url11, keyRemovalSet3);
     EXPECT_EQ(url11.string(), url12.string());
+    checkRemovedParameters(__LINE__, removedParameters11, { });
 
-    removeQueryParameters(url12, keyRemovalSet4);
+    auto removedParameters12 = removeQueryParameters(url12, keyRemovalSet4);
     EXPECT_EQ(url12.string(), url9.string());
+    checkRemovedParameters(__LINE__, removedParameters12, { "key"_s, "key1"_s });
 
-    removeQueryParameters(url13, keyRemovalSet1);
+    auto removedParameters13 = removeQueryParameters(url13, keyRemovalSet1);
     EXPECT_EQ(url13.string(), url8.string());
+    checkRemovedParameters(__LINE__, removedParameters13, { });
 
-    removeQueryParameters(url14, keyRemovalSet4);
+    auto removedParameters14 = removeQueryParameters(url14, keyRemovalSet4);
     EXPECT_EQ(url14.string(), url15.string());
+    checkRemovedParameters(__LINE__, removedParameters14, { "key1"_s });
 }
 
 TEST_F(WTF_URL, IsolatedCopy)


### PR DESCRIPTION
#### 71a2925a0afe123fc95af80b8336eeb93813fe9d
<pre>
Augment a WTF::URL helper function to return a list of query parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=250402">https://bugs.webkit.org/show_bug.cgi?id=250402</a>

Reviewed by Chris Dumez.

Tweak `removeQueryParameters` to return a list of query parameters that were removed, in the order
that they appear in the original URL (including duplicates).

Test: WTF_URL.URLRemoveQueryParameters

* Source/WTF/wtf/URL.cpp:
(WTF::removeQueryParameters):
* Source/WTF/wtf/URL.h:
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/258755@main">https://commits.webkit.org/258755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aead6d4fe3878745fd1ac182a69f0ccc3c93606

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35863 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112091 "Build was cancelled. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated wpe dependencies; Compiled WebKit (cancelled)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172311 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2864 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95084 "Build was cancelled. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Compiled WebKit (cancelled)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109761 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37604 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24697 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93044 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5408 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26112 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89404 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3094 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5556 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29675 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45602 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/92327 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6021 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7301 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20678 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->