### PR TITLE
Insert RemoteFrameView into render tree when replacing a FrameView

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -119,13 +119,13 @@ using namespace WebCore;
 
 WebFrameLoaderClient::WebFrameLoaderClient(Ref<WebFrame>&& frame)
     : m_frame(WTFMove(frame))
+    , m_frameInvalidator(makeScopeExit<Function<void()>>([frame = m_frame] {
+        frame->invalidate();
+    }))
 {
 }
 
-WebFrameLoaderClient::~WebFrameLoaderClient()
-{
-    m_frame->invalidate();
-}
+WebFrameLoaderClient::~WebFrameLoaderClient() = default;
 
 std::optional<WebPageProxyIdentifier> WebFrameLoaderClient::webPageProxyID() const
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -30,6 +30,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderClient.h>
 #include <pal/SessionID.h>
+#include <wtf/Scope.h>
 
 namespace WebKit {
 
@@ -66,6 +67,8 @@ public:
 #endif
 
     WebCore::AllowsContentJavaScript allowsContentJavaScriptFromMostRecentNavigation() const final;
+
+    ScopeExit<Function<void()>> takeFrameInvalidator() { return WTFMove(m_frameInvalidator); }
 
 private:
     bool hasHTMLView() const final;
@@ -272,6 +275,7 @@ private:
     inline bool hasPlugInView() const;
 
     Ref<WebFrame> m_frame;
+    ScopeExit<Function<void()>> m_frameInvalidator;
 
 #if ENABLE(PDFKIT_PLUGIN)
     RefPtr<PluginView> m_pluginView;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -28,9 +28,12 @@
 
 namespace WebKit {
 
-WebRemoteFrameClient::WebRemoteFrameClient(Ref<WebFrame>&& frame)
+WebRemoteFrameClient::WebRemoteFrameClient(Ref<WebFrame>&& frame, ScopeExit<Function<void()>>&& frameInvalidator)
     : m_frame(WTFMove(frame))
+    , m_frameInvalidator(WTFMove(frameInvalidator))
 {
 }
+
+WebRemoteFrameClient::~WebRemoteFrameClient() = default;
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -27,17 +27,20 @@
 
 #include "WebFrame.h"
 #include <WebCore/RemoteFrameClient.h>
+#include <wtf/Scope.h>
 
 namespace WebKit {
 
 class WebRemoteFrameClient final : public WebCore::RemoteFrameClient {
 public:
-    explicit WebRemoteFrameClient(Ref<WebFrame>&&);
+    explicit WebRemoteFrameClient(Ref<WebFrame>&&, ScopeExit<Function<void()>>&& frameInvalidator);
+    ~WebRemoteFrameClient();
 
     WebFrame& webFrame() const { return m_frame.get(); }
 
 private:
     Ref<WebFrame> m_frame;
+    ScopeExit<Function<void()>> m_frameInvalidator;
 };
 
 }


### PR DESCRIPTION
#### d1284d186bc0f4cc55f756ae2e7981130d4c7cc4
<pre>
Insert RemoteFrameView into render tree when replacing a FrameView
<a href="https://bugs.webkit.org/show_bug.cgi?id=250466">https://bugs.webkit.org/show_bug.cgi?id=250466</a>
rdar://104131312

Reviewed by Tim Horton.

In Frame::createView we call RenderWidget::setWidget so that the frame is drawn.
When removing the Frame and replacing it with a RemoteFrame, we used to get garbage
pixels drawn to the screen and lots of errors saying this:
&quot;ERROR: called FrameView::paint with nil renderer&quot;

To fix this we need to add a corresponding call to RenderWidget::setWidget with the
RemoteFrameView.  When this happens, though, the WebFrameLoaderClient is destroyed
which would call WebFrame::invalidate then cause all the tests to time out because
the UI process though there was no more frame.  To fix this problem I introduce a
ScopeExit that calls WebFrame::invalidate upon destruction, and I transfer
this object between the WebFrameLoaderClient and the corresponding equivalent for
RemoteFrames, the WebRemoteFrameClient.  This properly keeps the UI process informed
when the frame is actually destroyed but not when it has been converted to a remote
frame, about which the UI process is already aware.

After this PR a RemoteFrame no longer shows garbage pixels, but instead shows a white
rectangle, which is a step in the right direction.  Drawing colors in
RemoteFrameView::paintContents also does show to the screen, which indicates we are
also heading in the right direction.  A following step in this direction will be to
make layers and stitch them together in the UI process to actually show the iframe
content in the right location instead of just a blank rectangle.

* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::WebFrameLoaderClient):
(WebKit::WebFrameLoaderClient::takeFrameInvalidator):
(WebKit::WebFrameLoaderClient::~WebFrameLoaderClient): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::WebRemoteFrameClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didCommitLoadInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/258813@main">https://commits.webkit.org/258813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/486f1f1c8134a9cb71bb06039d9b105916c9ddd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112261 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3036 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95240 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37728 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24828 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5557 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2693 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45737 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7469 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3224 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->