### PR TITLE
VibrationActuator should stop vibrating when its document becomes hidden

### DIFF
--- a/LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active-expected.txt
+++ b/LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active-expected.txt
@@ -1,0 +1,12 @@
+Tests that the [playingEffectPromise] gets resolved with 'preempted' when the document is no longer fully active
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+* Starting dual-rumble effect
+* Detach iframe
+PASS result is "preempted"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active.html
+++ b/LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active.html
@@ -1,0 +1,34 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests that the [playingEffectPromise] gets resolved with 'preempted' when the document is no longer fully active");
+jsTestIsAsync = true;
+
+function runTest() {
+    testFrame = document.getElementById("testFrame");
+    testFrame.contentWindow.addEventListener("gamepadconnected", async e => {
+        gamepad = testFrame.contentWindow.navigator.getGamepads()[0];
+        debug("* Starting dual-rumble effect");
+        let promise = gamepad.vibrationActuator.playEffect('dual-rumble', { duration: 3000 });
+        debug("* Detach iframe");
+        testFrame.remove();
+	try {
+            result = await promise;
+            shouldBeEqualToString("result", "preempted");
+        } catch (error) {
+            testFailed("Promise got unexpectedly rejected: " + error);
+        }
+        finishJSTest();
+    });
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    testRunner.setMockGamepadAxisValue(0, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(0, 1, 1.0);
+    testRunner.connectMockGamepad(0);
+}
+onload = runTest;
+</script>
+<iframe id="testFrame" src="about:blank"></iframe>
+</body>

--- a/LayoutTests/gamepad/gamepad-vibration-visibility-change-expected.txt
+++ b/LayoutTests/gamepad/gamepad-vibration-visibility-change-expected.txt
@@ -1,0 +1,12 @@
+Tests that the [playingEffectPromise] gets resolved with 'preempted' when the document becomes hidden
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+* Starting dual-rumble effect
+* Changing page visibility to hidden
+PASS result is "preempted"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-vibration-visibility-change.html
+++ b/LayoutTests/gamepad/gamepad-vibration-visibility-change.html
@@ -1,0 +1,33 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests that the [playingEffectPromise] gets resolved with 'preempted' when the document becomes hidden");
+jsTestIsAsync = true;
+
+function runTest() {
+    addEventListener("gamepadconnected", async e => {
+        gamepad = e.gamepad;
+        debug("* Starting dual-rumble effect");
+        let promise = gamepad.vibrationActuator.playEffect('dual-rumble', { duration: 3000 });
+        debug("* Changing page visibility to hidden");
+        if (window.internals)
+            internals.setPageVisibility(false);
+	try {
+            result = await promise;
+            shouldBeEqualToString("result", "preempted");
+        } catch (error) {
+            testFailed("Promise got unexpectedly rejected: " + error);
+        }
+        finishJSTest();
+    });
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    testRunner.setMockGamepadAxisValue(0, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(0, 1, 1.0);
+    testRunner.connectMockGamepad(0);
+}
+onload = runTest;
+</script>
+</body>

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-Gamepad::Gamepad(const PlatformGamepad& platformGamepad)
+Gamepad::Gamepad(Document* document, const PlatformGamepad& platformGamepad)
     : m_id(platformGamepad.id())
     , m_index(platformGamepad.index())
     , m_connected(true)
@@ -43,6 +43,7 @@ Gamepad::Gamepad(const PlatformGamepad& platformGamepad)
     , m_mapping(platformGamepad.mapping())
     , m_supportedEffectTypes(platformGamepad.supportedEffectTypes())
     , m_axes(platformGamepad.axisValues().size(), 0.0)
+    , m_vibrationActuator(GamepadHapticActuator::create(document, GamepadHapticActuator::Type::DualRumble, *this))
 {
     unsigned buttonCount = platformGamepad.buttonValues().size();
     m_buttons.reserveInitialCapacity(buttonCount);
@@ -74,9 +75,7 @@ void Gamepad::updateFromPlatformGamepad(const PlatformGamepad& platformGamepad)
 
 GamepadHapticActuator& Gamepad::vibrationActuator()
 {
-    if (!m_vibrationActuator)
-        m_vibrationActuator = GamepadHapticActuator::create(GamepadHapticActuator::Type::DualRumble, *this);
-    return *m_vibrationActuator;
+    return m_vibrationActuator.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/Gamepad.h
+++ b/Source/WebCore/Modules/gamepad/Gamepad.h
@@ -36,15 +36,16 @@
 
 namespace WebCore {
 
+class Document;
 class GamepadButton;
 class GamepadHapticActuator;
 class PlatformGamepad;
 
 class Gamepad: public RefCounted<Gamepad>, public CanMakeWeakPtr<Gamepad> {
 public:
-    static Ref<Gamepad> create(const PlatformGamepad& platformGamepad)
+    static Ref<Gamepad> create(Document* document, const PlatformGamepad& platformGamepad)
     {
-        return adoptRef(*new Gamepad(platformGamepad));
+        return adoptRef(*new Gamepad(document, platformGamepad));
     }
     ~Gamepad();
 
@@ -64,7 +65,7 @@ public:
     GamepadHapticActuator& vibrationActuator();
 
 private:
-    explicit Gamepad(const PlatformGamepad&);
+    Gamepad(Document*, const PlatformGamepad&);
     String m_id;
     unsigned m_index;
     bool m_connected;
@@ -75,7 +76,7 @@ private:
     Vector<double> m_axes;
     Vector<Ref<GamepadButton>> m_buttons;
 
-    RefPtr<GamepadHapticActuator> m_vibrationActuator;
+    Ref<GamepadHapticActuator> m_vibrationActuator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl
@@ -34,14 +34,15 @@ enum GamepadHapticResult {
 };
 
 [
+    ActiveDOMObject,
     Conditional=GAMEPAD,
     EnabledBySetting=GamepadVibrationActuatorEnabled,
     Exposed=Window
 ] interface GamepadHapticActuator {
     readonly attribute GamepadHapticActuatorType type;
     boolean canPlayEffectType(GamepadHapticEffectType type);
-    [CallWith=RelevantDocument] Promise<GamepadHapticResult> playEffect(GamepadHapticEffectType type, optional GamepadEffectParameters params = {});
-    [CallWith=RelevantDocument] Promise<GamepadHapticResult> reset();
+    Promise<GamepadHapticResult> playEffect(GamepadHapticEffectType type, optional GamepadEffectParameters params = {});
+    Promise<GamepadHapticResult> reset();
 
     // Non standard: Supported for compatibility with Blink.
     [ImplementedAs=canPlayEffectType] boolean canPlay(GamepadHapticEffectType type);

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 
 static NavigatorGamepad* navigatorGamepadFromDOMWindow(DOMWindow* window)
 {
-    return NavigatorGamepad::from(&window->navigator());
+    return NavigatorGamepad::from(window->navigator());
 }
 
 GamepadManager& GamepadManager::singleton()

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -39,10 +39,10 @@ class PlatformGamepad;
 class NavigatorGamepad : public Supplement<Navigator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    NavigatorGamepad();
+    explicit NavigatorGamepad(Navigator&);
     virtual ~NavigatorGamepad();
 
-    static NavigatorGamepad* from(Navigator*);
+    static NavigatorGamepad* from(Navigator&);
 
     // The array of Gamepads might be sparse.
     // Null checking each entry is necessary.
@@ -60,6 +60,7 @@ private:
 
     const Vector<RefPtr<Gamepad>>& gamepads();
 
+    Navigator& m_navigator;
     Vector<RefPtr<Gamepad>> m_gamepads;
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -52,7 +52,7 @@ WebXRInputSource::WebXRInputSource(Document& document, WebXRSession& session, do
     , m_targetRaySpace(WebXRInputSpace::create(document, session, source.pointerOrigin))
     , m_connectTime(timestamp)
 #if ENABLE(GAMEPAD)
-    , m_gamepad(Gamepad::create(WebXRGamepad(timestamp, timestamp, source)))
+    , m_gamepad(Gamepad::create(&document, WebXRGamepad(timestamp, timestamp, source)))
 #endif
 {
     update(timestamp, source);

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -381,6 +381,12 @@ GPU* Navigator::gpu()
     return m_gpuForWebGPU.get();
 }
 
+Document* Navigator::document()
+{
+    auto* frame = this->frame();
+    return frame ? frame->document() : nullptr;
+}
+
 #if ENABLE(BADGING)
 
 void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -67,6 +67,8 @@ public:
 
     GPU* gpu();
 
+    Document* document();
+
 #if ENABLE(BADGING)
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearAppBadge(Ref<DeferredPromise>&&);

--- a/Source/WebCore/platform/gamepad/GamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/GamepadProvider.h
@@ -52,6 +52,8 @@ public:
     virtual void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) = 0;
     virtual void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) = 0;
 
+    virtual void clearGamepadsForTesting() { }
+
 protected:
     WEBCORE_EXPORT void dispatchPlatformGamepadInputActivity();
     void setShouldMakeGamepadsVisibile() { m_shouldMakeGamepadsVisible = true; }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -388,10 +388,6 @@
 #include "ImageControlsMac.h"
 #endif
 
-#if ENABLE(GAMEPAD)
-#include "MockGamepadProvider.h"
-#endif
-
 using JSC::CallData;
 using JSC::CodeBlock;
 using JSC::FunctionExecutable;
@@ -722,10 +718,6 @@ Internals::Internals(Document& document)
     VP9TestingOverrides::singleton().setHardwareDecoderDisabled(std::nullopt);
     VP9TestingOverrides::singleton().setVP9DecoderDisabled(std::nullopt);
     VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(std::nullopt);
-#endif
-
-#if ENABLE(GAMEPAD)
-    MockGamepadProvider::singleton().clearMockGamepads();
 #endif
 }
 

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -150,7 +150,7 @@ void MockGamepadProvider::gamepadInputActivity()
     });
 }
 
-void MockGamepadProvider::clearMockGamepads()
+void MockGamepadProvider::clearGamepadsForTesting()
 {
     // Disconnect any remaining connected gamepads.
     for (size_t i = 0; i < m_connectedGamepadVector.size(); ++i) {

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -45,13 +45,13 @@ public:
     bool isMockGamepadProvider() const final { return true; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
+    void clearGamepadsForTesting() final;
 
     void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount);
     bool setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
     bool setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
     bool connectMockGamepad(unsigned index);
     bool disconnectMockGamepad(unsigned index);
-    void clearMockGamepads();
 
 private:
     MockGamepadProvider();

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -46,6 +46,7 @@
 #include "WebContextInjectedBundleClient.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
+#include <WebCore/GamepadProvider.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -580,4 +581,12 @@ void WKContextSetLocalhostAliases(WKContextRef, WKArrayRef localhostAliases)
 {
     for (const auto& hostname : WebKit::toImpl(localhostAliases)->toStringVector())
         WebKit::LegacyGlobalSettings::singleton().registerHostnameAsLocal(hostname);
+}
+
+void WKContextClearMockGamepadsForTesting(WKContextRef)
+{
+#if ENABLE(GAMEPAD)
+    if (WebCore::GamepadProvider::singleton().isMockGamepadProvider())
+        WebCore::GamepadProvider::singleton().clearGamepadsForTesting();
+#endif
 }

--- a/Source/WebKit/UIProcess/API/C/WKContext.h
+++ b/Source/WebKit/UIProcess/API/C/WKContext.h
@@ -215,6 +215,8 @@ WK_EXPORT void WKContextRefreshPlugIns(WKContextRef context);
 
 WK_EXPORT void WKContextSetCustomWebContentServiceBundleIdentifier(WKContextRef contextRef, WKStringRef name);
 
+WK_EXPORT void WKContextClearMockGamepadsForTesting(WKContextRef contextRef);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1121,6 +1121,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
 
     WKContextClearCurrentModifierStateForTesting(TestController::singleton().context());
     WKContextSetUseSeparateServiceWorkerProcess(TestController::singleton().context(), false);
+    WKContextClearMockGamepadsForTesting(TestController::singleton().context());
 
     WKPageSetMockCameraOrientation(m_mainWebView->page(), 0);
     resetMockMediaDevices();


### PR DESCRIPTION
#### 6d29a35a2b0da6ab9ae6756dd7eb262fc77a51a2
<pre>
VibrationActuator should stop vibrating when its document becomes hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=250414">https://bugs.webkit.org/show_bug.cgi?id=250414</a>

Reviewed by Youenn Fablet.

VibrationActuator should stop vibrating when its document becomes hidden:
- <a href="https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface">https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface</a> (Page Visibility section)

Also address test flakiness by properly clearing mock gamepads between tests.
We used to call MockGamepadProvider::clearMockGamepads() inside the WebContent
process even though they are stored in the UIProcess nowadays.

* LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active.html: Added.
* LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active-expected.txt: Added.
* LayoutTests/gamepad/gamepad-vibration-visibility-change-expected.txt: Added.
* LayoutTests/gamepad/gamepad-vibration-visibility-change.html: Added.
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
(WebCore::Gamepad::Gamepad):
(WebCore::Gamepad::vibrationActuator):
* Source/WebCore/Modules/gamepad/Gamepad.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::create):
(WebCore::GamepadHapticActuator::GamepadHapticActuator):
(WebCore::GamepadHapticActuator::~GamepadHapticActuator):
(WebCore::GamepadHapticActuator::playEffect):
(WebCore::GamepadHapticActuator::reset):
(WebCore::GamepadHapticActuator::stopEffects):
(WebCore::GamepadHapticActuator::document):
(WebCore::GamepadHapticActuator::activeDOMObjectName const):
(WebCore::GamepadHapticActuator::suspend):
(WebCore::GamepadHapticActuator::stop):
(WebCore::GamepadHapticActuator::visibilityStateChanged):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.idl:
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::navigatorGamepadFromDOMWindow):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::NavigatorGamepad):
(WebCore::NavigatorGamepad::from):
(WebCore::NavigatorGamepad::gamepadFromPlatformGamepad):
(WebCore::NavigatorGamepad::getGamepads):
(WebCore::NavigatorGamepad::gamepadsBecameVisible):
(WebCore::NavigatorGamepad::gamepadConnected):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::WebXRInputSource):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::document):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/testing/MockGamepad.cpp:
(WebCore::MockGamepad::MockGamepad):

Canonical link: <a href="https://commits.webkit.org/258802@main">https://commits.webkit.org/258802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30c2a50eb42d635a6f260ee8c35471a5a44c0b70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102971 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112221 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2996 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95210 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108744 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5529 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5682 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45713 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6054 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7431 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->