### PR TITLE
Add support for inbound rtp trackIdentifier stat field

### DIFF
--- a/LayoutTests/webrtc/video-stats.html
+++ b/LayoutTests/webrtc/video-stats.html
@@ -122,8 +122,9 @@ function testTimestampDifference(timeStampDifference, numberOfFrames)
 function checkInboundFramesNumberIncreased(secondConnection, statsSecondConnection, count)
 {
     return getInboundRTPStats(secondConnection).then((stats) => {
-        assert_true("framesDropped" in stats);
-        assert_true(!!stats.kind);
+        assert_true("framesDropped" in stats, "framesDropped");
+        assert_true(!!stats.trackIdentifier, "trackIdentifier");
+        assert_true(!!stats.kind, "kind");
         if (stats.framesDecoded > statsSecondConnection.framesDecoded) {
             if (testTimestampDifference(stats.timestamp - statsSecondConnection.timestamp, stats.framesDecoded - statsSecondConnection.framesDecoded))
                 return Promise.reject("timestamp and frames increment do not match");

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -89,7 +89,7 @@ public:
     struct InboundRtpStreamStats : ReceivedRtpStreamStats {
         InboundRtpStreamStats() { type = RTCStatsReport::Type::InboundRtp; }
 
-        String receiverId;
+        String trackIdentifier;
         String remoteId;
         std::optional<uint32_t> framesDecoded;
         std::optional<uint32_t> keyFramesDecoded;

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
@@ -88,8 +88,7 @@ dictionary RTCReceivedRtpStreamStats : RTCRtpStreamStats {
 
 [ JSGenerateToJSObject ]
 dictionary RTCInboundRtpStreamStats : RTCReceivedRtpStreamStats {
-    // required DOMString receiverId;
-    DOMString remoteId;
+    required DOMString trackIdentifier;
     unsigned long framesDecoded;
     unsigned long keyFramesDecoded;
     unsigned long frameWidth;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -91,8 +91,11 @@ static inline void fillInboundRtpStreamStats(RTCStatsReport::InboundRtpStreamSta
 {
     fillReceivedRtpStreamStats(stats, rtcStats);
 
-    // receiverId
-    // remoteId
+    if (rtcStats.track_identifier.is_defined())
+        stats.trackIdentifier = fromStdString(*rtcStats.track_identifier);
+    if (rtcStats.remote_id.is_defined())
+        stats.remoteId = fromStdString(*rtcStats.remote_id);
+
     if (rtcStats.packets_received.is_defined())
         stats.packetsReceived = *rtcStats.packets_received;
     if (rtcStats.frames_dropped.is_defined())


### PR DESCRIPTION
#### fd6804135aa8312901cb94577f9ea6d33d6f7575
<pre>
Add support for inbound rtp trackIdentifier stat field
<a href="https://bugs.webkit.org/show_bug.cgi?id=250450">https://bugs.webkit.org/show_bug.cgi?id=250450</a>
rdar://problem/104118773

Expose trackIdentifier and remove receiverId.
This is needed as track stats might be removed in the future.

Reviewed by Eric Carlson.

* LayoutTests/webrtc/video-stats.html:
* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/RTCStatsReport.idl:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
(WebCore::fillInboundRtpStreamStats):

Canonical link: <a href="https://commits.webkit.org/258835@main">https://commits.webkit.org/258835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4c5fa4e14505a4c24bc12bfc6bba5087c21c5e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112186 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172404 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2962 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109849 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37678 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5496 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2636 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6077 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7397 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->