### PR TITLE
<textarea> element's validity state checks shouldn't be dependent on willValidate()

### DIFF
--- a/LayoutTests/fast/forms/ValidityState-tooLong-textarea-expected.txt
+++ b/LayoutTests/fast/forms/ValidityState-tooLong-textarea-expected.txt
@@ -17,6 +17,16 @@ PASS textarea.value.length is 4
 PASS textarea.validity.tooLong is true
 PASS textarea.validity.tooLong is false
 
+Dirty value and longer than maxLength (with "readonly" attribute)
+PASS textarea.value.length is 4
+PASS textarea.validity.tooLong is true
+PASS textarea.validity.tooLong is false
+
+Dirty value and longer than maxLength (with "disabled" attribute)
+PASS textarea.value.length is 4
+PASS textarea.validity.tooLong is true
+PASS textarea.validity.tooLong is false
+
 Sets a value via DOM property
 PASS textarea.validity.tooLong is false
 

--- a/LayoutTests/fast/forms/ValidityState-tooLong-textarea.html
+++ b/LayoutTests/fast/forms/ValidityState-tooLong-textarea.html
@@ -42,6 +42,40 @@ document.execCommand('delete');
 shouldBeFalse('textarea.validity.tooLong');
 
 debug('');
+debug('Dirty value and longer than maxLength (with "readonly" attribute)');
+textarea = document.createElement('textarea');
+document.body.appendChild(textarea);
+textarea.defaultValue = 'abcde';
+textarea.maxLength = 3;
+textarea.focus();
+textarea.setSelectionRange(5, 5); // Move the cursor at the end.
+document.execCommand('delete');
+shouldBe('textarea.value.length', '4');
+textarea.readOnly = true;
+shouldBeTrue('textarea.validity.tooLong');
+textarea.readOnly = false;
+// Make the value <= maxLength.
+document.execCommand('delete');
+shouldBeFalse('textarea.validity.tooLong');
+
+debug('');
+debug('Dirty value and longer than maxLength (with "disabled" attribute)');
+textarea = document.createElement('textarea');
+document.body.appendChild(textarea);
+textarea.defaultValue = 'abcde';
+textarea.maxLength = 3;
+textarea.focus();
+textarea.setSelectionRange(5, 5); // Move the cursor at the end.
+document.execCommand('delete');
+shouldBe('textarea.value.length', '4');
+textarea.disabled = true;
+shouldBeTrue('textarea.validity.tooLong');
+textarea.disabled = false;
+// Make the value <= maxLength.
+document.execCommand('delete');
+shouldBeFalse('textarea.validity.tooLong');
+
+debug('');
 debug('Sets a value via DOM property');
 textarea = document.createElement('textarea');
 document.body.appendChild(textarea);

--- a/LayoutTests/fast/forms/ValidityState-tooShort-textarea-expected.txt
+++ b/LayoutTests/fast/forms/ValidityState-tooShort-textarea-expected.txt
@@ -1,0 +1,26 @@
+Tests for tooShort flag with <textarea> elements.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+No minlength and no value
+PASS textarea.validity.tooShort is false
+
+Dirty value and longer than minLength
+PASS textarea.value.length is 3
+PASS textarea.validity.tooShort is true
+PASS textarea.validity.tooShort is false
+
+Dirty value and longer than minLength (with "readonly" attribute)
+PASS textarea.value.length is 3
+PASS textarea.validity.tooShort is true
+PASS textarea.validity.tooShort is false
+
+Dirty value and longer than minLength (with "disabled" attribute)
+PASS textarea.value.length is 3
+PASS textarea.validity.tooShort is true
+PASS textarea.validity.tooShort is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ValidityState-tooShort-textarea.html
+++ b/LayoutTests/fast/forms/ValidityState-tooShort-textarea.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description('Tests for tooShort flag with &lt;textarea> elements.');
+
+var textarea = document.createElement('textarea');
+document.body.appendChild(textarea);
+
+debug('No minlength and no value');
+shouldBeFalse('textarea.validity.tooShort');
+
+debug('');
+debug('Dirty value and longer than minLength');
+textarea = document.createElement('textarea');
+document.body.appendChild(textarea);
+textarea.defaultValue = 'ab';
+textarea.minLength = 4;
+textarea.focus();
+textarea.setSelectionRange(2, 2); // Move the cursor at the end.
+document.execCommand('insertText', false, 'c');
+shouldBe('textarea.value.length', '3');
+shouldBeTrue('textarea.validity.tooShort');
+// Make the value >= minLength.
+document.execCommand('insertText', false, 'd');
+shouldBeFalse('textarea.validity.tooShort');
+
+debug('');
+debug('Dirty value and longer than minLength (with "readonly" attribute)');
+textarea = document.createElement('textarea');
+document.body.appendChild(textarea);
+textarea.defaultValue = 'ab';
+textarea.minLength = 4;
+textarea.focus();
+textarea.setSelectionRange(2, 2); // Move the cursor at the end.
+document.execCommand('insertText', false, 'c');
+shouldBe('textarea.value.length', '3');
+textarea.readOnly = true;
+shouldBeTrue('textarea.validity.tooShort');
+textarea.readOnly = false;
+// Make the value >= minLength.
+document.execCommand('insertText', false, 'd');
+shouldBeFalse('textarea.validity.tooShort');
+
+debug('');
+debug('Dirty value and longer than minLength (with "disabled" attribute)');
+textarea = document.createElement('textarea');
+document.body.appendChild(textarea);
+textarea.defaultValue = 'ab';
+textarea.minLength = 4;
+textarea.focus();
+textarea.setSelectionRange(2, 2); // Move the cursor at the end.
+document.execCommand('insertText', false, 'c');
+shouldBe('textarea.value.length', '3');
+textarea.disabled = true;
+shouldBeTrue('textarea.validity.tooShort');
+textarea.disabled = false;
+// Make the value >= minLength.
+document.execCommand('insertText', false, 'd');
+shouldBeFalse('textarea.validity.tooShort');
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist-expected.txt
@@ -1,0 +1,3 @@
+
+PASS textarea element with "required" attribute and empty value is considered "suffering from being missing" even if inside datalist element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>textarea element with "required" attribute and empty value is considered "suffering from being missing" even if inside datalist element</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:suffering-from-being-missing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<datalist>
+  <textarea required></textarea>
+</datalist>
+
+<script>
+test(() => {
+  const textarea = document.querySelector("textarea");
+
+  assert_true(textarea.validity.valueMissing);
+  assert_false(textarea.validity.valid);
+});
+</script>

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -414,17 +414,17 @@ String HTMLTextAreaElement::validationMessage() const
 
 bool HTMLTextAreaElement::valueMissing() const
 {
-    return willValidate() && valueMissing({ });
+    return valueMissing({ });
 }
 
 bool HTMLTextAreaElement::tooShort() const
 {
-    return willValidate() && tooShort({ }, CheckDirtyFlag);
+    return tooShort({ }, CheckDirtyFlag);
 }
 
 bool HTMLTextAreaElement::tooLong() const
 {
-    return willValidate() && tooLong({ }, CheckDirtyFlag);
+    return tooLong({ }, CheckDirtyFlag);
 }
 
 bool HTMLTextAreaElement::valueMissing(StringView value) const


### PR DESCRIPTION
#### d3e21f7e246becf92fa8087859f304a1653e8d5a
<pre>
&lt;textarea&gt; element&apos;s validity state checks shouldn&apos;t be dependent on willValidate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250453">https://bugs.webkit.org/show_bug.cgi?id=250453</a>

Reviewed by Darin Adler.

This change aligns &lt;textarea&gt; element&apos;s validity checks with the spec, Blink / Gecko,
and &lt;input&gt; element&apos;s counterparts:
  * valueMissing() [1] depends on mutability concept rather than &quot;barred from constaint validation&quot;,
    which are observably different only if the &lt;textarea&gt; is a descendant of a &lt;datalist&gt; element;
  * tooShort() [2] / tooLong() [3] prose doesn&apos;t mention any requirement for willValidate().

Also this patch enables a follow-up revamp of updateWillValidateAndValidity() by untangling
computeValidity() and computeWillValidate() (currently the former implicitly depends on the latter).

Tests: fast/forms/ValidityState-tooShort-textarea.html
       fast/forms/ValidityState-tooLong-textarea.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html

[1] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a>:suffering-from-being-missing
[2] <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#setting-minimum-input-length-requirements">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#setting-minimum-input-length-requirements</a>:-the-minlength-attribute:suffering-from-being-too-short
[3] <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#limiting-user-input-length">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#limiting-user-input-length</a>:-the-maxlength-attribute:suffering-from-being-too-long

* LayoutTests/fast/forms/ValidityState-tooLong-textarea-expected.txt:
* LayoutTests/fast/forms/ValidityState-tooLong-textarea.html:
* LayoutTests/fast/forms/ValidityState-tooShort-textarea-expected.txt: Added.
* LayoutTests/fast/forms/ValidityState-tooShort-textarea.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/textarea-validity-valueMissing-inside-datalist.html: Added.
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::valueMissing const):
(WebCore::HTMLTextAreaElement::tooShort const):
(WebCore::HTMLTextAreaElement::tooLong const):

Canonical link: <a href="https://commits.webkit.org/258928@main">https://commits.webkit.org/258928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4a3a228f4766c9bf514036ede6e62dbf2adeeb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112631 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172838 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3419 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111546 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10408 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38039 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5905 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26476 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3005 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45985 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7837 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3265 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->