### PR TITLE
Secure Contexts: Documents whose environment has a data: top-level creation URL are not considered a secure context.

### DIFF
--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -125,7 +125,8 @@ static bool shouldTreatAsOpaqueOrigin(const URL& url)
 #if ENABLE(PDFJS)
         || url.protocolIs("webkit-pdfjs-viewer"_s)
 #endif
-        || url.protocolIs("blob"_s))
+        || url.protocolIsBlob()
+        || url.protocolIsData())
         return false;
 
     return !LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol());

--- a/Source/WebCore/platform/LegacySchemeRegistry.cpp
+++ b/Source/WebCore/platform/LegacySchemeRegistry.cpp
@@ -162,10 +162,7 @@ static Span<const ASCIILiteral> builtinSchemesWithUniqueOrigins()
 {
     static constexpr std::array schemes {
         "about"_s,
-        "javascript"_s,
-        // This is an intentional difference from the behavior the HTML specification calls for.
-        // See https://bugs.webkit.org/show_bug.cgi?id=11885
-        "data"_s,
+        "javascript"_s
     };
     return schemes;
 }


### PR DESCRIPTION
#### 7ea509cc2897b557b263d084521494f5c980028e
<pre>
Secure Contexts: Documents whose environment has a data: top-level creation URL are not considered a secure context.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250418">https://bugs.webkit.org/show_bug.cgi?id=250418</a>
rdar://104096486

Reviewed by NOBODY (OOPS!).

data URLs should create secure contexts [0]. This patch ensures that data URLs do not create
an opaque Security Origin which would cause their document to be considered a non-secure context.

[0] <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-contexts">https://html.spec.whatwg.org/multipage/webappapis.html#secure-contexts</a>

* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::shouldTreatAsOpaqueOrigin):
* Source/WebCore/platform/LegacySchemeRegistry.cpp:
(WebCore::builtinSchemesWithUniqueOrigins):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea509cc2897b557b263d084521494f5c980028e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112285 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172489 "Found 21 new test failures: fast/dom/DOMURL/parsing.html, fast/dom/DOMURL/url-origin.html, fast/dom/HTMLAnchorElement/anchor-element-href-parsing.html, fast/dom/anchor-origin.html, fast/eventloop/data-uri-document-has-its-own-event-loop.html, fast/frames/sandboxed-iframe-history-denied.html, fast/loader/stateobjects/pushstate-in-data-url-denied.html, http/tests/security/dataURL/xss-DENIED-from-data-url-in-foreign-domain-subframe.html, http/tests/security/dataURL/xss-DENIED-from-data-url-in-foreign-domain-window-open.html, http/tests/security/dataURL/xss-DENIED-from-data-url-sub-frame-2-level.html ... (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3064 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110549 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108811 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10119 "Found 60 new test failures: compositing/reflections/mask-and-reflection.html, editing/selection/ios/change-selection-by-tapping.html, fast/block/inside-inlines/basic-float-intrusion.html, fast/block/positioning/border-change-relayout-test.html, fast/borders/hidpi-border-image-gradient-on-subpixels.html, fast/canvas/image-pattern-rotate.html, fast/dom/DOMURL/parsing.html, fast/dom/DOMURL/url-origin.html, fast/dom/Geolocation/dataURL-getCurrentPosition.html, fast/dom/Geolocation/dataURL-watchPosition.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93311 "Found 2 new API test failures: TestWebKitAPI.SecurityOriginTest.IsPotentiallyTrustworthy, TestWebKitAPI.PermissionsAPI.DataURL (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37744 "Found 57 new test failures: fast/dom/DOMURL/parsing.html, fast/dom/DOMURL/url-origin.html, fast/dom/Geolocation/dataURL-getCurrentPosition.html, fast/dom/Geolocation/dataURL-watchPosition.html, fast/dom/HTMLAnchorElement/anchor-element-href-parsing.html, fast/dom/anchor-origin.html, fast/eventloop/data-uri-document-has-its-own-event-loop.html, fast/frames/sandboxed-iframe-history-denied.html, fast/loader/stateobjects/pushstate-in-data-url-denied.html, fullscreen/full-screen-iframe-without-allow-attribute-allowed-from-parent.html ... (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91960 "Found 2 new API test failures: TestWebKitAPI.SecurityOriginTest.IsPotentiallyTrustworthy, TestWebKitAPI.PermissionsAPI.DataURL (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24850 "Found 60 new test failures: fast/dom/DOMURL/parsing.html, fast/dom/DOMURL/url-origin.html, fast/dom/Geolocation/dataURL-getCurrentPosition.html, fast/dom/Geolocation/dataURL-watchPosition.html, fast/dom/HTMLAnchorElement/anchor-element-href-parsing.html, fast/dom/anchor-origin.html, fast/eventloop/data-uri-document-has-its-own-event-loop.html, fast/frames/sandboxed-iframe-history-denied.html, fast/loader/stateobjects/pushstate-in-data-url-denied.html, fullscreen/full-screen-iframe-without-allow-attribute-allowed-from-parent.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79479 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitSecurityManager/security-policy, /TestWebCore:SecurityOriginTest.IsPotentiallyTrustworthy (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5578 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26259 "Found 60 new test failures: accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html, fast/dom/DOMURL/parsing.html, fast/dom/DOMURL/url-origin.html, fast/dom/Geolocation/dataURL-getCurrentPosition.html, fast/dom/Geolocation/dataURL-watchPosition.html, fast/dom/HTMLAnchorElement/anchor-element-href-parsing.html, fast/dom/anchor-origin.html, fast/eventloop/data-uri-document-has-its-own-event-loop.html, fast/frames/sandboxed-iframe-history-denied.html, fast/loader/stateobjects/pushstate-in-data-url-denied.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5742 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2712 "Found 60 new test failures: animations/stop-animation-on-suspend.html, fast/dom/DOMURL/parsing.html, fast/dom/DOMURL/url-origin.html, fast/dom/Geolocation/dataURL-getCurrentPosition.html, fast/dom/Geolocation/dataURL-watchPosition.html, fast/dom/HTMLAnchorElement/anchor-element-href-parsing.html, fast/dom/anchor-origin.html, fast/eventloop/data-uri-document-has-its-own-event-loop.html, fast/events/wheel/redispatched-wheel-event.html, fast/frames/sandboxed-iframe-history-denied.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45759 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7493 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->