### PR TITLE
Use ThreadSafeWeakPtr to store m_parent in ScrollingStateNode

### DIFF
--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -282,6 +282,28 @@ inline bool is(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
+    typename SourcePtrTraits, typename SourceRefDerefTraits>
+inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(const RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits>& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    if (!is<Target>(source))
+        return nullptr;
+    return static_pointer_cast<Target, TargetPtrTraits, TargetRefDerefTraits>(source);
+}
+
+template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
+    typename SourcePtrTraits, typename SourceRefDerefTraits>
+inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits>&& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    if (!is<Target>(source))
+        return nullptr;
+    return static_pointer_cast<Target, TargetPtrTraits, TargetRefDerefTraits>(WTFMove(source));
+}
+
 } // namespace WTF
 
 using WTF::RefPtr;

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -185,7 +185,7 @@ public:
         return *this;
     }
 
-    template<typename U>
+    template<typename U, std::enable_if_t<!std::is_pointer_v<U>>* = nullptr>
     ThreadSafeWeakPtr& operator=(const U& retainedReference)
     {
         m_controlBlock = controlBlock(retainedReference);
@@ -198,6 +198,12 @@ public:
     {
         m_controlBlock = retainedPointer ? controlBlock(*retainedPointer) : nullptr;
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!retainedPointer || !m_controlBlock->objectHasBeenDeleted());
+        return *this;
+    }
+
+    ThreadSafeWeakPtr& operator=(std::nullptr_t)
+    {
+        m_controlBlock = nullptr;
         return *this;
     }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -131,10 +131,11 @@ void ScrollingStateNode::insertChild(Ref<ScrollingStateNode>&& childNode, size_t
 
 void ScrollingStateNode::removeFromParent()
 {
-    if (!m_parent)
+    RefPtr parent = m_parent.get();
+    if (!parent)
         return;
 
-    m_parent->removeChild(*this);
+    parent->removeChild(*this);
     m_parent = nullptr;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp
@@ -82,7 +82,7 @@ void ScrollingStateOverflowScrollProxyNode::dumpProperties(TextStream& ts, Optio
     
     ScrollingStateNode::dumpProperties(ts, behavior);
 
-    if (auto* relatedOverflowNode = scrollingStateTree().stateNodeForID(m_overflowScrollingNodeID)) {
+    if (auto relatedOverflowNode = scrollingStateTree().stateNodeForID(m_overflowScrollingNodeID)) {
         auto scrollPosition = downcast<ScrollingStateOverflowScrollingNode>(*relatedOverflowNode).scrollPosition();
         ts.dumpProperty("related overflow scrolling node scroll position", scrollPosition);
     }

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -99,7 +99,7 @@ FloatPoint ScrollingStateStickyNode::computeLayerPosition(const LayoutRect& view
         return m_constraints.layerPositionForConstrainingRect(constrainingRect);
     };
 
-    for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+    for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         if (is<ScrollingStateOverflowScrollProxyNode>(*ancestor)) {
             auto& overflowProxyNode = downcast<ScrollingStateOverflowScrollProxyNode>(*ancestor);
             auto overflowNode = scrollingStateTree().stateNodeForID(overflowProxyNode.overflowScrollingNode());

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -106,7 +106,7 @@ ScrollingNodeID ScrollingStateTree::createUnparentedNode(ScrollingNodeType nodeT
 {
     LOG_WITH_STREAM(ScrollingTree, stream << "ScrollingStateTree " << this << " createUnparentedNode " << newNodeID);
 
-    if (auto* node = stateNodeForID(newNodeID)) {
+    if (auto node = stateNodeForID(newNodeID)) {
         if (node->nodeType() == nodeType) {
             // If the node exists and is parented, unparent it. It may already be in m_unparentedNodes.
             unparentNode(newNodeID);
@@ -133,9 +133,9 @@ ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, Scrol
     LOG_WITH_STREAM(ScrollingTree, stream << "ScrollingStateTree " << this << " insertNode " << newNodeID << " in parent " << parentID << " at " << childIndex);
     ASSERT(newNodeID);
 
-    if (auto* node = stateNodeForID(newNodeID)) {
-        auto* parent = stateNodeForID(parentID);
-        if (nodeTypeAndParentMatch(*node, nodeType, parent)) {
+    if (auto node = stateNodeForID(newNodeID)) {
+        auto parent = stateNodeForID(parentID);
+        if (nodeTypeAndParentMatch(*node, nodeType, parent.get())) {
             if (!parentID)
                 return newNodeID;
 
@@ -176,7 +176,7 @@ ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, Scrol
         newNode = rootStateNode();
         m_hasNewRootStateNode = true;
     } else {
-        auto* parent = stateNodeForID(parentID);
+        auto parent = stateNodeForID(parentID);
         if (!parent) {
             ASSERT_NOT_REACHED();
             return 0;
@@ -314,7 +314,7 @@ void ScrollingStateTree::addNode(ScrollingStateNode& node)
 
 void ScrollingStateTree::removeNodeAndAllDescendants(ScrollingStateNode& node)
 {
-    auto* parent = node.parent();
+    auto parent = node.parent();
 
     recursiveNodeWillBeRemoved(node);
 
@@ -347,10 +347,10 @@ void ScrollingStateTree::willRemoveNode(ScrollingStateNode& node)
     setHasChangedProperties();
 }
 
-ScrollingStateNode* ScrollingStateTree::stateNodeForID(ScrollingNodeID scrollLayerID) const
+RefPtr<ScrollingStateNode> ScrollingStateTree::stateNodeForID(ScrollingNodeID nodeID) const
 {
-    auto* node = scrollLayerID ? m_stateNodeMap.get(scrollLayerID) : nullptr;
-    ASSERT(!node || node->scrollingNodeID() == scrollLayerID);
+    RefPtr node = nodeID ? m_stateNodeMap.get(nodeID) : nullptr;
+    RELEASE_ASSERT(!node || node->scrollingNodeID() == nodeID);
     return node;
 }
 
@@ -372,7 +372,7 @@ static void reconcileLayerPositionsRecursive(ScrollingStateNode& currentNode, co
 
 void ScrollingStateTree::reconcileViewportConstrainedLayerPositions(ScrollingNodeID scrollingNodeID, const LayoutRect& layoutViewport, ScrollingLayerPositionAction action)
 {
-    if (auto* scrollingNode = stateNodeForID(scrollingNodeID))
+    if (auto scrollingNode = stateNodeForID(scrollingNodeID))
         reconcileLayerPositionsRecursive(*scrollingNode, layoutViewport, action);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -49,7 +49,7 @@ public:
     WEBCORE_EXPORT ~ScrollingStateTree();
 
     ScrollingStateFrameScrollingNode* rootStateNode() const { return m_rootStateNode.get(); }
-    WEBCORE_EXPORT ScrollingStateNode* stateNodeForID(ScrollingNodeID) const;
+    WEBCORE_EXPORT RefPtr<ScrollingStateNode> stateNodeForID(ScrollingNodeID) const;
 
     ScrollingNodeID createUnparentedNode(ScrollingNodeType, ScrollingNodeID);
     WEBCORE_EXPORT ScrollingNodeID insertNode(ScrollingNodeType, ScrollingNodeID, ScrollingNodeID parentID, size_t childIndex);

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -32,6 +32,7 @@
 #include "ScrollingCoordinator.h"
 #include "ScrollingStateNode.h"
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -685,7 +685,7 @@ bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder)
             return false;
 
         m_scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
-        ScrollingStateNode* newNode = m_scrollingStateTree->stateNodeForID(nodeID);
+        auto newNode = m_scrollingStateTree->stateNodeForID(nodeID);
         ASSERT(newNode);
         ASSERT(!parentNodeID || newNode->parent());
         


### PR DESCRIPTION
#### 7eb147bf101d9a7a200e369c2fde12f81d1facf4
<pre>
Use ThreadSafeWeakPtr to store m_parent in ScrollingStateNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=250497">https://bugs.webkit.org/show_bug.cgi?id=250497</a>

Reviewed by Simon Fraser.

Use ThreadSafeWeakPtr to store m_parent in ScrollingStateNode much like <a href="https://commits.webkit.org/258795@main.">https://commits.webkit.org/258795@main.</a>

* Source/WTF/wtf/RefPtr.h:
(WTF::dynamicDowncast): Added versions of dynamicDowncast that take const RefPtr&amp; and RefPtr&amp;&amp;.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtr::operator=): Made operator= work with nullptr.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewLayoutUpdated):
(WebCore::AsyncScrollingCoordinator::frameViewVisualViewportChanged):
(WebCore::AsyncScrollingCoordinator::frameViewWillBeDetached):
(WebCore::AsyncScrollingCoordinator::updateIsMonitoringWheelEventsForFrameView):
(WebCore::AsyncScrollingCoordinator::frameViewRootLayerDidChange):
(WebCore::AsyncScrollingCoordinator::requestStartKeyboardScrollAnimation):
(WebCore::AsyncScrollingCoordinator::requestStopKeyboardScrollAnimation):
(WebCore::AsyncScrollingCoordinator::requestScrollPositionUpdate):
(WebCore::AsyncScrollingCoordinator::requestAnimatedScrollToPosition):
(WebCore::AsyncScrollingCoordinator::stopAnimatedScroll):
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
(WebCore::AsyncScrollingCoordinator::scrollableAreaScrollbarLayerDidChange):
(WebCore::AsyncScrollingCoordinator::parentOfNode const):
(WebCore::AsyncScrollingCoordinator::childrenOfNode const):
(WebCore::AsyncScrollingCoordinator::setNodeLayers):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
(WebCore::AsyncScrollingCoordinator::setViewportConstraintedNodeConstraints):
(WebCore::AsyncScrollingCoordinator::setPositionedNodeConstraints):
(WebCore::AsyncScrollingCoordinator::setRelatedOverflowScrollingNodes):
(WebCore::AsyncScrollingCoordinator::setSynchronousScrollingReasons):
(WebCore::AsyncScrollingCoordinator::synchronousScrollingReasons const):
(WebCore::AsyncScrollingCoordinator::updateScrollSnapPropertiesWithFrameView):

* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::removeFromParent):

* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::parent const):
(WebCore::ScrollingStateNode::setParent):
(WebCore::ScrollingStateNode::parentNodeID const):

* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp:
(WebCore::ScrollingStateOverflowScrollProxyNode::dumpProperties const):

* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::computeLayerPosition const):

* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::createUnparentedNode):
(WebCore::ScrollingStateTree::insertNode):
(WebCore::ScrollingStateTree::removeNodeAndAllDescendants):
(WebCore::ScrollingStateTree::stateNodeForID const):
(WebCore::ScrollingStateTree::reconcileViewportConstrainedLayerPositions):

* Source/WebCore/page/scrolling/ScrollingStateTree.h:

* Source/WebCore/page/scrolling/ScrollingTreeNode.h:

* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::RemoteScrollingCoordinatorTransaction::decode):

Canonical link: <a href="https://commits.webkit.org/258845@main">https://commits.webkit.org/258845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3b567e1eda0304eb57261c8c722acdc8a537b91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112306 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172508 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3085 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95279 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37767 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79500 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93234 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26280 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89630 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3319 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2731 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29718 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45782 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98225 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7514 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20700 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3238 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->