### PR TITLE
Change notification permissions delegate method to expect NSURLs instead of NSStrings

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -149,8 +149,9 @@ private:
             return { };
 
         HashMap<WTF::String, bool> result;
-        NSDictionary<NSString *, NSNumber *> *permissions = [m_delegate.getAutoreleased() notificationPermissionsForWebsiteDataStore:m_dataStore.getAutoreleased()];
-        for (NSString *key in permissions) {
+        NSDictionary<NSURL *, NSNumber *> *permissions = [m_delegate.getAutoreleased() notificationPermissionsForWebsiteDataStore:m_dataStore.getAutoreleased()];
+        for (NSURL *key in permissions) {
+            ASSERT(key.scheme);
             NSNumber *value = permissions[key];
             auto origin = WebCore::SecurityOriginData::fromURL(URL(key));
             result.set(origin.toString(), value.boolValue);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
@@ -38,7 +38,7 @@ WK_API_AVAILABLE(macos(10.15), ios(13.0))
 - (void)requestStorageSpace:(NSURL *)mainFrameURL frameOrigin:(NSURL *)frameURL quota:(NSUInteger)quota currentSize:(NSUInteger)currentSize spaceRequired:(NSUInteger)spaceRequired decisionHandler:(void (^)(unsigned long long quota))decisionHandler;
 - (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore openWindow:(NSURL *)url fromServiceWorkerOrigin:(WKSecurityOrigin *)serviceWorkerOrigin completionHandler:(void (^)(WKWebView *newWebView))completionHandler;
-- (NSDictionary<NSString *, NSNumber *> *)notificationPermissionsForWebsiteDataStore:(WKWebsiteDataStore *)dataStore;
+- (NSDictionary<NSURL *, NSNumber *> *)notificationPermissionsForWebsiteDataStore:(WKWebsiteDataStore *)dataStore;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore showNotification:(_WKNotificationData *)notificationData;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore workerOrigin:(WKSecurityOrigin *)workerOrigin updatedAppBadge:(NSNumber *)badge;
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -196,12 +196,12 @@ TEST(PushAPI, firePushEvent)
 }
 
 @interface FirePushEventDataStoreDelegate : NSObject <_WKWebsiteDataStoreDelegate>
-@property (readwrite, copy) NSDictionary<NSString *, NSNumber *> *permissions;
+@property (readwrite, copy) NSDictionary<NSURL *, NSNumber *> *permissions;
 @property (readonly, copy) _WKNotificationData *mostRecentNotification;
 @end
 
 @implementation FirePushEventDataStoreDelegate
-- (NSDictionary<NSString *, NSNumber *> *)notificationPermissionsForWebsiteDataStore:(WKWebsiteDataStore *)dataStore
+- (NSDictionary<NSURL *, NSNumber *> *)notificationPermissionsForWebsiteDataStore:(WKWebsiteDataStore *)dataStore
 {
     return _permissions;
 }
@@ -235,7 +235,7 @@ TEST(PushAPI, firePushEventDataStoreDelegate)
 
     RetainPtr<FirePushEventDataStoreDelegate> delegate = adoptNS([FirePushEventDataStoreDelegate new]);
     delegate.get().permissions = @{
-        (NSString *)server.origin() : @YES
+        [NSURL URLWithString:(NSString *)server.origin()] : @YES
     };
     [configuration websiteDataStore]._delegate = delegate.get();
 


### PR DESCRIPTION
#### f2855604234b9941bcc4f2132dbe96c25b2b7c24
<pre>
Change notification permissions delegate method to expect NSURLs instead of NSStrings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250432">https://bugs.webkit.org/show_bug.cgi?id=250432</a>
rdar://103918987

Reviewed by Tim Horton.

Makes it a bit harder for clients to do the wrong thing.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:
(-[FirePushEventDataStoreDelegate notificationPermissionsForWebsiteDataStore:]):

Canonical link: <a href="https://commits.webkit.org/258960@main">https://commits.webkit.org/258960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b859a2cba3256f5084caa945121452d506a65fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112148 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172366 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2922 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109808 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37647 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79383 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5462 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26151 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2602 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6159 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7360 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->