### PR TITLE
Gamepad.vibrationActuator should be nullable

### DIFF
--- a/LayoutTests/gamepad/gamepad-event-handlers.html
+++ b/LayoutTests/gamepad/gamepad-event-handlers.html
@@ -2,7 +2,7 @@
     <script>
         testRunner?.dumpAsText();
         testRunner?.waitUntilDone();
-        testRunner?.setMockGamepadDetails(0, "Test Joystick", "", 2, 2);
+        testRunner?.setMockGamepadDetails(0, "Test Joystick", "", 2, 2, false);
 
         function log(msg) {
             document.getElementById("logger").innerHTML += msg + "<br>";

--- a/LayoutTests/gamepad/gamepad-polling-access.html
+++ b/LayoutTests/gamepad/gamepad-polling-access.html
@@ -65,7 +65,7 @@ async function runTest() {
     // do one at a time...
     for (var i = 0; i < 20; ++i) {
         const p = makeHandlerListenerPair("connected");
-        testRunner.setMockGamepadDetails(i, i, "", i, i);
+        testRunner.setMockGamepadDetails(i, i, "", i, i, false);
         log("Connecting gamepad:");
         testRunner.connectMockGamepad(i);
         await p;
@@ -99,7 +99,8 @@ async function runTest() {
         "Awesome Joystick 5000",
         "standard",
         4,
-        16
+        16,
+        false
     );
     testRunner.setMockGamepadAxisValue(10, 0, 0.7);
     testRunner.setMockGamepadAxisValue(10, 1, -0.9);

--- a/LayoutTests/gamepad/gamepad-timestamp.html
+++ b/LayoutTests/gamepad/gamepad-timestamp.html
@@ -72,13 +72,13 @@ function handleGamepadConnect()
 function runTest() {
     addEventListener("gamepadconnected", handleGamepadConnect);
 
-    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2);
+    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2, false);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
     testRunner.setMockGamepadButtonValue(0, 0, 1.0);
     testRunner.setMockGamepadButtonValue(0, 1, 1.0);
     testRunner.connectMockGamepad(0);
-    testRunner.setMockGamepadDetails(1, "Test Joystick 2", "", 2, 2);
+    testRunner.setMockGamepadDetails(1, "Test Joystick 2", "", 2, 2, false);
     testRunner.setMockGamepadAxisValue(1, 0, 0.7);
     testRunner.setMockGamepadAxisValue(1, 1, -1.0);
     testRunner.setMockGamepadButtonValue(1, 0, 1.0);

--- a/LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active.html
+++ b/LayoutTests/gamepad/gamepad-vibration-document-no-longer-fully-active.html
@@ -21,7 +21,8 @@ function runTest() {
         }
         finishJSTest();
     });
-    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    const supportsDualRumble = true;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2, supportsDualRumble);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
     testRunner.setMockGamepadButtonValue(0, 0, 1.0);

--- a/LayoutTests/gamepad/gamepad-vibration-visibility-change.html
+++ b/LayoutTests/gamepad/gamepad-vibration-visibility-change.html
@@ -21,7 +21,8 @@ function runTest() {
         }
         finishJSTest();
     });
-    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    const supportsDualRumble = true;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2, supportsDualRumble);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
     testRunner.setMockGamepadButtonValue(0, 0, 1.0);

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-SameObject.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-SameObject.html
@@ -21,7 +21,8 @@ function runTest() {
         }, 0);
     });
 
-    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    const supportsDualRumble = true;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2, supportsDualRumble);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
     testRunner.setMockGamepadButtonValue(0, 0, 1.0);

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-nullable-expected.txt
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-nullable-expected.txt
@@ -1,0 +1,11 @@
+Tests that Gamepad.vibrationActuator is null when the gamepad doesn't support dual-rumble
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigator.getGamepads()[0].vibrationActuator is not null
+PASS navigator.getGamepads()[1].vibrationActuator is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-nullable.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-nullable.html
@@ -1,0 +1,41 @@
+<head>
+<script src="../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests that Gamepad.vibrationActuator is null when the gamepad doesn't support dual-rumble");
+jsTestIsAsync = true;
+
+let gamepadCount = 0;
+
+function runTest() {
+    addEventListener("gamepadconnected", e => {
+        gamepadCount++;
+        if (gamepadCount < 2)
+            return;
+
+        shouldNotBe("navigator.getGamepads()[0].vibrationActuator", "null");
+        shouldBe("navigator.getGamepads()[1].vibrationActuator", "null");
+
+        finishJSTest();
+    });
+
+    let supportsDualRumble = true;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2, supportsDualRumble);
+    testRunner.setMockGamepadAxisValue(0, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(0, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(0, 1, 1.0);
+    testRunner.connectMockGamepad(0);
+
+    supportsDualRumble = false;
+    testRunner.setMockGamepadDetails(1, "Test Gamepad Without Vibration", "", 2, 2, supportsDualRumble);
+    testRunner.setMockGamepadAxisValue(1, 0, 0.7);
+    testRunner.setMockGamepadAxisValue(1, 1, -1.0);
+    testRunner.setMockGamepadButtonValue(1, 0, 1.0);
+    testRunner.setMockGamepadButtonValue(1, 1, 1.0);
+    testRunner.connectMockGamepad(1);
+}
+
+onload = runTest;
+</script>
+</body>

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation.html
@@ -39,7 +39,8 @@ function runTest() {
         finishJSTest();
     });
 
-    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    const supportsDualRumble = true;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2, supportsDualRumble);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
     testRunner.setMockGamepadButtonValue(0, 0, 1.0);

--- a/LayoutTests/gamepad/gamepad-vibrationActuator-type.html
+++ b/LayoutTests/gamepad/gamepad-vibrationActuator-type.html
@@ -14,7 +14,8 @@ function runTest() {
         finishJSTest();
     });
 
-    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2);
+    const supportsDualRumble = true;
+    testRunner.setMockGamepadDetails(0, "Test Gamepad", "", 2, 2, supportsDualRumble);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);
     testRunner.setMockGamepadButtonValue(0, 0, 1.0);

--- a/LayoutTests/gamepad/gamepad-visibility-1.html
+++ b/LayoutTests/gamepad/gamepad-visibility-1.html
@@ -42,7 +42,7 @@ function runTest() {
 
     // Connecting the gamepad and changing axis values should *not* make it visible.
     // Only button presses should expose it.
-    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2);
+    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2, false);
     testRunner.connectMockGamepad(0);
     testRunner.setMockGamepadAxisValue(0, 0, 0.7);
     testRunner.setMockGamepadAxisValue(0, 1, -1.0);

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -43,7 +43,7 @@ Gamepad::Gamepad(Document* document, const PlatformGamepad& platformGamepad)
     , m_mapping(platformGamepad.mapping())
     , m_supportedEffectTypes(platformGamepad.supportedEffectTypes())
     , m_axes(platformGamepad.axisValues().size(), 0.0)
-    , m_vibrationActuator(GamepadHapticActuator::create(document, GamepadHapticActuator::Type::DualRumble, *this))
+    , m_vibrationActuator(platformGamepad.supportedEffectTypes().contains(GamepadHapticEffectType::DualRumble) ? RefPtr { GamepadHapticActuator::create(document, GamepadHapticActuator::Type::DualRumble, *this) } : nullptr)
 {
     unsigned buttonCount = platformGamepad.buttonValues().size();
     m_buttons.reserveInitialCapacity(buttonCount);
@@ -71,11 +71,6 @@ void Gamepad::updateFromPlatformGamepad(const PlatformGamepad& platformGamepad)
         m_buttons[i]->setValue(platformGamepad.buttonValues()[i].value());
 
     m_timestamp = platformGamepad.lastUpdateTime();
-}
-
-GamepadHapticActuator& Gamepad::vibrationActuator()
-{
-    return m_vibrationActuator.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/Gamepad.h
+++ b/Source/WebCore/Modules/gamepad/Gamepad.h
@@ -62,7 +62,7 @@ public:
     void updateFromPlatformGamepad(const PlatformGamepad&);
     void setConnected(bool connected) { m_connected = connected; }
 
-    GamepadHapticActuator& vibrationActuator();
+    GamepadHapticActuator* vibrationActuator() { return m_vibrationActuator.get(); }
 
 private:
     Gamepad(Document*, const PlatformGamepad&);
@@ -76,7 +76,7 @@ private:
     Vector<double> m_axes;
     Vector<Ref<GamepadButton>> m_buttons;
 
-    Ref<GamepadHapticActuator> m_vibrationActuator;
+    RefPtr<GamepadHapticActuator> m_vibrationActuator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/Gamepad.idl
+++ b/Source/WebCore/Modules/gamepad/Gamepad.idl
@@ -37,6 +37,6 @@
     readonly attribute sequence<GamepadButton> buttons;
 
     // Extension: https://w3c.github.io/gamepad/extensions.html#partial-gamepad-interface
-    [EnabledBySetting=GamepadVibrationActuatorEnabled, SameObject, CachedAttribute] readonly attribute GamepadHapticActuator vibrationActuator;
+    [EnabledBySetting=GamepadVibrationActuatorEnabled, SameObject, CachedAttribute] readonly attribute GamepadHapticActuator? vibrationActuator;
 };
 

--- a/Source/WebCore/testing/MockGamepad.cpp
+++ b/Source/WebCore/testing/MockGamepad.cpp
@@ -30,15 +30,14 @@
 
 namespace WebCore {
 
-MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount)
+MockGamepad::MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
     : PlatformGamepad(index)
 {
     m_connectTime = m_lastUpdateTime = MonotonicTime::now();
-    m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
-    updateDetails(gamepadID, mapping, axisCount, buttonCount);
+    updateDetails(gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);
 }
 
-void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount)
+void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
 {
     m_id = gamepadID;
     m_mapping = mapping;
@@ -49,6 +48,10 @@ void MockGamepad::updateDetails(const String& gamepadID, const String& mapping, 
     for (size_t i = 0; i < buttonCount; ++i)
         m_buttonValues.append({ });
     m_lastUpdateTime = MonotonicTime::now();
+    if (supportsDualRumble)
+        m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
+    else
+        m_supportedEffectTypes.remove(GamepadHapticEffectType::DualRumble);
 }
 
 bool MockGamepad::setAxisValue(unsigned index, double value)

--- a/Source/WebCore/testing/MockGamepad.h
+++ b/Source/WebCore/testing/MockGamepad.h
@@ -33,12 +33,12 @@ namespace WebCore {
 
 class MockGamepad : public PlatformGamepad {
 public:
-    MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount);
+    MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
 
     const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
     const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
 
-    void updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount);
+    void updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
     bool setAxisValue(unsigned index, double value);
     bool setButtonValue(unsigned index, double value);
 

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -56,15 +56,15 @@ void MockGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
     m_clients.remove(&client);
 }
 
-void MockGamepadProvider::setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount)
+void MockGamepadProvider::setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
 {
     if (index >= m_mockGamepadVector.size())
         m_mockGamepadVector.resize(index + 1);
 
     if (m_mockGamepadVector[index])
-        m_mockGamepadVector[index]->updateDetails(gamepadID, mapping, axisCount, buttonCount);
+        m_mockGamepadVector[index]->updateDetails(gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);
     else
-        m_mockGamepadVector[index] = makeUnique<MockGamepad>(index, gamepadID, mapping, axisCount, buttonCount);
+        m_mockGamepadVector[index] = makeUnique<MockGamepad>(index, gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);
 }
 
 bool MockGamepadProvider::connectMockGamepad(unsigned index)

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -47,7 +47,7 @@ public:
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
     void clearGamepadsForTesting() final;
 
-    void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount);
+    void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
     bool setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
     bool setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
     bool connectMockGamepad(unsigned index);

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -191,16 +191,17 @@ void disconnectMockGamepad(unsigned gamepadIndex)
 #endif
 }
 
-void setMockGamepadDetails(unsigned gamepadIndex, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount)
+void setMockGamepadDetails(unsigned gamepadIndex, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
 {
 #if ENABLE(GAMEPAD)
-    MockGamepadProvider::singleton().setMockGamepadDetails(gamepadIndex, gamepadID, mapping, axisCount, buttonCount);
+    MockGamepadProvider::singleton().setMockGamepadDetails(gamepadIndex, gamepadID, mapping, axisCount, buttonCount, supportsDualRumble);
 #else
     UNUSED_PARAM(gamepadIndex);
     UNUSED_PARAM(gamepadID);
     UNUSED_PARAM(mapping);
     UNUSED_PARAM(axisCount);
     UNUSED_PARAM(buttonCount);
+    UNUSED_PARAM(supportsDualRumble);
 #endif
 }
 

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -62,7 +62,7 @@ void setLinkedOnOrAfterEverythingForTesting() TEST_SUPPORT_EXPORT;
 void installMockGamepadProvider() TEST_SUPPORT_EXPORT;
 void connectMockGamepad(unsigned index) TEST_SUPPORT_EXPORT;
 void disconnectMockGamepad(unsigned index) TEST_SUPPORT_EXPORT;
-void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount) TEST_SUPPORT_EXPORT;
+void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble) TEST_SUPPORT_EXPORT;
 void setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value) TEST_SUPPORT_EXPORT;
 void setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value) TEST_SUPPORT_EXPORT;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -288,7 +288,7 @@ interface TestRunner {
     undefined setAllowedMenuActions(object actions);
 
     // Gamepad
-    undefined setMockGamepadDetails(unsigned long index, DOMString id, DOMString mapping, unsigned long axisCount, unsigned long buttonCount);
+    undefined setMockGamepadDetails(unsigned long index, DOMString id, DOMString mapping, unsigned long axisCount, unsigned long buttonCount, boolean supportsDualRumble);
     undefined setMockGamepadAxisValue(unsigned long index, unsigned long axisIndex, double value);
     undefined setMockGamepadButtonValue(unsigned long index, unsigned long buttonIndex, double value);
     undefined connectMockGamepad(unsigned long index);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1886,7 +1886,7 @@ void TestRunner::disconnectMockGamepad(unsigned index)
     postSynchronousMessage("DisconnectMockGamepad", index);
 }
 
-void TestRunner::setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount)
+void TestRunner::setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble)
 {
     postSynchronousMessage("SetMockGamepadDetails", createWKDictionary({
         { "GamepadID", toWK(gamepadID) },
@@ -1894,6 +1894,7 @@ void TestRunner::setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JS
         { "GamepadIndex", adoptWK(WKUInt64Create(index)) },
         { "AxisCount", adoptWK(WKUInt64Create(axisCount)) },
         { "ButtonCount", adoptWK(WKUInt64Create(buttonCount)) },
+        { "SupportsDualRumble", adoptWK(WKBooleanCreate(supportsDualRumble)) },
     }));
 }
 
@@ -1925,7 +1926,7 @@ void TestRunner::disconnectMockGamepad(unsigned)
 {
 }
 
-void TestRunner::setMockGamepadDetails(unsigned, JSStringRef, JSStringRef, unsigned, unsigned)
+void TestRunner::setMockGamepadDetails(unsigned, JSStringRef, JSStringRef, unsigned, unsigned, bool)
 {
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -373,7 +373,7 @@ public:
     // Gamepads
     void connectMockGamepad(unsigned index);
     void disconnectMockGamepad(unsigned index);
-    void setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount);
+    void setMockGamepadDetails(unsigned index, JSStringRef gamepadID, JSStringRef mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
     void setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
     void setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
     

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1035,7 +1035,8 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         auto mapping = stringValue(messageBodyDictionary, "Mapping");
         auto axisCount = uint64Value(messageBodyDictionary, "AxisCount");
         auto buttonCount = uint64Value(messageBodyDictionary, "ButtonCount");
-        WebCoreTestSupport::setMockGamepadDetails(gamepadIndex, toWTFString(gamepadID), toWTFString(mapping), axisCount, buttonCount);
+        bool supportsDualRumble = booleanValue(messageBodyDictionary, "SupportsDualRumble");
+        WebCoreTestSupport::setMockGamepadDetails(gamepadIndex, toWTFString(gamepadID), toWTFString(mapping), axisCount, buttonCount, supportsDualRumble);
         return nullptr;
     }
 


### PR DESCRIPTION
#### 3d4e479d3a85a13944f8ebabf3dd912fdfab7a47
<pre>
Gamepad.vibrationActuator should be nullable
<a href="https://bugs.webkit.org/show_bug.cgi?id=250411">https://bugs.webkit.org/show_bug.cgi?id=250411</a>

Reviewed by Brent Fulgham.

Gamepad.vibrationActuator should be nullable:
- <a href="https://github.com/w3c/gamepad/issues/178">https://github.com/w3c/gamepad/issues/178</a>

Gamepad.vibrationActuator is supposed to return null if the gamepad doesn&apos;t support dual-rumble:
- <a href="https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface">https://w3c.github.io/gamepad/extensions.html#gamepadhapticactuator-interface</a> (Construction section)

* LayoutTests/gamepad/gamepad-event-handlers.html:
* LayoutTests/gamepad/gamepad-polling-access.html:
* LayoutTests/gamepad/gamepad-timestamp.html:
* LayoutTests/gamepad/gamepad-vibrationActuator-SameObject.html:
* LayoutTests/gamepad/gamepad-vibrationActuator-nullable-expected.txt: Added.
* LayoutTests/gamepad/gamepad-vibrationActuator-nullable.html: Added.
* LayoutTests/gamepad/gamepad-vibrationActuator-playEffect-validation.html:
* LayoutTests/gamepad/gamepad-vibrationActuator-type.html:
* LayoutTests/gamepad/gamepad-visibility-1.html:
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
(WebCore::Gamepad::Gamepad):
(WebCore::Gamepad::vibrationActuator): Deleted.
* Source/WebCore/Modules/gamepad/Gamepad.h:
* Source/WebCore/Modules/gamepad/Gamepad.idl:
* Source/WebCore/testing/MockGamepad.cpp:
(WebCore::MockGamepad::MockGamepad):
(WebCore::MockGamepad::updateDetails):
* Source/WebCore/testing/MockGamepad.h:
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::setMockGamepadDetails):
* Source/WebCore/testing/MockGamepadProvider.h:
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::setMockGamepadDetails):
* Source/WebCore/testing/js/WebCoreTestSupport.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setMockGamepadDetails):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/258812@main">https://commits.webkit.org/258812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6beec08a9b573652dc25b21c95e7539d111ec13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112243 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172453 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3018 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110338 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37720 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24817 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26226 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5702 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45726 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6064 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7451 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->