### PR TITLE
[JSC] Use SlowPathFrameTracer and fix most of wasm GC operations

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmInstance.h
+++ b/Source/JavaScriptCore/wasm/WasmInstance.h
@@ -223,11 +223,6 @@ public:
     static constexpr size_t offsetOfTablePtr(unsigned numImportFunctions, unsigned i) { return offsetOfTail() + sizeof(ImportFunctionInfo) * numImportFunctions + sizeof(Table*) * i; }
     static constexpr size_t offsetOfGlobalPtr(unsigned numImportFunctions, unsigned numTables, unsigned i) { return roundUpToMultipleOf<sizeof(Global::Value)>(offsetOfTail() + sizeof(ImportFunctionInfo) * numImportFunctions + sizeof(Table*) * numTables) + sizeof(Global::Value) * i; }
 
-    void storeTopCallFrame(void* callFrame)
-    {
-        vm().topCallFrame = bitwise_cast<CallFrame*>(callFrame);
-    }
-
     const Tag& tag(unsigned i) const { return *m_tags[i]; }
     void setTag(unsigned, Ref<const Tag>&&);
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -747,11 +747,17 @@ JSC_DEFINE_JIT_OPERATION(operationWasmRefFunc, EncodedJSValue, (Instance* instan
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, bool useDefault, uint64_t* arguments))
 {
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
     return structNew(instance, typeIndex, useDefault, arguments);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (Instance* instance, uint32_t typeIndex))
 {
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
     JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
     JSGlobalObject* globalObject = jsInstance->globalObject();
     return JSValue::encode(JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex));
@@ -764,6 +770,9 @@ JSC_DEFINE_JIT_OPERATION(operationWasmStructGet, EncodedJSValue, (EncodedJSValue
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructSet, void, (Instance* instance, EncodedJSValue encodedStructReference, uint32_t fieldIndex, EncodedJSValue argument))
 {
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
     return structSet(instance, encodedStructReference, fieldIndex, argument);
 }
 
@@ -916,16 +925,25 @@ JSC_DEFINE_JIT_OPERATION(operationWasmRetrieveAndClearExceptionIfCatchable, void
 
 JSC_DEFINE_JIT_OPERATION(operationWasmArrayNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue))
 {
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
     return arrayNew(instance, typeIndex, size, encValue);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmArrayGet, EncodedJSValue, (Instance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index))
 {
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
     return arrayGet(instance, typeIndex, arrayValue, index);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmArraySet, void, (Instance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index, EncodedJSValue value))
 {
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    VM& vm = instance->vm();
+    NativeCallFrameTracer tracer(vm, callFrame);
     return arraySet(instance, typeIndex, arrayValue, index, value);
 }
 

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "BytecodeStructs.h"
+#include "FrameTracers.h"
 #include "JITExceptions.h"
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyException.h"
@@ -416,6 +417,8 @@ WASM_SLOW_PATH_DECL(array_new)
 
 WASM_SLOW_PATH_DECL(array_get)
 {
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+
     auto instruction = pc->as<WasmArrayGet>();
     EncodedJSValue arrayref = READ(instruction.m_arrayref).encodedJSValue();
     if (JSValue::decode(arrayref).isNull())
@@ -442,6 +445,8 @@ WASM_SLOW_PATH_DECL(array_get)
 
 WASM_SLOW_PATH_DECL(array_set)
 {
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+
     auto instruction = pc->as<WasmArraySet>();
     EncodedJSValue arrayref = READ(instruction.m_arrayref).encodedJSValue();
     if (JSValue::decode(arrayref).isNull())
@@ -461,6 +466,8 @@ WASM_SLOW_PATH_DECL(array_set)
 
 WASM_SLOW_PATH_DECL(struct_new)
 {
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+
     auto instruction = pc->as<WasmStructNew>();
     ASSERT(instruction.m_typeIndex < instance->module().moduleInformation().typeCount());
 
@@ -478,6 +485,8 @@ WASM_SLOW_PATH_DECL(struct_get)
 
 WASM_SLOW_PATH_DECL(struct_set)
 {
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+
     auto instruction = pc->as<WasmStructSet>();
     auto structReference = READ(instruction.m_structReference).encodedJSValue();
     auto value = READ(instruction.m_value).encodedJSValue();
@@ -537,7 +546,7 @@ WASM_SLOW_PATH_DECL(table_grow)
 
 WASM_SLOW_PATH_DECL(grow_memory)
 {
-    instance->storeTopCallFrame(callFrame);
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
     auto instruction = pc->as<WasmGrowMemory>();
     int32_t delta = READ(instruction.m_delta).unboxedInt32();
@@ -655,6 +664,8 @@ static size_t jsrSize()
 
 WASM_SLOW_PATH_DECL(call_builtin)
 {
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+
     auto instruction = pc->as<WasmCallBuiltin>();
     Register* stackBottom = callFrame->registers() - instruction.m_stackOffset;
     Register* stackStart = stackBottom + CallFrame::headerSizeInRegisters + /* indirect call target */ 1;
@@ -791,7 +802,7 @@ WASM_SLOW_PATH_DECL(memory_atomic_notify)
 
 WASM_SLOW_PATH_DECL(throw)
 {
-    instance->storeTopCallFrame(callFrame);
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
     JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
     JSGlobalObject* globalObject = jsInstance->globalObject();
@@ -826,7 +837,7 @@ WASM_SLOW_PATH_DECL(throw)
 
 WASM_SLOW_PATH_DECL(rethrow)
 {
-    instance->storeTopCallFrame(callFrame);
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
     JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
     JSGlobalObject* globalObject = jsInstance->globalObject();
@@ -1103,7 +1114,7 @@ WASM_SLOW_PATH_DECL(i64_trunc_sat_f64_s)
 extern "C" SlowPathReturnType slow_path_wasm_throw_exception(CallFrame* callFrame, const WasmInstruction* pc, Wasm::Instance* instance, Wasm::ExceptionType exceptionType)
 {
     UNUSED_PARAM(pc);
-    instance->storeTopCallFrame(callFrame);
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
     WASM_RETURN_TWO(Wasm::throwWasmToJSException(callFrame, exceptionType, instance), nullptr);
 }
 


### PR DESCRIPTION
#### 31ae64f178ab4378cd7eacf3976990fee13e0874
<pre>
[JSC] Use SlowPathFrameTracer and fix most of wasm GC operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250502">https://bugs.webkit.org/show_bug.cgi?id=250502</a>
rdar://104156324

Reviewed by Mark Lam.

Use SlowPathFrameTracer to configure topCallFrame in Wasm LLInt SlowPathes.
And remove storeTopCallFrame since it is no longer used: it was originally
introduced to make VM separate from Wasm::Instance etc. while keeping the
functionality of setting a CallFrame* to VM. But now we wiped this abstraction,
so this SlowPathFrameTracer change cleans up things.

We also fix bugs of wasm GC operations where they do not set topCallFrame correctly.
They need to set it since they do GC allocation, which can cause ShadowChicken processing,
and it requires topCallFrame. This patch fixes them.

* Source/JavaScriptCore/wasm/WasmInstance.h:
(JSC::Wasm::Instance::storeTopCallFrame): Deleted.
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
(JSC::LLInt::slow_path_wasm_throw_exception):

Canonical link: <a href="https://commits.webkit.org/258824@main">https://commits.webkit.org/258824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cafc4e5ac5f501ec913a51a3d837a3839799c25d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112304 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172506 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3083 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95277 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108830 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37764 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24871 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93232 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26278 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89628 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3317 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2729 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29717 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45780 "Passed tests") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/98223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7512 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/98223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3230 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->