### PR TITLE
Unable to reset messages.py unit test results

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+# Copyright (C) 2010-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 # cd Source/WebKit/Scripts && python3 -m webkit.messages_unittest
 # cd Source/WebKit/Scripts && python3 -m unittest discover -p '*_unittest.py'
 
+from __future__ import print_function
 import os
 import re
 import sys
@@ -110,26 +111,6 @@ class GeneratedFileContentsTest(unittest.TestCase):
         implementation_contents = messages.generate_message_argument_description_implementation(self.receivers, receiver_header_files)
         self.assertGeneratedFileContentsEqual(implementation_contents, os.path.join(tests_directory, 'MessageArgumentDescriptions.cpp'))
 
-def add_reset_results_to_unittest_help():
-    script_name = os.path.basename(__file__)
-    reset_results_help = '''
-Custom Options:
-  -r, --reset-results  Reset expected results for {0}
-'''.format(script_name)
-
-    options_regex = re.compile('^Usage:')
-    lines = unittest.TestProgram.USAGE.splitlines(True)
-    index = 0
-    for index, line in enumerate(lines):
-        if options_regex.match(line) and index + 1 < len(lines):
-            lines.insert(index + 1, reset_results_help)
-            break
-
-    if index == (len(lines) - 1):
-        lines.append(reset_results_help)
-
-    unittest.TestProgram.USAGE = ''.join(lines)
-
 
 def parse_sys_argv():
     global reset_results
@@ -139,8 +120,15 @@ def parse_sys_argv():
             del sys.argv[index + 1]
             break
 
+    for index, arg in enumerate(sys.argv[1:]):
+        if arg in ('-h', '--h', '--help') or '--help'.startswith(arg):
+            print('''
+Custom Options:
+  -r, --reset-results  Reset expected results for {script_name}
+'''.format(script_name=os.path.basename(__file__)))
+            break
+
 
 if __name__ == '__main__':
-    add_reset_results_to_unittest_help()
     parse_sys_argv()
     unittest.main()


### PR DESCRIPTION
#### 639329ca6b9a6fd8d1886b34f92889d4ce95f874
<pre>
Unable to reset messages.py unit test results
<a href="https://bugs.webkit.org/show_bug.cgi?id=250398">https://bugs.webkit.org/show_bug.cgi?id=250398</a>
&lt;rdar://104085791&gt;

Reviewed by Jonathan Bedard.

Remove the hack that relied on the existence of an internal
unittest.TestProgram.USAGE package variable, and instead just
print out our custom help message first.  (The reason the
internal variable was used was to make the custom help text to
look like it was integrated nicely with the default help text.)

We can&apos;t print our custom help message last since the package
exits early when a help switch is passed.

* Source/WebKit/Scripts/webkit/messages_unittest.py:
- Import print_function from __future__ to make the script work
  with python2.7.  Unit tests are still run with both versions.
(add_reset_results_to_unittest_help): Delete.
(parse_sys_argv):
- Print our custom help text if a help switch is used.

Canonical link: <a href="https://commits.webkit.org/258748@main">https://commits.webkit.org/258748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b65a48a1717d6dd53576935319ba7e7d942cc379

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112092 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2865 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109762 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108611 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37605 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/106349 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24700 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26115 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2563 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11576 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45605 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to download built product from S3") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6010 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7302 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->