### PR TITLE
[webkitcorepy] Prevent `TaskPool` from blocking after exceeding failure threshold

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -446,6 +446,10 @@ class TaskPool(object):
         try:
             inflight = sys.exc_info()
 
+            if inflight[1]:
+                # We're about to terminate all the workers. Ignore any unprocessed jobs.
+                self.queue.outgoing.cancel_join_thread()
+
             for worker in self.workers:
                 if worker.is_alive():
                     worker.terminate()


### PR DESCRIPTION
#### c4ef868fe788c1cf78a68a08bc18887159c88aae
<pre>
[webkitcorepy] Prevent `TaskPool` from blocking after exceeding failure threshold
<a href="https://bugs.webkit.org/show_bug.cgi?id=24784">https://bugs.webkit.org/show_bug.cgi?id=24784</a>

Reviewed by Jonathan Bedard.

`TaskPool` uses `_BiDirectionalQueue` to communicate with its worker
`_Process`es. `TaskPool` sends `Task`s to the queue and receives
`_Result` back. `_BiDirectionalQueue` is implemented as two
`multiprocessing.Queue`.

When `TaskPool` puts some tasks on the `outgoing` queue it will
by default not terminate until all of them have been flushed to the
underlying pipe. If we terminate all the workers because of an exception
the pipe might stay full with no one reading from it. It is a deadlock.

We now call `cancel_join_thread()` before terminating the workers and
closing the queue to make `join_thread()` do nothing.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
(_BiDirectionalQueue.__init__):
(_BiDirectionalQueue.close):

Canonical link: <a href="https://commits.webkit.org/259119@main">https://commits.webkit.org/259119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aaee29b355562cc523a0af50b28b7d68ab55fdc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113159 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173456 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3940 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112256 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38566 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107413 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3445 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/102798 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46443 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6279 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8337 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->