### PR TITLE
Move long-shipping features to the new 'shipping' status

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -237,7 +237,7 @@ class Preferences
   end
 
   # Corresponds to WebFeatureStatus enum cases. "developer" and up require human-readable names.
-  STATUSES = %w{ embedder unstable internal developer testable preview stable }
+  STATUSES = %w{ embedder unstable internal developer testable preview stable shipping }
 
   def initializeParsedPreferences(parsedPreferences)
     result = []

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -630,7 +630,7 @@ BackspaceKeyNavigationEnabled:
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 BeaconAPIEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "Beacon API"
   humanReadableDescription: "Beacon API"
   defaultValue:
@@ -2397,7 +2397,7 @@ GraphicsContextFiltersEnabled:
 
 HTTPEquivEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "http-equiv"
   humanReadableDescription: "Enable http-equiv attribute"
   webcoreName: httpEquivEnabled
@@ -3085,7 +3085,7 @@ JavaScriptCanOpenWindowsAutomatically:
 
 JavaScriptEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "JavaScript"
   humanReadableDescription: "Enable JavaScript"
   inspectorOverride: true
@@ -3405,7 +3405,7 @@ LocalFileContentSniffingEnabled:
 
 LocalStorageEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "Local Storage"
   humanReadableDescription: "Enable Local Storage"
   webKitLegacyPreferenceKey: WebKitLocalStorageEnabledPreferenceKey
@@ -3765,7 +3765,7 @@ MediaSessionPlaylistEnabled:
 
 MediaSourceEnabled:
   type: bool
-  status: stable
+  status: embedder
   humanReadableName: "Media Source API"
   humanReadableDescription: "Media Source API"
   defaultValue:
@@ -4852,7 +4852,7 @@ SKAttributionEnabled:
 
 SafeBrowsingEnabled:
   type: bool
-  status: stable
+  status: embedder
   humanReadableName: "Safe Browsing"
   humanReadableDescription: "Enable Safe Browsing"
   webcoreBinding: none
@@ -6530,7 +6530,7 @@ WebGLDraftExtensionsEnabled:
 
 WebGLEnabled:
   type: bool
-  status: stable
+  status: shipping
   humanReadableName: "WebGL"
   humanReadableDescription: "Enable WebGL"
   defaultValue:

--- a/Source/WebCore/Scripts/GenerateSettings.rb
+++ b/Source/WebCore/Scripts/GenerateSettings.rb
@@ -179,7 +179,7 @@ class Setting
     # settings that are on by default. Assuming embedder gets split into two
     # categories (off-by-default and on-by-default), only the latter should be
     # considered stable.
-    !@status or %w{ embedder internal stable }.include? @status
+    !@status or %w{ embedder internal stable shipping }.include? @status
   end
 end
 

--- a/Source/WebKit/UIProcess/API/APIFeatureStatus.h
+++ b/Source/WebKit/UIProcess/API/APIFeatureStatus.h
@@ -40,6 +40,8 @@ enum class FeatureStatus : uint8_t {
     // Enabled by default in Safari Technology Preview, but not considered ready to ship yet.
     Preview,
     // Enabled by default and ready for general use.
-    Stable
+    Stable,
+    // Enabled by default and in general use for more than a year.
+    Shipping
 };
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -67,6 +67,8 @@
         return WebFeatureStatusPreview;
     case API::FeatureStatus::Stable:
         return WebFeatureStatusStable;
+    case API::FeatureStatus::Shipping:
+        return WebFeatureStatusShipping;
     default:
         ASSERT_NOT_REACHED();
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFeature.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFeature.h
@@ -45,7 +45,9 @@ typedef NS_ENUM(NSUInteger, WebFeatureStatus) {
     /// Enabled by default in Safari Technology Preview, but not considered ready to ship yet.
     WebFeatureStatusPreview,
     /// Enabled by default and ready for general use.
-    WebFeatureStatusStable
+    WebFeatureStatusStable,
+    /// Enabled by default and in general use for more than a year.
+    WebFeatureStatusShipping
 };
 
 @interface WebFeature : NSObject


### PR DESCRIPTION
#### 0afbc6ef439ed2fceb65388d2cbb1d2f93705e74
<pre>
Move long-shipping features to the new &apos;shipping&apos; status
<a href="https://bugs.webkit.org/show_bug.cgi?id=250395">https://bugs.webkit.org/show_bug.cgi?id=250395</a>
&lt;rdar://problem/104081353&gt;

Reviewed by Patrick Angle and Elliott Williams.

Following Bug 247926, we expose &apos;stable&apos; features to the Safari &apos;Develop&apos; menu to
support A/B testing by developers so they can isolate the cause of page regression
to specific features.

This has created an overly-cumbersome UI, and surfaced features that cannot be
disabled on the modern web (and which have been shipping for many years).

This patch updates our Feature flag definitions to use &apos;shipping&apos; for long-shipping
features. These will no longer be displayed in the UI, and the feature toggles will
likely be removed in a future update as they are no longer conditional, but are
foundational to the modern web.

This also corrects MediaSourceEnabled and SafeBrowsing to be &apos;embedder&apos;.

* Source/WTF/Scripts/GeneratePreferences.rb: Add &apos;shipping&apos; as a recognized status.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Scripts/GenerateSettings.rb: Add &apos;shipping&apos; as a recognized status.
* Source/WebKit/UIProcess/API/APIFeatureStatus.h
* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
* Source/WebKitLegacy/mac/WebView/WebFeature.h

Canonical link: <a href="https://commits.webkit.org/258810@main">https://commits.webkit.org/258810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/094a38c9acd3d93c930091718a563674166b881a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112252 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3027 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95233 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108774 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/24826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93188 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5551 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89572 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3262 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2687 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29702 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45735 "Passed tests") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/95870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6059 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7460 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/95870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->