### PR TITLE
tiled-drawing/scrolling/scroll-snap tests fail with UI-side compositing

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -423,6 +423,12 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async keyboardScroll(key)
+    {
+        eventSender.keyDown(key);
+        await UIHelper.ensurePresentationUpdate();
+    }
+
     static toggleCapsLock()
     {
         return new Promise((resolve) => {

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard-scaled.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard-scaled.html
@@ -40,10 +40,10 @@
                 eventSender.scalePageBy(scale, 0, 0);
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollLeft;
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 expectTrue(document.scrollingElement.scrollLeft == (window.innerWidth * scale), "arrow key div scrolled to second div.");
 
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
                 expectTrue(document.scrollingElement.scrollLeft == scrollPositionBeforeSnap, "arrow key div scrolled back to first div.");
             } catch (e) {
                 console.log(e);

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard-smooth-scroll-enabled.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard-smooth-scroll-enabled.html
@@ -37,10 +37,10 @@
                 await UIHelper.delayFor(0);
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollLeft;
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 expectTrue(document.scrollingElement.scrollLeft == window.innerWidth, "arrow key div scrolled to second div.");
 
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
                 expectTrue(document.scrollingElement.scrollLeft == scrollPositionBeforeSnap, "arrow key div scrolled back to first div.");
             } catch (e) {
                 console.log(e);

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard.html
@@ -34,13 +34,13 @@
             if (window.internals)
                 internals.settings.setScrollAnimatorEnabled(false);
             try {
-                await UIHelper.delayFor(0);
+                await UIHelper.ensurePresentationUpdate();
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollLeft;
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 expectTrue(document.scrollingElement.scrollLeft == window.innerWidth, "arrow key div scrolled to second div.");
 
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
                 expectTrue(document.scrollingElement.scrollLeft == scrollPositionBeforeSnap, "arrow key div scrolled back to first div.");
             } catch (e) {
                 console.log(e);

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard-scaled.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard-scaled.html
@@ -43,20 +43,20 @@
                 let initialScrollPosition = document.scrollingElement.scrollTop;
                 let results = [];
 
-                eventSender.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 results.push([document.scrollingElement.scrollTop == windowHeight, "arrow key scrolled to second div."]);
 
-                eventSender.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 results.push([document.scrollingElement.scrollTop == (windowHeight * 2), "arrow key scrolled to third div."]);
 
-                eventSender.keyDown("upArrow");
-                eventSender.keyDown("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
                 results.push([document.scrollingElement.scrollTop == 0, "arrow key div scrolled back to first div."]);
 
-                eventSender.keyDown("pageDown");
+                await UIHelper.keyboardScroll("pageDown");
                 results.push([document.scrollingElement.scrollTop == windowHeight, "page down scrolled to second div."]);
 
-                eventSender.keyDown("pageUp");
+                await UIHelper.keyboardScroll("pageUp");
                 results.push([document.scrollingElement.scrollTop == 0, "page up div scrolled back to first div."]);
 
                 // We avoid modifying the DOM until the test is over, because sometimes

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard-smooth-scroll-enabled.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard-smooth-scroll-enabled.html
@@ -38,20 +38,20 @@
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollTop;
                 let results = [];
-                eventSender.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 results.push([document.scrollingElement.scrollTop == window.innerHeight, "arrow key scrolled to second div."]);
 
-                eventSender.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 results.push([document.scrollingElement.scrollTop == (window.innerHeight * 2), "arrow key scrolled to third div."]);
 
-                eventSender.keyDown("upArrow");
-                eventSender.keyDown("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
                 results.push([document.scrollingElement.scrollTop == scrollPositionBeforeSnap, "arrow key div scrolled back to first div."]);
 
-                eventSender.keyDown("pageDown");
+                await UIHelper.keyboardScroll("pageDown");
                 results.push([document.scrollingElement.scrollTop == window.innerHeight, "page down scrolled to second div."]);
 
-                eventSender.keyDown("pageUp");
+                await UIHelper.keyboardScroll("pageUp");
                 results.push([document.scrollingElement.scrollTop == scrollPositionBeforeSnap, "page up div scrolled back to first div."]);
 
                 // We avoid modifying the DOM until the test is over, because sometimes

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard.html
@@ -38,20 +38,20 @@
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollTop;
                 let results = [];
-                eventSender.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 results.push([document.scrollingElement.scrollTop == window.innerHeight, "arrow key scrolled to second div."]);
 
-                eventSender.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 results.push([document.scrollingElement.scrollTop == (window.innerHeight * 2), "arrow key scrolled to third div."]);
 
-                eventSender.keyDown("upArrow");
-                eventSender.keyDown("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
                 results.push([document.scrollingElement.scrollTop == scrollPositionBeforeSnap, "arrow key div scrolled back to first div."]);
 
-                eventSender.keyDown("pageDown");
+                await UIHelper.keyboardScroll("pageDown");
                 results.push([document.scrollingElement.scrollTop == window.innerHeight, "page down scrolled to second div."]);
 
-                eventSender.keyDown("pageUp");
+                await UIHelper.keyboardScroll("pageUp");
                 results.push([document.scrollingElement.scrollTop == scrollPositionBeforeSnap, "page up div scrolled back to first div."]);
 
                 // We avoid modifying the DOM until the test is over, because sometimes

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe-horizontal-with-keyboard.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe-horizontal-with-keyboard.html
@@ -37,9 +37,9 @@
                 await UIHelper.delayFor(0);
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollLeft;
-                eventSender.keyDown("rightArrow");
-                eventSender.keyDown("rightArrow");
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 var betweenFirstScrollPositionAndSecond =
                     document.scrollingElement.scrollLeft > scrollPositionBeforeSnap
                     && document.scrollingElement.scrollLeft < window.innerWidth;
@@ -48,10 +48,10 @@
                 // We reset the scrolling position because changing the DOM when we are not on
                 // a snap point can reset our scroll position.
                 document.scrollingElement.scrollLeft = scrollPositionBeforeSnap;
-                eventSender.keyDown("rightArrow");
-                eventSender.keyDown("rightArrow");
-                eventSender.keyDown("rightArrow");
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
+                await UIHelper.keyboardScroll("leftArrow");
 
                 // Reversing directions should snap back.
                 expectTrue(document.scrollingElement.scrollLeft == scrollPositionBeforeSnap, "left arrow snapped back.");

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe-vertical-with-keyboard.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe-vertical-with-keyboard.html
@@ -38,27 +38,27 @@
 
                 let scrollPositionBeforeSnap = document.scrollingElement.scrollTop;
                 let results = [];
-                await UIHelper.keyDown("downArrow");
-                await UIHelper.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 var betweenFirstScrollPositionAndSecond =
                     document.scrollingElement.scrollTop > scrollPositionBeforeSnap
                     && document.scrollingElement.scrollTop < window.innerHeight;
                 results.push([betweenFirstScrollPositionAndSecond, "down arrow key did not scroll to second snap point"]);
 
-                await UIHelper.keyDown("pageDown");
+                await UIHelper.keyboardScroll("pageDown");
                 results.push([document.scrollingElement.scrollTop == window.innerHeight, "page down scrolled to the first snap point"]);
 
                 // Directional scrolling should be able to escape a snap point.
-                await UIHelper.keyDown("downArrow");
-                await UIHelper.keyDown("downArrow");
-                await UIHelper.keyDown("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
+                await UIHelper.keyboardScroll("downArrow");
                 var betweenSecondScrollPositionAndThird =
                     document.scrollingElement.scrollTop > window.innerHeight
                     && document.scrollingElement.scrollTop < (window.innerHeight * 2);
                 results.push([betweenSecondScrollPositionAndThird, "down arrow key scrolled away from second div."]);
 
                 // Reversing directions should snap back though.
-                await UIHelper.keyDown("upArrow");
+                await UIHelper.keyboardScroll("upArrow");
                 results.push([document.scrollingElement.scrollTop == window.innerHeight, "up arrow scrolled back to second div"]);
 
                 // We avoid modifying the DOM until the test is over, because sometimes

--- a/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow-rtl-with-keyboard.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow-rtl-with-keyboard.html
@@ -55,33 +55,33 @@
                 let targetElement = document.getElementById("container");
                 expectTrue(0 == targetElement.scrollLeft, "scroll origin is 0");
 
-                eventSender.keyDown("leftArrow");
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
 
                 let scrollPositionBetweenFirstAndSecondSnapPoint = targetElement.scrollLeft < 0 && targetElement.scrollLeft  > -300;
                 expectTrue(scrollPositionBetweenFirstAndSecondSnapPoint, "arrow keys allow escaping first snap position");
 
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 expectTrue(targetElement.scrollLeft == 0, "right arrow key snapped back to first snap position");
 
                 // Move to the second scroll snap position.
                 targetElement.scrollLeft = -300;
                 await UIHelper.delayFor(0);
 
-                eventSender.keyDown("leftArrow");
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
                 let scrollPositionBetweenSecondAndThirdSnapPoint = targetElement.scrollLeft < -300 && targetElement.scrollLeft  > -600;
                 expectTrue(scrollPositionBetweenSecondAndThirdSnapPoint, "left arrow keys allow escaping second snap position");
 
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 expectTrue(targetElement.scrollLeft == -300, "right arrow key snapped back to second snap position");
 
-                eventSender.keyDown("rightArrow");
-                eventSender.keyDown("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
+                await UIHelper.keyboardScroll("rightArrow");
                 scrollPositionBetweenFirstAndSecondSnapPoint = targetElement.scrollLeft < 0 && targetElement.scrollLeft  > -300;
                 expectTrue(scrollPositionBetweenFirstAndSecondSnapPoint, "right arrow keys allow escaping second snap position");
 
-                eventSender.keyDown("leftArrow");
+                await UIHelper.keyboardScroll("leftArrow");
                 expectTrue(targetElement.scrollLeft == -300, "left arrow key snapped back to second snap position");
             } catch (e) {
                 console.log(e);


### PR DESCRIPTION
#### 0a58ac14fcc147d261595d7958d25fa46d7581d0
<pre>
tiled-drawing/scrolling/scroll-snap tests fail with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250438">https://bugs.webkit.org/show_bug.cgi?id=250438</a>
rdar://104108634

Reviewed by Wenson Hsieh.

These tests do things like:

    eventSender.keyDown(&quot;rightArrow&quot;);
    expectTrue(document.scrollingElement.scrollLeft == (window.innerWidth * scale), &quot;arrow key div scrolled to second div.&quot;);

With UI-side compositing, arrow handling hits AsyncScrollingCoordinator::requestScrollPositionUpdate(), which
bounces to the UI process, and then IPCs back to the web process via AsyncScrollingCoordinator::reconcileScrollingState()
which updates the ScrollableArea&apos;s scroll position, which is then read by `scrollLeft`.

So the tests need to wait for a presentation update after dispatching the key. Add a UIHelper function for this, and
change the tests to use it.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async keyboardScroll):
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard-scaled.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard-smooth-scroll-enabled.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-horizontal-with-keyboard.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard-scaled.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard-smooth-scroll-enabled.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-with-keyboard.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe-horizontal-with-keyboard.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe-vertical-with-keyboard.html:
* LayoutTests/tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow-rtl-with-keyboard.html:

Canonical link: <a href="https://commits.webkit.org/258790@main">https://commits.webkit.org/258790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a044d4b30e522703414a82fa2861853455d2bba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112161 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172377 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2935 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109819 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37655 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24749 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26163 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2614 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7372 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->