### PR TITLE
imported/w3c/web-platform-tests/service-workers/service-worker/navigation-sets-cookie.https.html is flaky crashing

### DIFF
--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -216,6 +216,31 @@ void ServiceWorkerGlobalScope::recordUserGesture()
     m_userGestureTimer.startOneShot(userGestureLifetime);
 }
 
+void ServiceWorkerGlobalScope::addOngoingFetchTask(std::pair<SWServerConnectionIdentifier, FetchIdentifier> key, Ref<ServiceWorkerFetch::Client>&& task)
+{
+    ASSERT(isContextThread());
+    ASSERT(!m_ongoingFetchTasks.contains(key));
+    m_ongoingFetchTasks.add(key, WTFMove(task));
+}
+
+RefPtr<ServiceWorkerFetch::Client> ServiceWorkerGlobalScope::ongoingFetchTask(std::pair<SWServerConnectionIdentifier, FetchIdentifier> key) const
+{
+    ASSERT(isContextThread());
+    return m_ongoingFetchTasks.get(key);
+}
+
+RefPtr<ServiceWorkerFetch::Client> ServiceWorkerGlobalScope::takeOngoingFetchTask(std::pair<SWServerConnectionIdentifier, FetchIdentifier> key)
+{
+    ASSERT(isContextThread());
+    return m_ongoingFetchTasks.take(key);
+}
+
+bool ServiceWorkerGlobalScope::hasOngoingFetchTasks() const
+{
+    ASSERT(isContextThread());
+    return !m_ongoingFetchTasks.isEmpty();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -30,6 +30,7 @@
 #include "NotificationClient.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerContextData.h"
+#include "ServiceWorkerFetch.h"
 #include "ServiceWorkerRegistration.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/MonotonicTime.h>
@@ -93,6 +94,11 @@ public:
     void recordUserGesture();
     void setIsProcessingUserGestureForTesting(bool value) { m_isProcessingUserGesture = value; }
 
+    bool hasOngoingFetchTasks() const;
+    void addOngoingFetchTask(std::pair<SWServerConnectionIdentifier, FetchIdentifier>, Ref<ServiceWorkerFetch::Client>&&);
+    RefPtr<ServiceWorkerFetch::Client> ongoingFetchTask(std::pair<SWServerConnectionIdentifier, FetchIdentifier>) const;
+    RefPtr<ServiceWorkerFetch::Client> takeOngoingFetchTask(std::pair<SWServerConnectionIdentifier, FetchIdentifier>);
+
 private:
     ServiceWorkerGlobalScope(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&);
     void notifyServiceWorkerPageOfCreationIfNecessary();
@@ -117,6 +123,7 @@ private:
     bool m_isProcessingUserGesture { false };
     Timer m_userGestureTimer;
     RefPtr<PushEvent> m_pushEvent;
+    HashMap<std::pair<SWServerConnectionIdentifier, FetchIdentifier>, Ref<ServiceWorkerFetch::Client>> m_ongoingFetchTasks;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
@@ -46,7 +46,7 @@ class ServiceWorkerGlobalScope;
 class SharedBuffer;
 
 namespace ServiceWorkerFetch {
-class Client : public ThreadSafeRefCounted<Client, WTF::DestructionThread::Main> {
+class Client : public ThreadSafeRefCounted<Client> {
 public:
     virtual ~Client() = default;
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -75,7 +75,7 @@ public:
 
     WEBCORE_EXPORT void notifyNetworkStateChange(bool isOnline);
 
-    WEBCORE_EXPORT void startFetch(SWServerConnectionIdentifier, FetchIdentifier, Ref<ServiceWorkerFetch::Client>&&, ResourceRequest&&, String&& referrer, FetchOptions&&, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);
+    WEBCORE_EXPORT void startFetch(SWServerConnectionIdentifier, FetchIdentifier, Function<Ref<WebCore::ServiceWorkerFetch::Client>()>&& createFetchTaskClient, ResourceRequest&&, String&& referrer, FetchOptions&&, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);
     WEBCORE_EXPORT void cancelFetch(SWServerConnectionIdentifier, FetchIdentifier);
     WEBCORE_EXPORT void convertFetchToDownload(SWServerConnectionIdentifier, FetchIdentifier);
     WEBCORE_EXPORT void continueDidReceiveFetchResponse(SWServerConnectionIdentifier, FetchIdentifier);
@@ -128,9 +128,6 @@ private:
     ServiceWorkerInspectorProxy m_inspectorProxy;
     uint64_t m_functionalEventTasksCounter { 0 };
     HashMap<uint64_t, CompletionHandler<void(bool)>> m_ongoingFunctionalEventTasks;
-
-    // Accessed in worker thread.
-    HashMap<std::pair<SWServerConnectionIdentifier, FetchIdentifier>, Ref<ServiceWorkerFetch::Client>> m_ongoingFetchTasks;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -257,10 +257,12 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
         serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(isAppInitiated);
     });
 
-    auto client = WebServiceWorkerFetchTaskClient::create(m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request.requester() == ResourceRequestRequester::Main);
-
+    bool needsContinueDidReceiveResponseMessage = request.requester() == ResourceRequestRequester::Main;
+    auto createFetchTaskClient = [connectionToNetworkProcess = m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, needsContinueDidReceiveResponseMessage]() -> Ref<WebCore::ServiceWorkerFetch::Client> {
+        return WebServiceWorkerFetchTaskClient::create(connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, needsContinueDidReceiveResponseMessage);
+    };
     request.setHTTPBody(formData.takeData());
-    serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTFMove(client), WTFMove(request), WTFMove(referrer), WTFMove(options), isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));
+    serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTFMove(createFetchTaskClient), WTFMove(request), WTFMove(referrer), WTFMove(options), isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));
 }
 
 void WebSWContextManagerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier serviceWorkerIdentifier, MessageWithMessagePorts&& message, ServiceWorkerOrClientData&& sourceData)


### PR DESCRIPTION
#### c3d3c3dde1b0d1f083114e7e4cfc05017040c298
<pre>
imported/w3c/web-platform-tests/service-workers/service-worker/navigation-sets-cookie.https.html is flaky crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250486">https://bugs.webkit.org/show_bug.cgi?id=250486</a>
rdar://104138207

Reviewed by NOBODY (OOPS!).

WebServiceWorkerFetchTaskClient objects were owned by the ServiceWorkerThreadProxy
via the m_ongoingFetchTasks HashMap. Even though ServiceWorkerThreadProxy is a
main thread object, it would make sure to only use `m_ongoingFetchTasks` on the
service worker thread.

WebServiceWorkerFetchTaskClient has a data member which is a ResourceResponse
and contains AtomString data members. As a result, which thread we destroy
the WebServiceWorkerFetchTaskClient on matters and getting it wrong causes crashes
such as the one in this bug.

The ResourceResponse in question gets constructed on the service worker thread,
which is expected given that WebServiceWorkerFetchTaskClient objects are mainly
used on this thread. However, ServiceWorkerFetch::Client (the base class for
WebServiceWorkerFetchTaskClient) was subclassing
`ThreadSafeRefCounted&lt;Client, WTF::DestructionThread::Main&gt;`, causing it to
always get destroyed on the main thread.

To address the issue, I made the following changes:
- Have ServiceWorkerFetch::Client subclass ThreadSafeRefCounted&lt;Client&gt; instead so
  that it can be destroyed on the service worker thread.
- Make sure that ServiceWorkerFetch::Client objects are always constructed, used
  and destroyed on the service worker thread.
- To make sure the previous step is always true, I moved the `m_ongoingFetchTasks`
  HashMap from ServiceWorkerThreadProxy (which is a main thread object) to
  ServiceWorkerGlobalScope (which lives on the service worker thread).
- I added threading assertions to make sure m_ongoingFetchTasks is always used on
  the service worker thread.

* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::addOngoingFetchTask):
(WebCore::ServiceWorkerGlobalScope::ongoingFetchTask const):
(WebCore::ServiceWorkerGlobalScope::takeOngoingFetchTask):
(WebCore::ServiceWorkerGlobalScope::hasOngoingFetchTasks const):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::startFetch):
(WebCore::ServiceWorkerThreadProxy::cancelFetch):
(WebCore::ServiceWorkerThreadProxy::convertFetchToDownload):
(WebCore::ServiceWorkerThreadProxy::navigationPreloadIsReady):
(WebCore::ServiceWorkerThreadProxy::navigationPreloadFailed):
(WebCore::ServiceWorkerThreadProxy::continueDidReceiveFetchResponse):
(WebCore::ServiceWorkerThreadProxy::removeFetch):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::startFetch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3d3c3dde1b0d1f083114e7e4cfc05017040c298

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112268 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172481 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3045 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95244 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37731 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79461 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5561 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26247 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2696 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45747 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7476 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->