### PR TITLE
Gamepad.vibrationActuator should be [SameObject]

### DIFF
--- a/LayoutTests/gamepad/gamepad-vibrationActuator-SameObject-expected.txt
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-SameObject-expected.txt
@@ -1,0 +1,12 @@
+Tests that Gamepad.vibrationActuator keeps returning the same object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gamepad.vibrationActuator.foo is "bar"
+PASS gamepad.vibrationActuator.foo is "bar"
+PASS gamepad.vibrationActuator.foo is "bar"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-SameObject.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-SameObject.html
@@ -1,0 +1,34 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests that Gamepad.vibrationActuator keeps returning the same object");
+jsTestIsAsync = true;
+
+function runTest() {
+    addEventListener("gamepadconnected", e => {
+        gamepad = e.gamepad;
+
+        gamepad.vibrationActuator.foo = "bar";
+        shouldBeEqualToString("gamepad.vibrationActuator.foo", "bar");
+        gc();
+        shouldBeEqualToString("gamepad.vibrationActuator.foo", "bar");
+        gc();
+        setTimeout(() => {
+            gc();
+            shouldBeEqualToString("gamepad.vibrationActuator.foo", "bar");
+            finishJSTest();
+        }, 0);
+    });
+
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    testRunner.setMockGamepadAxisValue(0, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(0, 1, 1.0);
+    testRunner.connectMockGamepad(0);
+}
+
+onload = runTest;
+</script>
+</body>

--- a/Source/WebCore/Modules/gamepad/Gamepad.idl
+++ b/Source/WebCore/Modules/gamepad/Gamepad.idl
@@ -37,6 +37,6 @@
     readonly attribute sequence<GamepadButton> buttons;
 
     // Extension: https://w3c.github.io/gamepad/extensions.html#partial-gamepad-interface
-    [EnabledBySetting=GamepadVibrationActuatorEnabled] readonly attribute GamepadHapticActuator vibrationActuator;
+    [EnabledBySetting=GamepadVibrationActuatorEnabled, SameObject, CachedAttribute] readonly attribute GamepadHapticActuator vibrationActuator;
 };
 


### PR DESCRIPTION
#### 326ecbfe967934fa156a5e5446cf0a07d1d7deb0
<pre>
Gamepad.vibrationActuator should be [SameObject]
<a href="https://bugs.webkit.org/show_bug.cgi?id=250413">https://bugs.webkit.org/show_bug.cgi?id=250413</a>

Reviewed by Brent Fulgham.

Gamepad.vibrationActuator should be [SameObject]&quot;
- <a href="https://w3c.github.io/gamepad/extensions.html#partial-gamepad-interface">https://w3c.github.io/gamepad/extensions.html#partial-gamepad-interface</a>

* LayoutTests/gamepad/gamepad-vibrationActuator-SameObject-expected.txt: Added.
* LayoutTests/gamepad/gamepad-vibrationActuator-SameObject.html: Added.
* Source/WebCore/Modules/gamepad/Gamepad.idl:

Canonical link: <a href="https://commits.webkit.org/258761@main">https://commits.webkit.org/258761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/651a6cfe583827776c2b36d4665a774c1df54e6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112113 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172333 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2886 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109781 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108634 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37621 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24710 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5430 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26124 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5578 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45615 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6018 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7324 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->