### PR TITLE
REGRESSION (@property): Crash with animations and rollback cascades

### DIFF
--- a/LayoutTests/fast/animation/animation-cascade-crash-expected.txt
+++ b/LayoutTests/fast/animation/animation-cascade-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/animation/animation-cascade-crash.html
+++ b/LayoutTests/fast/animation/animation-cascade-crash.html
@@ -1,0 +1,15 @@
+<style>
+  body {
+    transition-duration: 1ms;
+    width: revert;
+  }
+</style>
+<script>
+  if (window.testRunner)
+        testRunner.dumpAsText();
+  onload = () => {
+    document.styleSheets[0].insertRule(`body { width: 0em; }`);
+    document.styleSheets[0].insertRule(`html { font-size: 0; }`);
+  };
+</script>
+This test passes if it doesn't crash.

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -53,6 +53,7 @@ PropertyCascade::PropertyCascade(const PropertyCascade& parent, CascadeLevel max
     , m_maximumCascadeLevel(maximumCascadeLevel)
     , m_rollbackScope(rollbackScope)
     , m_maximumCascadeLayerPriorityForRollback(maximumCascadeLayerPriorityForRollback)
+    , m_animationLayer(parent.m_animationLayer)
 {
     buildCascade();
 }


### PR DESCRIPTION
#### 37dd354f5387f75c4433fa93edee8ea8f18e73c4
<pre>
REGRESSION (@property): Crash with animations and rollback cascades
<a href="https://bugs.webkit.org/show_bug.cgi?id=250458">https://bugs.webkit.org/show_bug.cgi?id=250458</a>
rdar://104119443

Reviewed by Alan Baradlay.

* LayoutTests/fast/animation/animation-cascade-crash-expected.txt: Added.
* LayoutTests/fast/animation/animation-cascade-crash.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):

Ensure that also rollback cascades have AnimationLayer.

Canonical link: <a href="https://commits.webkit.org/258797@main">https://commits.webkit.org/258797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8239666942655ba4c3ebb5b75038eba0f0235ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112198 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172416 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2972 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95188 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110020 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10051 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37689 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24784 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5506 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26193 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5660 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2647 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/navigation-sets-cookie.https.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45690 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6047 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7409 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->