### PR TITLE
[ATSPI] Make `Atspi::Role` enum class

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
@@ -23,7 +23,7 @@
 namespace WebCore {
 namespace Atspi {
 
-enum Role {
+enum class Role {
     InvalidRole,
     AcceleratorLabel,
     Alert,

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -22,7 +22,6 @@
 
 #if USE(ATSPI)
 #include "AXObjectCache.h"
-#include "AccessibilityAtspiEnums.h"
 #include "AccessibilityAtspiInterfaces.h"
 #include "AccessibilityObjectInterface.h"
 #include "AccessibilityRootAtspi.h"
@@ -150,7 +149,7 @@ void AccessibilityObjectAtspi::elementDestroyed()
     AccessibilityAtspi::singleton().unregisterObject(*this);
 }
 
-static unsigned atspiRole(AccessibilityRole role)
+static Atspi::Role atspiRole(AccessibilityRole role)
 {
     switch (role) {
     case AccessibilityRole::Annotation:
@@ -1200,7 +1199,7 @@ void AccessibilityObjectAtspi::loadEvent(const char* event)
     AccessibilityAtspi::singleton().loadEvent(*this, event);
 }
 
-std::optional<unsigned> AccessibilityObjectAtspi::effectiveRole() const
+std::optional<Atspi::Role> AccessibilityObjectAtspi::effectiveRole() const
 {
     if (m_coreObject->isPasswordField())
         return Atspi::Role::PasswordText;
@@ -1254,7 +1253,7 @@ std::optional<unsigned> AccessibilityObjectAtspi::effectiveRole() const
     return std::nullopt;
 }
 
-unsigned AccessibilityObjectAtspi::role() const
+Atspi::Role AccessibilityObjectAtspi::role() const
 {
     if (!m_coreObject)
         return Atspi::Role::InvalidRole;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -21,6 +21,7 @@
 
 #if USE(ATSPI)
 #include "AccessibilityAtspi.h"
+#include "AccessibilityAtspiEnums.h"
 #include "AccessibilityObjectInterface.h"
 #include "IntRect.h"
 #include <wtf/OptionSet.h>
@@ -82,7 +83,7 @@ public:
     WEBCORE_EXPORT CString name() const;
     WEBCORE_EXPORT CString description() const;
     WEBCORE_EXPORT String locale() const;
-    WEBCORE_EXPORT unsigned role() const;
+    WEBCORE_EXPORT Atspi::Role role() const;
     WEBCORE_EXPORT unsigned childCount() const;
     WEBCORE_EXPORT Vector<RefPtr<AccessibilityObjectAtspi>> children() const;
     WEBCORE_EXPORT AccessibilityObjectAtspi* childAt(unsigned) const;
@@ -166,7 +167,7 @@ private:
     void childAdded(AccessibilityObjectAtspi&);
     void childRemoved(AccessibilityObjectAtspi&);
 
-    std::optional<unsigned> effectiveRole() const;
+    std::optional<Atspi::Role> effectiveRole() const;
     String effectiveRoleName() const;
     String roleName() const;
     const char* effectiveLocalizedRoleName() const;
@@ -244,7 +245,7 @@ private:
         } attributes;
 
         struct {
-            Vector<unsigned> value;
+            Vector<Atspi::Role> value;
             uint16_t type { 0 };
         } roles;
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
@@ -109,12 +109,12 @@ AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule(GVariant* rul
     }
     attributes.type = attributesMatchType;
 
-    int role;
+    Atspi::Role role;
     i = 0;
     while (g_variant_iter_next(rolesIter.get(), "i", &role)) {
         for (int j = 0; j < 32; ++j) {
-            if (role & (1 << j))
-                roles.value.append(i * 32 + j);
+            if (static_cast<int>(role) & (1 << j))
+                roles.value.append(static_cast<Atspi::Role>(i * 32 + j));
         }
         i++;
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -678,7 +678,7 @@ static String xmlRoleValueString(const String& xmlRoles)
     return { };
 }
 
-static String roleValueToString(unsigned roleValue)
+static String roleValueToString(WebCore::Atspi::Role roleValue)
 {
     switch (roleValue) {
     case WebCore::Atspi::Role::Alert:


### PR DESCRIPTION
#### cd2a1fbef4618f12a8b08ad464162fa4fef51061
<pre>
[ATSPI] Make `Atspi::Role` enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250452">https://bugs.webkit.org/show_bug.cgi?id=250452</a>

Reviewed by Michael Catanzaro.

When working with ATSPI-related code, there are several different role
types. There are - ARIA role, `WebCore::AccessibilityRole`, and
`Atspi::Role`.

Currently `Atspi::Role` is implemented as `enum`, which makes it hard to
distinguish it from other role types when it&apos;s used as an argument or
a return type:

`std::optional&lt;unsigned&gt; AccessibilityObjectAtspi::effectiveRole() const`

Using `enum class` instead should make such code more readable:

`std::optional&lt;Atspi::Role&gt; AccessibilityObjectAtspi::effectiveRole() const`

* Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::atspiRole):
(WebCore::AccessibilityObjectAtspi::effectiveRole const):
(WebCore::AccessibilityObjectAtspi::role const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::roleValueToString):

Canonical link: <a href="https://commits.webkit.org/258788@main">https://commits.webkit.org/258788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9086a1c182d57c74aa3aa362262800da0241cc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112188 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172406 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2964 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95178 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109852 "Failed to checkout and rebase branch from PR 8522") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108712 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37680 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24776 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5498 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26185 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2638 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45682 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6043 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7399 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->