### PR TITLE
[Wasm-GC] Add structref type

### DIFF
--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -17,6 +17,7 @@
         "ref_null":  { "type": "varint7", "value":  -20, "b3type": "B3::Int64",  "width": 64 },
         "ref":       { "type": "varint7", "value":  -21, "b3type": "B3::Int64",  "width": 64 },
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void",   "width": 0 },
+        "structref": { "type": "varint7", "value":  -25, "b3type": "B3::Int64",  "width": 0 },
         "arrayref":  { "type": "varint7", "value":  -26, "b3type": "B3::Int64",  "width": 0 },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void",   "width": 0 },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void",   "width": 0 },

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -177,6 +177,7 @@ public:
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
+            case TypeKind::Structref:
             case TypeKind::Array:
             case TypeKind::Arrayref:
             case TypeKind::I31ref:
@@ -219,6 +220,7 @@ public:
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
+            case TypeKind::Structref:
             case TypeKind::Array:
             case TypeKind::Arrayref:
             case TypeKind::I31ref:

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -140,6 +140,13 @@ inline bool isArrayref(Type type)
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Arrayref);
 }
 
+inline bool isStructref(Type type)
+{
+    if (!Options::useWebAssemblyGC())
+        return false;
+    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Structref);
+}
+
 inline Type funcrefType()
 {
     if (Options::useWebAssemblyTypedFunctionReferences())
@@ -159,7 +166,7 @@ inline bool isRefWithTypeIndex(Type type)
     if (!Options::useWebAssemblyTypedFunctionReferences())
         return false;
 
-    return isRefType(type) && !isExternref(type) && !isFuncref(type) && !isI31ref(type) && !isArrayref(type);
+    return isRefType(type) && !typeIndexIsType(type.index);
 }
 
 // Determine if the ref type has a placeholder type index that is used
@@ -215,6 +222,9 @@ inline bool isSubtype(Type sub, Type parent)
         if (TypeInformation::get(sub.index).expand().is<ArrayType>() && isArrayref(parent))
             return true;
 
+        if (TypeInformation::get(sub.index).expand().is<StructType>() && isStructref(parent))
+            return true;
+
         if (TypeInformation::get(sub.index).expand().is<FunctionSignature>() && isFuncref(parent))
             return true;
 
@@ -245,6 +255,7 @@ inline bool isValidHeapTypeKind(TypeKind kind)
         return true;
     case TypeKind::I31ref:
     case TypeKind::Arrayref:
+    case TypeKind::Structref:
         return Options::useWebAssemblyGC();
     default:
         break;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1351,10 +1351,10 @@ template<typename Context>
 auto FunctionParser<Context>::parseStructTypeIndex(uint32_t& structTypeIndex, const char* operation) -> PartialResult
 {
     uint32_t typeIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for", operation);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for ", operation);
     WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), operation, " index ", typeIndex, " is out of bound");
     const TypeDefinition& type = m_info.typeSignatures[typeIndex].get();
-    WASM_VALIDATOR_FAIL_IF(!type.is<StructType>(), operation, ": invalid type index", typeIndex);
+    WASM_VALIDATOR_FAIL_IF(!type.is<StructType>(), operation, ": invalid type index ", typeIndex);
 
     structTypeIndex = typeIndex;
     return { };
@@ -1390,7 +1390,7 @@ template<typename Context>
 auto FunctionParser<Context>::parseStructFieldManipulation(StructFieldManipulation& result, const char* operation) -> PartialResult
 {
     StructTypeIndexAndFieldIndex typeIndexAndFieldIndex;
-    WASM_PARSER_FAIL_IF(!parseStructTypeIndexAndFieldIndex(typeIndexAndFieldIndex, operation));
+    WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndexAndFieldIndex(typeIndexAndFieldIndex, operation));
 
     TypedExpression structRef;
     WASM_TRY_POP_EXPRESSION_STACK_INTO(structRef, "struct reference");
@@ -1936,7 +1936,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::StructGet: {
             StructFieldManipulation structGetInput;
-            WASM_PARSER_FAIL_IF(!parseStructFieldManipulation(structGetInput, "struct.get"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructFieldManipulation(structGetInput, "struct.get"));
 
             ExpressionType result;
             const auto& structType = *m_info.typeSignatures[structGetInput.indices.structTypeIndex]->template as<StructType>();
@@ -1950,7 +1950,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "struct.set value");
 
             StructFieldManipulation structSetInput;
-            WASM_PARSER_FAIL_IF(!parseStructFieldManipulation(structSetInput, "struct.set"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructFieldManipulation(structSetInput, "struct.set"));
 
             const auto& field = structSetInput.field;
             WASM_PARSER_FAIL_IF(field.mutability != Mutability::Mutable, "the field ", structSetInput.indices.fieldIndex, " can't be set because it is immutable");

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -705,6 +705,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Structref:
         case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
@@ -741,6 +742,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Structref:
         case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
@@ -807,6 +809,7 @@ auto LLIntGenerator::callInformationForCallee(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Structref:
         case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
@@ -864,6 +867,7 @@ auto LLIntGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Structref:
         case TypeKind::Array:
         case TypeKind::Arrayref:
         case TypeKind::I31ref:

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -364,7 +364,7 @@ ALWAYS_INLINE bool Parser<SuccessType>::parseValueType(const ModuleInformation& 
 
     TypeKind typeKind = static_cast<TypeKind>(kind);
     TypeIndex typeIndex = 0;
-    if (Options::useWebAssemblyTypedFunctionReferences() && (typeKind == TypeKind::Funcref || typeKind == TypeKind::Externref || typeKind == TypeKind::I31ref || typeKind == TypeKind::Arrayref)) {
+    if (Options::useWebAssemblyTypedFunctionReferences() && isValidHeapTypeKind(typeKind)) {
         typeIndex = static_cast<TypeIndex>(typeKind);
         typeKind = TypeKind::RefNull;
     } else if (typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull) {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -279,6 +279,7 @@ constexpr size_t typeKindSizeInBytes(TypeKind kind)
     }
 
     case TypeKind::Arrayref:
+    case TypeKind::Structref:
     case TypeKind::Funcref:
     case TypeKind::Externref:
     case TypeKind::Ref:

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -134,6 +134,7 @@ void JSWebAssemblyStruct::set(JSGlobalObject* globalObject, uint32_t fieldIndex,
         return;
     }
     case TypeKind::Arrayref:
+    case TypeKind::Structref:
     case TypeKind::Externref:
     case TypeKind::Funcref:
     case TypeKind::Ref:

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -149,6 +149,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
+            case TypeKind::Structref:
             case TypeKind::Array:
             case TypeKind::Arrayref:
             case TypeKind::I31ref:
@@ -236,6 +237,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
+            case TypeKind::Structref:
             case TypeKind::Array:
             case TypeKind::Arrayref:
             case TypeKind::I31ref:

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -17,6 +17,7 @@
         "ref_null":  { "type": "varint7", "value":  -20, "b3type": "B3::Int64",  "width": 64 },
         "ref":       { "type": "varint7", "value":  -21, "b3type": "B3::Int64",  "width": 64 },
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void",   "width": 0 },
+        "structref": { "type": "varint7", "value":  -25, "b3type": "B3::Int64",  "width": 0 },
         "arrayref":  { "type": "varint7", "value":  -26, "b3type": "B3::Int64",  "width": 0 },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void",   "width": 0 },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void",   "width": 0 },


### PR DESCRIPTION
#### 013719c7ab1e309409a20f9dba77c3ab56af5867
<pre>
[Wasm-GC] Add structref type
<a href="https://bugs.webkit.org/show_bug.cgi?id=250474">https://bugs.webkit.org/show_bug.cgi?id=250474</a>

Reviewed by Justin Michaud.

Adds a `structref` type that is analogous to `arrayref` but for structs.

This patch also fixes some error messages in struct operations.

* JSTests/wasm/gc/structs.js:
(testStructDeclaration):
(testStructGet):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::WasmCallingConvention::numberOfStackResults const):
(JSC::Wasm::WasmCallingConvention::numberOfStackArguments const):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isStructref):
(JSC::Wasm::isRefWithTypeIndex):
(JSC::Wasm::isSubtype):
(JSC::Wasm::isValidHeapTypeKind):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructTypeIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructFieldManipulation):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::callInformationForCaller):
(JSC::Wasm::LLIntGenerator::callInformationForCallee):
(JSC::Wasm::LLIntGenerator::addArguments):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseValueType):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::typeKindSizeInBytes):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::set):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/259002@main">https://commits.webkit.org/259002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/313b96301fac58453700191b63ac985b5c88a973

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112403 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172602 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3183 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110620 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37841 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79573 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93311 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26354 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89727 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3412 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2809 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29738 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45856 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98320 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6183 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7608 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20720 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->