### PR TITLE
Autogenerate serializers for font attributes and nested enums inside it

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1581,7 +1581,7 @@ DataDetectorTypes:
     WebKit:
       default: 0
     WebCore:
-      default: DataDetectorType::None
+      default: '{ }'
 
 # FIXME: This is on by default in WebKit2 (for everything but WatchOS). Perhaps we should consider turning it on for WebKitLegacy as well.
 DataListElementEnabled:

--- a/Source/WebCore/editing/FontAttributes.h
+++ b/Source/WebCore/editing/FontAttributes.h
@@ -48,31 +48,6 @@ struct TextList {
 #endif
 };
 
-template<class Encoder> inline void TextList::encode(Encoder& encoder) const
-{
-    encoder << style << startingItemNumber << ordered;
-}
-
-template<class Decoder> inline std::optional<TextList> TextList::decode(Decoder& decoder)
-{
-    std::optional<ListStyleType> style;
-    decoder >> style;
-    if (!style)
-        return std::nullopt;
-
-    std::optional<int> startingItemNumber;
-    decoder >> startingItemNumber;
-    if (!startingItemNumber)
-        return std::nullopt;
-
-    std::optional<bool> ordered;
-    decoder >> ordered;
-    if (!ordered)
-        return std::nullopt;
-
-    return { { *style, *startingItemNumber, *ordered } };
-}
-
 struct FontAttributes {
     enum class SubscriptOrSuperscript : uint8_t { None, Subscript, Superscript };
     enum class HorizontalAlignment : uint8_t { Left, Center, Right, Justify, Natural };
@@ -94,27 +69,3 @@ struct FontAttributes {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::FontAttributes::SubscriptOrSuperscript> {
-    using values = EnumValues<
-        WebCore::FontAttributes::SubscriptOrSuperscript,
-        WebCore::FontAttributes::SubscriptOrSuperscript::None,
-        WebCore::FontAttributes::SubscriptOrSuperscript::Subscript,
-        WebCore::FontAttributes::SubscriptOrSuperscript::Superscript
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FontAttributes::HorizontalAlignment> {
-    using values = EnumValues<
-        WebCore::FontAttributes::HorizontalAlignment,
-        WebCore::FontAttributes::HorizontalAlignment::Left,
-        WebCore::FontAttributes::HorizontalAlignment::Center,
-        WebCore::FontAttributes::HorizontalAlignment::Right,
-        WebCore::FontAttributes::HorizontalAlignment::Justify,
-        WebCore::FontAttributes::HorizontalAlignment::Natural
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -27,7 +27,6 @@
 
 #include "TextGranularity.h"
 #include "VisiblePosition.h"
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
@@ -182,17 +181,3 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const VisibleSelect
 void showTree(const WebCore::VisibleSelection&);
 void showTree(const WebCore::VisibleSelection*);
 #endif
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SelectionDirection> {
-    using values = EnumValues<
-        WebCore::SelectionDirection,
-        WebCore::SelectionDirection::Forward,
-        WebCore::SelectionDirection::Backward,
-        WebCore::SelectionDirection::Right,
-        WebCore::SelectionDirection::Left
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/editing/WritingDirection.h
+++ b/Source/WebCore/editing/WritingDirection.h
@@ -36,16 +36,3 @@ enum class WritingDirection : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WritingDirection> {
-    using values = EnumValues<
-        WebCore::WritingDirection,
-        WebCore::WritingDirection::Natural,
-        WebCore::WritingDirection::LeftToRight,
-        WebCore::WritingDirection::RightToLeft
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/editing/cocoa/DataDetectorType.h
+++ b/Source/WebCore/editing/cocoa/DataDetectorType.h
@@ -27,12 +27,9 @@
 
 #if ENABLE(DATA_DETECTION)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class DataDetectorType : uint8_t {
-    None = 0,
     PhoneNumber = 1 << 0,
     Link = 1 << 1,
     Address = 1 << 2,
@@ -43,23 +40,5 @@ enum class DataDetectorType : uint8_t {
 };
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::DataDetectorType> {
-    using values = EnumValues<
-        WebCore::DataDetectorType,
-        WebCore::DataDetectorType::None,
-        WebCore::DataDetectorType::PhoneNumber,
-        WebCore::DataDetectorType::Link,
-        WebCore::DataDetectorType::Address,
-        WebCore::DataDetectorType::CalendarEvent,
-        WebCore::DataDetectorType::TrackingNumber,
-        WebCore::DataDetectorType::FlightNumber,
-        WebCore::DataDetectorType::LookupSuggestion
-    >;
-};
-
-} // namespace WTF
 
 #endif

--- a/Source/WebCore/html/AutocapitalizeTypes.h
+++ b/Source/WebCore/html/AutocapitalizeTypes.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class AutocapitalizeType : uint8_t {
@@ -38,18 +36,3 @@ enum class AutocapitalizeType : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::AutocapitalizeType> {
-    using values = EnumValues<
-        WebCore::AutocapitalizeType,
-        WebCore::AutocapitalizeType::Default,
-        WebCore::AutocapitalizeType::None,
-        WebCore::AutocapitalizeType::Words,
-        WebCore::AutocapitalizeType::Sentences,
-        WebCore::AutocapitalizeType::AllCharacters
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2667,7 +2667,7 @@ void FrameLoader::checkLoadCompleteForThisFrame()
             FRAMELOADER_RELEASE_LOG(ResourceLoading, "checkLoadCompleteForThisFrame: Finished frame load");
 #if ENABLE(DATA_DETECTION)
             auto document = m_frame.document();
-            auto types = OptionSet<DataDetectorType> { m_frame.settings().dataDetectorTypes() };
+            OptionSet<DataDetectorType> types = m_frame.settings().dataDetectorTypes();
             if (document && types) {
                 auto documentLevelResults = retainPtr(DataDetection::detectContentInRange(makeRangeSelectingNodeContents(*document), types, m_client->dataDetectionContext()));
                 m_frame.dataDetectionResults().setDocumentLevelResults(documentLevelResults.get());

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -88,7 +88,7 @@ DataDetectorTypes:
   condition: ENABLE(DATA_DETECTION)
   defaultValue:
     WebCore:
-      default: DataDetectorType::None
+      default: '{ }'
 
 DefaultVideoPosterURL:
   comment: >-

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -65,7 +65,6 @@
 #include <WebCore/FilterOperations.h>
 #include <WebCore/FloatQuad.h>
 #include <WebCore/Font.h>
-#include <WebCore/FontAttributes.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/IDBGetResult.h>
@@ -1184,75 +1183,6 @@ std::optional<Ref<SecurityOrigin>> ArgumentCoder<Ref<SecurityOrigin>>::decode(De
     if (!origin)
         return std::nullopt;
     return origin.releaseNonNull();
-}
-
-void ArgumentCoder<FontAttributes>::encode(Encoder& encoder, const FontAttributes& attributes)
-{
-    encoder << attributes.backgroundColor;
-    encoder << attributes.foregroundColor;
-    encoder << attributes.fontShadow;
-    encoder << attributes.hasUnderline;
-    encoder << attributes.hasStrikeThrough;
-    encoder << attributes.hasMultipleFonts;
-    encoder << attributes.textLists;
-    encoder << attributes.horizontalAlignment;
-    encoder << attributes.subscriptOrSuperscript;
-    encoder << attributes.font;
-}
-
-std::optional<FontAttributes> ArgumentCoder<FontAttributes>::decode(Decoder& decoder)
-{
-    std::optional<Color> backgroundColor;
-    decoder >> backgroundColor;
-    if (!backgroundColor)
-        return std::nullopt;
-
-    std::optional<Color> foregroundColor;
-    decoder >> foregroundColor;
-    if (!foregroundColor)
-        return std::nullopt;
-
-    std::optional<FontShadow> fontShadow;
-    decoder >> fontShadow;
-    if (!fontShadow)
-        return std::nullopt;
-
-    std::optional<bool> hasUnderline;
-    decoder >> hasUnderline;
-    if (!hasUnderline)
-        return std::nullopt;
-
-    std::optional<bool> hasStrikeThrough;
-    decoder >> hasStrikeThrough;
-    if (!hasStrikeThrough)
-        return std::nullopt;
-
-    std::optional<bool> hasMultipleFonts;
-    decoder >> hasMultipleFonts;
-    if (!hasMultipleFonts)
-        return std::nullopt;
-
-    std::optional<Vector<TextList>> textLists;
-    decoder >> textLists;
-    if (!textLists)
-        return std::nullopt;
-
-    std::optional<FontAttributes::HorizontalAlignment> horizontalAlignment;
-    decoder >> horizontalAlignment;
-    if (!horizontalAlignment)
-        return std::nullopt;
-
-    std::optional<FontAttributes::SubscriptOrSuperscript> subscriptOrSuperscript;
-    decoder >> subscriptOrSuperscript;
-    if (!subscriptOrSuperscript)
-        return std::nullopt;
-
-    std::optional<RefPtr<Font>> font;
-    decoder >> font;
-    if (!font)
-        return std::nullopt;
-
-    return { { WTFMove(*font), WTFMove(*backgroundColor), WTFMove(*foregroundColor), WTFMove(*fontShadow), *subscriptOrSuperscript, *horizontalAlignment, WTFMove(*textLists), *hasUnderline, *hasStrikeThrough, *hasMultipleFonts } };
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -155,7 +155,6 @@ struct DictationAlternative;
 struct DictionaryPopupInfo;
 struct EventTrackingRegions;
 struct ExceptionDetails;
-struct FontAttributes;
 struct FileChooserSettings;
 struct TextRecognitionDataDetector;
 struct Length;
@@ -445,11 +444,6 @@ template<> struct ArgumentCoder<RefPtr<WebCore::SecurityOrigin>> {
 template<> struct ArgumentCoder<Ref<WebCore::SecurityOrigin>> {
     static void encode(Encoder&, const Ref<WebCore::SecurityOrigin>&);
     static std::optional<Ref<WebCore::SecurityOrigin>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::FontAttributes> {
-    static void encode(Encoder&, const WebCore::FontAttributes&);
-    static std::optional<WebCore::FontAttributes> decode(Decoder&);
 };
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2543,3 +2543,74 @@ enum class WebCore::TextGranularity : uint8_t {
     ParagraphBoundary,
     DocumentBoundary
 };
+
+header: <WebCore/FontAttributes.h>
+[CustomHeader] struct WebCore::TextList {
+    WebCore::ListStyleType style
+    int startingItemNumber
+    bool ordered
+};
+
+[Nested] enum class WebCore::FontAttributes::SubscriptOrSuperscript : uint8_t {
+    None,
+    Subscript,
+    Superscript
+};
+
+[Nested] enum class WebCore::FontAttributes::HorizontalAlignment : uint8_t {
+    Left,
+    Center,
+    Right,
+    Justify,
+    Natural
+};
+
+[CustomHeader] struct WebCore::FontAttributes {
+    RefPtr<WebCore::Font> font
+    WebCore::Color backgroundColor
+    WebCore::Color foregroundColor
+    WebCore::FontShadow fontShadow
+    WebCore::FontAttributes::SubscriptOrSuperscript subscriptOrSuperscript
+    WebCore::FontAttributes::HorizontalAlignment horizontalAlignment
+    Vector<WebCore::TextList> textLists
+    bool hasUnderline
+    bool hasStrikeThrough
+    bool hasMultipleFonts
+};
+
+header: <WebCore/WritingDirection.h>
+enum class WebCore::WritingDirection : uint8_t {
+    Natural,
+    LeftToRight,
+    RightToLeft
+};
+
+header: <WebCore/VisibleSelection.h>
+enum class WebCore::SelectionDirection : uint8_t {
+    Forward,
+    Backward,
+    Right,
+    Left
+};
+
+#if ENABLE(DATA_DETECTION)
+header: <WebCore/DataDetectorType.h>
+[OptionSet] enum class WebCore::DataDetectorType : uint8_t {
+    PhoneNumber,
+    Link,
+    Address,
+    CalendarEvent,
+    TrackingNumber,
+    FlightNumber,
+    LookupSuggestion,
+};
+#endif
+
+header: <WebCore/AutocapitalizeTypes.h>
+enum class WebCore::AutocapitalizeType : uint8_t {
+    Default,
+    None,
+    Words,
+    Sentences,
+    AllCharacters
+};


### PR DESCRIPTION
#### 00b88f5cfcd77748f2192e071871822189045af3
<pre>
Autogenerate serializers for font attributes and nested enums inside it
<a href="https://bugs.webkit.org/show_bug.cgi?id=250465">https://bugs.webkit.org/show_bug.cgi?id=250465</a>
rdar://104130124

Reviewed by Alex Christensen.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/editing/FontAttributes.h:
(WebCore::TextList::encode const): Deleted.
(WebCore::TextList::decode): Deleted.
* Source/WebCore/editing/VisibleSelection.h:
* Source/WebCore/editing/WritingDirection.h:
* Source/WebCore/editing/cocoa/DataDetectorType.h:
* Source/WebCore/html/AutocapitalizeTypes.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/page/Settings.yaml:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;FontAttributes&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;FontAttributes&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/258877@main">https://commits.webkit.org/258877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d5fd00be6e4b9bb56dfd4f2c154e7dabd1c88a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12297 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112421 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172619 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3201 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110632 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10229 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37854 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92055 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79587 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93326 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5705 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89742 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3427 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2821 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29744 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11865 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98337 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6101 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7623 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20727 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->