### PR TITLE
Preserving inline style of the replaced block element for execCommand('FormatBlock') 

### DIFF
--- a/LayoutTests/editing/execCommand/format-block-with-block-expected.txt
+++ b/LayoutTests/editing/execCommand/format-block-with-block-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Block
+PASS Block with BR
+PASS Inline
+

--- a/LayoutTests/editing/execCommand/format-block-with-block.html
+++ b/LayoutTests/editing/execCommand/format-block-with-block.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/assert-selection.js"></script>
+<script>
+test(() => assert_selection(
+  [
+    '<div contenteditable>',
+      '^<div style="color: green">hello</div>|',
+    '</div>',
+  ].join(''),
+  'formatBlock h1',
+  [
+    '<div contenteditable>',
+      '<h1 style="color: green">^hello|</h1>',
+    '</div>',
+  ].join('')), 'Block');
+
+test(() => assert_selection(
+  [
+    '<div contenteditable>',
+      '^<div style="color: green"><br></div>|',
+    '</div>',
+  ].join(''),
+  'formatBlock h1',
+  [
+    '<div contenteditable>',
+      '<h1 style="color: green">|<br></h1>',
+    '</div>',
+  ].join('')), 'Block with BR');
+
+test(() => assert_selection(
+  [
+    '<div contenteditable>',
+      '^<span style="color: green">hello</span>|',
+    '</div>',
+  ].join(''),
+  'formatBlock h1',
+  [
+    '<div contenteditable>',
+      '<h1><span style="color: green">^hello|</span></h1>',
+    '</div>',
+  ].join('')), 'Inline');
+</script>

--- a/Source/WebCore/editing/FormatBlockCommand.cpp
+++ b/Source/WebCore/editing/FormatBlockCommand.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,6 +99,10 @@ void FormatBlockCommand::formatRange(const Position& start, const Position& end,
     bool wasEndOfParagraph = isEndOfParagraph(lastParagraphInBlockNode);
 
     moveParagraphWithClones(start, end, blockNode.get(), outerBlock.get());
+
+    // Copy the inline style of the original block element to the newly created block-style element.
+    if (outerBlock.get() != nodeAfterInsertionPosition.get() && downcast<HTMLElement>(nodeAfterInsertionPosition.get())->hasAttribute(styleAttr))
+        blockNode->setAttribute(styleAttr, downcast<HTMLElement>(nodeAfterInsertionPosition.get())->getAttribute(styleAttr));
 
     if (wasEndOfParagraph && lastParagraphInBlockNode.anchorNode()->isConnected()
         && !isEndOfParagraph(lastParagraphInBlockNode) && !isStartOfParagraph(lastParagraphInBlockNode))


### PR DESCRIPTION
<pre>
Preserving inline style of the replaced block element for execCommand('FormatBlock')
<a href="https://bugs.webkit.org/show_bug.cgi?id=47054">https://bugs.webkit.org/show_bug.cgi?id=47054</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=163137">https://src.chromium.org/viewvc/blink?view=revision&revision=163137</a>

With 'FormatBlock', the newly inserted block-style element would not possess any of the
inline style properties of the original block element containing the current selection.
Thus, as the associated bug describes, we need to either add a style attribute to the newly
added block-style element or, add another style span with the inline style of the replaced
block element.

This patch takes the approach of adding the inline style to the new block-style element itself.

* Source/WebCore/editing/FormatBlockCommand.cpp:
(FormatBlockCommand::formatRange): Add logic to preserve inline style
* LayoutTests/editing/execCommand/format-block-with-block.html: Add Test Case
* LayoutTests/editing/execCommand/format-block-with-block-expected.txt: Add Test Case Expectation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2d63c59099cedfd6226459a6a3b8a0b521137e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112235 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172447 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3010 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110332 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37717 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26220 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2674 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45720 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7444 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->