### PR TITLE
Null pointer web content crash in AsyncScrollingCoordinator callback

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -66,7 +66,7 @@ AsyncScrollingCoordinator::AsyncScrollingCoordinator(Page* page)
 
 void AsyncScrollingCoordinator::hysterisisTimerFired(PAL::HysteresisState state)
 {
-    if (state == PAL::HysteresisState::Stopped)
+    if (m_page && state == PAL::HysteresisState::Stopped)
         m_page->didFinishScrolling();
 }
 


### PR DESCRIPTION
#### d1c80025c33eaa179b2feba7abf682af6292ed6a
<pre>
Null pointer web content crash in AsyncScrollingCoordinator callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=250426">https://bugs.webkit.org/show_bug.cgi?id=250426</a>
rdar://104099969

Reviewed by Simon Fraser.

Adds a null check for `m_page` in the hysteresis callback of `AsyncScrollingCoordinator`.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::hysterisisTimerFired):

Canonical link: <a href="https://commits.webkit.org/258792@main">https://commits.webkit.org/258792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60cf9960bf3ee7e7670e5cc3044ca21d7d4599ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112133 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172355 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2906 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109798 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108655 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9998 "Found 8 new test failures: fast/css-generated-content/initial-letter-clearance.html, imported/w3c/web-platform-tests/css/css-text/word-break/word-break-break-all-010.html, imported/w3c/web-platform-tests/feature-policy/reporting/encrypted-media-reporting.https.html, imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.html, imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.worker.html, media/mediacapabilities/mediacapabilities-allowed-codecs.html, media/mediacapabilities/mediacapabilities-allowed-containers.html, webgl/1.0.3/conformance/ogles/GL/functions/functions_089_to_096.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37641 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91843 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24727 "Found 2 new test failures: http/tests/security/clean-origin-css-exposed-resource-timing.html, http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79377 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26141 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2593 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6051 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7346 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->