### PR TITLE
`appearance: slider-vertical` should only apply to range inputs

### DIFF
--- a/LayoutTests/fast/forms/slider-track-not-input-element-expected.html
+++ b/LayoutTests/fast/forms/slider-track-not-input-element-expected.html
@@ -1,5 +1,5 @@
 <style>
-  input, div {
+  input {
       width: 70px;
       height: 200px;
       appearance: slider-vertical;

--- a/LayoutTests/fast/forms/slider-track-not-input-element-expected.txt
+++ b/LayoutTests/fast/forms/slider-track-not-input-element-expected.txt
@@ -1,1 +1,0 @@
-This test passes if it does not crash.


### PR DESCRIPTION
#### b03a814cfb391bae7eb95a00bb0149aaa1ac8d7b
<pre>
`appearance: slider-vertical` should only apply to range inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=250492">https://bugs.webkit.org/show_bug.cgi?id=250492</a>
rdar://104147398

Reviewed by Tim Nguyen.

`slider-vertical` is a non-standard `appearance` value, maintained as legacy
`-webkit-appearance` behavior. It is not possible to paint `slider-vertical`
without an `&lt;input type=range&gt;`. However, there is currently logic that guards
against attempts to paint `slider-vertical` for non-range input elements, since
the effective appearance is not always adjusted.

Ensure that `slider-vertical` can only be an effective appearance for range
inputs, and replace checks for range inputs with assertions.

* LayoutTests/fast/forms/slider-track-not-input-element-expected.html: Added.
* LayoutTests/fast/forms/slider-track-not-input-element-expected.txt: Removed.
* LayoutTests/fast/forms/slider-track-not-input-element.html:

Updated crash test to be a reference test.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::createSliderTrackPartForRenderer):

Canonical link: <a href="https://commits.webkit.org/258924@main">https://commits.webkit.org/258924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/063394955a895a51b1f77b0fd3c8069101953723

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112521 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172720 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3308 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110783 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10309 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37947 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79673 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2909 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45900 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6134 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7724 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->