### PR TITLE
Add Guard-Malloc and ASAN as modifiers to test expectations

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2065,7 +2065,8 @@ fast/canvas/webgl/webgl-compressed-texture-astc.html [ Skip ]
 
 webkit.org/b/223820 inspector/debugger/csp-exceptions.html [ Pass Failure Timeout ]
 
-webkit.org/b/223949 crypto/crypto-random-values-oom.html [ Pass Timeout ]
+webkit.org/b/223949 [ Release Debug ] crypto/crypto-random-values-oom.html [ Pass Timeout ]
+[ Guard-Malloc ] crypto/crypto-random-values-oom.html [ Skip ]
 
 webkit.org/b/223973 [ Debug ] imported/w3c/web-platform-tests/xhr/xhr-timeout-longtask.any.worker.html [ Pass Failure ]
 

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -96,7 +96,7 @@ class Port(object):
     # Test names resemble unix relative paths, and use '/' as a directory separator.
     TEST_PATH_SEPARATOR = '/'
 
-    ALL_BUILD_TYPES = ('debug', 'release')
+    ALL_BUILD_TYPES = ('debug', 'release', 'guard-malloc', 'asan')
 
     DEFAULT_ARCHITECTURE = 'x86'
     DEVICE_TYPE = None
@@ -1094,7 +1094,13 @@ class Port(object):
     def test_configuration(self):
         """Returns the current TestConfiguration for the port."""
         if not self._test_configuration:
-            self._test_configuration = TestConfiguration(self.version_name(), self.architecture(), self._options.configuration.lower())
+            if self.get_option('guard_malloc'):
+                style = 'guard-malloc'
+            elif self._config.asan:
+                style = 'asan'
+            else:
+                style = self._options.configuration.lower()
+            self._test_configuration = TestConfiguration(self.version_name(), self.architecture(), style)
         return self._test_configuration
 
     # FIXME: Belongs on a Platform object.


### PR DESCRIPTION
#### 77cc784b7c9e760613ae2fe7849e3215184be868
<pre>
Add Guard-Malloc and ASAN as modifiers to test expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250407">https://bugs.webkit.org/show_bug.cgi?id=250407</a>

Reviewed by David Kilzer and Jonathan Bedard.

Add the support for &quot;ASAN&quot; and &quot;Guard-Malloc&quot; as test expectation modifiers.
These are build types like &quot;Release&quot; and &quot;Debug&quot;.

Use that to skip crypto/crypto-random-values-oom.html on guard malloc bots.

* LayoutTests/platform/mac/TestExpectations:
* Tools/Scripts/webkitpy/layout_tests/models/test_configuration_unittest.py:
(make_mock_all_test_configurations_set):
(TestConfigurationConverterTest.test_to_config_set_with_asan_and_guard_malloc):
(TestConfigurationConverterTest.test_macro_expansion):
(TestConfigurationConverterTest.test_to_specifier_lists):
* Tools/Scripts/webkitpy/port/base.py:
(Port):
(Port.test_configuration):

Canonical link: <a href="https://commits.webkit.org/258760@main">https://commits.webkit.org/258760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39a86cd84e547a14d6eb2e17e9db52ccfa1f9e23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112114 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172336 "Hash 39a86cd8 for PR 8482 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2887 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109782 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37626 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/106374 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24711 "Found 2 new test failures: http/tests/security/clean-origin-css-exposed-resource-timing.html, http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26125 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45616 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7325 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3205 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->