### PR TITLE
[git-webkit] Make pickable sub-classable

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.10.8',
+    version='5.10.9',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 10, 8)
+version = Version(5, 10, 9)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
@@ -111,19 +111,20 @@ class Pickable(Command):
     }
 
     @classmethod
-    def parser(cls, parser, loggers=None):
+    def parser(cls, parser, loggers=None, json=True):
         parser.add_argument(
             'argument', nargs=1,
             type=str, default=None,
             help='String representation of a commit, branch or range of commits to filter for cherry-pickable commits',
         )
-        parser.add_argument(
-            '--json', '-j',
-            help='Convert the commit to a machine-readable JSON object',
-            action='store_true',
-            dest='json',
-            default=False,
-        )
+        if json:
+            parser.add_argument(
+                '--json', '-j',
+                help='Convert the commit to a machine-readable JSON object',
+                action='store_true',
+                dest='json',
+                default=False,
+            )
         parser.add_argument(
             '--into', '-i',
             help='Branch to pick changes into',
@@ -203,7 +204,7 @@ class Pickable(Command):
         return [commit for commit in commits if str(commit) in filtered_in]
 
     @classmethod
-    def main(cls, args, repository, **kwargs):
+    def main(cls, args, repository, printer=None, **kwargs):
         if not isinstance(repository, local.Git):
             sys.stderr.write("Can only run '{}' on a native Git repository\n".format(cls.name))
             return 1
@@ -277,4 +278,5 @@ class Pickable(Command):
         if filters:
             commits = [commit for commit in commits if any([f(commit) for f in filters])]
 
-        return Info.print_(args, commits, verbose_default=1)
+        printer = printer or Info.print_
+        return printer(args, commits, verbose_default=1)


### PR DESCRIPTION
#### e1ba90357dfbfdbc4c27895ecda1991962e00538
<pre>
[git-webkit] Make pickable sub-classable
<a href="https://bugs.webkit.org/show_bug.cgi?id=250425">https://bugs.webkit.org/show_bug.cgi?id=250425</a>
rdar://104098971

Reviewed by Stephanie Lewis.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py:
(Pickable.parser): Allow caller to disable the --json option.
(Pickable.main): Allow caller to override the printer function we feed
the list of pickable commits to.

Canonical link: <a href="https://commits.webkit.org/258801@main">https://commits.webkit.org/258801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1de1b3b9006eee6cda6c0b57bd3012ba55463ec7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/102981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112232 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3007 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95218 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/108754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/106491 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5537 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5692 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/101867 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7441 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3219 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->