### PR TITLE
A no-store request should have its cache policy set to disallow even if its URL is not HTTP

### DIFF
--- a/LayoutTests/fast/constructors/event-source-caching-expected.txt
+++ b/LayoutTests/fast/constructors/event-source-caching-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ensure event source do not reuse memory cache
+

--- a/LayoutTests/fast/constructors/event-source-caching.html
+++ b/LayoutTests/fast/constructors/event-source-caching.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+promise_test(() => {
+    const url = window.location.href + "?test";
+    fetch(url, { integrity: "A" });
+
+    new EventSource(url);
+
+    return new Promise(resolve => setTimeout(resolve, 50));
+}, "ensure event source do not reuse memory cache");
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1071,6 +1071,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
 
     if (request.resourceRequest().url().protocolIsInHTTPFamily())
         updateHTTPRequestHeaders(frame.loader(), type, request);
+    request.disableCachingIfNeeded();
 
     auto& memoryCache = MemoryCache::singleton();
     if (request.allowsCaching() && memoryCache.disabled())

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -182,6 +182,12 @@ void CachedResourceRequest::setAcceptHeaderIfNone(CachedResource::Type type)
         m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::Accept, acceptHeaderValueFromType(type));
 }
 
+void CachedResourceRequest::disableCachingIfNeeded()
+{
+    if (m_options.cache == FetchOptions::Cache::NoStore)
+        m_options.cachingPolicy = CachingPolicy::DisallowCaching;
+}
+
 void CachedResourceRequest::updateAccordingCacheMode()
 {
     if (m_options.cache == FetchOptions::Cache::Default
@@ -198,7 +204,6 @@ void CachedResourceRequest::updateAccordingCacheMode()
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
         break;
     case FetchOptions::Cache::NoStore:
-        m_options.cachingPolicy = CachingPolicy::DisallowCaching;
         m_resourceRequest.setCachePolicy(ResourceRequestCachePolicy::DoNotUseAnyCache);
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::Pragma, HTTPHeaderValues::noCache());
         m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::CacheControl, HTTPHeaderValues::noCache());

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -86,6 +86,8 @@ public:
     void updateAccordingCacheMode();
     void updateAcceptEncodingHeader();
 
+    void disableCachingIfNeeded();
+
     void removeFragmentIdentifierIfNeeded();
 #if ENABLE(CONTENT_EXTENSIONS)
     void applyResults(ContentRuleListResults&&, Page*);


### PR DESCRIPTION
#### a107c4cce18136b2e307b91d2bdb9b20f651f0b5
<pre>
A no-store request should have its cache policy set to disallow even if its URL is not HTTP
<a href="https://bugs.webkit.org/show_bug.cgi?id=250451">https://bugs.webkit.org/show_bug.cgi?id=250451</a>
rdar://102888724

Reviewed by Chris Dumez.

There is a debug assert checking fetch options cache mode when checking whether to reuse a MemoryCache cache entry.
EventSource should never reuse the memory cache and set fetch options cache mode to no-store.
Previously, we were only setting the cache option to disallow for HTTP URLs.
We are now doing it for all URLs.

* LayoutTests/fast/constructors/event-source-caching-expected.txt: Added.
* LayoutTests/fast/constructors/event-source-caching.html: Added.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):

Canonical link: <a href="https://commits.webkit.org/258942@main">https://commits.webkit.org/258942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afb88a30dbaac588dabf84a46d061ea8050c65d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112332 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172536 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3111 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110576 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37786 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5625 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26304 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2755 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45806 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6145 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7540 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->