### PR TITLE
[JSC] Save more code size by aligning wasm operations to JS's convention

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1917,6 +1917,7 @@
 		E33095DD23210A1B00EB7856 /* JSInternalFieldObjectImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = E33095DC23210A1400EB7856 /* JSInternalFieldObjectImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E334CBB521FD96A9000EB178 /* RegExpGlobalData.h in Headers */ = {isa = PBXBuildFile; fileRef = E334CBB321FD96A9000EB178 /* RegExpGlobalData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33637A61B63220200EE0840 /* ReflectObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E33637A41B63220200EE0840 /* ReflectObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3369129296EEBFE00324FD7 /* WasmOperationsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3369128296EEBFE00324FD7 /* WasmOperationsInlines.h */; };
 		E337B967224324EA0093A820 /* WasmCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = E337B966224324E50093A820 /* WasmCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E339700523210E0B00B0AE21 /* JSInternalFieldObjectImplInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E339700423210E0A00B0AE21 /* JSInternalFieldObjectImplInlines.h */; };
 		E33A94962255323000D42B06 /* RandomizingFuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = E33A94942255322900D42B06 /* RandomizingFuzzerAgent.h */; };
@@ -5402,6 +5403,7 @@
 		E334CBB321FD96A9000EB178 /* RegExpGlobalData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegExpGlobalData.h; sourceTree = "<group>"; };
 		E33637A31B63220200EE0840 /* ReflectObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReflectObject.cpp; sourceTree = "<group>"; };
 		E33637A41B63220200EE0840 /* ReflectObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReflectObject.h; sourceTree = "<group>"; };
+		E3369128296EEBFE00324FD7 /* WasmOperationsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmOperationsInlines.h; sourceTree = "<group>"; };
 		E337B966224324E50093A820 /* WasmCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCapabilities.h; sourceTree = "<group>"; };
 		E339700423210E0A00B0AE21 /* JSInternalFieldObjectImplInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSInternalFieldObjectImplInlines.h; sourceTree = "<group>"; };
 		E33A94922255322900D42B06 /* FuzzerAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FuzzerAgent.h; sourceTree = "<group>"; };
@@ -7550,6 +7552,7 @@
 				53C6FEEE1E8ADFA900B18425 /* WasmOpcodeOrigin.h */,
 				E39D8B2C23021E1E00265852 /* WasmOperations.cpp */,
 				E39D8B2D23021E1E00265852 /* WasmOperations.h */,
+				E3369128296EEBFE00324FD7 /* WasmOperationsInlines.h */,
 				E3C694B123026873006FBE42 /* WasmOSREntryData.h */,
 				527E6CEA2772B9C5005E0782 /* WasmOSREntryPlan.cpp */,
 				527E6CEB2772B9C5005E0782 /* WasmOSREntryPlan.h */,
@@ -11420,6 +11423,7 @@
 				5311BD4B1EA581E500525281 /* WasmOMGPlan.h in Headers */,
 				53C6FEEF1E8ADFA900B18425 /* WasmOpcodeOrigin.h in Headers */,
 				E39D8B2E23021E2600265852 /* WasmOperations.h in Headers */,
+				E3369129296EEBFE00324FD7 /* WasmOperationsInlines.h in Headers */,
 				53B4BD121F68B32500D2BEA3 /* WasmOps.h in Headers */,
 				E3C694B323026877006FBE42 /* WasmOSREntryData.h in Headers */,
 				527E6CEC2772B9CB005E0782 /* WasmOSREntryPlan.h in Headers */,

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -383,6 +383,11 @@ JS_EXPORT_PRIVATE bool isFromJSCode(void* returnAddress);
 #define DECLARE_CALL_FRAME(vm) ((vm).topCallFrame)
 #endif
 
+#if USE(BUILTIN_FRAME_ADDRESS)
+#define DECLARE_WASM_CALL_FRAME(instance) DECLARE_CALL_FRAME(instance->vm())
+#else
+#define DECLARE_WASM_CALL_FRAME(instance) ((instance)->temporaryCallFrame())
+#endif
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -43,6 +43,7 @@
 #if ENABLE(WEBASSEMBLY)
 #include "WasmMemoryInformation.h"
 #include "WasmContextInlines.h"
+#include "WasmInstance.h"
 #endif
 
 namespace JSC {
@@ -1084,6 +1085,14 @@ bool AssemblyHelpers::loadWasmContextInstanceNeedsMacroScratchRegister()
 bool AssemblyHelpers::storeWasmContextInstanceNeedsMacroScratchRegister()
 {
     return false;
+}
+
+void AssemblyHelpers::prepareWasmCallOperation(GPRReg instanceGPR)
+{
+    UNUSED_PARAM(instanceGPR);
+#if !USE(BUILTIN_FRAME_ADDRESS) || ASSERT_ENABLED
+    storePtr(GPRInfo::callFrameRegister, Address(instanceGPR, Wasm::Instance::offsetOfTemporaryCallFrame()));
+#endif
 }
 
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -76,6 +76,10 @@ public:
 #endif
     }
 
+#if ENABLE(WEBASSEMBLY)
+    void prepareWasmCallOperation(GPRReg instanceGPR);
+#endif
+
     void checkStackPointerAlignment()
     {
         // This check is both unneeded and harder to write correctly for ARM64

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -806,6 +806,11 @@ protected:
             return m_proc.addConstant(B3::Origin(), toB3Type(tmp.type()), 0);
         };
 
+#if !USE(BUILTIN_FRAME_ADDRESS) || ASSERT_ENABLED
+        // Prepare wasm operation calls.
+        self().emitStore(ExpressionType { Tmp(GPRInfo::callFrameRegister), Types::IPtr }, instanceValue().tmp(), Instance::offsetOfTemporaryCallFrame());
+#endif
+
         B3::Value* dummyFunc = m_proc.addConstant(B3::Origin(), B3::pointerType(), bitwise_cast<uintptr_t>(func));
         B3::Value* origin = m_proc.add<B3::CCallValue>(resultType, B3::Origin(), B3::Effects::none(), dummyFunc, makeDummyValue(theArgs)...);
 
@@ -1444,7 +1449,7 @@ template <typename Derived, typename ExpressionType>
 auto AirIRGeneratorBase<Derived, ExpressionType>::addGrowMemory(ExpressionType delta, ExpressionType& result) -> PartialResult
 {
     result = self().g32();
-    emitCCall(&operationGrowMemory, result, ExpressionType { Tmp(GPRInfo::callFrameRegister), Types::IPtr }, instanceValue(), delta);
+    emitCCall(&operationGrowMemory, result, instanceValue(), delta);
     restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_currentBlock);
 
     return { };

--- a/Source/JavaScriptCore/wasm/WasmBinding.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBinding.cpp
@@ -44,34 +44,24 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
     // https://bugs.webkit.org/show_bug.cgi?id=184157
     JIT jit;
 
-    GPRReg scratch = wasmCallingConvention().prologueScratchGPRs[0];
-#if USE(JSVALUE32_64)
-    GPRReg baseMemory = wasmCallingConvention().prologueScratchGPRs[1];
-    GPRReg sizeRegAsScratch = wasmCallingConvention().prologueScratchGPRs[2];
-#else
     const PinnedRegisterInfo& pinnedRegs = PinnedRegisterInfo::get();
-    GPRReg baseMemory = pinnedRegs.baseMemoryPointer;
-    GPRReg sizeRegAsScratch = pinnedRegs.boundsCheckingSizeRegister;
-#endif
-    ASSERT(baseMemory != GPRReg::InvalidGPRReg);
-    ASSERT(sizeRegAsScratch != GPRReg::InvalidGPRReg);
+    GPRReg scratch = wasmCallingConvention().prologueScratchGPRs[0];
     ASSERT(scratch != GPRReg::InvalidGPRReg);
-    ASSERT(noOverlap(scratch, baseMemory, sizeRegAsScratch));
+    ASSERT(noOverlap(scratch, PinnedRegisterInfo::get().wasmContextInstancePointer));
 
     // B3's call codegen ensures that the JSCell is a WebAssemblyFunction.
-    jit.loadWasmContextInstance(sizeRegAsScratch); // Old Instance*
-    // Get the callee's Wasm::Instance and set it as WasmContext's instance. The caller will take care of restoring its own Instance.
-    jit.loadPtr(JIT::Address(sizeRegAsScratch, Instance::offsetOfTargetInstance(importIndex)), baseMemory); // Instance*.
     // While we're accessing that cacheline, also get the wasm entrypoint so we can tail call to it below.
-    jit.loadPtr(JIT::Address(sizeRegAsScratch, Instance::offsetOfWasmEntrypointLoadLocation(importIndex)), scratch);
-    jit.storeWasmContextInstance(baseMemory);
+    jit.loadPtr(JIT::Address(pinnedRegs.wasmContextInstancePointer, Instance::offsetOfWasmEntrypointLoadLocation(importIndex)), scratch);
+    // Get the callee's Wasm::Instance and set it as WasmContext's instance. The caller will take care of restoring its own Instance.
+    // This switches the current instance.
+    jit.loadPtr(JIT::Address(pinnedRegs.wasmContextInstancePointer, Instance::offsetOfTargetInstance(importIndex)), pinnedRegs.wasmContextInstancePointer); // Instance*.
 
 #if !CPU(ARM) // ARM has no pinned registers for Wasm Memory, so no need to set them up
     // FIXME the following code assumes that all Wasm::Instance have the same pinned registers. https://bugs.webkit.org/show_bug.cgi?id=162952
-    // Set up the callee's baseMemory register as well as the memory size registers.
+    // Set up the callee's baseMemoryPointer register as well as the memory size registers.
     {
-        jit.loadPairPtr(baseMemory, CCallHelpers::TrustedImm32(Wasm::Instance::offsetOfCachedMemory()), baseMemory, pinnedRegs.boundsCheckingSizeRegister);
-        jit.cageConditionallyAndUntag(Gigacage::Primitive, baseMemory, pinnedRegs.boundsCheckingSizeRegister, wasmCallingConvention().prologueScratchGPRs[1], /* validateAuth */ true, /* mayBeNull */ false);
+        jit.loadPairPtr(pinnedRegs.wasmContextInstancePointer, CCallHelpers::TrustedImm32(Wasm::Instance::offsetOfCachedMemory()), pinnedRegs.baseMemoryPointer, pinnedRegs.boundsCheckingSizeRegister);
+        jit.cageConditionallyAndUntag(Gigacage::Primitive, pinnedRegs.baseMemoryPointer, pinnedRegs.boundsCheckingSizeRegister, wasmCallingConvention().prologueScratchGPRs[1], /* validateAuth */ true, /* mayBeNull */ false);
     }
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmInstance.h
+++ b/Source/JavaScriptCore/wasm/WasmInstance.h
@@ -196,6 +196,7 @@ public:
     static ptrdiff_t offsetOfGlobals() { return OBJECT_OFFSETOF(Instance, m_globals); }
     static ptrdiff_t offsetOfCachedMemory() { return OBJECT_OFFSETOF(Instance, m_cachedMemory); }
     static ptrdiff_t offsetOfCachedBoundsCheckingSize() { return OBJECT_OFFSETOF(Instance, m_cachedBoundsCheckingSize); }
+    static ptrdiff_t offsetOfTemporaryCallFrame() { return OBJECT_OFFSETOF(Instance, m_temporaryCallFrame); }
 
     // Tail accessors.
     static constexpr size_t offsetOfTail() { return WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(Instance)); }
@@ -230,6 +231,12 @@ public:
     const Tag& tag(unsigned i) const { return *m_tags[i]; }
     void setTag(unsigned, Ref<const Tag>&&);
 
+    CallFrame* temporaryCallFrame() const { return m_temporaryCallFrame; }
+    void setTemporaryCallFrame(CallFrame* callFrame)
+    {
+        m_temporaryCallFrame = callFrame;
+    }
+
 private:
     Instance(VM&, Ref<Module>&&);
     
@@ -244,6 +251,7 @@ private:
     Ref<Module> m_module;
     RefPtr<Memory> m_memory;
 
+    CallFrame* m_temporaryCallFrame { nullptr };
     Global::Value* m_globals { nullptr };
     FunctionWrapperMap m_functionWrappers;
     BitVector m_globalsToMark;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -43,8 +43,6 @@
 #include "JSWebAssemblyStruct.h"
 #include "ProbeContext.h"
 #include "ReleaseHeapAccessScope.h"
-#include "TypedArrayController.h"
-#include "WaiterListManager.h"
 #include "WasmCallee.h"
 #include "WasmCallingConvention.h"
 #include "WasmContextInlines.h"
@@ -55,6 +53,7 @@
 #include "WasmOMGPlan.h"
 #include "WasmOSREntryData.h"
 #include "WasmOSREntryPlan.h"
+#include "WasmOperationsInlines.h"
 #include "WasmWorklist.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
@@ -500,70 +499,67 @@ JSC_DEFINE_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (Instance* instanc
 }
 #endif
 
-JSC_DEFINE_JIT_OPERATION(operationWasmUnwind, void, (CallFrame* callFrame))
+JSC_DEFINE_JIT_OPERATION(operationWasmUnwind, void, (Instance* instance))
 {
-    // FIXME: Consider passing JSWebAssemblyInstance* instead.
-    // https://bugs.webkit.org/show_bug.cgi?id=203206
-    VM& vm = callFrame->deprecatedVM();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
     NativeCallFrameTracer tracer(vm, callFrame);
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationConvertToI64, int64_t, (CallFrame* callFrame, EncodedJSValue v))
+JSC_DEFINE_JIT_OPERATION(operationConvertToI64, int64_t, (Instance* instance, EncodedJSValue v))
 {
-    // FIXME: Consider passing JSWebAssemblyInstance* instead.
-    // https://bugs.webkit.org/show_bug.cgi?id=203206
-    VM& vm = callFrame->deprecatedVM();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
     NativeCallFrameTracer tracer(vm, callFrame);
-    return JSValue::decode(v).toBigInt64(callFrame->lexicalGlobalObject(vm));
+    return JSValue::decode(v).toBigInt64(globalObject);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationConvertToF64, double, (CallFrame* callFrame, EncodedJSValue v))
+JSC_DEFINE_JIT_OPERATION(operationConvertToF64, double, (Instance* instance, EncodedJSValue v))
 {
-    // FIXME: Consider passing JSWebAssemblyInstance* instead.
-    // https://bugs.webkit.org/show_bug.cgi?id=203206
-    VM& vm = callFrame->deprecatedVM();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
     NativeCallFrameTracer tracer(vm, callFrame);
-    return JSValue::decode(v).toNumber(callFrame->lexicalGlobalObject(vm));
+    return JSValue::decode(v).toNumber(globalObject);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationConvertToI32, int32_t, (CallFrame* callFrame, EncodedJSValue v))
+JSC_DEFINE_JIT_OPERATION(operationConvertToI32, int32_t, (Instance* instance, EncodedJSValue v))
 {
-    // FIXME: Consider passing JSWebAssemblyInstance* instead.
-    // https://bugs.webkit.org/show_bug.cgi?id=203206
-    VM& vm = callFrame->deprecatedVM();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
     NativeCallFrameTracer tracer(vm, callFrame);
-    return JSValue::decode(v).toInt32(callFrame->lexicalGlobalObject(vm));
+    return JSValue::decode(v).toInt32(globalObject);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationConvertToF32, float, (CallFrame* callFrame, EncodedJSValue v))
+JSC_DEFINE_JIT_OPERATION(operationConvertToF32, float, (Instance* instance, EncodedJSValue v))
 {
-    // FIXME: Consider passing JSWebAssemblyInstance* instead.
-    // https://bugs.webkit.org/show_bug.cgi?id=203206
-    VM& vm = callFrame->deprecatedVM();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
     NativeCallFrameTracer tracer(vm, callFrame);
-    return static_cast<float>(JSValue::decode(v).toNumber(callFrame->lexicalGlobalObject(vm)));
+    return static_cast<float>(JSValue::decode(v).toNumber(globalObject));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationConvertToBigInt, EncodedJSValue, (CallFrame* callFrame, Instance* instance, EncodedWasmValue value))
+JSC_DEFINE_JIT_OPERATION(operationConvertToBigInt, EncodedJSValue, (Instance* instance, EncodedWasmValue value))
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
     NativeCallFrameTracer tracer(vm, callFrame);
     return JSValue::encode(JSBigInt::makeHeapBigIntOrBigInt32(globalObject, value));
 }
 
 // https://webassembly.github.io/multi-value/js-api/index.html#run-a-host-function
-JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (CallFrame* callFrame, Instance* instance, const TypeDefinition* type, EncodedJSValue encResult, uint64_t* registerResults, uint64_t* calleeFramePointer))
+JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (Instance* instance, const TypeDefinition* type, EncodedJSValue encResult, uint64_t* registerResults, uint64_t* calleeFramePointer))
 {
-    // FIXME: Consider passing JSWebAssemblyInstance* instead.
-    // https://bugs.webkit.org/show_bug.cgi?id=203206
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
-    NativeCallFrameTracer(vm, callFrame);
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
+    NativeCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     const FunctionSignature* signature = type->as<FunctionSignature>();
@@ -638,14 +634,14 @@ JSC_DEFINE_JIT_OPERATION(operationIterateResults, void, (CallFrame* callFrame, I
 // FIXME: It would be much easier to inline this when we have a global GC, which could probably mean we could avoid
 // spilling the results onto the stack.
 // Saved result registers should be placed on the stack just above the last stack result.
-JSC_DEFINE_JIT_OPERATION(operationAllocateResultsArray, JSArray*, (CallFrame* callFrame, Wasm::Instance* instance, const TypeDefinition* type, IndexingType indexingType, JSValue* stackPointerFromCallee))
+JSC_DEFINE_JIT_OPERATION(operationAllocateResultsArray, JSArray*, (Wasm::Instance* instance, const TypeDefinition* type, IndexingType indexingType, JSValue* stackPointerFromCallee))
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    VM& vm = jsInstance->vm();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
     NativeCallFrameTracer tracer(vm, callFrame);
 
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    ObjectInitializationScope initializationScope(globalObject->vm());
+    ObjectInitializationScope initializationScope(vm);
     const FunctionSignature* signature = type->as<FunctionSignature>();
     JSArray* result = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, globalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType), signature->returnCount());
 
@@ -691,217 +687,67 @@ JSC_DEFINE_JIT_OPERATION(operationPopcount64, uint64_t, (int64_t value))
     return __builtin_popcountll(value);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationGrowMemory, int32_t, (void* callFrame, Instance* instance, int32_t delta))
+JSC_DEFINE_JIT_OPERATION(operationGrowMemory, int32_t, (Instance* instance, int32_t delta))
 {
-    instance->storeTopCallFrame(callFrame);
-
-    if (delta < 0)
-        return -1;
-
-    auto grown = instance->memory()->grow(instance->vm(), PageCount(delta));
-    if (!grown) {
-        switch (grown.error()) {
-        case GrowFailReason::InvalidDelta:
-        case GrowFailReason::InvalidGrowSize:
-        case GrowFailReason::WouldExceedMaximum:
-        case GrowFailReason::OutOfMemory:
-        case GrowFailReason::GrowSharedUnavailable:
-            return -1;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    return grown.value().pageCount();
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
+    return growMemory(instance, delta);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmMemoryFill, size_t, (Instance* instance, uint32_t dstAddress, uint32_t targetValue, uint32_t count))
 {
-    return instance->memory()->fill(dstAddress, static_cast<uint8_t>(targetValue), count);
+    return memoryFill(instance, dstAddress, targetValue, count);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmMemoryCopy, size_t, (Instance* instance, uint32_t dstAddress, uint32_t srcAddress, uint32_t count))
 {
-    return instance->memory()->copy(dstAddress, srcAddress, count);
+    return memoryCopy(instance, dstAddress, srcAddress, count);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (Instance* instance, unsigned tableIndex, int32_t signedIndex))
 {
-    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
-    if (signedIndex < 0)
-        return 0;
-
-    uint32_t index = signedIndex;
-    if (index >= instance->table(tableIndex)->length())
-        return 0;
-
-    return JSValue::encode(instance->table(tableIndex)->get(index));
-}
-
-static bool setWasmTableElement(Instance* instance, unsigned tableIndex, uint32_t index, EncodedJSValue encValue)
-{
-    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
-
-    if (index >= instance->table(tableIndex)->length())
-        return false;
-
-    JSValue value = JSValue::decode(encValue);
-    if (instance->table(tableIndex)->type() == Wasm::TableElementType::Externref)
-        instance->table(tableIndex)->set(index, value);
-    else if (instance->table(tableIndex)->type() == Wasm::TableElementType::Funcref) {
-        WebAssemblyFunction* wasmFunction;
-        WebAssemblyWrapperFunction* wasmWrapperFunction;
-
-        if (isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction)) {
-            ASSERT(!!wasmFunction || !!wasmWrapperFunction);
-            if (wasmFunction)
-                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmFunction->importableFunction(), &wasmFunction->instance()->instance());
-            else
-                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmWrapperFunction->importableFunction(), &wasmWrapperFunction->instance()->instance());
-        } else if (value.isNull())
-            instance->table(tableIndex)->clear(index);
-        else
-            ASSERT_NOT_REACHED();
-    } else
-        ASSERT_NOT_REACHED();
-
-    return true;
+    return tableGet(instance, tableIndex, signedIndex);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationSetWasmTableElement, uint32_t, (Instance* instance, unsigned tableIndex, uint32_t signedIndex, EncodedJSValue encValue))
 {
-    return setWasmTableElement(instance, tableIndex, signedIndex, encValue);
+    return tableSet(instance, tableIndex, signedIndex, encValue);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmTableInit, size_t, (Instance* instance, unsigned elementIndex, unsigned tableIndex, uint32_t dstOffset, uint32_t srcOffset, uint32_t length))
 {
-    ASSERT(elementIndex < instance->module().moduleInformation().elementCount());
-    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
-
-    if (WTF::sumOverflows<uint32_t>(srcOffset, length))
-        return false;
-
-    if (WTF::sumOverflows<uint32_t>(dstOffset, length))
-        return false;
-
-    if (dstOffset + length > instance->table(tableIndex)->length())
-        return false;
-
-    const uint32_t lengthOfElementSegment = instance->elementAt(elementIndex) ? instance->elementAt(elementIndex)->length() : 0U;
-    if (srcOffset + length > lengthOfElementSegment)
-        return false;
-
-    if (!lengthOfElementSegment)
-        return true;
-
-    instance->tableInit(dstOffset, srcOffset, length, elementIndex, tableIndex);
-    return true;
+    return tableInit(instance, elementIndex, tableIndex, dstOffset, srcOffset, length);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmElemDrop, void, (Instance* instance, unsigned elementIndex))
 {
-    ASSERT(elementIndex < instance->module().moduleInformation().elementCount());
-    instance->elemDrop(elementIndex);
+    return elemDrop(instance, elementIndex);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmTableGrow, int32_t, (Instance* instance, unsigned tableIndex, EncodedJSValue fill, uint32_t delta))
 {
-    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
-    auto oldSize = instance->table(tableIndex)->length();
-    auto newSize = instance->table(tableIndex)->grow(delta, jsNull());
-    if (!newSize)
-        return -1;
-
-    for (unsigned i = oldSize; i < instance->table(tableIndex)->length(); ++i)
-        setWasmTableElement(instance, tableIndex, i, fill);
-
-    return oldSize;
+    return tableGrow(instance, tableIndex, fill, delta);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmTableFill, size_t, (Instance* instance, unsigned tableIndex, uint32_t offset, EncodedJSValue fill, uint32_t count))
 {
-    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
-
-    if (WTF::sumOverflows<uint32_t>(offset, count))
-        return false;
-
-    if (offset + count > instance->table(tableIndex)->length())
-        return false;
-
-    for (uint32_t index = 0; index < count; ++index)
-        setWasmTableElement(instance, tableIndex, offset + index, fill);
-
-    return true;
+    return tableFill(instance, tableIndex, offset, fill, count);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmTableCopy, size_t, (Instance* instance, unsigned dstTableIndex, unsigned srcTableIndex, int32_t dstOffset, int32_t srcOffset, int32_t length))
 {
-    ASSERT(dstTableIndex < instance->module().moduleInformation().tableCount());
-    ASSERT(srcTableIndex < instance->module().moduleInformation().tableCount());
-    const Table* dstTable = instance->table(dstTableIndex);
-    const Table* srcTable = instance->table(srcTableIndex);
-    ASSERT(dstTable->type() == srcTable->type());
-
-    if ((srcOffset < 0) || (dstOffset < 0) || (length < 0))
-        return false;
-
-    CheckedUint32 lastDstElementIndexChecked = static_cast<uint32_t>(dstOffset);
-    lastDstElementIndexChecked += static_cast<uint32_t>(length);
-
-    if (lastDstElementIndexChecked.hasOverflowed())
-        return false;
-
-    if (lastDstElementIndexChecked > dstTable->length())
-        return false;
-
-    CheckedUint32 lastSrcElementIndexChecked = static_cast<uint32_t>(srcOffset);
-    lastSrcElementIndexChecked += static_cast<uint32_t>(length);
-
-    if (lastSrcElementIndexChecked.hasOverflowed())
-        return false;
-
-    if (lastSrcElementIndexChecked > srcTable->length())
-        return false;
-
-    instance->tableCopy(dstOffset, srcOffset, length, dstTableIndex, srcTableIndex);
-    return true;
+    return tableCopy(instance, dstTableIndex, srcTableIndex, dstOffset, srcOffset, length);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmRefFunc, EncodedJSValue, (Instance* instance, uint32_t index))
 {
-    JSValue value = instance->getFunctionWrapper(index);
-    ASSERT(value.isCallable());
-    return JSValue::encode(value);
+    return refFunc(instance, index);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, bool useDefault, uint64_t* arguments))
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    Ref<TypeDefinition> structTypeDefinition = jsInstance->instance().module().moduleInformation().typeSignatures[typeIndex];
-    const StructType& structType = *structTypeDefinition->as<StructType>();
-
-    JSWebAssemblyStruct* structValue = JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex);
-    RELEASE_ASSERT(structValue);
-    if (static_cast<Wasm::UseDefaultValue>(useDefault) == Wasm::UseDefaultValue::Yes) {
-        for (unsigned i = 0; i < structType.fieldCount(); ++i) {
-            JSValue value = JSValue(0);
-            if (Wasm::isRefType(structType.field(i).type))
-                value = jsNull();
-            else if (structType.field(i).type.as<Type>().kind == Wasm::TypeKind::I64) {
-                // This will convert to the appropriate I64 via ToBigInt() in set().
-                value = jsBoolean(false);
-            }
-            structValue->set(globalObject, i, value);
-        }
-    } else {
-        ASSERT(arguments);
-        for (unsigned i = 0; i < structType.fieldCount(); ++i) {
-            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
-            ASSERT(structType.field(i).type.is<Type>());
-            structValue->set(globalObject, i, toJSValue(globalObject, structType.field(i).type.as<Type>(), arguments[i]));
-        }
-    }
-    return JSValue::encode(structValue);
+    return structNew(instance, typeIndex, useDefault, arguments);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (Instance* instance, uint32_t typeIndex))
@@ -913,119 +759,53 @@ JSC_DEFINE_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (Instance*
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructGet, EncodedJSValue, (EncodedJSValue encodedStructReference, uint32_t fieldIndex))
 {
-    auto structReference = JSValue::decode(encodedStructReference);
-    ASSERT(structReference.isObject());
-    JSObject* structureAsObject = jsCast<JSObject*>(structReference);
-    ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
-    JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
-    return structPointer->get(fieldIndex);
+    return structGet(encodedStructReference, fieldIndex);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructSet, void, (Instance* instance, EncodedJSValue encodedStructReference, uint32_t fieldIndex, EncodedJSValue argument))
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    auto structReference = JSValue::decode(encodedStructReference);
-    ASSERT(structReference.isObject());
-    JSObject* structureAsObject = jsCast<JSObject*>(structReference);
-    ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
-    JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
-
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
-    ASSERT(structPointer->structType()->field(fieldIndex).type.is<Type>());
-
-    const auto fieldType = structPointer->structType()->field(fieldIndex).type.as<Type>();
-    return structPointer->set(jsInstance->globalObject(), fieldIndex, toJSValue(jsInstance->globalObject(), fieldType, argument));
+    return structSet(instance, encodedStructReference, fieldIndex, argument);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetWasmTableSize, int32_t, (Instance* instance, unsigned tableIndex))
 {
-    return instance->table(tableIndex)->length();
-}
-
-template<typename ValueType>
-static int32_t wait(VM& vm, ValueType* pointer, ValueType expectedValue, int64_t timeoutInNanoseconds)
-{
-    Seconds timeout = Seconds::infinity();
-    if (timeoutInNanoseconds >= 0)
-        timeout = Seconds::fromNanoseconds(timeoutInNanoseconds);
-    return static_cast<int32_t>(WaiterListManager::singleton().waitSync(vm, pointer, expectedValue, timeout));
+    return tableSize(instance, tableIndex);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationMemoryAtomicWait32, int32_t, (Instance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds))
 {
-    VM& vm = instance->vm();
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
-    if (offsetInMemory & (0x4 - 1))
-        return -1;
-    if (!instance->memory())
-        return -1;
-    if (offsetInMemory >= instance->memory()->size())
-        return -1;
-    if (instance->memory()->sharingMode() != MemorySharingMode::Shared)
-        return -1;
-    if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread())
-        return -1;
-    int32_t* pointer = bitwise_cast<int32_t*>(bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory);
-    return wait<int32_t>(vm, pointer, value, timeoutInNanoseconds);
+    return memoryAtomicWait32(instance, base, offset, value, timeoutInNanoseconds);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationMemoryAtomicWait64, int32_t, (Instance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds))
 {
-    VM& vm = instance->vm();
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
-    if (offsetInMemory & (0x8 - 1))
-        return -1;
-    if (!instance->memory())
-        return -1;
-    if (offsetInMemory >= instance->memory()->size())
-        return -1;
-    if (instance->memory()->sharingMode() != MemorySharingMode::Shared)
-        return -1;
-    if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread())
-        return -1;
-    int64_t* pointer = bitwise_cast<int64_t*>(bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory);
-    return wait<int64_t>(vm, pointer, value, timeoutInNanoseconds);
+    return memoryAtomicWait64(instance, base, offset, value, timeoutInNanoseconds);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationMemoryAtomicNotify, int32_t, (Instance* instance, unsigned base, unsigned offset, int32_t countValue))
 {
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
-    if (offsetInMemory & (0x4 - 1))
-        return -1;
-    if (!instance->memory())
-        return -1;
-    if (offsetInMemory >= instance->memory()->size())
-        return -1;
-    if (instance->memory()->sharingMode() != MemorySharingMode::Shared)
-        return 0;
-    uint8_t* pointer = bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory;
-    unsigned count = UINT_MAX;
-    if (countValue >= 0)
-        count = static_cast<unsigned>(countValue);
-
-    return static_cast<int32_t>(WaiterListManager::singleton().notifyWaiter(pointer, count));
+    return memoryAtomicNotify(instance, base, offset, countValue);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmMemoryInit, size_t, (Instance* instance, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length))
 {
-    ASSERT(dataSegmentIndex < instance->module().moduleInformation().dataSegmentsCount());
-    return instance->memoryInit(dstAddress, srcAddress, length, dataSegmentIndex);
+    return memoryInit(instance, dataSegmentIndex, dstAddress, srcAddress, length);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmDataDrop, void, (Instance* instance, unsigned dataSegmentIndex))
 {
-    ASSERT(dataSegmentIndex < instance->module().moduleInformation().dataSegmentsCount());
-    instance->dataDrop(dataSegmentIndex);
+    return dataDrop(instance, dataSegmentIndex);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationWasmThrow, void*, (Instance* instance, CallFrame* callFrame, unsigned exceptionIndex, uint64_t* arguments))
+JSC_DEFINE_JIT_OPERATION(operationWasmThrow, void*, (Instance* instance, unsigned exceptionIndex, uint64_t* arguments))
 {
-    instance->storeTopCallFrame(callFrame);
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
     JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     const Wasm::Tag& tag = instance->tag(exceptionIndex);
 
@@ -1058,14 +838,15 @@ JSC_DEFINE_JIT_OPERATION(operationWasmThrow, void*, (Instance* instance, CallFra
     return vm.targetMachinePCForThrow;
 }
 
-JSC_DEFINE_JIT_OPERATION(operationWasmRethrow, void*, (Instance* instance, CallFrame* callFrame, EncodedJSValue thrownValue))
+JSC_DEFINE_JIT_OPERATION(operationWasmRethrow, void*, (Instance* instance, EncodedJSValue thrownValue))
 {
-    instance->storeTopCallFrame(callFrame);
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
     JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     throwException(globalObject, throwScope, JSValue::decode(thrownValue));
 
@@ -1085,51 +866,19 @@ JSC_DEFINE_JIT_OPERATION(operationWasmRethrow, void*, (Instance* instance, CallF
     return vm.targetMachinePCForThrow;
 }
 
-JSC_DEFINE_JIT_OPERATION(operationWasmToJSException, void*, (CallFrame* callFrame, Wasm::ExceptionType type, Instance* wasmInstance))
+JSC_DEFINE_JIT_OPERATION(operationWasmToJSException, void*, (Instance* instance, Wasm::ExceptionType type))
 {
-    wasmInstance->storeTopCallFrame(callFrame);
-    JSWebAssemblyInstance* instance = wasmInstance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = instance->globalObject();
-
-    // Do not retrieve VM& from CallFrame since CallFrame's callee is not a JSCell.
-    VM& vm = globalObject->vm();
-
-    {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
-
-        JSObject* error;
-        if (type == ExceptionType::StackOverflow)
-            error = createStackOverflowError(globalObject);
-        else if (isTypeErrorExceptionType(type))
-            error = createTypeError(globalObject, Wasm::errorMessageForExceptionType(type));
-        else
-            error = createJSWebAssemblyRuntimeError(globalObject, vm, type);
-        throwException(globalObject, throwScope, error);
-    }
-
-    genericUnwind(vm, callFrame);
-    ASSERT(!!vm.callFrameForCatch);
-    ASSERT(!!vm.targetMachinePCForThrow);
-    // FIXME: We could make this better:
-    // This is a total hack, but the llint (both op_catch and llint_handle_uncaught_exception)
-    // require a cell in the callee field to load the VM. (The baseline JIT does not require
-    // this since it is compiled with a constant VM pointer.) We could make the calling convention
-    // for exceptions first load callFrameForCatch info call frame register before jumping
-    // to the exception handler. If we did this, we could remove this terrible hack.
-    // https://bugs.webkit.org/show_bug.cgi?id=170440
-    vm.calleeForWasmCatch = callFrame->callee();
-    Register* calleeSlot = bitwise_cast<Register*>(callFrame) + static_cast<int>(CallFrameSlot::callee);
-    *calleeSlot = bitwise_cast<JSCell*>(instance->module());
-    return vm.targetMachinePCForThrow;
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
+    return throwWasmToJSException(callFrame, type, instance);
 }
 
 namespace WasmOperationsInternal {
 
 static ThrownExceptionInfo retrieveAndClearExceptionIfCatchableImpl(Instance* instance)
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
+    VM& vm = instance->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     RELEASE_ASSERT(!!throwScope.exception());
@@ -1167,96 +916,17 @@ JSC_DEFINE_JIT_OPERATION(operationWasmRetrieveAndClearExceptionIfCatchable, void
 
 JSC_DEFINE_JIT_OPERATION(operationWasmArrayNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue))
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
-
-    ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
-
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
-    ASSERT(arraySignature.is<ArrayType>());
-    Wasm::FieldType fieldType = arraySignature.as<ArrayType>()->elementType();
-
-    size_t elementSize = fieldType.type.elementSize();
-
-    JSWebAssemblyArray* array = nullptr;
-
-    switch (elementSize) {
-    case sizeof(uint8_t): {
-        // `encValue` must be an unboxed int32 (since the typechecker guarantees that its type is i32); so it's safe to truncate it in the cases below.
-        ASSERT(encValue <= UINT32_MAX);
-        FixedVector<uint8_t> values(size);
-        for (unsigned i = 0; i < size; i++)
-            values[i] = static_cast<uint8_t>(encValue);
-        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
-        break;
-    }
-    case sizeof(uint16_t): {
-        ASSERT(encValue <= UINT32_MAX);
-        FixedVector<uint16_t> values(size);
-        for (unsigned i = 0; i < size; i++)
-            values[i] = static_cast<uint16_t>(encValue);
-        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
-        break;
-    }
-    case sizeof(uint32_t): {
-        ASSERT(encValue <= UINT32_MAX);
-        FixedVector<uint32_t> values(size);
-        for (unsigned i = 0; i < size; i++)
-            values[i] = static_cast<uint32_t>(encValue);
-        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
-        break;
-    }
-    case sizeof(uint64_t): {
-        FixedVector<uint64_t> values(size);
-        for (unsigned i = 0; i < size; i++)
-            values[i] = static_cast<uint64_t>(encValue);
-        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
-        break;
-    }
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-    return JSValue::encode(JSValue(array));
+    return arrayNew(instance, typeIndex, size, encValue);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmArrayGet, EncodedJSValue, (Instance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index))
 {
-#if ASSERT_ENABLED
-    ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
-    ASSERT(arraySignature.is<ArrayType>());
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(typeIndex);
-#endif
-
-    JSValue arrayRef = JSValue::decode(arrayValue);
-    ASSERT(arrayRef.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
-
-    return arrayObject->get(index);
+    return arrayGet(instance, typeIndex, arrayValue, index);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmArraySet, void, (Instance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index, EncodedJSValue value))
 {
-    ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    VM& vm = globalObject->vm();
-
-#if ASSERT_ENABLED
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
-    ASSERT(arraySignature.is<ArrayType>());
-#else
-    UNUSED_PARAM(typeIndex);
-#endif
-
-    JSValue arrayRef = JSValue::decode(arrayValue);
-    ASSERT(arrayRef.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
-
-    arrayObject->set(vm, index, value);
+    return arraySet(instance, typeIndex, arrayValue, index, value);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -53,22 +53,21 @@ void loadValuesIntoBuffer(Probe::Context&, const StackMap&, uint64_t* buffer, Sa
 JSC_DECLARE_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe::Context&));
 JSC_DECLARE_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (Instance*, uint32_t functionIndex));
 #endif
-JSC_DECLARE_JIT_OPERATION(operationWasmUnwind, void, (CallFrame*));
+JSC_DECLARE_JIT_OPERATION(operationWasmUnwind, void, (Instance*));
 
-JSC_DECLARE_JIT_OPERATION(operationConvertToI64, int64_t, (CallFrame*, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationConvertToF64, double, (CallFrame*, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationConvertToI32, int32_t, (CallFrame*, EncodedJSValue));
-JSC_DECLARE_JIT_OPERATION(operationConvertToF32, float, (CallFrame*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationConvertToI64, int64_t, (Instance*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationConvertToF64, double, (Instance*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationConvertToI32, int32_t, (Instance*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationConvertToF32, float, (Instance*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationConvertToBigInt, EncodedJSValue, (Instance*, EncodedWasmValue));
 
-JSC_DECLARE_JIT_OPERATION(operationConvertToBigInt, EncodedJSValue, (CallFrame*, Instance*, EncodedWasmValue));
-
-JSC_DECLARE_JIT_OPERATION(operationIterateResults, void, (CallFrame*, Instance*, const TypeDefinition*, EncodedJSValue, uint64_t*, uint64_t*));
-JSC_DECLARE_JIT_OPERATION(operationAllocateResultsArray, JSArray*, (CallFrame*, Wasm::Instance*, const TypeDefinition*, IndexingType, JSValue*));
+JSC_DECLARE_JIT_OPERATION(operationIterateResults, void, (Instance*, const TypeDefinition*, EncodedJSValue, uint64_t*, uint64_t*));
+JSC_DECLARE_JIT_OPERATION(operationAllocateResultsArray, JSArray*, (Wasm::Instance*, const TypeDefinition*, IndexingType, JSValue*));
 
 JSC_DECLARE_JIT_OPERATION(operationWasmWriteBarrierSlowPath, void, (JSCell*, VM*));
 JSC_DECLARE_JIT_OPERATION(operationPopcount32, uint32_t, (int32_t));
 JSC_DECLARE_JIT_OPERATION(operationPopcount64, uint64_t, (int64_t));
-JSC_DECLARE_JIT_OPERATION(operationGrowMemory, int32_t, (void*, Instance*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationGrowMemory, int32_t, (Instance*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationWasmMemoryFill, size_t, (Instance*, uint32_t dstAddress, uint32_t targetValue, uint32_t count));
 JSC_DECLARE_JIT_OPERATION(operationWasmMemoryCopy, size_t, (Instance*, uint32_t dstAddress, uint32_t srcAddress, uint32_t count));
 
@@ -93,10 +92,10 @@ JSC_DECLARE_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (Instance
 JSC_DECLARE_JIT_OPERATION(operationWasmStructGet, EncodedJSValue, (EncodedJSValue, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationWasmStructSet, void, (Instance*, EncodedJSValue, uint32_t, EncodedJSValue));
 
-JSC_DECLARE_JIT_OPERATION(operationWasmThrow, void*, (Instance*, CallFrame*, unsigned exceptionIndex, uint64_t*));
-JSC_DECLARE_JIT_OPERATION(operationWasmRethrow, void*, (Instance*, CallFrame*, EncodedJSValue thrownValue));
+JSC_DECLARE_JIT_OPERATION(operationWasmThrow, void*, (Instance*, unsigned exceptionIndex, uint64_t*));
+JSC_DECLARE_JIT_OPERATION(operationWasmRethrow, void*, (Instance*, EncodedJSValue thrownValue));
 
-JSC_DECLARE_JIT_OPERATION(operationWasmToJSException, void*, (CallFrame*, Wasm::ExceptionType, Instance*));
+JSC_DECLARE_JIT_OPERATION(operationWasmToJSException, void*, (Instance*, Wasm::ExceptionType));
 
 struct ThrownExceptionInfo {
     EncodedJSValue thrownValue;

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -1,0 +1,483 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WasmOperations.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "JSWebAssemblyHelpers.h"
+#include "JSWebAssemblyStruct.h"
+#include "TypedArrayController.h"
+#include "WaiterListManager.h"
+
+namespace JSC {
+namespace Wasm {
+
+inline EncodedJSValue refFunc(Instance* instance, uint32_t index)
+{
+    JSValue value = instance->getFunctionWrapper(index);
+    ASSERT(value.isCallable());
+    return JSValue::encode(value);
+}
+
+inline EncodedJSValue arrayNew(Instance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue)
+{
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
+    VM& vm = instance->vm();
+
+    ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
+
+    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    ASSERT(arraySignature.is<ArrayType>());
+    Wasm::FieldType fieldType = arraySignature.as<ArrayType>()->elementType();
+
+    size_t elementSize = fieldType.type.elementSize();
+
+    JSWebAssemblyArray* array = nullptr;
+
+    switch (elementSize) {
+    case sizeof(uint8_t): {
+        // `encValue` must be an unboxed int32 (since the typechecker guarantees that its type is i32); so it's safe to truncate it in the cases below.
+        ASSERT(encValue <= UINT32_MAX);
+        FixedVector<uint8_t> values(size);
+        for (unsigned i = 0; i < size; i++)
+            values[i] = static_cast<uint8_t>(encValue);
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
+        break;
+    }
+    case sizeof(uint16_t): {
+        ASSERT(encValue <= UINT32_MAX);
+        FixedVector<uint16_t> values(size);
+        for (unsigned i = 0; i < size; i++)
+            values[i] = static_cast<uint16_t>(encValue);
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
+        break;
+    }
+    case sizeof(uint32_t): {
+        ASSERT(encValue <= UINT32_MAX);
+        FixedVector<uint32_t> values(size);
+        for (unsigned i = 0; i < size; i++)
+            values[i] = static_cast<uint32_t>(encValue);
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
+        break;
+    }
+    case sizeof(uint64_t): {
+        FixedVector<uint64_t> values(size);
+        for (unsigned i = 0; i < size; i++)
+            values[i] = static_cast<uint64_t>(encValue);
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
+        break;
+    }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    return JSValue::encode(JSValue(array));
+}
+
+inline EncodedJSValue arrayGet(Instance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index)
+{
+#if ASSERT_ENABLED
+    ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
+    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    ASSERT(arraySignature.is<ArrayType>());
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(typeIndex);
+#endif
+
+    JSValue arrayRef = JSValue::decode(arrayValue);
+    ASSERT(arrayRef.isObject());
+    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
+
+    return arrayObject->get(index);
+}
+
+inline void arraySet(Instance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index, EncodedJSValue value)
+{
+    ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
+    VM& vm = instance->vm();
+
+#if ASSERT_ENABLED
+    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    ASSERT(arraySignature.is<ArrayType>());
+#else
+    UNUSED_PARAM(typeIndex);
+#endif
+
+    JSValue arrayRef = JSValue::decode(arrayValue);
+    ASSERT(arrayRef.isObject());
+    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
+
+    arrayObject->set(vm, index, value);
+}
+
+inline EncodedJSValue structNew(Instance* instance, uint32_t typeIndex, bool useDefault, uint64_t* arguments)
+{
+    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
+    JSGlobalObject* globalObject = jsInstance->globalObject();
+    Ref<TypeDefinition> structTypeDefinition = instance->module().moduleInformation().typeSignatures[typeIndex];
+    const StructType& structType = *structTypeDefinition->as<StructType>();
+
+    JSWebAssemblyStruct* structValue = JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex);
+    RELEASE_ASSERT(structValue);
+    if (static_cast<Wasm::UseDefaultValue>(useDefault) == Wasm::UseDefaultValue::Yes) {
+        for (unsigned i = 0; i < structType.fieldCount(); ++i) {
+            JSValue value = JSValue(0);
+            if (Wasm::isRefType(structType.field(i).type))
+                value = jsNull();
+            else if (structType.field(i).type.as<Type>().kind == Wasm::TypeKind::I64) {
+                // This will convert to the appropriate I64 via ToBigInt() in set().
+                value = jsBoolean(false);
+            }
+            structValue->set(globalObject, i, value);
+        }
+    } else {
+        ASSERT(arguments);
+        for (unsigned i = 0; i < structType.fieldCount(); ++i) {
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+            ASSERT(structType.field(i).type.is<Type>());
+            structValue->set(globalObject, i, toJSValue(globalObject, structType.field(i).type.as<Type>(), arguments[i]));
+        }
+    }
+    return JSValue::encode(structValue);
+}
+
+inline EncodedJSValue structGet(EncodedJSValue encodedStructReference, uint32_t fieldIndex)
+{
+    auto structReference = JSValue::decode(encodedStructReference);
+    ASSERT(structReference.isObject());
+    JSObject* structureAsObject = jsCast<JSObject*>(structReference);
+    ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
+    JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
+    return structPointer->get(fieldIndex);
+}
+
+inline void structSet(Instance* instance, EncodedJSValue encodedStructReference, uint32_t fieldIndex, EncodedJSValue argument)
+{
+    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
+    auto structReference = JSValue::decode(encodedStructReference);
+    ASSERT(structReference.isObject());
+    JSObject* structureAsObject = jsCast<JSObject*>(structReference);
+    ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
+    JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+    ASSERT(structPointer->structType()->field(fieldIndex).type.is<Type>());
+
+    const auto fieldType = structPointer->structType()->field(fieldIndex).type.as<Type>();
+    return structPointer->set(globalObject, fieldIndex, toJSValue(globalObject, fieldType, argument));
+}
+
+inline EncodedJSValue tableGet(Instance* instance, unsigned tableIndex, int32_t signedIndex)
+{
+    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
+    if (signedIndex < 0)
+        return 0;
+
+    uint32_t index = signedIndex;
+    if (index >= instance->table(tableIndex)->length())
+        return 0;
+
+    return JSValue::encode(instance->table(tableIndex)->get(index));
+}
+
+inline bool tableSet(Instance* instance, unsigned tableIndex, uint32_t index, EncodedJSValue encValue)
+{
+    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
+
+    if (index >= instance->table(tableIndex)->length())
+        return false;
+
+    JSValue value = JSValue::decode(encValue);
+    if (instance->table(tableIndex)->type() == Wasm::TableElementType::Externref)
+        instance->table(tableIndex)->set(index, value);
+    else if (instance->table(tableIndex)->type() == Wasm::TableElementType::Funcref) {
+        WebAssemblyFunction* wasmFunction;
+        WebAssemblyWrapperFunction* wasmWrapperFunction;
+
+        if (isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction)) {
+            ASSERT(!!wasmFunction || !!wasmWrapperFunction);
+            if (wasmFunction)
+                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmFunction->importableFunction(), &wasmFunction->instance()->instance());
+            else
+                instance->table(tableIndex)->asFuncrefTable()->setFunction(index, jsCast<JSObject*>(value), wasmWrapperFunction->importableFunction(), &wasmWrapperFunction->instance()->instance());
+        } else if (value.isNull())
+            instance->table(tableIndex)->clear(index);
+        else
+            ASSERT_NOT_REACHED();
+    } else
+        ASSERT_NOT_REACHED();
+
+    return true;
+}
+
+inline size_t tableInit(Instance* instance, unsigned elementIndex, unsigned tableIndex, uint32_t dstOffset, uint32_t srcOffset, uint32_t length)
+{
+    ASSERT(elementIndex < instance->module().moduleInformation().elementCount());
+    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
+
+    if (WTF::sumOverflows<uint32_t>(srcOffset, length))
+        return false;
+
+    if (WTF::sumOverflows<uint32_t>(dstOffset, length))
+        return false;
+
+    if (dstOffset + length > instance->table(tableIndex)->length())
+        return false;
+
+    const uint32_t lengthOfElementSegment = instance->elementAt(elementIndex) ? instance->elementAt(elementIndex)->length() : 0U;
+    if (srcOffset + length > lengthOfElementSegment)
+        return false;
+
+    if (!lengthOfElementSegment)
+        return true;
+
+    instance->tableInit(dstOffset, srcOffset, length, elementIndex, tableIndex);
+    return true;
+}
+
+inline size_t tableFill(Instance* instance, unsigned tableIndex, uint32_t offset, EncodedJSValue fill, uint32_t count)
+{
+    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
+
+    if (WTF::sumOverflows<uint32_t>(offset, count))
+        return false;
+
+    if (offset + count > instance->table(tableIndex)->length())
+        return false;
+
+    for (uint32_t index = 0; index < count; ++index)
+        tableSet(instance, tableIndex, offset + index, fill);
+
+    return true;
+}
+
+inline size_t tableGrow(Instance* instance, unsigned tableIndex, EncodedJSValue fill, uint32_t delta)
+{
+    ASSERT(tableIndex < instance->module().moduleInformation().tableCount());
+    auto oldSize = instance->table(tableIndex)->length();
+    auto newSize = instance->table(tableIndex)->grow(delta, jsNull());
+    if (!newSize)
+        return -1;
+
+    for (unsigned i = oldSize; i < instance->table(tableIndex)->length(); ++i)
+        tableSet(instance, tableIndex, i, fill);
+
+    return oldSize;
+}
+
+inline size_t tableCopy(Instance* instance, unsigned dstTableIndex, unsigned srcTableIndex, int32_t dstOffset, int32_t srcOffset, int32_t length)
+{
+    ASSERT(dstTableIndex < instance->module().moduleInformation().tableCount());
+    ASSERT(srcTableIndex < instance->module().moduleInformation().tableCount());
+    const Table* dstTable = instance->table(dstTableIndex);
+    const Table* srcTable = instance->table(srcTableIndex);
+    ASSERT(dstTable->type() == srcTable->type());
+
+    if ((srcOffset < 0) || (dstOffset < 0) || (length < 0))
+        return false;
+
+    CheckedUint32 lastDstElementIndexChecked = static_cast<uint32_t>(dstOffset);
+    lastDstElementIndexChecked += static_cast<uint32_t>(length);
+
+    if (lastDstElementIndexChecked.hasOverflowed())
+        return false;
+
+    if (lastDstElementIndexChecked > dstTable->length())
+        return false;
+
+    CheckedUint32 lastSrcElementIndexChecked = static_cast<uint32_t>(srcOffset);
+    lastSrcElementIndexChecked += static_cast<uint32_t>(length);
+
+    if (lastSrcElementIndexChecked.hasOverflowed())
+        return false;
+
+    if (lastSrcElementIndexChecked > srcTable->length())
+        return false;
+
+    instance->tableCopy(dstOffset, srcOffset, length, dstTableIndex, srcTableIndex);
+    return true;
+}
+
+inline int32_t tableSize(Instance* instance, unsigned tableIndex)
+{
+    return instance->table(tableIndex)->length();
+}
+
+inline int32_t growMemory(Instance* instance, int32_t delta)
+{
+    if (delta < 0)
+        return -1;
+
+    auto grown = instance->memory()->grow(instance->vm(), PageCount(delta));
+    if (!grown) {
+        switch (grown.error()) {
+        case GrowFailReason::InvalidDelta:
+        case GrowFailReason::InvalidGrowSize:
+        case GrowFailReason::WouldExceedMaximum:
+        case GrowFailReason::OutOfMemory:
+        case GrowFailReason::GrowSharedUnavailable:
+            return -1;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    return grown.value().pageCount();
+}
+
+inline size_t memoryInit(Instance* instance, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length)
+{
+    ASSERT(dataSegmentIndex < instance->module().moduleInformation().dataSegmentsCount());
+    return instance->memoryInit(dstAddress, srcAddress, length, dataSegmentIndex);
+}
+
+inline size_t memoryFill(Instance* instance, uint32_t dstAddress, uint32_t targetValue, uint32_t count)
+{
+    return instance->memory()->fill(dstAddress, static_cast<uint8_t>(targetValue), count);
+}
+
+inline size_t memoryCopy(Instance* instance, uint32_t dstAddress, uint32_t srcAddress, uint32_t count)
+{
+    return instance->memory()->copy(dstAddress, srcAddress, count);
+}
+
+inline void dataDrop(Instance* instance, unsigned dataSegmentIndex)
+{
+    ASSERT(dataSegmentIndex < instance->module().moduleInformation().dataSegmentsCount());
+    instance->dataDrop(dataSegmentIndex);
+}
+
+inline void elemDrop(Instance* instance, unsigned elementIndex)
+{
+    ASSERT(elementIndex < instance->module().moduleInformation().elementCount());
+    instance->elemDrop(elementIndex);
+}
+
+template<typename ValueType>
+static inline int32_t waitImpl(VM& vm, ValueType* pointer, ValueType expectedValue, int64_t timeoutInNanoseconds)
+{
+    Seconds timeout = Seconds::infinity();
+    if (timeoutInNanoseconds >= 0)
+        timeout = Seconds::fromNanoseconds(timeoutInNanoseconds);
+    return static_cast<int32_t>(WaiterListManager::singleton().waitSync(vm, pointer, expectedValue, timeout));
+}
+
+inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds)
+{
+    VM& vm = instance->vm();
+    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
+    if (offsetInMemory & (0x4 - 1))
+        return -1;
+    if (!instance->memory())
+        return -1;
+    if (offsetInMemory >= instance->memory()->size())
+        return -1;
+    if (instance->memory()->sharingMode() != MemorySharingMode::Shared)
+        return -1;
+    if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread())
+        return -1;
+    int32_t* pointer = bitwise_cast<int32_t*>(bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory);
+    return waitImpl<int32_t>(vm, pointer, value, timeoutInNanoseconds);
+}
+
+inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds)
+{
+    VM& vm = instance->vm();
+    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
+    if (offsetInMemory & (0x8 - 1))
+        return -1;
+    if (!instance->memory())
+        return -1;
+    if (offsetInMemory >= instance->memory()->size())
+        return -1;
+    if (instance->memory()->sharingMode() != MemorySharingMode::Shared)
+        return -1;
+    if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread())
+        return -1;
+    int64_t* pointer = bitwise_cast<int64_t*>(bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory);
+    return waitImpl<int64_t>(vm, pointer, value, timeoutInNanoseconds);
+}
+
+inline int32_t memoryAtomicNotify(Instance* instance, unsigned base, unsigned offset, int32_t countValue)
+{
+    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
+    if (offsetInMemory & (0x4 - 1))
+        return -1;
+    if (!instance->memory())
+        return -1;
+    if (offsetInMemory >= instance->memory()->size())
+        return -1;
+    if (instance->memory()->sharingMode() != MemorySharingMode::Shared)
+        return 0;
+    uint8_t* pointer = bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory;
+    unsigned count = UINT_MAX;
+    if (countValue >= 0)
+        count = static_cast<unsigned>(countValue);
+
+    return static_cast<int32_t>(WaiterListManager::singleton().notifyWaiter(pointer, count));
+}
+
+inline void* throwWasmToJSException(CallFrame* callFrame, Wasm::ExceptionType type, Instance* wasmInstance)
+{
+    JSWebAssemblyInstance* instance = wasmInstance->owner<JSWebAssemblyInstance>();
+    JSGlobalObject* globalObject = instance->globalObject();
+
+    // Do not retrieve VM& from CallFrame since CallFrame's callee is not a JSCell.
+    VM& vm = globalObject->vm();
+
+    {
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+        JSObject* error;
+        if (type == ExceptionType::StackOverflow)
+            error = createStackOverflowError(globalObject);
+        else if (isTypeErrorExceptionType(type))
+            error = createTypeError(globalObject, Wasm::errorMessageForExceptionType(type));
+        else
+            error = createJSWebAssemblyRuntimeError(globalObject, vm, type);
+        throwException(globalObject, throwScope, error);
+    }
+
+    genericUnwind(vm, callFrame);
+    ASSERT(!!vm.callFrameForCatch);
+    ASSERT(!!vm.targetMachinePCForThrow);
+    // FIXME: We could make this better:
+    // This is a total hack, but the llint (both op_catch and llint_handle_uncaught_exception)
+    // require a cell in the callee field to load the VM. (The baseline JIT does not require
+    // this since it is compiled with a constant VM pointer.) We could make the calling convention
+    // for exceptions first load callFrameForCatch info call frame register before jumping
+    // to the exception handler. If we did this, we could remove this terrible hack.
+    // https://bugs.webkit.org/show_bug.cgi?id=170440
+    vm.calleeForWasmCatch = callFrame->callee();
+    Register* calleeSlot = bitwise_cast<Register*>(callFrame) + static_cast<int>(CallFrameSlot::callee);
+    *calleeSlot = bitwise_cast<JSCell*>(instance->module());
+    return vm.targetMachinePCForThrow;
+}
+
+} } // namespace JSC::Wasm
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -47,12 +47,12 @@ MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromWasmThunkGenerator(const
 
     // The thing that jumps here must move ExceptionType into the argumentGPR1 before jumping here.
     // We're allowed to use temp registers here. We are not allowed to use callee saves.
-    jit.loadWasmContextInstance(GPRInfo::argumentGPR2);
-    jit.loadPtr(CCallHelpers::Address(GPRInfo::argumentGPR2, Instance::offsetOfVM()), GPRInfo::argumentGPR0);
-    jit.loadPtr(CCallHelpers::Address(GPRInfo::argumentGPR0, VM::topEntryFrameOffset()), GPRInfo::argumentGPR0);
-    jit.copyCalleeSavesToEntryFrameCalleeSavesBuffer(GPRInfo::argumentGPR0);
-    jit.move(GPRInfo::callFrameRegister, GPRInfo::argumentGPR0);
+    jit.loadWasmContextInstance(GPRInfo::argumentGPR0);
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::argumentGPR0, Instance::offsetOfVM()), GPRInfo::argumentGPR2);
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::argumentGPR2, VM::topEntryFrameOffset()), GPRInfo::argumentGPR2);
+    jit.copyCalleeSavesToEntryFrameCalleeSavesBuffer(GPRInfo::argumentGPR2);
 
+    jit.prepareWasmCallOperation(GPRInfo::argumentGPR0);
     CCallHelpers::Call call = jit.call(OperationPtrTag);
     jit.farJump(GPRInfo::returnValueGPR, ExceptionHandlerPtrTag);
     jit.breakpoint(); // We should not reach this.


### PR DESCRIPTION
#### 773f16e4b6254ca5f7ad09e410000f6e10ccc6d6
<pre>
[JSC] Save more code size by aligning wasm operations to JS&apos;s convention
<a href="https://bugs.webkit.org/show_bug.cgi?id=250455">https://bugs.webkit.org/show_bug.cgi?id=250455</a>
rdar://problem/104121534

Reviewed by Saam Barati.

This patch fixes bunch of problems in wasm operations so that we can save code size, and we can make implementation clean by removing many FIXMEs.

1. We get CallFrame* via __builtin_frame_address(1) as the same way to JS&apos;s operation. This reduces code size in JIT code.
   Each wasm operation call now calls prepareWasmCallOperation, which set up frame pointer in Instance* if __builtin_frame_address(1) is not available.
   If __builtin_frame_address(1) is available, this is nop. Wasm operation retrieves CallFrame* from __builtin_frame_address(1) or passed Instance*.
2. We must not call Wasm operations from C++ world. This is because (1) strongly assumes that Wasm operations are called from JIT code. This patch
   extracts code to WasmOperationsInlines.h so that we no longer call Wasm operations from C++ world. This was met in JS operations before. Now wasm
   operations meet this too.
3. We appropriately pass Instance*. And we remove `CallFrame::deprecatedVM()` use in wasm operations completely. This is well aligned to how JS operations
   work: JS operations take JSGlobalObject* as its realm. Now wasm operations take Instance*.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::prepareWasmCallOperation):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp:
(JSC::Wasm::AirIRGenerator32::emitCatchImpl):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitCatchImpl):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::AirIRGeneratorBase::emitCCall):
(JSC::Wasm::ExpressionType&gt;::addGrowMemory):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitPrepareWasmOperation):
(JSC::Wasm::B3IRGenerator::addTableGet):
(JSC::Wasm::B3IRGenerator::addTableSet):
(JSC::Wasm::B3IRGenerator::addRefFunc):
(JSC::Wasm::B3IRGenerator::addTableInit):
(JSC::Wasm::B3IRGenerator::addElemDrop):
(JSC::Wasm::B3IRGenerator::addTableSize):
(JSC::Wasm::B3IRGenerator::addTableGrow):
(JSC::Wasm::B3IRGenerator::addTableFill):
(JSC::Wasm::B3IRGenerator::addTableCopy):
(JSC::Wasm::B3IRGenerator::addGrowMemory):
(JSC::Wasm::B3IRGenerator::addMemoryFill):
(JSC::Wasm::B3IRGenerator::addMemoryInit):
(JSC::Wasm::B3IRGenerator::addMemoryCopy):
(JSC::Wasm::B3IRGenerator::addDataDrop):
(JSC::Wasm::B3IRGenerator::setGlobal):
(JSC::Wasm::B3IRGenerator::emitWriteBarrier):
(JSC::Wasm::B3IRGenerator::atomicWait):
(JSC::Wasm::B3IRGenerator::atomicNotify):
(JSC::Wasm::B3IRGenerator::pushArrayNew):
(JSC::Wasm::B3IRGenerator::addArrayGet):
(JSC::Wasm::B3IRGenerator::addArraySet):
(JSC::Wasm::B3IRGenerator::addStructNew):
(JSC::Wasm::B3IRGenerator::addStructNewDefault):
(JSC::Wasm::B3IRGenerator::emitCatchImpl):
(JSC::Wasm::B3IRGenerator::addI32Popcnt):
(JSC::Wasm::B3IRGenerator::addI64Popcnt):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
(JSC::Wasm::wasmToWasm):
* Source/JavaScriptCore/wasm/WasmInstance.h:
(JSC::Wasm::Instance::offsetOfTemporaryCallFrame):
(JSC::Wasm::Instance::temporaryCallFrame const):
(JSC::Wasm::Instance::setTemporaryCallFrame):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
(JSC::Wasm::WasmOperationsInternal::retrieveAndClearExceptionIfCatchableImpl):
(JSC::Wasm::setWasmTableElement): Deleted.
(JSC::Wasm::wait): Deleted.
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h: Added.
(JSC::Wasm::refFunc):
(JSC::Wasm::arrayNew):
(JSC::Wasm::arrayGet):
(JSC::Wasm::arraySet):
(JSC::Wasm::structNew):
(JSC::Wasm::structGet):
(JSC::Wasm::structSet):
(JSC::Wasm::tableGet):
(JSC::Wasm::tableSet):
(JSC::Wasm::tableInit):
(JSC::Wasm::tableFill):
(JSC::Wasm::tableGrow):
(JSC::Wasm::tableCopy):
(JSC::Wasm::tableSize):
(JSC::Wasm::growMemory):
(JSC::Wasm::memoryInit):
(JSC::Wasm::memoryFill):
(JSC::Wasm::memoryCopy):
(JSC::Wasm::dataDrop):
(JSC::Wasm::elemDrop):
(JSC::Wasm::waitImpl):
(JSC::Wasm::memoryAtomicWait32):
(JSC::Wasm::memoryAtomicWait64):
(JSC::Wasm::memoryAtomicNotify):
(JSC::Wasm::throwWasmToJSException):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
(JSC::LLInt::slow_path_wasm_throw_exception):
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::throwExceptionFromWasmThunkGenerator):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::materializeImportJSCell):
(JSC::Wasm::handleBadImportTypeUse):
(JSC::Wasm::wasmToJS):
(JSC::Wasm::emitThrowWasmToJSException):

Canonical link: <a href="https://commits.webkit.org/258820@main">https://commits.webkit.org/258820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abc0f0f2247f0be8647dcc9b75b634f9b5d6ef67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103045 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112293 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3072 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95269 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108819 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24861 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/93223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5586 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89617 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3306 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5750 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29712 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45770 "Passed tests") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/98218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7501 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/98218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3226 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->