### PR TITLE
Web Inspector: “Inspect Element” doesn’t reveal element in DOM tree if the element is hidden behind the "Show All Nodes" button

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
@@ -468,7 +468,7 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
             this._previousHoveredElement = null;
         }
 
-        if (element) {
+        if (element instanceof WI.DOMTreeElement) {
             element.hovered = true;
             this._previousHoveredElement = element;
 

--- a/Source/WebInspectorUI/UserInterface/Views/TreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeElement.js
@@ -491,13 +491,15 @@ WI.TreeElement = class TreeElement extends WI.Object
         return false;
     }
 
-    reveal()
+    reveal({skipExpandingAncestors} = {})
     {
-        var currentAncestor = this.parent;
-        while (currentAncestor && !currentAncestor.root) {
-            if (!currentAncestor.expanded)
-                currentAncestor.expand();
-            currentAncestor = currentAncestor.parent;
+        if (!skipExpandingAncestors) {
+            let currentAncestor = this.parent;
+            while (currentAncestor && !currentAncestor.root) {
+                if (!currentAncestor.expanded)
+                    currentAncestor.expand();
+                currentAncestor = currentAncestor.parent;
+            }
         }
 
         // This must be called before onreveal, as some subclasses will scrollIntoViewIfNeeded and


### PR DESCRIPTION
#### 93e932263fc0a5a9483af9d6e0ba2199365be54d
<pre>
Web Inspector: “Inspect Element” doesn’t reveal element in DOM tree if the element is hidden behind the &quot;Show All Nodes&quot; button
<a href="https://bugs.webkit.org/show_bug.cgi?id=250430">https://bugs.webkit.org/show_bug.cgi?id=250430</a>
rdar://102669246

Reviewed by Devin Rousso.

Revealing a TreeElement currently makes sure to traverse up through parent elements to expand each element to make sure
the element is visible. This doesn&apos;t necessilary work for DOMTreeElements, though, since they may additionally have
hidden elements behind a &quot;Show All Nodes&quot; button. This means we need to provide each parent element an opportunity to
fill in these hidden elements so that the entire chain of tree elements is actually loaded, otherwise we won&apos;t actually
reveal the element we wanted to.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.reveal):
- Tree elements should call to each ancestor to make sure the entire chain of elements is actually revealed by providing
the parent elements an opportunity to fill in missing elements that they are not currently displaying.

(WI.DOMTreeElement.prototype.onexpand):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js:
(WI.DOMTreeOutline.prototype._onmousemove):
- Related fixes: The element will not always be a DOMTreeElement (namely the button for showing more elements).

* Source/WebInspectorUI/UserInterface/Views/TreeElement.js:
(WI.TreeElement.prototype.reveal):
- Provide a way for to bypass expanding the ancestor tree. This is used by DOMTreeElement which overrides this method,
and expands the tree itself before calling here.

Canonical link: <a href="https://commits.webkit.org/258805@main">https://commits.webkit.org/258805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f562e09f3f3c696c48ac7af361529d1673b1a25a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112204 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172422 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2978 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95194 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110124 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10056 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37694 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24787 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26196 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2650 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45693 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6058 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7415 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->