### PR TITLE
REGRESSION(258663@main) [GStreamer] MIME API test crashes due to GStreamer being initialized in UIProcess

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -82,6 +82,7 @@ Vector<String> extractGStreamerOptionsFromCommandLine();
 void setGStreamerOptionsFromUIProcess(Vector<String>&&);
 bool ensureGStreamerInitialized();
 void registerWebKitGStreamerElements();
+void registerWebKitGStreamerVideoEncoder();
 unsigned getGstPlayFlag(const char* nick);
 uint64_t toGstUnsigned64Time(const MediaTime&);
 #if ENABLE(THUNDER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -50,9 +50,17 @@ GST_DEBUG_CATEGORY_STATIC(webkit_media_gst_registry_scanner_debug);
 #define MEDIA_MAX_HEIGHT 4320.0f
 #define MEDIA_MAX_FRAMERATE 60.0f
 
+static bool singletonInitialized = false;
+
+bool GStreamerRegistryScanner::singletonNeedsInitialization()
+{
+    return singletonInitialized;
+}
+
 GStreamerRegistryScanner& GStreamerRegistryScanner::singleton()
 {
     static NeverDestroyed<GStreamerRegistryScanner> sharedInstance;
+    singletonInitialized = true;
     return sharedInstance;
 }
 
@@ -233,7 +241,16 @@ GStreamerRegistryScanner::GStreamerRegistryScanner(bool isMediaSource)
     }
 
     GST_DEBUG_CATEGORY_INIT(webkit_media_gst_registry_scanner_debug, "webkitregistryscanner", 0, "WebKit GStreamer registry scanner");
-    registerWebKitGStreamerElements();
+
+    refresh();
+}
+
+void GStreamerRegistryScanner::refresh()
+{
+#if USE(GSTREAMER_WEBRTC)
+    m_audioRtpExtensions.reset();
+    m_videoRtpExtensions.reset();
+#endif
 
     ElementFactories factories(OptionSet<ElementFactories::Type>::fromRaw(static_cast<unsigned>(ElementFactories::Type::All)));
     initializeDecoders(factories);
@@ -293,6 +310,8 @@ void GStreamerRegistryScanner::fillMimeTypeSetFromCapsMapping(const GStreamerReg
 
 void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner::ElementFactories& factories)
 {
+    m_decoderCodecMap.clear();
+    m_decoderMimeTypeSet.clear();
     if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)4")) {
         m_decoderMimeTypeSet.add(AtomString("audio/aac"_s));
         m_decoderMimeTypeSet.add(AtomString("audio/mp4"_s));
@@ -480,6 +499,9 @@ void GStreamerRegistryScanner::initializeEncoders(const GStreamerRegistryScanner
     // MSE is about playback, which means decoding. No need to check for encoders then.
     if (m_isMediaSource)
         return;
+
+    m_encoderCodecMap.clear();
+    m_encoderMimeTypeSet.clear();
 
     auto aacSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)4");
     if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)4")) {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -38,11 +38,14 @@ class ContentType;
 
 class GStreamerRegistryScanner {
 public:
+    static bool singletonNeedsInitialization();
     static GStreamerRegistryScanner& singleton();
     static void getSupportedDecodingTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
 
     explicit GStreamerRegistryScanner(bool isMediaSource = false);
     ~GStreamerRegistryScanner() = default;
+
+    void refresh();
 
     enum Configuration {
         Decoding = 0,

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
@@ -80,6 +80,7 @@ void GStreamerWebRTCProvider::initializeAudioEncodingCapabilities()
 
 void GStreamerWebRTCProvider::initializeVideoEncodingCapabilities()
 {
+    registerWebKitGStreamerVideoEncoder();
     m_videoEncodingCapabilities = GStreamerRegistryScanner::singleton().videoRtpCapabilities(GStreamerRegistryScanner::Configuration::Encoding);
     m_videoEncodingCapabilities->codecs.removeAllMatching([isSupportingVP9Profile0 = isSupportingVP9Profile0(), isSupportingVP9Profile2 = isSupportingVP9Profile2(), isSupportingH265 = isSupportingH265()](const auto& codec) {
         if (!isSupportingVP9Profile0 && codec.sdpFmtpLine == "profile-id=0"_s)

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -133,9 +133,6 @@
     },
     "TestWebKitWebView": {
         "subtests": {
-            "/webkit/WebKitWebView/can-show-mime-type": {
-                "expected": {"all": {"status": ["CRASH"], "bug": "webkit.org/b/250480"}}
-            },
             "/webkit/WebKitWebView/is-playing-audio": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/210635"}}
             },
@@ -376,13 +373,6 @@
             },
             "/webkit/WebKitWebView/tls-errors-redirect-to-http": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/224955"}}
-            }
-        }
-    },
-    "TestWebCore": {
-        "subtests": {
-            "MIMETypeRegistry.CanShowMIMEType": {
-                "expected": {"all": {"status": ["CRASH"], "bug": "webkit.org/b/250480"}}
             }
         }
     }


### PR DESCRIPTION
#### 8c38ebd63c971d13906e3dbf83e5ddc4e21378b7
<pre>
REGRESSION(258663@main) [GStreamer] MIME API test crashes due to GStreamer being initialized in UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=250480">https://bugs.webkit.org/show_bug.cgi?id=250480</a>

Reviewed by Xabier Rodriguez-Calvar.

The registry no longer directly registers GStreamer elements. Instead it is done from call-sites,
such as the WebRTC provider, when needed. Also the scanner is now able to refresh its internal
state, this is needed in situations where the singleton might have been created before the
registration of additional elements.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::registerVideoEncoder):
(WebCore::registerWebKitGStreamerElements):
(WebCore::registerWebKitGStreamerVideoEncoder):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::singletonNeedsInitialization):
(WebCore::GStreamerRegistryScanner::singleton):
(WebCore::GStreamerRegistryScanner::GStreamerRegistryScanner):
(WebCore::GStreamerRegistryScanner::refresh):
(WebCore::GStreamerRegistryScanner::initializeDecoders):
(WebCore::GStreamerRegistryScanner::initializeEncoders):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp:
(WebCore::GStreamerWebRTCProvider::initializeVideoEncodingCapabilities):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/258848@main">https://commits.webkit.org/258848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d5265b67c85b6bc0aad3797171e3186bcf66053

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112345 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172548 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3124 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95318 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37805 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79534 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26323 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2768 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6081 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7553 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->