### PR TITLE
Stop marking libyuv headers as private

### DIFF
--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -476,29 +476,6 @@
 		410B38E8292BAA610003E515 /* sad_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 410B35A0292B6E730003E515 /* sad_neon.c */; };
 		410B38E9292BAA610003E515 /* transpose_neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B35A1292B6E740003E515 /* transpose_neon.h */; };
 		410B38EB292BAAF20003E515 /* arm_cpudetect.c in Sources */ = {isa = PBXBuildFile; fileRef = 410B38EA292BAAF10003E515 /* arm_cpudetect.c */; };
-		410B3913292CC1800003E515 /* compare_row.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B38FC292CC1700003E515 /* compare_row.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3914292CC1800003E515 /* basic_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B38FD292CC1700003E515 /* basic_types.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3915292CC1800003E515 /* loongson_intrinsics.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B38FE292CC1700003E515 /* loongson_intrinsics.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3916292CC1800003E515 /* macros_msa.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B38FF292CC1710003E515 /* macros_msa.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3917292CC1800003E515 /* scale_argb.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3900292CC1710003E515 /* scale_argb.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3918292CC1800003E515 /* scale_uv.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3901292CC1710003E515 /* scale_uv.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3919292CC1800003E515 /* scale_row.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3902292CC1720003E515 /* scale_row.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B391A292CC1800003E515 /* compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3903292CC1730003E515 /* compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B391B292CC1800003E515 /* video_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3904292CC1730003E515 /* video_common.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B391C292CC1800003E515 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3905292CC1740003E515 /* version.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B391D292CC1800003E515 /* convert_argb.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3906292CC1750003E515 /* convert_argb.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B391E292CC1800003E515 /* rotate_row.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3907292CC1760003E515 /* rotate_row.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B391F292CC1800003E515 /* convert_from.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3908292CC1770003E515 /* convert_from.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3920292CC1800003E515 /* rotate.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3909292CC1770003E515 /* rotate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3921292CC1800003E515 /* mjpeg_decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B390A292CC1780003E515 /* mjpeg_decoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3922292CC1800003E515 /* convert_from_argb.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B390B292CC1780003E515 /* convert_from_argb.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3923292CC1800003E515 /* convert.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B390C292CC1790003E515 /* convert.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3924292CC1800003E515 /* scale_rgb.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B390D292CC1790003E515 /* scale_rgb.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3925292CC1800003E515 /* scale.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B390E292CC17A0003E515 /* scale.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3926292CC1800003E515 /* cpu_id.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B390F292CC17B0003E515 /* cpu_id.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3927292CC1800003E515 /* planar_functions.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3910292CC17C0003E515 /* planar_functions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3928292CC1800003E515 /* row.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3911292CC17E0003E515 /* row.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		410B3929292CC1800003E515 /* rotate_argb.h in Headers */ = {isa = PBXBuildFile; fileRef = 410B3912292CC17E0003E515 /* rotate_argb.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		410BA1232570F60C002E2F8A /* deprecated_rtp_sender_egress.cc in Sources */ = {isa = PBXBuildFile; fileRef = 410BA1212570F60C002E2F8A /* deprecated_rtp_sender_egress.cc */; };
 		410BA1242570F60C002E2F8A /* deprecated_rtp_sender_egress.h in Headers */ = {isa = PBXBuildFile; fileRef = 410BA1222570F60C002E2F8A /* deprecated_rtp_sender_egress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		410BA1292570F6A5002E2F8A /* libaom_av1_decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 410BA1272570F6A5002E2F8A /* libaom_av1_decoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -19963,29 +19940,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				410B3914292CC1800003E515 /* basic_types.h in Headers */,
-				410B391A292CC1800003E515 /* compare.h in Headers */,
-				410B3913292CC1800003E515 /* compare_row.h in Headers */,
-				410B3923292CC1800003E515 /* convert.h in Headers */,
-				410B391D292CC1800003E515 /* convert_argb.h in Headers */,
-				410B391F292CC1800003E515 /* convert_from.h in Headers */,
-				410B3922292CC1800003E515 /* convert_from_argb.h in Headers */,
-				410B3926292CC1800003E515 /* cpu_id.h in Headers */,
-				410B3915292CC1800003E515 /* loongson_intrinsics.h in Headers */,
-				410B3916292CC1800003E515 /* macros_msa.h in Headers */,
-				410B3921292CC1800003E515 /* mjpeg_decoder.h in Headers */,
-				410B3927292CC1800003E515 /* planar_functions.h in Headers */,
-				410B3920292CC1800003E515 /* rotate.h in Headers */,
-				410B3929292CC1800003E515 /* rotate_argb.h in Headers */,
-				410B391E292CC1800003E515 /* rotate_row.h in Headers */,
-				410B3928292CC1800003E515 /* row.h in Headers */,
-				410B3925292CC1800003E515 /* scale.h in Headers */,
-				410B3917292CC1800003E515 /* scale_argb.h in Headers */,
-				410B3924292CC1800003E515 /* scale_rgb.h in Headers */,
-				410B3919292CC1800003E515 /* scale_row.h in Headers */,
-				410B3918292CC1800003E515 /* scale_uv.h in Headers */,
-				410B391C292CC1800003E515 /* version.h in Headers */,
-				410B391B292CC1800003E515 /* video_common.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
#### 9a480a158e649d9dbf5a3f1685e99a8283dc887a
<pre>
Stop marking libyuv headers as private
<a href="https://bugs.webkit.org/show_bug.cgi?id=250405">https://bugs.webkit.org/show_bug.cgi?id=250405</a>
rdar://104084590

Reviewed by Eric Carlson.

These headers are not needed as private.

* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/258744@main">https://commits.webkit.org/258744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce558fc3bb13c996a76e1048e58b7b79ed644340

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112097 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172317 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2870 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95091 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108617 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5414 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45609 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7307 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3196 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->