### PR TITLE
Some UI-side scrolling tests fail because we fail to clear latched nodes

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -175,7 +175,7 @@ public:
 
     ScrollingTreeFrameScrollingNode* rootNode() const { return m_rootNode.get(); }
     std::optional<ScrollingNodeID> latchedNodeID() const;
-    void clearLatchedNode();
+    WEBCORE_EXPORT void clearLatchedNode();
 
     bool hasFixedOrSticky() const { return !!m_fixedOrStickyNodeCount; }
     void fixedOrStickyNodeAdded() { ++m_fixedOrStickyNodeCount; }

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -137,6 +137,8 @@ void ThreadedScrollingCoordinator::hasNodeWithAnimatedScrollChanged(bool hasAnim
 
 void ThreadedScrollingCoordinator::startMonitoringWheelEvents(bool clearLatchingState)
 {
+    // setIsMonitoringWheelEvents() is called on the root node via AsyncScrollingCoordinator::frameViewLayoutUpdated().
+
     if (clearLatchingState)
         scrollingTree()->clearLatchedNode();
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -625,6 +625,8 @@ static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingState
 
 void RemoteScrollingCoordinatorTransaction::encode(IPC::Encoder& encoder) const
 {
+    encoder << m_clearScrollLatching;
+
     int numNodes = m_scrollingStateTree ? m_scrollingStateTree->nodeCount() : 0;
     encoder << numNodes;
     
@@ -650,6 +652,9 @@ bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder, Remote
 
 bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder)
 {
+    if (!decoder.decode(m_clearScrollLatching))
+        return false;
+
     int numNodes;
     if (!decoder.decode(numNodes))
         return false;
@@ -945,6 +950,9 @@ String RemoteScrollingCoordinatorTransaction::description() const
 {
     TextStream ts;
 
+    if (m_clearScrollLatching)
+        ts.dumpProperty("clear scroll latching", clearScrollLatching());
+
     ts.startGroup();
     ts << "scrolling state tree";
 
@@ -963,7 +971,7 @@ String RemoteScrollingCoordinatorTransaction::description() const
 
 void RemoteScrollingCoordinatorTransaction::dump() const
 {
-    fprintf(stderr, "%s", description().utf8().data());
+    WTFLogAlways("%s", description().utf8().data());
 }
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -44,6 +44,9 @@ public:
     void encode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, RemoteScrollingCoordinatorTransaction&);
 
+    bool clearScrollLatching() const { return m_clearScrollLatching; }
+    void setClearScrollLatching(bool clearLatching) { m_clearScrollLatching = clearLatching; }
+
 #if !defined(NDEBUG) || !LOG_DISABLED
     String description() const;
     void dump() const;
@@ -53,6 +56,10 @@ private:
     WARN_UNUSED_RETURN bool decode(IPC::Decoder&);
     
     std::unique_ptr<WebCore::ScrollingStateTree> m_scrollingStateTree;
+    
+    // Data encoded here should be "imperative" (valid just for one transaction). Stateful things should live on scrolling tree nodes.
+    // Maybe RequestedScrollData should move here.
+    bool m_clearScrollLatching { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -90,6 +90,9 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
     m_scrollingTree->commitTreeState(WTFMove(stateTree));
 
     establishLayerTreeScrollingRelations(*layerTreeHost);
+    
+    if (transaction.clearScrollLatching())
+        m_scrollingTree->clearLatchedNode();
 
     return std::exchange(m_requestedScroll, { });
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -73,6 +73,8 @@ private:
     bool isScrollSnapInProgress(WebCore::ScrollingNodeID) const final;
 
     void setScrollPinningBehavior(WebCore::ScrollPinningBehavior) override;
+    
+    void startMonitoringWheelEvents(bool clearLatchingState) final;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
@@ -91,6 +93,8 @@ private:
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveRubberBanding;
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveScrollSnap;
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveUserScrolls;
+    
+    bool m_clearScrollLatchingInNextTransaction { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -43,6 +43,7 @@
 #import <WebCore/Page.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderView.h>
+#import <WebCore/ScrollingStateFrameScrollingNode.h>
 #import <WebCore/ScrollingTreeFixedNodeCocoa.h>
 #import <WebCore/ScrollingTreeStickyNodeCocoa.h>
 #import <WebCore/WheelEventTestMonitor.h>
@@ -102,6 +103,8 @@ void RemoteScrollingCoordinator::setScrollPinningBehavior(ScrollPinningBehavior)
 void RemoteScrollingCoordinator::buildTransaction(RemoteScrollingCoordinatorTransaction& transaction)
 {
     willCommitTree();
+
+    transaction.setClearScrollLatching(std::exchange(m_clearScrollLatchingInNextTransaction, false));
     transaction.setStateTreeToEncode(scrollingStateTree()->commit(LayerRepresentation::PlatformLayerIDRepresentation));
 }
 
@@ -145,6 +148,12 @@ void RemoteScrollingCoordinator::addNodeWithActiveRubberBanding(ScrollingNodeID 
 void RemoteScrollingCoordinator::removeNodeWithActiveRubberBanding(ScrollingNodeID nodeID)
 {
     m_nodesWithActiveRubberBanding.remove(nodeID);
+}
+
+void RemoteScrollingCoordinator::startMonitoringWheelEvents(bool clearLatchingState)
+{
+    if (clearLatchingState)
+        m_clearScrollLatchingInNextTransaction = true;
 }
 
 void RemoteScrollingCoordinator::receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase)


### PR DESCRIPTION
#### 5ddd8c7440e84ce10907c96c173e92945a81dc52
<pre>
Some UI-side scrolling tests fail because we fail to clear latched nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250424">https://bugs.webkit.org/show_bug.cgi?id=250424</a>
rdar://104099444

Reviewed by Tim Horton.

After 258549@main undid the attempt to have `monitorWheelEvents` change state directly in the UI process,
we lost the code that clears latched nodes on the ScrollingTreeLatchingController when a test calls
`eventSender.monitorWheelEvents()`.

So the `clearScrollLatching` argument to `startMonitoringWheelEvents()` needs to be plumbed through
to the UI process. The natural way to do this would be to treat it like other &quot;tree-wide&quot; state that
transits through the root ScrollingStateScrollingNode node, but that&apos;s problematic for data that is
imperative, rather than stateful; it&apos;s clearer to have imperative commands be state on a single
transaction, so have RemoteScrollingCoordinatorTransaction store this state. Maybe programmatic
scroll requests should be migrated to this model at some point.

* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::startMonitoringWheelEvents):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::RemoteScrollingCoordinatorTransaction::encode const):
(WebKit::RemoteScrollingCoordinatorTransaction::decode):
(WebKit::RemoteScrollingCoordinatorTransaction::description const):
(WebKit::RemoteScrollingCoordinatorTransaction::dump const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
(WebKit::RemoteScrollingCoordinatorTransaction::clearScrollLatching const):
(WebKit::RemoteScrollingCoordinatorTransaction::setClearScrollLatching):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::buildTransaction):
(WebKit::RemoteScrollingCoordinator::startMonitoringWheelEvents):

Canonical link: <a href="https://commits.webkit.org/258771@main">https://commits.webkit.org/258771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a56ae0e60f5284f42a5bfe568b83765738520db2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112132 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172354 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2905 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109797 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9994 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37637 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24726 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5449 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2592 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6031 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7344 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->