### PR TITLE
Resync web-platform-tests/custom-elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility-expected.txt
@@ -13,7 +13,7 @@ PASS ariaCurrent is defined in ElementInternals
 PASS ariaDescribedByElements is defined in ElementInternals
 PASS ariaDetailsElements is defined in ElementInternals
 PASS ariaDisabled is defined in ElementInternals
-FAIL ariaErrorMessageElement is defined in ElementInternals assert_inherits: property "ariaErrorMessageElement" not found in prototype chain
+PASS ariaErrorMessageElements is defined in ElementInternals
 PASS ariaExpanded is defined in ElementInternals
 PASS ariaFlowToElements is defined in ElementInternals
 PASS ariaHasPopup is defined in ElementInternals
@@ -45,4 +45,5 @@ PASS ariaValueMax is defined in ElementInternals
 PASS ariaValueMin is defined in ElementInternals
 PASS ariaValueNow is defined in ElementInternals
 PASS ariaValueText is defined in ElementInternals
+PASS ariaErrorMessageElement is not defined in ElementInternals
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility.html
@@ -38,7 +38,7 @@ const properties = [
   "ariaDescribedByElements",
   "ariaDetailsElements",
   "ariaDisabled",
-  "ariaErrorMessageElement",
+  "ariaErrorMessageElements",
   "ariaExpanded",
   "ariaFlowToElements",
   "ariaHasPopup",
@@ -76,4 +76,5 @@ for (const property of properties) {
     assert_inherits(element.internals, property);
   }, property + " is defined in ElementInternals");
 }
+test(() => assert_false('ariaErrorMessageElement' in element.internals), 'ariaErrorMessageElement is not defined in ElementInternals')
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling proxy constructor directly assert_throws_js: Should not be able to construct an HTMLElement named 'button' function "function () { new countingProxy() }" did not throw
+FAIL HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling via Reflect assert_throws_js: Should not be able to construct an HTMLElement named 'button' function "function () { Reflect.construct(HTMLElement, [], countingProxy) }" did not throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: HTMLElement must allow subclassing</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTMLElement must allow subclassing">
+<link rel="help" href="https://html.spec.whatwg.org/#html-element-constructors">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function() {
+    class SomeCustomElement extends HTMLElement {};
+    var getCount = 0;
+    var countingProxy = new Proxy(SomeCustomElement, {
+        get: function(target, prop, receiver) {
+            if (prop == "prototype") {
+                ++getCount;
+            }
+            return Reflect.get(target, prop, receiver);
+        }
+    });
+    customElements.define("failure-counting-element-1", countingProxy,
+                          { extends: "button" });
+    // define() gets the prototype of the constructor it's passed, so
+    // reset the counter.
+    getCount = 0;
+    assert_throws_js(TypeError,
+                     function () { new countingProxy() },
+                     "Should not be able to construct an HTMLElement named 'button'");
+    assert_equals(getCount, 0, "Should never have gotten .prototype");
+}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling proxy constructor directly');
+
+test(function() {
+    class SomeCustomElement extends HTMLElement {};
+    var getCount = 0;
+    var countingProxy = new Proxy(SomeCustomElement, {
+        get: function(target, prop, receiver) {
+            if (prop == "prototype") {
+                ++getCount;
+            }
+            return Reflect.get(target, prop, receiver);
+        }
+    });
+    customElements.define("failure-counting-element-2", countingProxy,
+                          { extends: "button" });
+    // define() gets the prototype of the constructor it's passed, so
+    // reset the counter.
+    getCount = 0;
+    assert_throws_js(TypeError,
+                     function () { Reflect.construct(HTMLElement, [], countingProxy) },
+                     "Should not be able to construct an HTMLElement named 'button'");
+    assert_equals(getCount, 0, "Should never have gotten .prototype");
+}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling via Reflect');
+
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-expected.txt
@@ -11,7 +11,5 @@ PASS HTMLElement constructor must only get .prototype once, calling proxy constr
 PASS HTMLElement constructor must only get .prototype once, calling proxy constructor via Reflect
 PASS HTMLElement constructor must only get .prototype once, calling proxy constructor via Reflect with no inheritance
 FAIL HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling proxy constructor directly assert_throws_js: Should not be able to construct an HTMLElement named 'button' function "function () { new countingProxy() }" did not throw
-FAIL HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling via Reflect assert_throws_js: Should not be able to construct an HTMLElement named 'button' function "function () { Reflect.construct(HTMLElement, [], countingProxy) }" did not throw
-PASS HTMLElement constructor must not get .prototype until it finishes its registration sanity checks, calling proxy constructor directly
 PASS HTMLElement constructor must not get .prototype until it finishes its registration  sanity checks, calling via Reflect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor.html
@@ -195,47 +195,6 @@ test(function() {
             return Reflect.get(target, prop, receiver);
         }
     });
-    customElements.define("failure-counting-element-2", countingProxy,
-                          { extends: "button" });
-    // define() gets the prototype of the constructor it's passed, so
-    // reset the counter.
-    getCount = 0;
-    assert_throws_js(TypeError,
-                     function () { Reflect.construct(HTMLElement, [], countingProxy) },
-                     "Should not be able to construct an HTMLElement named 'button'");
-    assert_equals(getCount, 0, "Should never have gotten .prototype");
-}, 'HTMLElement constructor must not get .prototype until it finishes its extends sanity checks, calling via Reflect');
-
-test(function() {
-    class SomeCustomElement extends HTMLElement {};
-    var getCount = 0;
-    var countingProxy = new Proxy(SomeCustomElement, {
-        get: function(target, prop, receiver) {
-            if (prop == "prototype") {
-                ++getCount;
-            }
-            return Reflect.get(target, prop, receiver);
-        }
-    });
-
-    // Purposefully don't register it.
-    assert_throws_js(TypeError,
-                     function () { new countingProxy() },
-                     "Should not be able to construct an HTMLElement named 'button'");
-    assert_equals(getCount, 0, "Should never have gotten .prototype");
-}, 'HTMLElement constructor must not get .prototype until it finishes its registration sanity checks, calling proxy constructor directly');
-
-test(function() {
-    class SomeCustomElement extends HTMLElement {};
-    var getCount = 0;
-    var countingProxy = new Proxy(SomeCustomElement, {
-        get: function(target, prop, receiver) {
-            if (prop == "prototype") {
-                ++getCount;
-            }
-            return Reflect.get(target, prop, receiver);
-        }
-    });
 
     // Purposefully don't register it.
     assert_throws_js(TypeError,

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/AriaMixin-element-attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/AriaMixin-element-attributes-expected.txt
@@ -7,8 +7,8 @@ PASS ariaDescribedByElements in Element must enqueue an attributeChanged reactio
 PASS ariaDescribedByElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
 PASS ariaDetailsElements in Element must enqueue an attributeChanged reaction when adding aria-details content attribute
 PASS ariaDetailsElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
-FAIL ariaErrorMessageElement in Element must enqueue an attributeChanged reaction when adding aria-errormessage content attribute assert_array_equals: lengths differ, expected array ["attributeChanged"] length 1, got [] length 0
-FAIL ariaErrorMessageElement in Element must enqueue an attributeChanged reaction when replacing an existing attribute assert_array_equals: lengths differ, expected array ["constructed", "connected", "attributeChanged"] length 3, got ["constructed", "connected"] length 2
+PASS ariaErrorMessageElements in Element must enqueue an attributeChanged reaction when adding aria-errormessage content attribute
+PASS ariaErrorMessageElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
 PASS ariaFlowToElements in Element must enqueue an attributeChanged reaction when adding aria-flowto content attribute
 PASS ariaFlowToElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
 PASS ariaLabelledByElements in Element must enqueue an attributeChanged reaction when adding aria-labelledby content attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/AriaMixin-element-attributes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/AriaMixin-element-attributes.html
@@ -55,7 +55,7 @@ testElementReflectAttribute('ariaActiveDescendantElement', 'aria-activedescendan
 testElementReflectAttribute('ariaControlsElements', 'aria-controls', [dummy1], [dummy2], 'ariaControlsElements in Element');
 testElementReflectAttribute('ariaDescribedByElements', 'aria-describedby', [dummy1], [dummy2], 'ariaDescribedByElements in Element');
 testElementReflectAttribute('ariaDetailsElements', 'aria-details', [dummy1], [dummy2], 'ariaDetailsElements in Element');
-testElementReflectAttribute('ariaErrorMessageElement', 'aria-errormessage', dummy1, dummy2, 'ariaErrorMessageElement in Element');
+testElementReflectAttribute('ariaErrorMessageElements', 'aria-errormessage', [dummy1], [dummy2], 'ariaErrorMessageElements in Element');
 testElementReflectAttribute('ariaFlowToElements', 'aria-flowto', [dummy1], [dummy2], 'ariaFlowToElements in Element');
 testElementReflectAttribute('ariaLabelledByElements', 'aria-labelledby', [dummy1], [dummy2], 'ariaLabelledByElements in Element')
 testElementReflectAttribute('ariaOwnsElements', 'aria-owns', [dummy1], [dummy2], 'ariaOwnsElements in Element')

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log
@@ -23,6 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/Document-createElementNS.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-attachInternals.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/adopted-callback.html


### PR DESCRIPTION
#### b645d8fd1bb6395f0354b0785e834deb216b3234
<pre>
Resync web-platform-tests/custom-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=250505">https://bugs.webkit.org/show_bug.cgi?id=250505</a>

Reviewed by Alexey Shvayka.

Resync web platform tests for custom elements as of fe2111adb8769ba2715016d3ede2aaf88cb06710.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/ElementInternals-accessibility.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-customized-bulitins.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-constructor.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/AriaMixin-element-attributes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/reactions/AriaMixin-element-attributes.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/258846@main">https://commits.webkit.org/258846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02b884242fb00f4fa702c8906f143708cff6aa7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112309 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172515 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3088 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95282 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37765 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26281 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2735 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45783 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7517 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3239 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->