### PR TITLE
Disable DOMParser's includeShadowRoots option by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1654,6 +1654,19 @@ DeclarativeShadowDOMEnabled:
     WebCore:
       default: true
 
+DeclarativeShadowDOMInDOMParserEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "DOMParser support for Declarative Shadow DOM"
+  humanReadableDescription: "Enable Declarative Shadow DOM in DOMParser"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DefaultARIAForCustomElementsEnabled:
   type: bool
   status: stable
@@ -5594,19 +5607,6 @@ StorageBlockingPolicy:
       default: WebCore::StorageBlockingPolicy::BlockThirdParty
     WebCore:
       default: StorageBlockingPolicy::AllowAll
-
-StreamingDeclarativeShadowDOMEnabled:
-  type: bool
-  status: stable
-  humanReadableName: "Streaming for Declarative Shadow DOM"
-  humanReadableDescription: "Enable Streaming for Declarative Shadow DOM"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
 
 SubgridEnabled:
   type: bool

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -536,8 +536,7 @@ void HTMLConstructionSite::insertHTMLElement(AtomHTMLToken&& token)
 
 void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
 {
-    if (m_document.settings().declarativeShadowDOMEnabled() && m_document.settings().streamingDeclarativeShadowDOMEnabled()
-        && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM)) {
+    if (m_document.settings().declarativeShadowDOMEnabled() && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM)) {
         std::optional<ShadowRootMode> mode;
         bool delegatesFocus = false;
         for (auto& attribute : token.attributes()) {
@@ -762,12 +761,6 @@ inline Document& HTMLConstructionSite::ownerDocumentForCurrentNode()
     if (is<HTMLTemplateElement>(currentNode()))
         return downcast<HTMLTemplateElement>(currentNode()).fragmentForInsertion().document();
     return currentNode().document();
-}
-
-void HTMLConstructionSite::attachDeclarativeShadowRootIfNeeded(Element& shadowHost, HTMLTemplateElement& templateElement)
-{
-    if (m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM) && m_document.settings().declarativeShadowDOMEnabled() && !shadowHost.document().templateDocumentHost())
-        templateElement.attachAsDeclarativeShadowRootIfNeeded(shadowHost);
 }
 
 static inline JSCustomElementInterface* findCustomElementInterface(Document& ownerDocument, const AtomString& localName)

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -177,8 +177,6 @@ public:
 
     OptionSet<ParserContentPolicy> parserContentPolicy() { return m_parserContentPolicy; }
 
-    void attachDeclarativeShadowRootIfNeeded(Element& host, HTMLTemplateElement&);
-
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
     bool isTelephoneNumberParsingEnabled() { return m_document.isTelephoneNumberParsingEnabled(); }
 #endif

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -914,8 +914,6 @@ bool HTMLTreeBuilder::processTemplateEndTag(AtomHTMLToken&& token)
     m_templateInsertionModes.removeLast();
     resetInsertionModeAppropriately();
 
-    m_tree.attachDeclarativeShadowRootIfNeeded(shadowHost.get(), templateElement);
-
     return true;
 }
 

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -45,7 +45,7 @@ ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, cons
     auto document = DOMImplementation::createDocument(contentType, nullptr, m_settings, URL { });
     if (m_contextDocument)
         document->setContextDocument(*m_contextDocument.get());
-    if (options.includeShadowRoots)
+    if (options.includeShadowRoots && document->settings().declarativeShadowDOMInDOMParserEnabled())
         document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent, ParserContentPolicy::AllowDeclarativeShadowDOM });
     else
         document->setParserContentPolicy({ ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });


### PR DESCRIPTION
#### fefa4f6d0b96e6ed774fd8103df98d8546ef24ec
<pre>
Disable DOMParser&apos;s includeShadowRoots option by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=250421">https://bugs.webkit.org/show_bug.cgi?id=250421</a>

Reviewed by Chris Dumez.

Add a new runtime flag to enable includeShadowRoots option in DOMParser
and turn this feature off by default.

Also deleted a runtime flag for streaming declarative shadow DOM
as we&apos;re only supporting streaming going forward.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement):
(WebCore::HTMLConstructionSite::attachDeclarativeShadowRootIfNeeded): Deleted.
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processTemplateEndTag):
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):

Canonical link: <a href="https://commits.webkit.org/258768@main">https://commits.webkit.org/258768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ec6e067eadda92f39183e5196b5a5579a145c73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112126 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172348 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2899 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109793 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108647 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37636 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24723 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93076 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5444 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26137 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89441 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3130 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2587 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29680 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45629 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/92367 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7338 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20683 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3207 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->