### PR TITLE
VibrationActuator should limit the duration of vibration effects

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
@@ -34,6 +34,10 @@ struct GamepadEffectParameters {
     double startDelay = 0.0;
     double strongMagnitude = 0.0;
     double weakMagnitude = 0.0;
+
+    // A maximum duration of 5 seconds is recommended by the specification:
+    // - https://w3c.github.io/gamepad/extensions.html#gamepadeffectparameters-dictionary
+    static constexpr Seconds maximumDuration = 5_s;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -87,6 +87,9 @@ void GamepadHapticActuator::playEffect(Document& document, EffectType effectType
         promise->reject(Exception { NotSupportedError, "This gamepad doesn't support playing such effect"_s });
         return;
     }
+
+    effectParameters.duration = std::min(effectParameters.duration, GamepadEffectParameters::maximumDuration.milliseconds());
+
     m_playingEffectPromise = WTFMove(promise);
     GamepadProvider::singleton().playEffect(m_gamepad->index(), m_gamepad->id(), effectType, effectParameters, [this, protectedThis = Ref { *this }, document = Ref { document }, playingEffectPromise = m_playingEffectPromise](bool success) {
         if (m_playingEffectPromise != playingEffectPromise)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -44,7 +44,7 @@ std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(G
                 @{ CHHapticPatternKeyEvent: @{
                     CHHapticPatternKeyEventType: CHHapticEventTypeHapticContinuous,
                     CHHapticPatternKeyTime: [NSNumber numberWithDouble:std::max<double>(parameters.startDelay / 1000., 0)],
-                    CHHapticPatternKeyEventDuration: [NSNumber numberWithDouble:std::max<double>(parameters.duration / 1000., 0)],
+                    CHHapticPatternKeyEventDuration: [NSNumber numberWithDouble:std::clamp<double>(parameters.duration / 1000., 0, GamepadEffectParameters::maximumDuration.seconds())],
                     CHHapticPatternKeyEventParameters: @[ @{
                         CHHapticPatternKeyParameterID: CHHapticEventParameterIDHapticIntensity,
                         CHHapticPatternKeyParameterValue: [NSNumber numberWithDouble:std::clamp<double>(intensity, 0, 1)],


### PR DESCRIPTION
#### cebb0928942f5aaa233f202f1dc99fe4fd8565c1
<pre>
VibrationActuator should limit the duration of vibration effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=250415">https://bugs.webkit.org/show_bug.cgi?id=250415</a>

Reviewed by Brent Fulgham.

VibrationActuator should limit the duration of vibration effects:
- <a href="https://w3c.github.io/gamepad/extensions.html#gamepadeffectparameters-dictionary">https://w3c.github.io/gamepad/extensions.html#gamepadeffectparameters-dictionary</a>

The specification recommends a maximum of 5 seconds.

* Source/WebCore/Modules/gamepad/GamepadEffectParameters.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::playEffect):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):

Canonical link: <a href="https://commits.webkit.org/258759@main">https://commits.webkit.org/258759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd803a934a57c8f4416e51cb7f8aea7af3cd1a0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112117 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172339 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2890 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95112 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108638 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37624 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24713 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26127 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2578 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45619 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6020 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7328 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->