### PR TITLE
imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window.html is a flaky failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Send and receive messages using a message port in a same origin window. promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL Send and receive messages using a message port in a blob window. promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
-FAIL Send and receive messages using a message port in a sandboxed same origin window. promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
+FAIL Send and receive messages using a message port in a sandboxed same origin window. promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-windows.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-windows.https.window-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Send and receive messages using a same origin window. promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL Send and receive messages using a blob window. promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
-FAIL Send and receive messages using a sandboxed same origin window. promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
+FAIL Send and receive messages using a sandboxed same origin window. promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/resources/message-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/resources/message-target.html
@@ -5,7 +5,7 @@
 <script id="inline_script">
   'use strict'
 
-  if (window.parent !== null) {
+  if (window.parent !== null && window.parent != window) {
     window.parent.postMessage('LOADED', { targetOrigin: '*' });
   }
 


### PR DESCRIPTION
#### ae82ca3063489132dc69d068c7ad4613647f83ef
<pre>
imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=250499">https://bugs.webkit.org/show_bug.cgi?id=250499</a>
rdar://104154652

Reviewed by Tim Nguyen.

In current implementation, message-target.html could post a &quot;LOADED&quot; message to itself. However, it does not know how to
handle &quot;LOADED&quot; message, and it would send a &quot;ERROR&quot; message to the source (itself) when it receives an unexpected
message (as shown in add_message_event_handlers() in message-target.js). Since it does not know how to handle &quot;ERROR&quot;
message too, it would keep posting this message to itself. For the flaky test, this means the child window created in a
previous subtest could become the entry global object for code in a subsequent subtest, leading to unexpected result.
For example, parsed url in window.open() can change when entry global object is different; see window open steps in
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps.">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-open-steps.</a>

To fix this issue, make sure message-target.html does not post &quot;LOADED&quot; message to itself.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-windows.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/resources/message-target.html:

Canonical link: <a href="https://commits.webkit.org/258840@main">https://commits.webkit.org/258840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4ffdf9acd127605ebe155e849d014d9a4ddbadc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112298 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172501 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3077 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95274 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10132 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37760 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79495 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5591 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2723 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45774 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6075 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7506 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->