### PR TITLE
gamepad.vibrationActuator.playEffect() should throw for invalid effect parameters

### DIFF
--- a/LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation-expected.txt
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation-expected.txt
@@ -1,0 +1,23 @@
+Tests input validation for vibrationActuator.playEffect
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gamepad.vibrationActuator.canPlayEffectType('dual-rumble') is true
+PASS result is "complete"
+* Invalid input test: Negative duration
+PASS playEffect() threw exception: TypeError: Invalid effect parameter
+* Invalid input test: Negative startDelay
+PASS playEffect() threw exception: TypeError: Invalid effect parameter
+* Invalid input test: Negative weakMagnitude
+PASS playEffect() threw exception: TypeError: Invalid effect parameter
+* Invalid input test: Negative strongMagnitude
+PASS playEffect() threw exception: TypeError: Invalid effect parameter
+* Invalid input test: weakMagnitude > 1
+PASS playEffect() threw exception: TypeError: Invalid effect parameter
+* Invalid input test: strongMagnitude > 1
+PASS playEffect() threw exception: TypeError: Invalid effect parameter
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation.html
@@ -1,0 +1,53 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests input validation for vibrationActuator.playEffect");
+jsTestIsAsync = true;
+
+let gamepad = null;
+
+async function shouldThrowDueToInvalidParameter(description, parameters)
+{
+    debug("* Invalid input test: " + description);
+    try {
+        await gamepad.vibrationActuator.playEffect('dual-rumble', parameters);
+        testFailed("playEffect() did not throw an exception()");
+    } catch (error) {
+        testPassed("playEffect() threw exception: " + error);
+    }
+}
+
+function runTest() {
+    addEventListener("gamepadconnected", async e => {
+        gamepad = event.gamepad;
+        shouldBeTrue("gamepad.vibrationActuator.canPlayEffectType('dual-rumble')");
+        try {
+            result = await gamepad.vibrationActuator.playEffect('dual-rumble');
+            shouldBeEqualToString("result", "complete");
+        } catch (error) {
+            testFailed("playEffect('dual-rumble') unexpectedly threw exception: " + error);
+        }
+
+        await shouldThrowDueToInvalidParameter("Negative duration", { duration: -1 });
+        await shouldThrowDueToInvalidParameter("Negative startDelay", { startDelay: -1 });
+        await shouldThrowDueToInvalidParameter("Negative weakMagnitude", { weakMagnitude: -1 });
+        await shouldThrowDueToInvalidParameter("Negative strongMagnitude", { strongMagnitude: -1 });
+        await shouldThrowDueToInvalidParameter("weakMagnitude > 1", { weakMagnitude: 2 });
+        await shouldThrowDueToInvalidParameter("strongMagnitude > 1", { strongMagnitude: 2 });
+
+        finishJSTest();
+    });
+
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    testRunner.setMockGamepadAxisValue(0, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(0, 1, 1.0);
+    testRunner.connectMockGamepad(0);
+}
+
+onload = runTest;
+
+</script>
+</body>

--- a/Source/WebCore/testing/MockGamepad.cpp
+++ b/Source/WebCore/testing/MockGamepad.cpp
@@ -34,6 +34,7 @@ MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& 
     : PlatformGamepad(index)
 {
     m_connectTime = m_lastUpdateTime = MonotonicTime::now();
+    m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
     updateDetails(gamepadID, mapping, axisCount, buttonCount);
 }
 


### PR DESCRIPTION
#### f5f611375e53ede72b6ab8154ffc6e1c2b74ca53
<pre>
gamepad.vibrationActuator.playEffect() should throw for invalid effect parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=250409">https://bugs.webkit.org/show_bug.cgi?id=250409</a>

Reviewed by Brent Fulgham.

gamepad.vibrationActuator.playEffect() should throw for invalid effect parameters:
- <a href="https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuator-playeffect">https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuator-playeffect</a> (Step 1)

* LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation-expected.txt: Added.
* LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation.html: Added.
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::areEffectParametersValid):
(WebCore::GamepadHapticActuator::playEffect):
* Source/WebCore/testing/MockGamepad.cpp:
(WebCore::MockGamepad::MockGamepad):

Canonical link: <a href="https://commits.webkit.org/258752@main">https://commits.webkit.org/258752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/291b81ff2dd1433231c1e5824fc1047529b92dae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112109 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172329 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12992 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/2882 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; killing old processes; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109777 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108630 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37617 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24703 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26117 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/2882 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; killing old processes; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45608 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7320 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3199 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->