### PR TITLE
HTMLFormControlElement: refine a few overrides with `final` specifier

### DIFF
--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,13 +38,13 @@ class HTMLFormControlElement : public HTMLElement, public ValidatedFormListedEle
 public:
     virtual ~HTMLFormControlElement();
 
-    bool isValidatedFormListedElement() const override { return true; }
-    bool isFormListedElement() const override { return true; }
+    bool isValidatedFormListedElement() const final { return true; }
+    bool isFormListedElement() const final { return true; }
 
-    bool matchesValidPseudoClass() const override { return willValidate() && isValidFormControlElement(); }
-    bool matchesInvalidPseudoClass() const override { return willValidate() && !isValidFormControlElement(); }
+    bool matchesValidPseudoClass() const override { return ValidatedFormListedElement::matchesValidPseudoClass(); }
+    bool matchesInvalidPseudoClass() const override { return ValidatedFormListedElement::matchesInvalidPseudoClass(); }
 
-    bool isDisabledFormControl() const override { return isDisabled(); }
+    bool isDisabledFormControl() const final { return isDisabled(); }
     bool supportsFocus() const override { return !isDisabled(); }
 
     WEBCORE_EXPORT String formEnctype() const;
@@ -121,8 +121,8 @@ protected:
     void dispatchBlurEvent(RefPtr<Element>&& newFocusedElement) override;
 
 private:
-    void refFormAssociatedElement() const override { ref(); }
-    void derefFormAssociatedElement() const override { deref(); }
+    void refFormAssociatedElement() const final { ref(); }
+    void derefFormAssociatedElement() const final { deref(); }
 
     void runFocusingStepsForAutofocus() final;
     HTMLElement* validationAnchorElement() final { return this; }


### PR DESCRIPTION
#### 7a991acfb80faa48e886c1b9b7001dd68feb0380
<pre>
HTMLFormControlElement: refine a few overrides with `final` specifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=250512">https://bugs.webkit.org/show_bug.cgi?id=250512</a>

Reviewed by Aditya Keerthi.

These methods shouldn&apos;t be overridden.
Also reuse ValidatedFormListedElement&apos;s matchesValidPseudoClass() / matchesInvalidPseudoClass().
No new tests, no behavior change.

* Source/WebCore/html/HTMLFormControlElement.h:

Canonical link: <a href="https://commits.webkit.org/259001@main">https://commits.webkit.org/259001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0909afdf6e6a3c5e61c8a1e89ecbf31c63b1d9e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103605 "Failed to checkout and rebase branch from PR 8571") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112838 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/107559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3619 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109377 "Failed to checkout and rebase branch from PR 8571") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6277 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8029 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3287 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->