### PR TITLE
Clean up PlatformCAFilters

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -291,8 +291,8 @@ private:
     bool setTransformAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize);
     bool setTransformAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction);
     
-    bool setFilterAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, int internalFilterPropertyIndex);
-    bool setFilterAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, int internalFilterPropertyIndex, FilterOperation::OperationType, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool setFilterAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex);
+    bool setFilterAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, FilterOperation::OperationType, bool keyframesShouldUseAnimationWideTimingFunction);
 
     bool isRunningTransformAnimation() const;
 
@@ -490,16 +490,15 @@ private:
     // a single transition or keyframe animation, so index is used to distinguish these.
     enum class PlayState { Playing, PlayPending, Paused, PausePending };
     struct LayerPropertyAnimation {
-        LayerPropertyAnimation(Ref<PlatformCAAnimation>&& caAnimation, const String& animationName, AnimatedPropertyID property, int index, int subIndex, Seconds timeOffset)
+        LayerPropertyAnimation(Ref<PlatformCAAnimation>&& caAnimation, const String& animationName, AnimatedPropertyID property, int index, Seconds timeOffset)
             : m_animation(WTFMove(caAnimation))
             , m_name(animationName)
             , m_property(property)
             , m_index(index)
-            , m_subIndex(subIndex)
             , m_timeOffset(timeOffset)
         { }
 
-        String animationIdentifier() const { return makeString(m_name, '_', static_cast<unsigned>(m_property), '_', m_index, '_', m_subIndex); }
+        String animationIdentifier() const { return makeString(m_name, '_', static_cast<unsigned>(m_property), '_', m_index); }
         std::optional<Seconds> computedBeginTime() const
         {
             if (m_beginTime)
@@ -511,7 +510,6 @@ private:
         String m_name;
         AnimatedPropertyID m_property;
         int m_index;
-        int m_subIndex;
         Seconds m_timeOffset { 0_s };
         std::optional<Seconds> m_beginTime;
         PlayState m_playState { PlayState::PlayPending };

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
@@ -95,14 +95,14 @@ public:
     virtual void setFromValue(const WebCore::TransformationMatrix&) = 0;
     virtual void setFromValue(const FloatPoint3D&) = 0;
     virtual void setFromValue(const WebCore::Color&) = 0;
-    virtual void setFromValue(const FilterOperation*, int internalFilterPropertyIndex) = 0;
+    virtual void setFromValue(const FilterOperation*) = 0;
     virtual void copyFromValueFrom(const PlatformCAAnimation&) = 0;
 
     virtual void setToValue(float) = 0;
     virtual void setToValue(const WebCore::TransformationMatrix&) = 0;
     virtual void setToValue(const FloatPoint3D&) = 0;
     virtual void setToValue(const WebCore::Color&) = 0;
-    virtual void setToValue(const FilterOperation*, int internalFilterPropertyIndex) = 0;
+    virtual void setToValue(const FilterOperation*) = 0;
     virtual void copyToValueFrom(const PlatformCAAnimation&) = 0;
 
     // Keyframe-animation properties.
@@ -110,7 +110,7 @@ public:
     virtual void setValues(const Vector<WebCore::TransformationMatrix>&) = 0;
     virtual void setValues(const Vector<FloatPoint3D>&) = 0;
     virtual void setValues(const Vector<WebCore::Color>&) = 0;
-    virtual void setValues(const Vector<RefPtr<FilterOperation>>&, int internalFilterPropertyIndex) = 0;
+    virtual void setValues(const Vector<RefPtr<FilterOperation>>&) = 0;
     virtual void copyValuesFrom(const PlatformCAAnimation&) = 0;
 
     virtual void setKeyTimes(const Vector<float>&) = 0;

--- a/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
@@ -30,12 +30,6 @@
 #include "PlatformLayer.h"
 #include <wtf/RetainPtr.h>
 
-#if PLATFORM(COCOA)
-#define USE_CA_FILTERS 1
-#else
-#define USE_CA_FILTERS 0
-#endif
-
 OBJC_CLASS NSValue;
 
 namespace WebCore {
@@ -46,17 +40,13 @@ class PlatformCAFilters {
 public:
     WEBCORE_EXPORT static void setFiltersOnLayer(PlatformLayer*, const FilterOperations&);
     WEBCORE_EXPORT static void setBlendingFiltersOnLayer(PlatformLayer*, const BlendMode);
-    static int numAnimatedFilterProperties(FilterOperation::OperationType);
-    static const char* animatedFilterPropertyName(FilterOperation::OperationType, int internalFilterPropertyIndex);
+    static bool isAnimatedFilterProperty(FilterOperation::OperationType);
+    static const char* animatedFilterPropertyName(FilterOperation::OperationType);
 
-#if PLATFORM(COCOA)
-    WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation*, int internalFilterPropertyIndex);
-#endif
+    WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation*);
 
-#ifdef USE_CA_FILTERS
     // A null operation indicates that we should make a "no-op" filter of the given type.
     static RetainPtr<NSValue> colorMatrixValueForFilter(FilterOperation::OperationType, const FilterOperation*);
-#endif
 };
 
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
@@ -99,14 +99,14 @@ public:
     void setFromValue(const WebCore::TransformationMatrix&) override;
     void setFromValue(const FloatPoint3D&) override;
     void setFromValue(const WebCore::Color&) override;
-    void setFromValue(const FilterOperation*, int internalFilterPropertyIndex) override;
+    void setFromValue(const FilterOperation*) override;
     void copyFromValueFrom(const PlatformCAAnimation&) override;
 
     void setToValue(float) override;
     void setToValue(const WebCore::TransformationMatrix&) override;
     void setToValue(const FloatPoint3D&) override;
     void setToValue(const WebCore::Color&) override;
-    void setToValue(const FilterOperation*, int internalFilterPropertyIndex) override;
+    void setToValue(const FilterOperation*) override;
     void copyToValueFrom(const PlatformCAAnimation&) override;
 
     // Keyframe-animation properties.
@@ -114,7 +114,7 @@ public:
     void setValues(const Vector<WebCore::TransformationMatrix>&) override;
     void setValues(const Vector<FloatPoint3D>&) override;
     void setValues(const Vector<WebCore::Color>&) override;
-    void setValues(const Vector<RefPtr<FilterOperation>>&, int internalFilterPropertyIndex) override;
+    void setValues(const Vector<RefPtr<FilterOperation>>&) override;
     void copyValuesFrom(const PlatformCAAnimation&) override;
 
     void setKeyTimes(const Vector<float>&) override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -428,9 +428,9 @@ void PlatformCAAnimationCocoa::setFromValue(const Color& value)
     [static_cast<CABasicAnimation *>(m_animation.get()) setFromValue:@[@(r), @(g), @(b), @(a)]];
 }
 
-void PlatformCAAnimationCocoa::setFromValue(const FilterOperation* operation, int internalFilterPropertyIndex)
+void PlatformCAAnimationCocoa::setFromValue(const FilterOperation* operation)
 {
-    auto value = PlatformCAFilters::filterValueForOperation(operation, internalFilterPropertyIndex);
+    auto value = PlatformCAFilters::filterValueForOperation(operation);
     [static_cast<CABasicAnimation *>(m_animation.get()) setFromValue:value.get()];
 }
 
@@ -471,9 +471,9 @@ void PlatformCAAnimationCocoa::setToValue(const Color& value)
     [static_cast<CABasicAnimation *>(m_animation.get()) setToValue:@[@(r), @(g), @(b), @(a)]];
 }
 
-void PlatformCAAnimationCocoa::setToValue(const FilterOperation* operation, int internalFilterPropertyIndex)
+void PlatformCAAnimationCocoa::setToValue(const FilterOperation* operation)
 {
-    auto value = PlatformCAFilters::filterValueForOperation(operation, internalFilterPropertyIndex);
+    auto value = PlatformCAFilters::filterValueForOperation(operation);
     [static_cast<CABasicAnimation *>(m_animation.get()) setToValue:value.get()];
 }
 
@@ -529,13 +529,13 @@ void PlatformCAAnimationCocoa::setValues(const Vector<Color>& value)
     }).get()];
 }
 
-void PlatformCAAnimationCocoa::setValues(const Vector<RefPtr<FilterOperation>>& values, int internalFilterPropertyIndex)
+void PlatformCAAnimationCocoa::setValues(const Vector<RefPtr<FilterOperation>>& values)
 {
     if (animationType() != Keyframe)
         return;
 
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(values, [&] (auto& value) {
-        return PlatformCAFilters::filterValueForOperation(value.get(), internalFilterPropertyIndex);
+        return PlatformCAFilters::filterValueForOperation(value.get());
     }).get()];
 }
 

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
@@ -378,7 +378,7 @@ void PlatformCAAnimationWin::setFromValue(const WebCore::Color& value)
     CACFAnimationSetFromValue(m_animation.get(), v.get());
 }
 
-void PlatformCAAnimationWin::setFromValue(const FilterOperation*, int)
+void PlatformCAAnimationWin::setFromValue(const FilterOperation*)
 {
     // FIXME: Hardware filter animation not implemented on Windows
 }
@@ -430,7 +430,7 @@ void PlatformCAAnimationWin::setToValue(const WebCore::Color& value)
     CACFAnimationSetToValue(m_animation.get(), v.get());
 }
 
-void PlatformCAAnimationWin::setToValue(const FilterOperation*, int)
+void PlatformCAAnimationWin::setToValue(const FilterOperation*)
 {
     // FIXME: Hardware filter animation not implemented on Windows
 }
@@ -485,7 +485,7 @@ void PlatformCAAnimationWin::setValues(const Vector<WebCore::Color>& values)
     }).get());
 }
 
-void PlatformCAAnimationWin::setValues(const Vector<RefPtr<FilterOperation> >&, int)
+void PlatformCAAnimationWin::setValues(const Vector<RefPtr<FilterOperation> >&)
 {
     // FIXME: Hardware filter animation not implemented on Windows
 }

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h
@@ -88,14 +88,14 @@ public:
     void setFromValue(const WebCore::TransformationMatrix&) override;
     void setFromValue(const FloatPoint3D&) override;
     void setFromValue(const WebCore::Color&) override;
-    void setFromValue(const FilterOperation*, int internalFilterPropertyIndex) override;
+    void setFromValue(const FilterOperation*) override;
     void copyFromValueFrom(const PlatformCAAnimation&) override;
 
     void setToValue(float) override;
     void setToValue(const WebCore::TransformationMatrix&) override;
     void setToValue(const FloatPoint3D&) override;
     void setToValue(const WebCore::Color&) override;
-    void setToValue(const FilterOperation*, int internalFilterPropertyIndex) override;
+    void setToValue(const FilterOperation*) override;
     void copyToValueFrom(const PlatformCAAnimation&) override;
 
     // Keyframe-animation properties.
@@ -103,7 +103,7 @@ public:
     void setValues(const Vector<WebCore::TransformationMatrix>&) override;
     void setValues(const Vector<FloatPoint3D>&) override;
     void setValues(const Vector<WebCore::Color>&) override;
-    void setValues(const Vector<RefPtr<FilterOperation>>&, int internalFilterPropertyIndex) override;
+    void setValues(const Vector<RefPtr<FilterOperation>>&) override;
     void copyValuesFrom(const PlatformCAAnimation&) override;
 
     void setKeyTimes(const Vector<float>&) override;

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAFiltersWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAFiltersWin.cpp
@@ -30,18 +30,18 @@
 
 using namespace WebCore;
 
-void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOperations& filters)
+void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOperations&)
 {
     // Hardware filter animation not implemented on Windows.
 }
 
-int PlatformCAFilters::numAnimatedFilterProperties(FilterOperation::OperationType type)
+bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::OperationType)
 {
     // Hardware filter animation not implemented on Windows.
-    return 0;
+    return false;
 }
 
-const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::OperationType type, int internalFilterPropertyIndex)
+const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::OperationType)
 {
     // Hardware filter animation not implemented on Windows.
     return "";

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -95,14 +95,14 @@ public:
     void setFromValue(const WebCore::TransformationMatrix&) override;
     void setFromValue(const WebCore::FloatPoint3D&) override;
     void setFromValue(const WebCore::Color&) override;
-    void setFromValue(const WebCore::FilterOperation*, int internalFilterPropertyIndex) override;
+    void setFromValue(const WebCore::FilterOperation*) override;
     void copyFromValueFrom(const WebCore::PlatformCAAnimation&) override;
 
     void setToValue(float) override;
     void setToValue(const WebCore::TransformationMatrix&) override;
     void setToValue(const WebCore::FloatPoint3D&) override;
     void setToValue(const WebCore::Color&) override;
-    void setToValue(const WebCore::FilterOperation*, int internalFilterPropertyIndex) override;
+    void setToValue(const WebCore::FilterOperation*) override;
     void copyToValueFrom(const WebCore::PlatformCAAnimation&) override;
 
     // Keyframe-animation properties.
@@ -110,7 +110,7 @@ public:
     void setValues(const Vector<WebCore::TransformationMatrix>&) override;
     void setValues(const Vector<WebCore::FloatPoint3D>&) override;
     void setValues(const Vector<WebCore::Color>&) override;
-    void setValues(const Vector<RefPtr<WebCore::FilterOperation>>&, int internalFilterPropertyIndex) override;
+    void setValues(const Vector<RefPtr<WebCore::FilterOperation>>&) override;
     void copyValuesFrom(const WebCore::PlatformCAAnimation&) override;
 
     void setKeyTimes(const Vector<float>&) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -401,7 +401,7 @@ void PlatformCAAnimationRemote::setFromValue(const Color& value)
     m_properties.keyValues[0] = KeyframeValue(value);
 }
 
-void PlatformCAAnimationRemote::setFromValue(const FilterOperation* operation, int internalFilterPropertyIndex)
+void PlatformCAAnimationRemote::setFromValue(const FilterOperation* operation)
 {
     if (animationType() != Basic)
         return;
@@ -457,12 +457,11 @@ void PlatformCAAnimationRemote::setToValue(const Color& value)
     m_properties.keyValues[1] = KeyframeValue(value);
 }
 
-void PlatformCAAnimationRemote::setToValue(const FilterOperation* operation, int internalFilterPropertyIndex)
+void PlatformCAAnimationRemote::setToValue(const FilterOperation* operation)
 {
     if (animationType() != Basic)
         return;
     
-    UNUSED_PARAM(internalFilterPropertyIndex);
     ASSERT(operation);
     m_properties.keyValues.resize(2);
     m_properties.keyValues[1] = KeyframeValue(operation->clone());
@@ -511,10 +510,8 @@ void PlatformCAAnimationRemote::setValues(const Vector<Color>& values)
     m_properties.keyValues = toKeyframeValueVector(values);
 }
 
-void PlatformCAAnimationRemote::setValues(const Vector<RefPtr<FilterOperation>>& values, int internalFilterPropertyIndex)
+void PlatformCAAnimationRemote::setValues(const Vector<RefPtr<FilterOperation>>& values)
 {
-    UNUSED_PARAM(internalFilterPropertyIndex);
-    
     if (animationType() != Keyframe)
         return;
 
@@ -580,7 +577,7 @@ static RetainPtr<NSObject> animationValueFromKeyframeValue(const PlatformCAAnima
             return [NSValue valueWithCATransform3D:matrix];
         },
         [&](const RefPtr<WebCore::FilterOperation> filter) -> RetainPtr<NSObject> {
-            return PlatformCAFilters::filterValueForOperation(filter.get(), 0 /* unused */);
+            return PlatformCAFilters::filterValueForOperation(filter.get());
         }
     );
 }


### PR DESCRIPTION
#### ebc58cded3cedd1d63ee3489de51c0765cbe45c5
<pre>
Clean up PlatformCAFilters
<a href="https://bugs.webkit.org/show_bug.cgi?id=250509">https://bugs.webkit.org/show_bug.cgi?id=250509</a>

Reviewed by Simon Fraser.

PlatformCAFilters has a `USE_CA_FILTERS` compile-time flag that can no longer be false
on Cocoa ports and the notion of an &quot;internalFilterPropertyIndex&quot; which is no longer
relevant without `USE_CA_FILTERS`.

The removal of internalFilterPropertyIndex percolates up to GraphicsLayerCA since it was
used for animation purposes, so we remove any trace of an animation &quot;sub-index&quot; there too.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateAnimations):
(WebCore::GraphicsLayerCA::createAnimationFromKeyframes):
(WebCore::GraphicsLayerCA::appendToUncommittedAnimations):
(WebCore::GraphicsLayerCA::setFilterAnimationEndpoints):
(WebCore::GraphicsLayerCA::setFilterAnimationKeyframes):
(WebCore::GraphicsLayerCA::dumpAnimations):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
(WebCore::GraphicsLayerCA::LayerPropertyAnimation::LayerPropertyAnimation):
(WebCore::GraphicsLayerCA::LayerPropertyAnimation::animationIdentifier const):
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h:
* Source/WebCore/platform/graphics/ca/PlatformCAFilters.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::PlatformCAAnimationCocoa::setFromValue):
(WebCore::PlatformCAAnimationCocoa::setToValue):
(WebCore::PlatformCAAnimationCocoa::setValues):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::setFiltersOnLayer):
(WebCore::PlatformCAFilters::filterValueForOperation):
(WebCore::PlatformCAFilters::colorMatrixValueForFilter):
(WebCore::PlatformCAFilters::setBlendingFiltersOnLayer):
(WebCore::PlatformCAFilters::isAnimatedFilterProperty):
(WebCore::PlatformCAFilters::animatedFilterPropertyName):
(WebCore::PlatformCAFilters::numAnimatedFilterProperties): Deleted.
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp:
(PlatformCAAnimationWin::setFromValue):
(PlatformCAAnimationWin::setToValue):
(PlatformCAAnimationWin::setValues):
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h:
* Source/WebCore/platform/graphics/ca/win/PlatformCAFiltersWin.cpp:
(PlatformCAFilters::setFiltersOnLayer):
(PlatformCAFilters::isAnimatedFilterProperty):
(PlatformCAFilters::animatedFilterPropertyName):
(PlatformCAFilters::numAnimatedFilterProperties): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::setFromValue):
(WebKit::PlatformCAAnimationRemote::setToValue):
(WebKit::PlatformCAAnimationRemote::setValues):
(WebKit::animationValueFromKeyframeValue):

Canonical link: <a href="https://commits.webkit.org/258836@main">https://commits.webkit.org/258836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920d8f249209dc4ed2d8afa8299567e342ea519c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112323 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172527 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3102 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95296 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37779 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24890 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5616 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26297 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2747 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45799 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7531 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3234 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->