### PR TITLE
Rename WorkerClient to WorkerGraphicsClient.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1329,7 +1329,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/WheelEventTestMonitor.h
     page/WindowFeatures.h
     page/WindowOrWorkerGlobalScope.h
-    page/WorkerClient.h
+    page/WorkerGraphicsClient.h
 
     page/csp/CSPViolationReportBody.h
     page/csp/ContentSecurityPolicy.h

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -39,8 +39,8 @@
 #include "InspectorInstrumentation.h"
 #include "StyleCanvasImage.h"
 #include "WebCoreOpaqueRoot.h"
-#include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerGraphicsClient.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSLock.h>
 #include <atomic>
@@ -289,7 +289,7 @@ GraphicsClient* CanvasBase::graphicsClient() const
     if (scriptExecutionContext()->isDocument() && downcast<Document>(scriptExecutionContext())->page())
         return &downcast<Document>(scriptExecutionContext())->page()->chrome();
     if (is<WorkerGlobalScope>(scriptExecutionContext()))
-        return downcast<WorkerGlobalScope>(scriptExecutionContext())->workerClient();
+        return downcast<WorkerGlobalScope>(scriptExecutionContext())->workerGraphicsClient();
 
     return nullptr;
 }

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -54,8 +54,8 @@
 #include "SharedBuffer.h"
 #include "SuspendableTimer.h"
 #include "WebCodecsVideoFrame.h"
-#include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerGraphicsClient.h"
 #include <variant>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Scope.h>
@@ -102,7 +102,7 @@ RefPtr<ImageBuffer> ImageBitmap::createImageBuffer(ScriptExecutionContext& scrip
             client = document.view()->root()->hostWindow();
         }
     } else if (scriptExecutionContext.isWorkerGlobalScope())
-        client = downcast<WorkerGlobalScope>(scriptExecutionContext).workerClient();
+        client = downcast<WorkerGlobalScope>(scriptExecutionContext).workerGraphicsClient();
 
     return ImageBuffer::create(size, RenderingPurpose::Canvas, resolutionScale, *imageBufferColorSpace, PixelFormat::BGRA8, bufferOptions, { client });
 }

--- a/Source/WebCore/html/ImageBitmapBacking.cpp
+++ b/Source/WebCore/html/ImageBitmapBacking.cpp
@@ -28,8 +28,8 @@
 
 #include "Chrome.h"
 #include "Page.h"
-#include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerGraphicsClient.h"
 
 namespace WebCore {
 
@@ -83,8 +83,8 @@ void ImageBitmapBacking::connect(ScriptExecutionContext& context)
     if (!m_serializedBitmap)
         return;
 
-    if (is<WorkerGlobalScope>(context) && downcast<WorkerGlobalScope>(context).workerClient()) {
-        auto* client = downcast<WorkerGlobalScope>(context).workerClient();
+    if (is<WorkerGlobalScope>(context) && downcast<WorkerGlobalScope>(context).workerGraphicsClient()) {
+        auto* client = downcast<WorkerGlobalScope>(context).workerGraphicsClient();
         m_bitmapData = client->sinkIntoImageBuffer(WTFMove(m_serializedBitmap));
     } else if (is<Document>(context)) {
         ASSERT(downcast<Document>(context).page());

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -42,8 +42,8 @@
 #include "OffscreenCanvasRenderingContext2D.h"
 #include "Page.h"
 #include "PlaceholderRenderingContext.h"
-#include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerGraphicsClient.h"
 #include <wtf/IsoMallocInlines.h>
 
 #if ENABLE(WEBGL)
@@ -72,7 +72,7 @@ RefPtr<ImageBuffer> DetachedOffscreenCanvas::takeImageBuffer(ScriptExecutionCont
         return nullptr;
     GraphicsClient* client = nullptr;
     if (is<WorkerGlobalScope>(context)) {
-        client = downcast<WorkerGlobalScope>(context).workerClient();
+        client = downcast<WorkerGlobalScope>(context).workerGraphicsClient();
         ASSERT(client);
     } else if (is<Document>(context)) {
         ASSERT(downcast<Document>(context).page());

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -116,8 +116,8 @@
 #include "WebGLVertexArrayObject.h"
 #include "WebGLVertexArrayObjectOES.h"
 #include "WebXRSystem.h"
-#include "WorkerClient.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerGraphicsClient.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallStack.h>

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -51,7 +51,7 @@
 #include "StorageNamespace.h"
 #include "StorageNamespaceProvider.h"
 #include "WindowFeatures.h"
-#include "WorkerClient.h"
+#include "WorkerGraphicsClient.h"
 #include <JavaScriptCore/VM.h>
 #include <wtf/SetForScope.h>
 #include <wtf/Vector.h>
@@ -542,9 +542,9 @@ RefPtr<ImageBuffer> Chrome::sinkIntoImageBuffer(std::unique_ptr<SerializedImageB
     return m_client.sinkIntoImageBuffer(WTFMove(imageBuffer));
 }
 
-std::unique_ptr<WorkerClient> Chrome::createWorkerClient(SerialFunctionDispatcher& dispatcher)
+std::unique_ptr<WorkerGraphicsClient> Chrome::createWorkerGraphicsClient(SerialFunctionDispatcher& dispatcher)
 {
-    return m_client.createWorkerClient(dispatcher);
+    return m_client.createWorkerGraphicsClient(dispatcher);
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -61,7 +61,7 @@ class PopupMenu;
 class PopupMenuClient;
 class PopupOpeningObserver;
 class SearchPopupMenu;
-class WorkerClient;
+class WorkerGraphicsClient;
 
 struct AppHighlight;
 struct ContactInfo;
@@ -175,7 +175,7 @@ public:
     std::unique_ptr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&);
 #endif
 
-    std::unique_ptr<WorkerClient> createWorkerClient(SerialFunctionDispatcher&);
+    std::unique_ptr<WorkerGraphicsClient> createWorkerGraphicsClient(SerialFunctionDispatcher&);
 
 #if ENABLE(APP_HIGHLIGHTS)
     void storeAppHighlight(AppHighlight&&) const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -51,7 +51,7 @@
 #include "ScrollingCoordinator.h"
 #include "SearchPopupMenu.h"
 #include "WebCoreKeyboardUIMode.h"
-#include "WorkerClient.h"
+#include "WorkerGraphicsClient.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <pal/graphics/WebGPU/WebGPU.h>
 #include <wtf/Assertions.h>
@@ -278,7 +278,7 @@ public:
     // the new cache.
     virtual void reachedApplicationCacheOriginQuota(SecurityOrigin&, int64_t totalSpaceNeeded) = 0;
 
-    virtual std::unique_ptr<WorkerClient> createWorkerClient(SerialFunctionDispatcher&) { return nullptr; }
+    virtual std::unique_ptr<WorkerGraphicsClient> createWorkerGraphicsClient(SerialFunctionDispatcher&) { return nullptr; }
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     virtual void didPreventDefaultForEvent() = 0;

--- a/Source/WebCore/page/WorkerGraphicsClient.h
+++ b/Source/WebCore/page/WorkerGraphicsClient.h
@@ -31,13 +31,13 @@
 
 namespace WebCore {
 
-class WorkerClient : public GraphicsClient {
+class WorkerGraphicsClient : public GraphicsClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
 
-    virtual std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) = 0;
+    virtual std::unique_ptr<WorkerGraphicsClient> clone(SerialFunctionDispatcher&) = 0;
 
-    virtual ~WorkerClient() = default;
+    virtual ~WorkerGraphicsClient() = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -58,7 +58,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DedicatedWorkerGlobalScope);
 
-Ref<DedicatedWorkerGlobalScope> DedicatedWorkerGlobalScope::create(const WorkerParameters& params, Ref<SecurityOrigin>&& origin, DedicatedWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerClient>&& workerClient)
+Ref<DedicatedWorkerGlobalScope> DedicatedWorkerGlobalScope::create(const WorkerParameters& params, Ref<SecurityOrigin>&& origin, DedicatedWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerGraphicsClient>&& workerClient)
 {
     auto context = adoptRef(*new DedicatedWorkerGlobalScope(params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, WTFMove(workerClient)));
     context->addToContextsMap();
@@ -67,7 +67,7 @@ Ref<DedicatedWorkerGlobalScope> DedicatedWorkerGlobalScope::create(const WorkerP
     return context;
 }
 
-DedicatedWorkerGlobalScope::DedicatedWorkerGlobalScope(const WorkerParameters& params, Ref<SecurityOrigin>&& origin, DedicatedWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerClient>&& workerClient)
+DedicatedWorkerGlobalScope::DedicatedWorkerGlobalScope(const WorkerParameters& params, Ref<SecurityOrigin>&& origin, DedicatedWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerGraphicsClient>&& workerClient)
     : WorkerGlobalScope(WorkerThreadType::DedicatedWorker, params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, WTFMove(workerClient))
     , m_name(params.name)
 {

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -65,7 +65,7 @@ using TransferredMessagePort = std::pair<WebCore::MessagePortIdentifier, WebCore
 class DedicatedWorkerGlobalScope final : public WorkerGlobalScope {
     WTF_MAKE_ISO_ALLOCATED(DedicatedWorkerGlobalScope);
 public:
-    static Ref<DedicatedWorkerGlobalScope> create(const WorkerParameters&, Ref<SecurityOrigin>&&, DedicatedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
+    static Ref<DedicatedWorkerGlobalScope> create(const WorkerParameters&, Ref<SecurityOrigin>&&, DedicatedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerGraphicsClient>&&);
     virtual ~DedicatedWorkerGlobalScope();
 
     const String& name() const { return m_name; }
@@ -92,7 +92,7 @@ public:
 private:
     using Base = WorkerGlobalScope;
 
-    DedicatedWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, DedicatedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
+    DedicatedWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, DedicatedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerGraphicsClient>&&);
 
     Type type() const final { return Type::DedicatedWorker; }
 

--- a/Source/WebCore/workers/DedicatedWorkerThread.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerThread.cpp
@@ -49,7 +49,7 @@ DedicatedWorkerThread::~DedicatedWorkerThread() = default;
 
 Ref<WorkerGlobalScope> DedicatedWorkerThread::createWorkerGlobalScope(const WorkerParameters& params, Ref<SecurityOrigin>&& origin, Ref<SecurityOrigin>&& topOrigin)
 {
-    auto scope = DedicatedWorkerGlobalScope::create(params, WTFMove(origin), *this, WTFMove(topOrigin), idbConnectionProxy(), socketProvider(), WTFMove(m_workerClient));
+    auto scope = DedicatedWorkerGlobalScope::create(params, WTFMove(origin), *this, WTFMove(topOrigin), idbConnectionProxy(), socketProvider(), WTFMove(m_workerGraphicsClient));
 #if ENABLE(SERVICE_WORKER)
     if (params.serviceWorkerData)
         scope->setActiveServiceWorker(ServiceWorker::getOrCreate(scope.get(), ServiceWorkerData { *params.serviceWorkerData }));

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -55,9 +55,9 @@
 #include "URLKeepingBlobAlive.h"
 #include "ViolationReportType.h"
 #include "WorkerCacheStorageConnection.h"
-#include "WorkerClient.h"
 #include "WorkerFileSystemStorageConnection.h"
 #include "WorkerFontLoadRequest.h"
+#include "WorkerGraphicsClient.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerLocation.h"
 #include "WorkerMessagePortChannelProvider.h"
@@ -95,7 +95,7 @@ static WorkQueue& sharedFileSystemStorageQueue()
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WorkerGlobalScope);
 
-WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, WorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerClient>&& workerClient)
+WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, WorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerGraphicsClient>&& workerGraphicsClient)
     : WorkerOrWorkletGlobalScope(type, params.sessionID, isMainThread() ? Ref { commonVM() } : JSC::VM::create(), params.referrerPolicy, &thread, params.clientIdentifier)
     , m_url(params.scriptURL)
     , m_ownerURL(params.ownerURL)
@@ -108,7 +108,7 @@ WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParamete
     , m_socketProvider(socketProvider)
     , m_performance(Performance::create(this, params.timeOrigin))
     , m_reportingScope(ReportingScope::create(*this))
-    , m_workerClient(WTFMove(workerClient))
+    , m_workerGraphicsClient(WTFMove(workerGraphicsClient))
     , m_settingsValues(params.settingsValues)
     , m_workerType(params.workerType)
     , m_credentials(params.credentials)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -61,7 +61,7 @@ class ScheduledAction;
 class ScriptBuffer;
 class ScriptBufferSourceProvider;
 class WorkerCacheStorageConnection;
-class WorkerClient;
+class WorkerGraphicsClient;
 class WorkerFileSystemStorageConnection;
 class WorkerLocation;
 class WorkerMessagePortChannelProvider;
@@ -168,10 +168,10 @@ public:
 
     ClientOrigin clientOrigin() const { return { topOrigin().data(), securityOrigin()->data() }; }
 
-    WorkerClient* workerClient() { return m_workerClient.get(); }
+    WorkerGraphicsClient* workerGraphicsClient() { return m_workerGraphicsClient.get(); }
 
 protected:
-    WorkerGlobalScope(WorkerThreadType, const WorkerParameters&, Ref<SecurityOrigin>&&, WorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
+    WorkerGlobalScope(WorkerThreadType, const WorkerParameters&, Ref<SecurityOrigin>&&, WorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerGraphicsClient>&&);
 
     void applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders&);
     void updateSourceProviderBuffers(const ScriptBuffer& mainScript, const HashMap<URL, ScriptBuffer>& importedScripts);
@@ -242,7 +242,7 @@ private:
     RefPtr<WorkerSWClientConnection> m_swClientConnection;
 #endif
     std::unique_ptr<CSSValuePool> m_cssValuePool;
-    std::unique_ptr<WorkerClient> m_workerClient;
+    std::unique_ptr<WorkerGraphicsClient> m_workerGraphicsClient;
     RefPtr<CSSFontSelector> m_cssFontSelector;
     Settings::Values m_settingsValues;
     WorkerType m_workerType;

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -152,13 +152,13 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
 
     if (parentWorkerGlobalScope) {
         parentWorkerGlobalScope->thread().addChildThread(thread);
-        if (parentWorkerGlobalScope->thread().workerClient())
-            thread->setWorkerClient(parentWorkerGlobalScope->thread().workerClient()->clone(thread.get()));
+        if (parentWorkerGlobalScope->thread().workerGraphicsClient())
+            thread->setWorkerGraphicsClient(parentWorkerGlobalScope->thread().workerGraphicsClient()->clone(thread.get()));
     } else if (is<Document>(m_scriptExecutionContext.get())) {
         auto& document = downcast<Document>(*m_scriptExecutionContext);
         if (auto* page = document.page()) {
-            if (auto workerClient = page->chrome().createWorkerClient(thread.get()))
-                thread->setWorkerClient(WTFMove(workerClient));
+            if (auto workerClient = page->chrome().createWorkerGraphicsClient(thread.get()))
+                thread->setWorkerGraphicsClient(WTFMove(workerClient));
         }
     }
 

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -31,7 +31,7 @@
 #include "NotificationPermission.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerRegistrationData.h"
-#include "WorkerClient.h"
+#include "WorkerGraphicsClient.h"
 #include "WorkerOrWorkletThread.h"
 #include "WorkerRunLoop.h"
 #include "WorkerType.h"
@@ -110,8 +110,8 @@ public:
     JSC::RuntimeFlags runtimeFlags() const { return m_runtimeFlags; }
     bool isInStaticScriptEvaluation() const { return m_isInStaticScriptEvaluation; }
 
-    void setWorkerClient(std::unique_ptr<WorkerClient>&& client) { m_workerClient = WTFMove(client); }
-    WorkerClient* workerClient() { return m_workerClient.get(); }
+    void setWorkerGraphicsClient(std::unique_ptr<WorkerGraphicsClient>&& client) { m_workerGraphicsClient = WTFMove(client); }
+    WorkerGraphicsClient* workerGraphicsClient() { return m_workerGraphicsClient.get(); }
 protected:
     WorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerReportingProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
 
@@ -123,7 +123,7 @@ protected:
     IDBClient::IDBConnectionProxy* idbConnectionProxy();
     SocketProvider* socketProvider();
 
-    std::unique_ptr<WorkerClient> m_workerClient;
+    std::unique_ptr<WorkerGraphicsClient> m_workerGraphicsClient;
 private:
     virtual ASCIILiteral threadName() const = 0;
 

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SharedWorkerGlobalScope);
 
 #define SCOPE_RELEASE_LOG(fmt, ...) RELEASE_LOG(SharedWorker, "%p - [sharedWorkerIdentifier=%" PRIu64 "] SharedWorkerGlobalScope::" fmt, this, this->thread().identifier().toUInt64(), ##__VA_ARGS__)
 
-SharedWorkerGlobalScope::SharedWorkerGlobalScope(const String& name, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, SharedWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerClient>&& workerClient)
+SharedWorkerGlobalScope::SharedWorkerGlobalScope(const String& name, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, SharedWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<WorkerGraphicsClient>&& workerClient)
     : WorkerGlobalScope(WorkerThreadType::SharedWorker, params, WTFMove(origin), thread, WTFMove(topOrigin), connectionProxy, socketProvider, WTFMove(workerClient))
     , m_name(name)
 {

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -52,7 +52,7 @@ public:
     void postConnectEvent(TransferredMessagePort&&, const String& sourceOrigin);
 
 private:
-    SharedWorkerGlobalScope(const String& name, const WorkerParameters&, Ref<SecurityOrigin>&&, SharedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
+    SharedWorkerGlobalScope(const String& name, const WorkerParameters&, Ref<SecurityOrigin>&&, SharedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerGraphicsClient>&&);
 
     EventTargetInterface eventTargetInterface() const final { return SharedWorkerGlobalScopeEventTargetInterfaceType; }
     FetchOptions::Destination destination() const final { return FetchOptions::Destination::Sharedworker; }

--- a/Source/WebCore/workers/shared/context/SharedWorkerThread.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThread.cpp
@@ -44,7 +44,7 @@ SharedWorkerThread::SharedWorkerThread(SharedWorkerIdentifier identifier, const 
 Ref<WorkerGlobalScope> SharedWorkerThread::createWorkerGlobalScope(const WorkerParameters& parameters, Ref<SecurityOrigin>&& origin, Ref<SecurityOrigin>&& topOrigin)
 {
     RELEASE_LOG(SharedWorker, "%p - SharedWorkerThread::createWorkerGlobalScope: m_identifier=%" PRIu64, this, m_identifier.toUInt64());
-    auto scope = SharedWorkerGlobalScope::create(std::exchange(m_name, { }), parameters, WTFMove(origin), *this, WTFMove(topOrigin), idbConnectionProxy(), socketProvider(), WTFMove(m_workerClient));
+    auto scope = SharedWorkerGlobalScope::create(std::exchange(m_name, { }), parameters, WTFMove(origin), *this, WTFMove(topOrigin), idbConnectionProxy(), socketProvider(), WTFMove(m_workerGraphicsClient));
 #if ENABLE(SERVICE_WORKER)
     if (parameters.serviceWorkerData)
         scope->setActiveServiceWorker(ServiceWorker::getOrCreate(scope.get(), ServiceWorkerData { *parameters.serviceWorkerData }));

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -44,8 +44,8 @@
 #include "SharedWorkerGlobalScope.h"
 #include "SharedWorkerThread.h"
 #include "WebRTCProvider.h"
-#include "WorkerClient.h"
 #include "WorkerFetchResult.h"
+#include "WorkerGraphicsClient.h"
 #include "WorkerInitializationData.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
@@ -112,8 +112,8 @@ SharedWorkerThreadProxy::SharedWorkerThreadProxy(UniqueRef<Page>&& page, SharedW
         addedListener = true;
     }
 
-    if (auto workerClient = m_page->chrome().createWorkerClient(thread()))
-        thread().setWorkerClient(WTFMove(workerClient));
+    if (auto workerClient = m_page->chrome().createWorkerGraphicsClient(thread()))
+        thread().setWorkerGraphicsClient(WTFMove(workerClient));
 }
 
 SharedWorkerThreadProxy::~SharedWorkerThreadProxy()

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -822,7 +822,7 @@ WebProcess/WebCoreSupport/WebUserMediaClient.cpp
 WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
 WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
 WebProcess/WebCoreSupport/WebStorageConnection.cpp
-WebProcess/WebCoreSupport/WebWorkerClient.cpp
+WebProcess/WebCoreSupport/WebWorkerGraphicsClient.cpp
 
 WebProcess/WebPage/DrawingArea.cpp
 WebProcess/WebPage/EventDispatcher.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1747,7 +1747,7 @@
 		A5E391FD2183C1F800C8FB31 /* InspectorTargetProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E391FC2183C1E900C8FB31 /* InspectorTargetProxy.h */; };
 		A5EC6AD42151BD7B00677D17 /* WebPageDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EC6AD32151BD6900677D17 /* WebPageDebuggable.h */; };
 		A5EFD38C16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A7A3D555289395E2008D683D /* WebWorkerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A3D553289395E2008D683D /* WebWorkerClient.h */; };
+		A7A3D555289395E2008D683D /* WebWorkerGraphicsClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A3D553289395E2008D683D /* WebWorkerGraphicsClient.h */; };
 		A7D792D81767CCA300881CBE /* ActivityAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D792D41767CB0900881CBE /* ActivityAssertion.h */; };
 		AAB145E6223F931200E489D8 /* PrefetchCache.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB145E4223F931200E489D8 /* PrefetchCache.h */; };
 		AAFA634F234F7C6400FFA864 /* AsyncRevalidation.h in Headers */ = {isa = PBXBuildFile; fileRef = AAFA634E234F7C6300FFA864 /* AsyncRevalidation.h */; };
@@ -6480,8 +6480,8 @@
 		A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageVisibilityTypes.h; sourceTree = "<group>"; };
 		A72D5D7F1236CBA800A88B15 /* APISerializedScriptValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APISerializedScriptValue.h; sourceTree = "<group>"; };
 		A78CCDD8193AC9E3005ECC25 /* com.apple.WebKit.Networking.sb.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = com.apple.WebKit.Networking.sb.in; sourceTree = "<group>"; };
-		A7A3D552289395E2008D683D /* WebWorkerClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebWorkerClient.cpp; sourceTree = "<group>"; };
-		A7A3D553289395E2008D683D /* WebWorkerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebWorkerClient.h; sourceTree = "<group>"; };
+		A7A3D552289395E2008D683D /* WebWorkerGraphicsClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebWorkerGraphicsClient.cpp; sourceTree = "<group>"; };
+		A7A3D553289395E2008D683D /* WebWorkerGraphicsClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebWorkerGraphicsClient.h; sourceTree = "<group>"; };
 		A7D792D41767CB0900881CBE /* ActivityAssertion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActivityAssertion.h; sourceTree = "<group>"; };
 		A7D792D51767CB6E00881CBE /* ActivityAssertion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActivityAssertion.cpp; sourceTree = "<group>"; };
 		A7E93CEB192531AA00A1DC48 /* AuxiliaryProcessIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AuxiliaryProcessIOS.mm; path = ios/AuxiliaryProcessIOS.mm; sourceTree = "<group>"; };
@@ -12360,8 +12360,8 @@
 				4A410F4919AF7B80002EBAB5 /* WebUserMediaClient.h */,
 				83EE57591DB7D60600C74C50 /* WebValidationMessageClient.cpp */,
 				83EE575A1DB7D60600C74C50 /* WebValidationMessageClient.h */,
-				A7A3D552289395E2008D683D /* WebWorkerClient.cpp */,
-				A7A3D553289395E2008D683D /* WebWorkerClient.h */,
+				A7A3D552289395E2008D683D /* WebWorkerGraphicsClient.cpp */,
+				A7A3D553289395E2008D683D /* WebWorkerGraphicsClient.h */,
 			);
 			path = WebCoreSupport;
 			sourceTree = "<group>";
@@ -15899,7 +15899,7 @@
 				0FD07E5028A3414700B38C81 /* WebViewImpl.h in Headers */,
 				DDA0A34F27E55E4F005E086E /* WebViewPrivate.h in Headers */,
 				DDA0A2FD27E55E4E005E086E /* WebVisiblePosition.h in Headers */,
-				A7A3D555289395E2008D683D /* WebWorkerClient.h in Headers */,
+				A7A3D555289395E2008D683D /* WebWorkerGraphicsClient.h in Headers */,
 				29CD55AA128E294F00133C85 /* WKAccessibilityWebPageObjectBase.h in Headers */,
 				29232DF418B29D6800D0596F /* WKAccessibilityWebPageObjectMac.h in Headers */,
 				934B724419F5B9BE00AE96D6 /* WKActionMenuItemTypes.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -32,7 +32,7 @@
 #include "PlatformImageBufferShareableBackend.h"
 #include "RemoteRenderingBackendProxy.h"
 #include "WebPage.h"
-#include "WebWorkerClient.h"
+#include "WebWorkerGraphicsClient.h"
 #include <WebCore/Document.h>
 #include <WebCore/WorkerGlobalScope.h>
 #include <wtf/SystemTracing.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -64,7 +64,7 @@
 #include "WebProcessPoolMessages.h"
 #include "WebProcessProxyMessages.h"
 #include "WebSearchPopupMenu.h"
-#include "WebWorkerClient.h"
+#include "WebWorkerGraphicsClient.h"
 #include <WebCore/AppHighlight.h>
 #include <WebCore/ApplicationCacheStorage.h>
 #include <WebCore/AXObjectCache.h>
@@ -922,9 +922,9 @@ RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<Seriali
 }
 #endif
 
-std::unique_ptr<WebCore::WorkerClient> WebChromeClient::createWorkerClient(SerialFunctionDispatcher& dispatcher)
+std::unique_ptr<WebCore::WorkerGraphicsClient> WebChromeClient::createWorkerGraphicsClient(SerialFunctionDispatcher& dispatcher)
 {
-    return makeUnique<WebWorkerClient>(&m_page, dispatcher);
+    return makeUnique<WebWorkerGraphicsClient>(&m_page, dispatcher);
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -252,7 +252,7 @@ private:
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, bool avoidBackendSizeCheck = false) const final;
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) final;
 #endif
-    std::unique_ptr<WebCore::WorkerClient> createWorkerClient(SerialFunctionDispatcher&) final;
+    std::unique_ptr<WebCore::WorkerGraphicsClient> createWorkerGraphicsClient(SerialFunctionDispatcher&) final;
 
 #if ENABLE(WEBGL)
     RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerGraphicsClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerGraphicsClient.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "WebWorkerClient.h"
+#include "WebWorkerGraphicsClient.h"
 
 #include "ImageBufferShareableBitmapBackend.h"
 #include "RemoteImageBufferProxy.h"
@@ -43,7 +43,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-WebWorkerClient::WebWorkerClient(WebPage* page, SerialFunctionDispatcher& dispatcher)
+WebWorkerGraphicsClient::WebWorkerGraphicsClient(WebPage* page, SerialFunctionDispatcher& dispatcher)
     : m_dispatcher(dispatcher)
 #if ENABLE(GPU_PROCESS)
     , m_connection(WebProcess::singleton().ensureGPUProcessConnection().connection())
@@ -60,7 +60,7 @@ WebWorkerClient::WebWorkerClient(WebPage* page, SerialFunctionDispatcher& dispat
 }
 
 #if ENABLE(GPU_PROCESS)
-WebWorkerClient::WebWorkerClient(IPC::Connection& connection, SerialFunctionDispatcher& dispatcher, RemoteRenderingBackendCreationParameters& creationParameters, WebCore::PlatformDisplayID& displayID, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)
+WebWorkerGraphicsClient::WebWorkerGraphicsClient(IPC::Connection& connection, SerialFunctionDispatcher& dispatcher, RemoteRenderingBackendCreationParameters& creationParameters, WebCore::PlatformDisplayID& displayID, Ref<RemoteVideoFrameObjectHeapProxy>&& videoFrameObjectHeapProxy)
     : m_dispatcher(dispatcher)
     , m_connection(connection)
     , m_creationParameters(creationParameters)
@@ -68,14 +68,14 @@ WebWorkerClient::WebWorkerClient(IPC::Connection& connection, SerialFunctionDisp
     , m_displayID(displayID)
 { }
 #else
-WebWorkerClient::WebWorkerClient(SerialFunctionDispatcher& dispatcher, WebCore::PlatformDisplayID& displayID)
+WebWorkerGraphicsClient::WebWorkerGraphicsClient(SerialFunctionDispatcher& dispatcher, WebCore::PlatformDisplayID& displayID)
     : m_dispatcher(dispatcher)
     , m_displayID(displayID)
 { }
 #endif
 
 #if ENABLE(GPU_PROCESS)
-RemoteRenderingBackendProxy& WebWorkerClient::ensureRenderingBackend() const
+RemoteRenderingBackendProxy& WebWorkerGraphicsClient::ensureRenderingBackend() const
 {
     assertIsCurrent(m_dispatcher);
     if (!m_remoteRenderingBackendProxy)
@@ -84,23 +84,23 @@ RemoteRenderingBackendProxy& WebWorkerClient::ensureRenderingBackend() const
 }
 #endif
 
-std::unique_ptr<WorkerClient> WebWorkerClient::clone(SerialFunctionDispatcher& dispatcher)
+std::unique_ptr<WorkerGraphicsClient> WebWorkerGraphicsClient::clone(SerialFunctionDispatcher& dispatcher)
 {
     assertIsCurrent(m_dispatcher);
 #if ENABLE(GPU_PROCESS)
-    return makeUnique<WebWorkerClient>(m_connection, dispatcher, m_creationParameters, m_displayID, m_videoFrameObjectHeapProxy.copyRef());
+    return makeUnique<WebWorkerGraphicsClient>(m_connection, dispatcher, m_creationParameters, m_displayID, m_videoFrameObjectHeapProxy.copyRef());
 #else
-    return makeUnique<WebWorkerClient>(dispatcher, m_displayID);
+    return makeUnique<WebWorkerGraphicsClient>(dispatcher, m_displayID);
 #endif
 }
 
-PlatformDisplayID WebWorkerClient::displayID() const
+PlatformDisplayID WebWorkerGraphicsClient::displayID() const
 {
     assertIsCurrent(m_dispatcher);
     return m_displayID;
 }
 
-RefPtr<ImageBuffer> WebWorkerClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
+RefPtr<ImageBuffer> WebWorkerGraphicsClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
 #if ENABLE(GPU_PROCESS)
     if (!is<RemoteSerializedImageBufferProxy>(imageBuffer))
@@ -112,7 +112,7 @@ RefPtr<ImageBuffer> WebWorkerClient::sinkIntoImageBuffer(std::unique_ptr<Seriali
 #endif
 }
 
-RefPtr<ImageBuffer> WebWorkerClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidBackendSizeCheck) const
+RefPtr<ImageBuffer> WebWorkerGraphicsClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidBackendSizeCheck) const
 {
     assertIsCurrent(m_dispatcher);
 #if ENABLE(GPU_PROCESS)
@@ -123,7 +123,7 @@ RefPtr<ImageBuffer> WebWorkerClient::createImageBuffer(const FloatSize& size, Re
 }
 
 #if ENABLE(WEBGL)
-RefPtr<GraphicsContextGL> WebWorkerClient::createGraphicsContextGL(const GraphicsContextGLAttributes& attributes) const
+RefPtr<GraphicsContextGL> WebWorkerGraphicsClient::createGraphicsContextGL(const GraphicsContextGLAttributes& attributes) const
 {
 #if ENABLE(GPU_PROCESS)
     if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerGraphicsClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerGraphicsClient.h
@@ -28,14 +28,14 @@
 #include "Connection.h"
 #include "RemoteRenderingBackendCreationParameters.h"
 #include "RemoteVideoFrameObjectHeapProxy.h"
-#include <WebCore/WorkerClient.h>
+#include <WebCore/WorkerGraphicsClient.h>
 
 namespace WebKit {
 
 class WebPage;
 class RemoteRenderingBackendProxy;
 
-class WebWorkerClient : public WebCore::WorkerClient {
+class WebWorkerGraphicsClient : public WebCore::WorkerGraphicsClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     // Constructed on the main thread, and then transferred to the
@@ -43,18 +43,18 @@ public:
     // happen on the worker.
     // Any details needed from the page must be copied at this
     // point, but can't hold references to any main-thread objects.
-    WebWorkerClient(WebPage*, SerialFunctionDispatcher&);
+    WebWorkerGraphicsClient(WebPage*, SerialFunctionDispatcher&);
 
     // Used for constructing clients for nested workers. Created on the
     // worker thread of the outer worker, and then transferred to the
     // nested worker.
 #if ENABLE(GPU_PROCESS)
-    WebWorkerClient(IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
+    WebWorkerGraphicsClient(IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
 #else
-    WebWorkerClient(SerialFunctionDispatcher&, WebCore::PlatformDisplayID&);
+    WebWorkerGraphicsClient(SerialFunctionDispatcher&, WebCore::PlatformDisplayID&);
 #endif
 
-    std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) final;
+    std::unique_ptr<WorkerGraphicsClient> clone(SerialFunctionDispatcher&) final;
 
     WebCore::PlatformDisplayID displayID() const final;
 


### PR DESCRIPTION
#### 9af2a8098cda3c0c92d7c2de520cf61482996e83
<pre>
Rename WorkerClient to WorkerGraphicsClient.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250472">https://bugs.webkit.org/show_bug.cgi?id=250472</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::graphicsClient const):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createImageBuffer):
* Source/WebCore/html/ImageBitmapBacking.cpp:
(WebCore::ImageBitmapBacking::connect):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::DetachedOffscreenCanvas::takeImageBuffer):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createWorkerGraphicsClient):
(WebCore::Chrome::createWorkerClient): Deleted.
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::createWorkerGraphicsClient):
(WebCore::ChromeClient::createWorkerClient): Deleted.
* Source/WebCore/page/WorkerGraphicsClient.h: Renamed from Source/WebCore/page/WorkerClient.h.
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::create):
(WebCore::DedicatedWorkerGlobalScope::DedicatedWorkerGlobalScope):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
* Source/WebCore/workers/DedicatedWorkerThread.cpp:
(WebCore::DedicatedWorkerThread::createWorkerGlobalScope):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::WorkerGlobalScope):
* Source/WebCore/workers/WorkerGlobalScope.h:
(WebCore::WorkerGlobalScope::workerGraphicsClient):
(WebCore::WorkerGlobalScope::workerClient): Deleted.
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/WorkerThread.h:
(WebCore::WorkerThread::setWorkerGraphicsClient):
(WebCore::WorkerThread::workerGraphicsClient):
(WebCore::WorkerThread::setWorkerClient): Deleted.
(WebCore::WorkerThread::workerClient): Deleted.
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp:
(WebCore::SharedWorkerGlobalScope::SharedWorkerGlobalScope):
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.h:
* Source/WebCore/workers/shared/context/SharedWorkerThread.cpp:
(WebCore::SharedWorkerThread::createWorkerGlobalScope):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWorkerGraphicsClient):
(WebKit::WebChromeClient::createWorkerClient): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerGraphicsClient.cpp: Renamed from Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp.
(WebKit::WebWorkerGraphicsClient::WebWorkerGraphicsClient):
(WebKit::WebWorkerGraphicsClient::ensureRenderingBackend const):
(WebKit::WebWorkerGraphicsClient::clone):
(WebKit::WebWorkerGraphicsClient::displayID const):
(WebKit::WebWorkerGraphicsClient::sinkIntoImageBuffer):
(WebKit::WebWorkerGraphicsClient::createImageBuffer const):
(WebKit::WebWorkerGraphicsClient::createGraphicsContextGL const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerGraphicsClient.h: Renamed from Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9af2a8098cda3c0c92d7c2de520cf61482996e83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112236 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172448 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3011 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110333 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37714 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79442 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26222 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2675 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45722 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7445 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->