### PR TITLE
REGRESSION (254017@main): Arabic default signature in Mail.app is not right-to-left

### DIFF
--- a/LayoutTests/fast/dom/HTMLElement/attr-dir-value-change-auto-parent-expected.txt
+++ b/LayoutTests/fast/dom/HTMLElement/attr-dir-value-change-auto-parent-expected.txt
@@ -1,0 +1,6 @@
+PASS getComputedStyle(element).getPropertyValue('direction') is 'rtl'
+PASS getComputedStyle(element).getPropertyValue('direction') is 'rtl'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+مرحبا

--- a/LayoutTests/fast/dom/HTMLElement/attr-dir-value-change-auto-parent.html
+++ b/LayoutTests/fast/dom/HTMLElement/attr-dir-value-change-auto-parent.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body dir="auto">
+    <div id="test">مرحبا</div>
+</body>
+<script>
+    var element = document.getElementById("test");
+    shouldBe("getComputedStyle(element).getPropertyValue('direction')", "'rtl'");
+    element.setAttribute("dir", "auto");
+    shouldBe("getComputedStyle(element).getPropertyValue('direction')", "'rtl'");
+</script>
+</html>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -845,7 +845,8 @@ void HTMLElement::dirAttributeChanged(const AtomString& value)
     RefPtr<Element> parent = parentOrShadowHostElement();
     bool isValid = true;
 
-    switch (parseTextDirection(value)) {
+    auto direction = parseTextDirection(value);
+    switch (direction) {
     case TextDirectionDirective::Invalid:
         isValid = false;
         if (selfOrPrecedingNodesAffectDirAuto() && (!parent || !parent->selfOrPrecedingNodesAffectDirAuto()) && !is<HTMLBDIElement>(*this))
@@ -875,7 +876,7 @@ void HTMLElement::dirAttributeChanged(const AtomString& value)
     }
 
     if (is<HTMLElement>(parent) && parent->selfOrPrecedingNodesAffectDirAuto()) {
-        if (isValid)
+        if (isValid && direction != TextDirectionDirective::Auto)
             setHasDirAutoFlagRecursively(this, false);
         downcast<HTMLElement>(*parent).adjustDirectionalityIfNeededAfterChildAttributeChanged(this);
     }


### PR DESCRIPTION
#### 222e3c7feef0cd1227e2afdad6234208528815eb
<pre>
REGRESSION (254017@main): Arabic default signature in Mail.app is not right-to-left
<a href="https://bugs.webkit.org/show_bug.cgi?id=250443">https://bugs.webkit.org/show_bug.cgi?id=250443</a>
rdar://102207392

Reviewed by Darin Adler and Ryosuke Niwa.

Mail.app controls the directionality of the signature by adding `dir=&quot;auto&quot;` to
the signature element, getting the element&apos;s computed style, and then updating
the attribute to reflect the computed value. The `&lt;body&gt;` of the email has
`dir=&quot;auto&quot;` specified.

Following 254017@main, adding the `dir` attribute to an element with a
`dir=&quot;auto&quot;` parent, results in an unconditional call to unset the
`SelfOrPrecedingNodesAffectDirAuto` node flag. This flag is read in
`HTMLElement::directionalityIfDirIsAuto`, which returns `std::nullopt` if the
flag is unset, rather than computing the directionality from the text.
Consequently, a fallback left-to-right value is used when resolving style.

To fix, only unset the `SelfOrPrecedingNodesAffectDirAuto` node flag if the
specified direction is valid, and not `auto`.

* LayoutTests/fast/dom/HTMLElement/attr-dir-value-change-auto-parent-expected.txt: Added.
* LayoutTests/fast/dom/HTMLElement/attr-dir-value-change-auto-parent.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::dirAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/258799@main">https://commits.webkit.org/258799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002d4268e1d8207ba1000f745d11d596e3240231

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112164 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172381 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2938 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109822 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37659 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79396 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26166 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2617 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6055 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7375 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->