### PR TITLE
Use ThreadSafeWeakPtr for m_parent in ScrollingTreeNode

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -199,9 +199,10 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
     return result;
 }
 
-WheelEventHandlingResult ScrollingTree::handleWheelEventWithNode(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps, ScrollingTreeNode* node, EventTargeting eventTargeting)
+WheelEventHandlingResult ScrollingTree::handleWheelEventWithNode(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps, ScrollingTreeNode* startingNode, EventTargeting eventTargeting)
 {
     auto adjustedWheelEvent = wheelEvent;
+    RefPtr node = startingNode;
     while (node) {
         if (is<ScrollingTreeScrollingNode>(*node)) {
             auto& scrollingNode = downcast<ScrollingTreeScrollingNode>(*node);
@@ -388,14 +389,14 @@ void ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
         auto parentIt = m_nodeMap.find(parentNodeID);
         ASSERT_WITH_SECURITY_IMPLICATION(parentIt != m_nodeMap.end());
         if (parentIt != m_nodeMap.end()) {
-            auto* parent = parentIt->value.get();
+            RefPtr parent = parentIt->value.get();
 
-            auto* oldParent = node->parent();
+            RefPtr oldParent = node->parent();
             if (oldParent)
                 oldParent->removeChild(*node);
 
             if (oldParent != parent)
-                node->setParent(parent);
+                node->setParent(parent.copyRef());
 
             parent->appendChild(*node);
         } else {

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
@@ -62,7 +62,7 @@ FloatPoint ScrollingTreeFixedNode::computeLayerPosition() const
 {
     FloatSize overflowScrollDelta;
     ScrollingTreeStickyNode* lastStickyNode = nullptr;
-    for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+    for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         if (is<ScrollingTreeFrameScrollingNode>(*ancestor)) {
             // Fixed nodes are positioned relative to the containing frame scrolling node.
             // We bail out after finding one.

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
@@ -90,22 +90,22 @@ void ScrollingTreeNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateT
         ts.dumpProperty("nodeID", scrollingNodeID());
 }
 
-ScrollingTreeFrameScrollingNode* ScrollingTreeNode::enclosingFrameNodeIncludingSelf()
+RefPtr<ScrollingTreeFrameScrollingNode> ScrollingTreeNode::enclosingFrameNodeIncludingSelf()
 {
-    auto* node = this;
+    RefPtr node = this;
     while (node && !node->isFrameScrollingNode())
         node = node->parent();
 
-    return downcast<ScrollingTreeFrameScrollingNode>(node);
+    return downcast<ScrollingTreeFrameScrollingNode>(node.get());
 }
 
-ScrollingTreeScrollingNode* ScrollingTreeNode::enclosingScrollingNodeIncludingSelf()
+RefPtr<ScrollingTreeScrollingNode> ScrollingTreeNode::enclosingScrollingNodeIncludingSelf()
 {
-    auto* node = this;
+    RefPtr node = this;
     while (node && !node->isScrollingNode())
         node = node->parent();
 
-    return downcast<ScrollingTreeScrollingNode>(node);
+    return downcast<ScrollingTreeScrollingNode>(node.get());
 }
 
 void ScrollingTreeNode::dump(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -41,7 +41,7 @@ class ScrollingTree;
 class ScrollingTreeFrameScrollingNode;
 class ScrollingTreeScrollingNode;
 
-class ScrollingTreeNode : public ThreadSafeRefCounted<ScrollingTreeNode> {
+class ScrollingTreeNode : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingTreeNode> {
     WTF_MAKE_FAST_ALLOCATED;
     friend class ScrollingTree;
 public:
@@ -75,9 +75,9 @@ public:
     
     virtual void willBeDestroyed() { }
 
-    ScrollingTreeNode* parent() const { return m_parent; }
-    void setParent(ScrollingTreeNode* parent) { m_parent = parent; }
-    
+    RefPtr<ScrollingTreeNode> parent() const { return m_parent.get(); }
+    void setParent(RefPtr<ScrollingTreeNode>&& parent) { m_parent = parent; }
+
     WEBCORE_EXPORT bool isRootNode() const;
 
     const Vector<Ref<ScrollingTreeNode>>& children() const { return m_children; }
@@ -86,8 +86,8 @@ public:
     void removeChild(ScrollingTreeNode&);
     void removeAllChildren();
 
-    WEBCORE_EXPORT ScrollingTreeFrameScrollingNode* enclosingFrameNodeIncludingSelf();
-    WEBCORE_EXPORT ScrollingTreeScrollingNode* enclosingScrollingNodeIncludingSelf();
+    WEBCORE_EXPORT RefPtr<ScrollingTreeFrameScrollingNode> enclosingFrameNodeIncludingSelf();
+    WEBCORE_EXPORT RefPtr<ScrollingTreeScrollingNode> enclosingScrollingNodeIncludingSelf();
 
     WEBCORE_EXPORT void dump(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const;
 
@@ -107,7 +107,7 @@ private:
     const ScrollingNodeType m_nodeType;
     const ScrollingNodeID m_nodeID;
 
-    ScrollingTreeNode* m_parent { nullptr };
+    ThreadSafeWeakPtr<ScrollingTreeNode> m_parent;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -87,7 +87,7 @@ FloatPoint ScrollingTreeStickyNode::computeLayerPosition() const
         return m_constraints.layerPositionForConstrainingRect(constrainingRect);
     };
 
-    for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+    for (RefPtr ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         if (is<ScrollingTreeOverflowScrollProxyNode>(*ancestor)) {
             auto& overflowProxyNode = downcast<ScrollingTreeOverflowScrollProxyNode>(*ancestor);
             auto overflowNode = scrollingTree().nodeForID(overflowProxyNode.overflowScrollingNodeID());


### PR DESCRIPTION
#### d185a07dccbfd36d052f51b9bde0e42ddfc92d7f
<pre>
Use ThreadSafeWeakPtr for m_parent in ScrollingTreeNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=250447">https://bugs.webkit.org/show_bug.cgi?id=250447</a>

Reviewed by Simon Fraser and Chris Dumez.

Use ThreadSafeWeakPtr to store the parent node in ScrollingTreeNode.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::handleWheelEventWithNode):
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
* Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
(WebCore::ScrollingTreeFixedNode::computeLayerPosition const):
* Source/WebCore/page/scrolling/ScrollingTreeNode.cpp:
(WebCore::ScrollingTreeNode::enclosingFrameNodeIncludingSelf):
(WebCore::ScrollingTreeNode::enclosingScrollingNodeIncludingSelf):
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::parent const):
(WebCore::ScrollingTreeNode::setParent):
(): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::computeLayerPosition const):

Canonical link: <a href="https://commits.webkit.org/258795@main">https://commits.webkit.org/258795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1ccac433d4f5d21f197f1bfb6ecaaec8900f0cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112177 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172395 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2953 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109832 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108701 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37671 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24766 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26178 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2626 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45673 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7388 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3215 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->