### PR TITLE
Crash when using `appearance: meter` with a pseudo-element not backed by `PseudoElement`

### DIFF
--- a/LayoutTests/fast/forms/meter-appearance-on-pseudo-element-expected.txt
+++ b/LayoutTests/fast/forms/meter-appearance-on-pseudo-element-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/forms/meter-appearance-on-pseudo-element.html
+++ b/LayoutTests/fast/forms/meter-appearance-on-pseudo-element.html
@@ -1,0 +1,14 @@
+<style>
+    dialog::backdrop {
+        appearance: meter;
+    }
+ </style>
+<body>
+    <dialog id="dialog"></dialog>
+    <p>This test passes if it does not crash.</p>
+    <script>
+        dialog.showModal();
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+</body>

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -102,8 +102,10 @@ RenderTheme::RenderTheme()
 
 StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, const Element* element, StyleAppearance autoAppearance) const
 {
-    if (!element)
+    if (!element) {
+        style.setEffectiveAppearance(StyleAppearance::None);
         return StyleAppearance::None;
+    }
 
     auto appearance = style.effectiveAppearance();
     if (appearance == autoAppearance)


### PR DESCRIPTION
#### 3600cce060cb8295efbe80ba546ecfcbaaaed623
<pre>
Crash when using `appearance: meter` with a pseudo-element not backed by `PseudoElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250488">https://bugs.webkit.org/show_bug.cgi?id=250488</a>
rdar://104118606

Reviewed by Tim Nguyen.

257981@main introduced a crash due to an unconditional downcast to `RenderMeter`.
The idea behind the unconditional downcast is that `appearance: meter` should
behave like `appearance: auto`, and only apply to `&lt;meter&gt;`.

However, this behavior is currently broken for pseudo-elements not backed by
`PseudoElement`. In this case, the `element` passed into `StyleAdjuster` is
`null`, resulting in an early return from `RenderTheme::adjustAppearanceForElement`,
where the effective appearance is not adjusted.

In this scenario, `appearance: auto` should behave like `appearance: none`. Fix
by ensuring the effective appearance of these pseudo-elements is `none`.

* LayoutTests/fast/forms/meter-appearance-on-pseudo-element-expected.txt: Added.
* LayoutTests/fast/forms/meter-appearance-on-pseudo-element.html: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):

Canonical link: <a href="https://commits.webkit.org/258843@main">https://commits.webkit.org/258843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bda129b344f9097e06218f61c2b025eca80b867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112356 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172554 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3135 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95328 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37807 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24920 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5646 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26326 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6080 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7562 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->