### PR TITLE
Update whitespace expectations for custom properties to match CSS Syntax Level 3 in some WPTs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Properties declared with @property reify correctly assert_equals: expected " 100px" but got "100px"
+PASS Properties declared with @property reify correctly
 PASS Re-declaring a property with a different type affects reification
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom.html
@@ -12,7 +12,7 @@ test(() => {
     // Before registering the property, ${name} should reify as a
     // a token sequence.
     assert_equals(div.computedStyleMap().get(name).constructor.name, 'CSSUnparsedValue');
-    assert_equals(div.computedStyleMap().get(name).toString(), ' 100px');
+    assert_equals(div.computedStyleMap().get(name).toString(), '100px');
 
     with_at_property({
       name: name,
@@ -29,7 +29,7 @@ test(() => {
     // After @property is removed, the computed value is once again a token
     // sequence.
     assert_equals(div.computedStyleMap().get(name).constructor.name, 'CSSUnparsedValue');
-    assert_equals(div.computedStyleMap().get(name).toString(), ' 100px');
+    assert_equals(div.computedStyleMap().get(name).toString(), '100px');
   });
 }, 'Properties declared with @property reify correctly');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
@@ -6,7 +6,7 @@ PASS Registered lists may be concatenated
 PASS Font-relative units are absolutized when substituting
 PASS Calc expressions are resolved when substituting
 PASS Lists with relative units are absolutized when substituting
-FAIL Values are absolutized when substituting into properties with universal syntax assert_equals: expected " 100px" but got "100px"
+PASS Values are absolutized when substituting into properties with universal syntax
 PASS Valid fallback does not invalidate var()-reference [<length>, 10px]
 PASS Valid fallback does not invalidate var()-reference [<length> | <color>, red]
 PASS Valid fallback does not invalidate var()-reference [<length> | none, none]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties.html
@@ -141,7 +141,7 @@ test(function(){
     let universal = generate_property('*');
     element.style = `font-size: 10px; ${length}: 10em; ${universal}: var(${length})`;
     let computedStyle = getComputedStyle(element);
-    assert_equals(computedStyle.getPropertyValue(universal), ' 100px');
+    assert_equals(computedStyle.getPropertyValue(universal), '100px');
     element.style = '';
 }, 'Values are absolutized when substituting into properties with universal syntax');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition-expected.txt
@@ -15,13 +15,13 @@ PASS parsing three dashes at start of variable
 PASS parsing multiple dashes with one dash at start of variable
 PASS  leading white space (single space)
 PASS  middle white space (single space)
-FAIL  trailing white space (single space) assert_equals: Expected Value should match actual value expected "value " but got "value"
+PASS  trailing white space (single space)
 PASS  leading white space (double space) 2
-FAIL  middle white space (double space) 2 assert_equals: Expected Value should match actual value expected "value1  value2" but got "value1 value2"
-FAIL  trailing white space (double space) 2 assert_equals: Expected Value should match actual value expected "value  " but got "value"
-FAIL !important assert_equals: Expected Value should match actual value expected "value1 " but got "value1"
+PASS  middle white space (double space) 2
+PASS  trailing white space (double space) 2
+PASS !important
 PASS !important 2
-FAIL !important (with space) assert_equals: Expected Value should match actual value expected "value1 " but got "value1"
+PASS !important (with space)
 PASS no variable (Computed Style)
 PASS variable (Computed Style)
 PASS single char variable (Computed Style)
@@ -38,13 +38,13 @@ PASS parsing three dashes at start of variable (Computed Style)
 PASS parsing multiple dashes with one dash at start of variable (Computed Style)
 PASS  leading white space (single space) (Computed Style)
 PASS  middle white space (single space) (Computed Style)
-FAIL  trailing white space (single space) (Computed Style) assert_equals: Expected Value should match actual value expected "value " but got "value"
+PASS  trailing white space (single space) (Computed Style)
 PASS  leading white space (double space) 2 (Computed Style)
-FAIL  middle white space (double space) 2 (Computed Style) assert_equals: Expected Value should match actual value expected "value1  value2" but got "value1 value2"
-FAIL  trailing white space (double space) 2 (Computed Style) assert_equals: Expected Value should match actual value expected "value  " but got "value"
-FAIL !important (Computed Style) assert_equals: Expected Value should match actual value expected "value1 " but got "value1"
+PASS  middle white space (double space) 2 (Computed Style)
+PASS  trailing white space (double space) 2 (Computed Style)
+PASS !important (Computed Style)
 PASS !important 2 (Computed Style)
-FAIL !important (with space) (Computed Style) assert_equals: Expected Value should match actual value expected "value1 " but got "value1"
+PASS !important (with space) (Computed Style)
 PASS no variable (Cascading)
 PASS variable (Cascading)
 PASS single char variable (Cascading)
@@ -61,13 +61,13 @@ PASS parsing three dashes at start of variable (Cascading)
 PASS parsing multiple dashes with one dash at start of variable (Cascading)
 PASS  leading white space (single space) (Cascading)
 PASS  middle white space (single space) (Cascading)
-FAIL  trailing white space (single space) (Cascading) assert_equals: Expected Value should match actual value expected "value " but got "value"
+PASS  trailing white space (single space) (Cascading)
 PASS  leading white space (double space) 2 (Cascading)
-FAIL  middle white space (double space) 2 (Cascading) assert_equals: Expected Value should match actual value expected "value1  value2" but got "value1 value2"
-FAIL  trailing white space (double space) 2 (Cascading) assert_equals: Expected Value should match actual value expected "value  " but got "value"
-FAIL !important (Cascading) assert_equals: Expected Value should match actual value expected "value1 " but got "value1"
+PASS  middle white space (double space) 2 (Cascading)
+PASS  trailing white space (double space) 2 (Cascading)
+PASS !important (Cascading)
 PASS !important 2 (Cascading)
-FAIL !important (with space) (Cascading) assert_equals: Expected Value should match actual value expected "value1 " but got "value1"
+PASS !important (with space) (Cascading)
 PASS basic CSSOM.setProperty
 FAIL CSSOM.setProperty with space 1 assert_equals: Expected Value should match actual value expected "" but got "green"
 FAIL CSSOM.setProperty with space 2 assert_equals: Expected Value should match actual value expected "" but got "green"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition.html
@@ -34,13 +34,13 @@
         { varName:"-var4" ,    expectedValue:"",        style:"-var4:value3",               testName:"parsing multiple dashes with one dash at start of variable"},
         { varName:"--var",     expectedValue:"value",  style:"--var: value",               testName:" leading white space (single space)"},
         { varName:"--var",     expectedValue:"value1 value2", style:"--var:value1 value2",  testName:" middle white space (single space)"},
-        { varName:"--var",     expectedValue:"value ",  style:"--var:value ",               testName:" trailing white space (single space)"},
+        { varName:"--var",     expectedValue:"value",  style:"--var:value ",               testName:" trailing white space (single space)"},
         { varName:"--var",     expectedValue:"value", style:"--var:  value",              testName:" leading white space (double space) 2"},
-        { varName:"--var",     expectedValue:"value1  value2", style:"--var:value1  value2",testName:" middle white space (double space) 2"},
-        { varName:"--var",     expectedValue:"value  ", style:"--var:value  ",              testName:" trailing white space (double space) 2"},
-        { varName:"--var",     expectedValue:"value1 ",  style:"--var:value1 !important;", testName:"!important"},
+        { varName:"--var",     expectedValue:"value1 value2", style:"--var:value1  value2",testName:" middle white space (double space) 2"},
+        { varName:"--var",     expectedValue:"value", style:"--var:value  ",              testName:" trailing white space (double space) 2"},
+        { varName:"--var",     expectedValue:"value1",  style:"--var:value1 !important;", testName:"!important"},
         { varName:"--var",     expectedValue:"value1",  style:"--var:value1!important;--var:value2;", testName:"!important 2"},
-        { varName:"--var",     expectedValue:"value1 ", style:"--var:value1 !important;--var:value2;", testName:"!important (with space)"}
+        { varName:"--var",     expectedValue:"value1", style:"--var:value1 !important;--var:value2;", testName:"!important (with space)"}
     ];
 
     templates.forEach(function (template) {


### PR DESCRIPTION
#### 7a3b462e1d002afff41928f1324c7a9477426d19
<pre>
Update whitespace expectations for custom properties to match CSS Syntax Level 3 in some WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=250506">https://bugs.webkit.org/show_bug.cgi?id=250506</a>
rdar://104162464

Reviewed by Sam Weinig.

Tokenization and parsing for whitespaces described in CSS Syntax Module Level 3 matches the current WebKit behavior in custom properties.
Some WPTs still have wrong expectations.

Chrome fails in leading/trailing cases while Firefox fails in trailing and whitespace collapsing cases.

Both leading and trailing whitespaces should be stripped:

<a href="https://drafts.csswg.org/css-syntax/#consume-declaration">https://drafts.csswg.org/css-syntax/#consume-declaration</a>

    ...
    4. While the next input token is a &lt;whitespace-token&gt;, consume the next input token.
    ...
    7. While the last token in decl’s value is a &lt;whitespace-token&gt;, remove that token.

Middle whitespaces collapse to a single &lt;whitespace-token&gt; during tokenization:

<a href="https://drafts.csswg.org/css-syntax/#consume-token">https://drafts.csswg.org/css-syntax/#consume-token</a>

    whitespace
    Consume as much whitespace as possible. Return a &lt;whitespace-token&gt;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-typedom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-definition.html:

Canonical link: <a href="https://commits.webkit.org/258866@main">https://commits.webkit.org/258866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38b377063e9376f0435e298a58ec1461fffe771

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112335 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172539 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3114 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110578 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37790 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79521 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5628 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26308 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2759 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6094 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7543 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->