### PR TITLE
Gamepad.vibrationActuator.type should be "dual-rumble"

### DIFF
--- a/LayoutTests/gamepad/gamepad-vibrationActuator-type-expected.txt
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-type-expected.txt
@@ -1,0 +1,10 @@
+Tests for vibrationActuator.type
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gamepad.vibrationActuator.type is "dual-rumble"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-type.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-type.html
@@ -1,0 +1,27 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests for vibrationActuator.type");
+jsTestIsAsync = true;
+
+function runTest() {
+    addEventListener("gamepadconnected", e => {
+        gamepad = e.gamepad;
+
+        shouldBeEqualToString("gamepad.vibrationActuator.type", "dual-rumble");
+
+        finishJSTest();
+    });
+
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    testRunner.setMockGamepadAxisValue(0, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(0, 1, 1.0);
+    testRunner.connectMockGamepad(0);
+}
+
+onload = runTest;
+</script>
+</body>

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -75,7 +75,7 @@ void Gamepad::updateFromPlatformGamepad(const PlatformGamepad& platformGamepad)
 GamepadHapticActuator& Gamepad::vibrationActuator()
 {
     if (!m_vibrationActuator)
-        m_vibrationActuator = GamepadHapticActuator::create(*this);
+        m_vibrationActuator = GamepadHapticActuator::create(GamepadHapticActuator::Type::DualRumble, *this);
     return *m_vibrationActuator;
 }
 

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -38,13 +38,13 @@
 
 namespace WebCore {
 
-Ref<GamepadHapticActuator> GamepadHapticActuator::create(Gamepad& gamepad)
+Ref<GamepadHapticActuator> GamepadHapticActuator::create(Type type, Gamepad& gamepad)
 {
-    return adoptRef(*new GamepadHapticActuator(gamepad));
+    return adoptRef(*new GamepadHapticActuator(type, gamepad));
 }
 
-GamepadHapticActuator::GamepadHapticActuator(Gamepad& gamepad)
-    : m_type { Type::Vibration }
+GamepadHapticActuator::GamepadHapticActuator(Type type, Gamepad& gamepad)
+    : m_type { type }
     , m_gamepad { gamepad }
 {
 }

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
@@ -41,12 +41,12 @@ struct GamepadEffectParameters;
 
 class GamepadHapticActuator : public RefCounted<GamepadHapticActuator> {
 public:
-    static Ref<GamepadHapticActuator> create(Gamepad&);
-    ~GamepadHapticActuator();
-
     using EffectType = GamepadHapticEffectType;
     enum class Type : uint8_t { Vibration, DualRumble };
     enum class Result : uint8_t { Complete, Preempted };
+
+    static Ref<GamepadHapticActuator> create(Type, Gamepad&);
+    ~GamepadHapticActuator();
 
     Type type() const { return m_type; }
     bool canPlayEffectType(EffectType) const;
@@ -54,7 +54,7 @@ public:
     void reset(Document&, Ref<DeferredPromise>&&);
 
 private:
-    explicit GamepadHapticActuator(Gamepad&);
+    GamepadHapticActuator(Type, Gamepad&);
 
     Type m_type;
     WeakPtr<Gamepad> m_gamepad;


### PR DESCRIPTION
#### 4eaf82bc0732bda0d63b7886f7e3647df6405d01
<pre>
Gamepad.vibrationActuator.type should be &quot;dual-rumble&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=250410">https://bugs.webkit.org/show_bug.cgi?id=250410</a>

Reviewed by Alex Christensen.

Gamepad.vibrationActuator.type should be &quot;dual-rumble&quot;, not &quot;vibration&quot;:
- <a href="https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuatortype">https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuatortype</a>

* LayoutTests/gamepad/gamepad-vibrationActuator-type-expected.txt: Added.
* LayoutTests/gamepad/gamepad-vibrationActuator-type.html: Added.
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
(WebCore::Gamepad::vibrationActuator):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::create):
(WebCore::GamepadHapticActuator::GamepadHapticActuator):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h:

Canonical link: <a href="https://commits.webkit.org/258758@main">https://commits.webkit.org/258758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d1caa1d06f91a5e62a09dff667e12f6995952c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112111 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172331 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2884 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109779 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108632 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37619 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24702 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2574 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45607 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7322 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3204 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->