### PR TITLE
Add a comment to UnifiedWebPreferences.yaml documenting feature statuses

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -21,6 +21,49 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 
+# Web preferences are assigned a `status` which implies a default value and
+# controls the interfaces where the preference is declared.
+#
+# == Web Platform Features ==
+# unstable::
+#   Feature in active development. Unfinished, no promise it is usable or safe.
+#   OFF by default.
+# testable::
+#   Feature in active development. Stable enough for testing, but not ready to ship.
+#   OFF by default. Enabled in test infrastructure only.
+# preview::
+#   Ready to be used in beta contexts like Safari Technology Preview.
+#   OFF by default. May be enabled automatically by clients.
+# stable::
+#   Ready for general use, but should be able to be toggled to support
+#   debugging, A/B testing.
+#   ON by default. Some platforms may deviate from default behavior due to
+#   support or needed dependencies.
+# shipping::
+#   Already in general use, with no UI to toggle. Features in this status may be
+#   cleaned up and removed altogether.
+#   ON by default. Some platforms may deviate from default behavior due to
+#   support or needed dependencies.
+#
+# == Developer Features ==
+# developer::
+#   Tools for web developers, not part of a feature that will ever be enabled
+#   for end users.
+#   OFF by default.
+# internal::
+#   Tools for debugging the WebKit engine. Not generally useful to web developers.
+#   OFF by default.
+#
+# == Embedder Controls ==
+# embedder::
+#   Adjusts WebKit behavior for embedding application needs. Not part of a
+#   web platform feature or a "shipping" feature intended to be always-on.
+#   ANY default value.
+#
+# FIXME: Currently, default values are unchecked. We should audit and refactor
+# features so that their defaults agree with their status's definition, and use
+# the generator to enforce this in the future.
+
 AVFoundationEnabled:
   type: bool
   status: internal


### PR DESCRIPTION
#### 8d7684b083805e97c56b02a6c87dae668b8f9afc
<pre>
Add a comment to UnifiedWebPreferences.yaml documenting feature statuses
<a href="https://bugs.webkit.org/show_bug.cgi?id=250487">https://bugs.webkit.org/show_bug.cgi?id=250487</a>

Reviewed by Brent Fulgham and Michael Catanzaro.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/259113@main">https://commits.webkit.org/259113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97b0ab00b0ad80553ab0c59d2a4c65ea55789bd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12406 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36260 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112525 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172724 "The change is no longer eligible for processing.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3312 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95505 "The change is no longer eligible for processing.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110787 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109057 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10316 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36260 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95505 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92133 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36260 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95505 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93431 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5801 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36260 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89854 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3534 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2915 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29763 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11960 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36260 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98449 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7728 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20744 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3326 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->