### PR TITLE
REGRESSION(258307@main) ASSERTION FAILED: scale == [webView->_scrollView zoomScale]

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -564,7 +564,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 static CGFloat contentZoomScale(WKWebView *webView)
 {
     CGFloat scale = webView._currentContentView.layer.affineTransform.a;
-    ASSERT(scale == [webView->_scrollView zoomScale]);
+    ASSERT(_resizeAnimationView || scale == [webView->_scrollView zoomScale]);
     return scale;
 }
 


### PR DESCRIPTION
#### 80bba9e9dc19d0455a0cedbeb6d8bd96bbc8af15
<pre>
REGRESSION(258307@main) ASSERTION FAILED: scale == [webView-&gt;_scrollView zoomScale]
<a href="https://bugs.webkit.org/show_bug.cgi?id=250484">https://bugs.webkit.org/show_bug.cgi?id=250484</a>
rdar://104142370

Reviewed by Wenson Hsieh and Saam Barati.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(contentZoomScale):
After 258307@main, this function will still return the correct value, but
the assertion will never be true while the resizeAnimationView is installed.

Adjust the assertion to ignore this case.

Canonical link: <a href="https://commits.webkit.org/258842@main">https://commits.webkit.org/258842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f6532e073e35ae69aa2480d56f774c5fdd270fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112281 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3060 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95257 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37741 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79476 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5574 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26256 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2707 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45756 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6066 "Found 1 new test failure: imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-windows.https.window.html (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7489 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3236 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->