### PR TITLE
[css-transitions] crash when transition-property is set to inherit from a parent with mismatched items in another transition property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Using a single "transition-property" value set to a custom property and two "transition-duration" values correctly yields a CSS Transition when the transition properties are set on a parent and the child inherits.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="container"><div id="target"></div></div>
+<script>
+
+test(() => {
+    const customProperty = generate_name();
+    CSS.registerProperty({
+      name: customProperty,
+      syntax: "<number>",
+      inherits: false,
+      initialValue: "1"
+    });
+
+    // Create transitions for our custom property with
+    // a longer list of transition-duration values.
+    const container = document.getElementById("container");
+    container.style.transitionProperty = customProperty;
+    container.style.transitionDuration = "100s, 200s";
+
+    const target = document.getElementById("target");
+    target.style.transitionProperty = "inherit";
+    target.style.transitionDuration = "inherit";
+
+    // Trigger a style change by getting the custom property
+    // value from the computed style.
+    getComputedStyle(target).getPropertyValue(customProperty);
+
+    // Set a new value for the custom property, which will yield a
+    // transition.
+    target.style.setProperty(customProperty, "2");
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1, "A single transition was generated");
+
+    const transition = animations[0];
+    assert_class_string(transition, "CSSTransition", "A CSSTransition is running");
+    assert_equals(transition.transitionProperty, customProperty);
+}, 'Using a single "transition-property" value set to a custom property and two "transition-duration" values correctly yields a CSS Transition when the transition properties are set on a parent and the child inherits.');
+
+</script>

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -32,6 +32,7 @@
 #include "AnimationPlaybackEvent.h"
 #include "CSSAnimation.h"
 #include "CSSAnimationEvent.h"
+#include "CSSPropertyNames.h"
 #include "CSSSelector.h"
 #include "CSSTransition.h"
 #include "CSSTransitionEvent.h"
@@ -329,6 +330,18 @@ ExceptionOr<PseudoId> pseudoIdFromString(const String& pseudoElement)
     if (pseudoType == CSSSelector::PseudoElementUnknown || pseudoType == CSSSelector::PseudoElementWebKitCustom)
         return Exception { SyntaxError };
     return CSSSelector::pseudoId(pseudoType);
+}
+
+AtomString animatablePropertyAsString(AnimatableProperty property)
+{
+    return WTF::switchOn(property,
+        [] (CSSPropertyID propertyId) {
+            return nameString(propertyId);
+        },
+        [] (const AtomString& customProperty) {
+            return customProperty;
+        }
+    );
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -59,6 +59,7 @@ bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&)
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
 String pseudoIdAsString(PseudoId);
 ExceptionOr<PseudoId> pseudoIdFromString(const String&);
+AtomString animatablePropertyAsString(AnimatableProperty);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -441,11 +441,8 @@ void CSSToStyleMap::mapAnimationProperty(Animation& animation, const CSSValue& v
     }
     if (primitiveValue.propertyID() == CSSPropertyInvalid) {
         auto stringValue = primitiveValue.stringValue();
-        if (isCustomPropertyName(stringValue))
-            animation.setProperty({ Animation::TransitionMode::CustomProperty, CSSPropertyCustom });
-        else
-            animation.setProperty({ Animation::TransitionMode::UnknownProperty, CSSPropertyInvalid });
-        animation.setCustomOrUnknownProperty(stringValue);
+        auto transitionMode = isCustomPropertyName(stringValue) ? Animation::TransitionMode::SingleProperty : Animation::TransitionMode::UnknownProperty;
+        animation.setProperty({ transitionMode, AtomString { stringValue } });
         return;
     }
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -74,6 +74,7 @@
 #include "StyleScope.h"
 #include "Styleable.h"
 #include "TranslateTransformOperation.h"
+#include "WebAnimationUtilities.h"
 
 namespace WebCore {
 
@@ -1297,16 +1298,16 @@ static Ref<CSSValue> valueForGridPosition(const GridPosition& position)
 
 static Ref<CSSValue> createTransitionPropertyValue(const Animation& animation)
 {
-    switch (animation.property().mode) {
+    auto transitionProperty = animation.property();
+    switch (transitionProperty.mode) {
     case Animation::TransitionMode::None:
         return CSSValuePool::singleton().createIdentifierValue(CSSValueNone);
     case Animation::TransitionMode::All:
         return CSSValuePool::singleton().createIdentifierValue(CSSValueAll);
     case Animation::TransitionMode::SingleProperty:
-        return CSSValuePool::singleton().createCustomIdent(nameString(animation.property().id));
-    case Animation::TransitionMode::CustomProperty:
     case Animation::TransitionMode::UnknownProperty:
-        return CSSValuePool::singleton().createCustomIdent(animation.customOrUnknownProperty());
+        auto transitionPropertyAsString = animatablePropertyAsString(transitionProperty.animatableProperty);
+        return CSSValuePool::singleton().createCustomIdent(transitionPropertyAsString);
     }
     ASSERT_NOT_REACHED();
     return CSSValuePool::singleton().createIdentifierValue(CSSValueNone);

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -223,6 +223,18 @@ void ContentChangeObserver::completeDurationBasedContentObservation()
     adjustObservedState(Event::EndedFixedObservationTimeWindow);
 }
 
+static bool isObservedPropertyForTransition(AnimatableProperty property)
+{
+    return WTF::switchOn(property,
+        [] (CSSPropertyID propertyId) {
+            return propertyId == CSSPropertyLeft || propertyId == CSSPropertyOpacity;
+        },
+        [] (const AtomString&) {
+            return false;
+        }
+    );
+}
+
 void ContentChangeObserver::didAddTransition(const Element& element, const Animation& transition)
 {
     if (!isContentChangeObserverEnabled())
@@ -235,7 +247,7 @@ void ContentChangeObserver::didAddTransition(const Element& element, const Anima
         return;
     if (!transition.isDurationSet() || !transition.isPropertySet())
         return;
-    if (!isObservedPropertyForTransition(transition.property().id))
+    if (!isObservedPropertyForTransition(transition.property().animatableProperty))
         return;
     auto transitionEnd = Seconds { transition.duration() + std::max<double>(0, transition.isDelaySet() ? transition.delay() : 0) };
     if (transitionEnd > maximumDelayForTransitions)

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -34,6 +34,7 @@
 #include "RenderStyleConstants.h"
 #include "Timer.h"
 #include "WKContentObservation.h"
+#include "WebAnimationTypes.h"
 #include <wtf/HashSet.h>
 #include <wtf/Seconds.h>
 #include <wtf/WeakPtr.h>
@@ -138,7 +139,6 @@ private:
     void setShouldObserveDOMTimerSchedulingAndTransitions(bool);
     bool isObservingDOMTimerScheduling() const { return m_isObservingDOMTimerScheduling; }
     bool isObservingTransitions() const { return m_isObservingTransitions; }
-    bool isObservedPropertyForTransition(CSSPropertyID propertyId) const { return propertyId == CSSPropertyLeft || propertyId == CSSPropertyOpacity; }
     void domTimerExecuteDidStart(const DOMTimer&);
     void domTimerExecuteDidFinish(const DOMTimer&);
     void registerDOMTimer(const DOMTimer&);

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -23,6 +23,7 @@
 #include "Animation.h"
 
 #include "CommonAtomStrings.h"
+#include "WebAnimationUtilities.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>
 
@@ -48,7 +49,6 @@ Animation::Animation()
     , m_propertySet(false)
     , m_timingFunctionSet(false)
     , m_compositeOperationSet(false)
-    , m_customOrUnknownPropertySet(false)
     , m_isNone(false)
     , m_delayFilled(false)
     , m_directionFilled(false)
@@ -66,7 +66,6 @@ Animation::Animation(const Animation& o)
     : RefCounted<Animation>()
     , m_property(o.m_property)
     , m_name(o.m_name)
-    , m_customOrUnknownProperty(o.m_customOrUnknownProperty)
     , m_iterationCount(o.m_iterationCount)
     , m_delay(o.m_delay)
     , m_duration(o.m_duration)
@@ -86,7 +85,6 @@ Animation::Animation(const Animation& o)
     , m_propertySet(o.m_propertySet)
     , m_timingFunctionSet(o.m_timingFunctionSet)
     , m_compositeOperationSet(o.m_compositeOperationSet)
-    , m_customOrUnknownPropertySet(o.m_customOrUnknownPropertySet)
     , m_isNone(o.m_isNone)
     , m_delayFilled(o.m_delayFilled)
     , m_directionFilled(o.m_directionFilled)
@@ -108,7 +106,6 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_playState == other.m_playState
         && m_compositeOperation == other.m_compositeOperation
         && m_playStateSet == other.m_playStateSet
-        && m_customOrUnknownProperty == other.m_customOrUnknownProperty
         && m_iterationCount == other.m_iterationCount
         && m_delay == other.m_delay
         && m_duration == other.m_duration
@@ -124,13 +121,12 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_nameSet == other.m_nameSet
         && m_timingFunctionSet == other.m_timingFunctionSet
         && m_compositeOperationSet == other.m_compositeOperationSet
-        && m_customOrUnknownPropertySet == other.m_customOrUnknownPropertySet
         && m_isNone == other.m_isNone;
 
     if (!result)
         return false;
 
-    return !matchProperties || (m_property.mode == other.m_property.mode && m_property.id == other.m_property.id && m_propertySet == other.m_propertySet);
+    return !matchProperties || (m_property.mode == other.m_property.mode && m_property.animatableProperty == other.m_property.animatableProperty && m_propertySet == other.m_propertySet);
 }
 
 auto Animation::initialName() -> const Name&
@@ -144,8 +140,7 @@ TextStream& operator<<(TextStream& ts, Animation::TransitionProperty transitionP
     switch (transitionProperty.mode) {
     case Animation::TransitionMode::All: ts << "all"; break;
     case Animation::TransitionMode::None: ts << "none"; break;
-    case Animation::TransitionMode::SingleProperty: ts << nameLiteral(transitionProperty.id); break;
-    case Animation::TransitionMode::CustomProperty: ts << "custom property"; break;
+    case Animation::TransitionMode::SingleProperty: ts << animatablePropertyAsString(transitionProperty.animatableProperty); break;
     case Animation::TransitionMode::UnknownProperty: ts << "unknown property"; break;
     }
     return ts;

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -29,6 +29,7 @@
 #include "RenderStyleConstants.h"
 #include "StyleScopeOrdinal.h"
 #include "TimingFunction.h"
+#include "WebAnimationTypes.h"
 
 namespace WebCore {
 
@@ -49,7 +50,6 @@ public:
     bool isPropertySet() const { return m_propertySet; }
     bool isTimingFunctionSet() const { return m_timingFunctionSet; }
     bool isCompositeOperationSet() const { return m_compositeOperationSet; }
-    bool isCustomOrUnknownPropertySet() const { return m_customOrUnknownPropertySet; }
 
     // Flags this to be the special "none" animation (animation-name: none)
     bool isNoneAnimation() const { return m_isNone; }
@@ -63,7 +63,7 @@ public:
         return !m_directionSet && !m_durationSet && !m_fillModeSet
             && !m_nameSet && !m_playStateSet && !m_iterationCountSet
             && !m_delaySet && !m_timingFunctionSet && !m_propertySet
-            && !m_isNone && !m_compositeOperationSet && !m_customOrUnknownPropertySet;
+            && !m_isNone && !m_compositeOperationSet;
     }
 
     bool isEmptyOrZeroDuration() const
@@ -81,7 +81,6 @@ public:
     void clearProperty() { m_propertySet = false; m_propertyFilled = false; }
     void clearTimingFunction() { m_timingFunctionSet = false; m_timingFunctionFilled = false; }
     void clearCompositeOperation() { m_compositeOperationSet = false; m_compositeOperationFilled = false; }
-    void clearCustomOrUnknownProperty() { m_customOrUnknownPropertySet = false; }
 
     void clearAll()
     {
@@ -95,7 +94,6 @@ public:
         clearProperty();
         clearTimingFunction();
         clearCompositeOperation();
-        clearCustomOrUnknownProperty();
     }
 
     double delay() const { return m_delay; }
@@ -104,13 +102,12 @@ public:
         All,
         None,
         SingleProperty,
-        CustomProperty,
         UnknownProperty
     };
 
     struct TransitionProperty {
         TransitionMode mode;
-        CSSPropertyID id;
+        AnimatableProperty animatableProperty;
     };
 
     enum AnimationDirection {
@@ -139,7 +136,6 @@ public:
     Style::ScopeOrdinal nameStyleScopeOrdinal() const { return m_nameStyleScopeOrdinal; }
     AnimationPlayState playState() const { return static_cast<AnimationPlayState>(m_playState); }
     TransitionProperty property() const { return m_property; }
-    const String& customOrUnknownProperty() const { return m_customOrUnknownProperty; }
     TimingFunction* timingFunction() const { return m_timingFunction.get(); }
     TimingFunction* defaultTimingFunctionForKeyframes() const { return m_defaultTimingFunctionForKeyframes.get(); }
 
@@ -157,7 +153,6 @@ public:
     }
     void setPlayState(AnimationPlayState d) { m_playState = static_cast<unsigned>(d); m_playStateSet = true; }
     void setProperty(TransitionProperty t) { m_property = t; m_propertySet = true; }
-    void setCustomOrUnknownProperty(const String& property) { m_customOrUnknownProperty = property; m_customOrUnknownPropertySet = true; }
     void setTimingFunction(RefPtr<TimingFunction>&& function) { m_timingFunction = WTFMove(function); m_timingFunctionSet = true; }
     void setDefaultTimingFunctionForKeyframes(RefPtr<TimingFunction>&& function) { m_defaultTimingFunctionForKeyframes = WTFMove(function); }
 
@@ -172,7 +167,6 @@ public:
     void fillProperty(TransitionProperty property) { setProperty(property); m_propertyFilled = true; }
     void fillTimingFunction(RefPtr<TimingFunction>&& timingFunction) { setTimingFunction(WTFMove(timingFunction)); m_timingFunctionFilled = true; }
     void fillCompositeOperation(CompositeOperation compositeOperation) { setCompositeOperation(compositeOperation); m_compositeOperationFilled = true; }
-    void fillCustomOrUnknownProperty(const String& property) { setCustomOrUnknownProperty(property); }
 
     bool isDelayFilled() const { return m_delayFilled; }
     bool isDirectionFilled() const { return m_directionFilled; }
@@ -205,7 +199,6 @@ private:
     TransitionProperty m_property { TransitionMode::All, CSSPropertyInvalid };
 
     Name m_name;
-    String m_customOrUnknownProperty;
     double m_iterationCount;
     double m_delay;
     double m_duration;
@@ -230,7 +223,6 @@ private:
     bool m_propertySet : 1;
     bool m_timingFunctionSet : 1;
     bool m_compositeOperationSet : 1;
-    bool m_customOrUnknownPropertySet : 1;
 
     bool m_isNone : 1;
 

--- a/Source/WebCore/platform/animation/AnimationList.cpp
+++ b/Source/WebCore/platform/animation/AnimationList.cpp
@@ -58,7 +58,6 @@ void AnimationList::fillUnsetProperties()
     FILL_UNSET_PROPERTY(isTimingFunctionSet, timingFunction, fillTimingFunction);
     FILL_UNSET_PROPERTY(isPropertySet, property, fillProperty);
     FILL_UNSET_PROPERTY(isCompositeOperationSet, compositeOperation, fillCompositeOperation);
-    FILL_UNSET_PROPERTY(isCustomOrUnknownPropertySet, customOrUnknownProperty, fillCustomOrUnknownProperty);
 }
 
 bool AnimationList::operator==(const AnimationList& other) const


### PR DESCRIPTION
#### 65cbbd06b50bb3c8e45aabd0c47322e540baf4fd
<pre>
[css-transitions] crash when transition-property is set to inherit from a parent with mismatched items in another transition property
<a href="https://bugs.webkit.org/show_bug.cgi?id=250460">https://bugs.webkit.org/show_bug.cgi?id=250460</a>
rdar://104118149

Reviewed by Antti Koivisto and Dean Jackson.

We fixed a bug yesterday to correctly handle a case where transition-property is set to a
custom property and another transition property has a longer list of items: bug 250401.
However, this doesn&apos;t work and crashes when those properties are set on a parent and a
child uses &quot;inherit&quot; to replicate them.

The issue is that while basic information about the transition-property value is stored
in Animation::m_property, the potential custom property name as a string is stored as
Animation::m_customOrUnknownProperty. In the fix for bug 250401 we added the required
code to also replicate m_customOrUnknownProperty when filling mismatching animations.

But in the case where &quot;inherits&quot; is used, the m_property variable is set by the
BuilderFunctions::applyInheritTransitionProperty() method, which is fairly generic
code generated from CSSProperties.json. Instead of changing the code generator, we
consolidate all information derived from the &quot;transition-property&quot; value in the single
m_property instance variable and replace the TransitionProperty.id field to be
TransitionProperty.animatableProperty and thus represent either a regular or a custom
property.

This also allows us to remove TransitionMode::CustomProperty and also use the
TransitionMode::SingleProperty mode for custom properties.

Overall this yields a more elegant and less error-prone design.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers.html: Added.
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::animatablePropertyAsString):
* Source/WebCore/animation/WebAnimationUtilities.h:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationProperty):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::createTransitionPropertyValue):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::isObservedPropertyForTransition const):
(WebCore::ContentChangeObserver::didAddTransition):
* Source/WebCore/page/ios/ContentChangeObserver.h:
(WebCore::ContentChangeObserver::isObservedPropertyForTransition const): Deleted.
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isCompositeOperationSet const):
(WebCore::Animation::isEmpty const):
(WebCore::Animation::clearCompositeOperation):
(WebCore::Animation::clearAll):
(WebCore::Animation::property const):
(WebCore::Animation::setProperty):
(WebCore::Animation::fillCompositeOperation):
(WebCore::Animation::isCustomOrUnknownPropertySet const): Deleted.
(WebCore::Animation::clearCustomOrUnknownProperty): Deleted.
(WebCore::Animation::customOrUnknownProperty const): Deleted.
(WebCore::Animation::setCustomOrUnknownProperty): Deleted.
(WebCore::Animation::fillCustomOrUnknownProperty): Deleted.
* Source/WebCore/platform/animation/AnimationList.cpp:
(WebCore::AnimationList::fillUnsetProperties):
* Source/WebCore/style/Styleable.cpp:
(WebCore::transitionMatchesProperty):
(WebCore::compileTransitionPropertiesInStyle):

Canonical link: <a href="https://commits.webkit.org/258821@main">https://commits.webkit.org/258821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e5db42585e460f062a6784b1a13fd267710b29b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112246 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172455 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3021 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95230 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110340 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37725 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79452 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26233 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2683 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45733 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7454 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3227 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->