### PR TITLE
[@property] Invalidate matched declarations cache when property registrations change

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Properties declared with @property reify correctly assert_equals: expected " 100px" but got "100px"
-FAIL Re-declaring a property with a different type affects reification assert_equals: expected "number" but got "px"
+PASS Re-declaring a property with a different type affects reification
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration-expected.txt
@@ -6,7 +6,7 @@ PASS @property later in stylesheet wins
 PASS CSS.registerProperty determines the registration when uncontested
 PASS @property registrations are cleared when rule removed
 PASS Computed value becomes token sequence when @property is removed
-FAIL Inherited status is reflected in computed styles when @property is removed assert_equals: expected "0px" but got "10px"
+PASS Inherited status is reflected in computed styles when @property is removed
 PASS Invalid @property rule (missing syntax) does not overwrite previous valid rule
 PASS Invalid @property rule (missing inherits descriptor) does not overwrite previous valid rule
 PASS Invalid @property rule (missing initial-value) does not overwrite previous valid rule

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -116,6 +116,9 @@ void CustomPropertyRegistry::registerFromStylesheet(const StyleRuleProperty::Des
     // Last rule wins.
     // https://drafts.css-houdini.org/css-properties-values-api/#determining-registration
     m_propertiesFromStylesheet.set(property.name, makeUnique<const CSSRegisteredCustomProperty>(WTFMove(property)));
+
+    // Changing property registration may affect computed property values in the cache.
+    m_scope.invalidateMatchedDeclarationsCache();
 }
 
 void CustomPropertyRegistry::clearRegisteredFromStylesheets()


### PR DESCRIPTION
#### f09c90ff743565c58e3d4835f025a99a61585157
<pre>
[@property] Invalidate matched declarations cache when property registrations change
<a href="https://bugs.webkit.org/show_bug.cgi?id=250446">https://bugs.webkit.org/show_bug.cgi?id=250446</a>
rdar://104113725

Reviewed by Antoine Quint.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration-expected.txt:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):

Property registrations may affect interpretations of custom properties in the cache.

Canonical link: <a href="https://commits.webkit.org/258787@main">https://commits.webkit.org/258787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92218a16f68f54adae3757bda9280f87e06e5966

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112192 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172410 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2967 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109881 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108715 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37684 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24778 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5501 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5654 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45684 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6041 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7403 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->