### PR TITLE
[WebGPU] Support GPURenderPassDepthStencilAttachment.depthReadOnly

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -168,9 +168,10 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         }
     }
 
+    bool depthReadOnly = false, stencilReadOnly = false;
     if (const auto* attachment = descriptor.depthStencilAttachment) {
         const auto& mtlAttachment = mtlDescriptor.depthAttachment;
-        ASSERT("FIXME: Add support for depthReadOnly" && !attachment->depthReadOnly);
+        depthReadOnly = attachment->depthReadOnly;
         mtlAttachment.clearDepth = attachment->clearDepth;
         mtlAttachment.texture = fromAPI(attachment->view).texture();
         mtlAttachment.loadAction = loadAction(attachment->depthLoadOp);
@@ -179,7 +180,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 
     if (const auto* attachment = descriptor.depthStencilAttachment) {
         const auto& mtlAttachment = mtlDescriptor.stencilAttachment;
-        ASSERT("FIXME: Add support for stencilReadOnly" && !attachment->stencilReadOnly);
+        stencilReadOnly = attachment->stencilReadOnly;
         // FIXME: assign the correct stencil texture
         // mtlAttachment.texture = fromAPI(attachment->view).texture();
         mtlAttachment.clearStencil = attachment->clearStencil;
@@ -211,7 +212,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 
     auto mtlRenderCommandEncoder = [m_commandBuffer renderCommandEncoderWithDescriptor:mtlDescriptor];
 
-    return RenderPassEncoder::create(mtlRenderCommandEncoder, visibilityResultBufferSize, m_device);
+    return RenderPassEncoder::create(mtlRenderCommandEncoder, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, m_device);
 }
 
 bool CommandEncoder::validateCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -47,9 +47,9 @@ class RenderPipeline;
 class RenderPassEncoder : public WGPURenderPassEncoderImpl, public RefCounted<RenderPassEncoder>, public CommandsMixin {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPassEncoder> create(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, Device& device)
+    static Ref<RenderPassEncoder> create(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, Device& device)
     {
-        return adoptRef(*new RenderPassEncoder(renderCommandEncoder, visibilityResultBufferSize, device));
+        return adoptRef(*new RenderPassEncoder(renderCommandEncoder, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, device));
     }
     static Ref<RenderPassEncoder> createInvalid(Device& device)
     {
@@ -86,7 +86,7 @@ public:
     bool isValid() const { return m_renderCommandEncoder; }
 
 private:
-    RenderPassEncoder(id<MTLRenderCommandEncoder>, NSUInteger, Device&);
+    RenderPassEncoder(id<MTLRenderCommandEncoder>, NSUInteger, bool depthReadOnly, bool stencilReadOnly, Device&);
     RenderPassEncoder(Device&);
 
     bool validatePopDebugGroup() const;
@@ -105,6 +105,8 @@ private:
     NSUInteger m_vertexShaderInputBufferCount { 0 };
     NSUInteger m_visibilityResultBufferOffset { 0 };
     NSUInteger m_visibilityResultBufferSize { 0 };
+    bool m_depthReadOnly { false };
+    bool m_stencilReadOnly { false };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -35,10 +35,12 @@
 
 namespace WebGPU {
 
-RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, Device& device)
+RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, bool depthReadOnly, bool stencilReadOnly, Device& device)
     : m_renderCommandEncoder(renderCommandEncoder)
     , m_device(device)
     , m_visibilityResultBufferSize(visibilityResultBufferSize)
+    , m_depthReadOnly(depthReadOnly)
+    , m_stencilReadOnly(stencilReadOnly)
 {
 }
 
@@ -196,6 +198,9 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
 {
     // FIXME: validation according to
     // https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setpipeline.
+    if (!pipeline.validateDepthStencilState(m_depthReadOnly, m_stencilReadOnly))
+        return;
+
     m_primitiveType = pipeline.primitiveType();
     m_vertexShaderInputBufferCount = pipeline.vertexShaderInputBufferCount();
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -43,14 +43,14 @@ class PipelineLayout;
 class RenderPipeline : public WGPURenderPipelineImpl, public RefCounted<RenderPipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, id<MTLDepthStencilState> depthStencilState, MTLRenderPipelineReflection *reflection, uint32_t vertexShaderInputBufferCount, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthStencilDescriptor *depthStencilDescriptor, MTLRenderPipelineReflection *reflection, uint32_t vertexShaderInputBufferCount, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilState, reflection, vertexShaderInputBufferCount, device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilDescriptor, reflection, vertexShaderInputBufferCount, device));
     }
 
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, id<MTLDepthStencilState> depthStencilState, const PipelineLayout &pipelineLayout, uint32_t vertexShaderInputBufferCount, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthStencilDescriptor *depthStencilDescriptor, const PipelineLayout &pipelineLayout, uint32_t vertexShaderInputBufferCount, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilState, pipelineLayout, vertexShaderInputBufferCount, device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilDescriptor, pipelineLayout, vertexShaderInputBufferCount, device));
     }
 
     static Ref<RenderPipeline> createInvalid(Device& device)
@@ -66,7 +66,8 @@ public:
     bool isValid() const { return m_renderPipelineState; }
 
     id<MTLRenderPipelineState> renderPipelineState() const { return m_renderPipelineState; }
-    id<MTLDepthStencilState> depthStencilState() const { return m_depthStencilState; }
+    id<MTLDepthStencilState> depthStencilState() const;
+    bool validateDepthStencilState(bool depthReadOnly, bool stencilReadOnly) const;
     MTLPrimitiveType primitiveType() const { return m_primitiveType; }
     MTLWinding frontFace() const { return m_frontFace; }
     MTLCullMode cullMode() const { return m_cullMode; }
@@ -75,8 +76,8 @@ public:
     uint32_t vertexShaderInputBufferCount() const { return m_vertexShaderInputBufferCount; }
 
 private:
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, id<MTLDepthStencilState>, MTLRenderPipelineReflection*, uint32_t, Device&);
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, id<MTLDepthStencilState>, const PipelineLayout&, uint32_t, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthStencilDescriptor *, MTLRenderPipelineReflection*, uint32_t, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthStencilDescriptor *, const PipelineLayout&, uint32_t, Device&);
     RenderPipeline(Device&);
 
     const id<MTLRenderPipelineState> m_renderPipelineState { nil };
@@ -87,6 +88,7 @@ private:
     std::optional<MTLIndexType> m_indexType;
     MTLWinding m_frontFace;
     MTLCullMode m_cullMode;
+    MTLDepthStencilDescriptor *m_depthStencilDescriptor;
     id<MTLDepthStencilState> m_depthStencilState;
 #if HAVE(METAL_BUFFER_BINDING_REFLECTION)
     MTLRenderPipelineReflection *m_reflection { nil };


### PR DESCRIPTION
#### 218228b576832dad35ef35fd02dd47d66c4a7790
<pre>
[WebGPU] Support GPURenderPassDepthStencilAttachment.depthReadOnly
<a href="https://bugs.webkit.org/show_bug.cgi?id=250103">https://bugs.webkit.org/show_bug.cgi?id=250103</a>
&lt;radar://103888373&gt;

Reviewed by Myles C. Maxfield.

Support GPURenderPassDepthStencilAttachment.depthReadOnly  / stencilReadOnly.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
Support depth/Stencil read only.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::create):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::setPipeline):
Set the correct depthStencil state based on depth/stecilReadOnly

* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::create):
(WebGPU::RenderPipeline::depthStencilState const): Deleted.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::RenderPipeline):
(WebGPU::RenderPipeline::depthStencilState const):
Create the correct depthStencil states.

Canonical link: <a href="https://commits.webkit.org/259123@main">https://commits.webkit.org/259123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad3f0db832fa29abf8d9d44a354a7f7968fb9071

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112844 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3625 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112010 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93661 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38336 "Failed to checkout and rebase branch from PR 8541") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79993 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6102 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26665 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3189 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6284 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8035 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->