### PR TITLE
Refactoring font-face src parsing

### DIFF
--- a/LayoutTests/fast/css/font-face-src-parsing-expected.txt
+++ b/LayoutTests/fast/css/font-face-src-parsing-expected.txt
@@ -17,10 +17,10 @@ Valid rules from the stylesheet:
 @font-face { src: url("font.ttf"); }
 @font-face { src: url("font.ttf"), local("font2"); }
 @font-face { src: local("font"); }
+@font-face { src: url("font.ttf"); }
+@font-face { src: url("foo.ttf"); }
 Invalid rules from the stylesheet:
 
-@font-face { }
-@font-face { }
 @font-face { }
 @font-face { }
 @font-face { }

--- a/LayoutTests/fast/css/font-face-src-parsing.html
+++ b/LayoutTests/fast/css/font-face-src-parsing.html
@@ -45,6 +45,12 @@
 @font-face {
     src: ,local(font);
 }
+@font-face {
+    src: url(font.ttf), invalid();
+}
+@font-face {
+    src: url(foo.ttf), invalid;
+}
 </style>
 
 <!-- Invalid src descriptor rules. -->
@@ -53,14 +59,7 @@
     src: url(font.ttf invalid);
 }
 @font-face {
-    src: url(font.ttf), invalid();
-}
-@font-face {
     src: url(foo.ttf) invalid;
-}
-
-@font-face {
-    src: url(foo.ttf), invalid;
 }
 @font-face {
     src: url(foo.ttf) "invalid";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
@@ -28,7 +28,7 @@ PASS Check that src: url("foo.ttf") format("svg"), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(svg), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(xyzz 200px), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(xyzz), url("bar.html") is valid
-FAIL Check that src: url("foo.ttf") dummy(xyzzy), url("bar.html") is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") dummy(xyzzy), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(none), url("bar.html") is valid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt
@@ -3,13 +3,13 @@ PASS Check that src: local(inherit), url(foo.ttf) is valid
 PASS Check that src: local("myfont"), local(unset) is valid
 PASS Check that src: local(), url(foo.ttf) is valid
 PASS Check that src: local(12px monospace), url(foo.ttf) is valid
-FAIL Check that src: local("myfont") format(opentype), url(foo.ttf) is valid assert_equals: expected true but got false
-FAIL Check that src: url(not a valid url/bar.ttf), url(foo.ttf) is valid assert_equals: expected true but got false
+PASS Check that src: local("myfont") format(opentype), url(foo.ttf) is valid
+PASS Check that src: url(not a valid url/bar.ttf), url(foo.ttf) is valid
 PASS Check that src: url(foo.ttf) format(bad), url(foo.ttf) is valid
-FAIL Check that src: url(foo.ttf) tech(unknown), url(foo.ttf) is valid assert_equals: expected true but got false
+PASS Check that src: url(foo.ttf) tech(unknown), url(foo.ttf) is valid
 PASS Check that src: url(foo.ttf), url(something.ttf) format(broken) is valid
 PASS Check that src: /* an empty component */, url(foo.ttf) is valid
-FAIL Check that src: local(""), url(foo.ttf), unparseable-garbage, local("another font name") is valid assert_equals: expected true but got false
+PASS Check that src: local(""), url(foo.ttf), unparseable-garbage, local("another font name") is valid
 PASS Check that src: local(), local(initial) is invalid
 PASS Check that src: local("textfont") format(opentype), local("emoji") tech(color-COLRv0) is invalid
 PASS Check that src: local(), /*empty*/, url(should be quoted.ttf), junk is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
@@ -26,14 +26,14 @@ PASS Check that src: url("foo.ttf") tech(normal) is invalid
 PASS Check that src: url("foo.ttf") tech(xyzzy) is invalid
 FAIL Check that src: url("foo.ttf") format(opentype) tech(features-opentype) is valid assert_equals: expected true but got false
 PASS Check that src: url("foo.ttf") tech(features-opentype) format(opentype) is invalid
-FAIL Check that src: url("foo.ttf") tech(incremental), url("bar.html") is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(incremental, color-SVG, features-graphite, features-aat), url("bar.html") is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(color-SVG, features-graphite), url("bar.html") is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(color-SVG), url("bar.html") is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(incremental), url("bar.html") is valid
+PASS Check that src: url("foo.ttf") tech(incremental, color-SVG, features-graphite, features-aat), url("bar.html") is valid
+PASS Check that src: url("foo.ttf") tech(color-SVG, features-graphite), url("bar.html") is valid
+PASS Check that src: url("foo.ttf") tech(color-SVG), url("bar.html") is valid
+PASS Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") dummy("opentype") tech(variations) is invalid
 PASS Check that src: url("foo.ttf") dummy("opentype") dummy(variations) is invalid
 PASS Check that src: url("foo.ttf") format(opentype) tech(features-opentype) dummy(something) is invalid
 FAIL Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(color), url("bar.html") is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(color), url("bar.html") is valid
 


### PR DESCRIPTION
#### ef82a019637be51b1882305e819eeb2bba96f316
<pre>
Refactoring font-face src parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250471">https://bugs.webkit.org/show_bug.cgi?id=250471</a>
rdar://104135235

Reviewed by Myles C. Maxfield.

Refactoring font-face src parsing such that we parse each component
separated by commas, individually.

If all components can&apos;t be parsed, then the src descriptor is
invalidated. This was already done before, but now each component parser,
such as consumeFontFaceSrcURI() and consumeFontFaceSrcLocal() will
receive a subrange, and the whole subrange has to be parsed for the
component to be valid.  This will fix test failures we had when parsing
format() in a URI component.

The optional format() token can optionally follow a url() token. Before,
if garbage was following the url() token, we would ignore it and still
validate the component with an empty format. However, we would not
consume the range being parsed, and if the next token was not a Comma,
we would invalidate the whole descriptor.

* LayoutTests/fast/css/font-face-src-parsing-expected.txt:
Update on which src descriptors are valid.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt:
Missing failures should pass now.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt:
We don&apos;t support tech() yet but we need to rebaseline here. Increment
tests will pass now.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcLocal):
Component is invalidated if the whole range is not consumed.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrc):

* LayoutTests/fast/css/font-face-src-parsing-expected.txt:
* LayoutTests/fast/css/font-face-src-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcLocal):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrc):

Canonical link: <a href="https://commits.webkit.org/258870@main">https://commits.webkit.org/258870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d59f711a28ed6df6a049e4d79e5eba219f7a107

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12336 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112458 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172655 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3240 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95436 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108985 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37892 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92080 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79622 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5739 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2851 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11899 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6096 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7658 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->