### PR TITLE
imported/w3c/web-platform-tests/service-workers/service-worker/navigation-sets-cookie.https.html is flaky crashing

### DIFF
--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
@@ -62,7 +62,7 @@ public:
     virtual void continueDidReceiveResponse() = 0;
     virtual void convertFetchToDownload() = 0;
     virtual void setFetchEvent(Ref<FetchEvent>&&) = 0;
-    virtual void navigationPreloadIsReady(ResourceResponse&&) = 0;
+    virtual void navigationPreloadIsReady(ResourceResponse::CrossThreadData&&) = 0;
     virtual void navigationPreloadFailed(ResourceError&&) = 0;
     virtual void usePreload() = 0;
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -279,7 +279,7 @@ void ServiceWorkerThreadProxy::navigationPreloadIsReady(SWServerConnectionIdenti
     ASSERT(!isMainThread());
     postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, connectionIdentifier, fetchIdentifier, responseData = response.crossThreadData()] (auto&) mutable {
         if (auto client = m_ongoingFetchTasks.get({ connectionIdentifier, fetchIdentifier }))
-            client->navigationPreloadIsReady(ResourceResponse::fromCrossThreadData(WTFMove(responseData)));
+            client->navigationPreloadIsReady(WTFMove(responseData));
     }, WorkerRunLoop::defaultMode());
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -230,8 +230,9 @@ void WebServiceWorkerFetchTaskClient::setFetchEvent(Ref<WebCore::FetchEvent>&& e
 {
     m_event = WTFMove(event);
 
-    if (!m_preloadResponse.isNull()) {
-        m_event->navigationPreloadIsReady(WTFMove(m_preloadResponse));
+    if (m_preloadResponse) {
+        m_event->navigationPreloadIsReady(ResourceResponse::fromCrossThreadData(WTFMove(*m_preloadResponse)));
+        m_preloadResponse = std::nullopt;
         m_event = nullptr;
         return;
     }
@@ -242,14 +243,14 @@ void WebServiceWorkerFetchTaskClient::setFetchEvent(Ref<WebCore::FetchEvent>&& e
     }
 }
 
-void WebServiceWorkerFetchTaskClient::navigationPreloadIsReady(ResourceResponse&& response)
+void WebServiceWorkerFetchTaskClient::navigationPreloadIsReady(ResourceResponse::CrossThreadData&& response)
 {
     if (!m_event) {
         m_preloadResponse = WTFMove(response);
         return;
     }
 
-    m_event->navigationPreloadIsReady(WTFMove(response));
+    m_event->navigationPreloadIsReady(ResourceResponse::fromCrossThreadData(WTFMove(response)));
     m_event = nullptr;
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -62,7 +62,7 @@ private:
     void convertFetchToDownload() final;
     void setCancelledCallback(Function<void()>&&) final;
     void setFetchEvent(Ref<WebCore::FetchEvent>&&);
-    void navigationPreloadIsReady(WebCore::ResourceResponse&&) final;
+    void navigationPreloadIsReady(WebCore::ResourceResponse::CrossThreadData&&) final;
     void navigationPreloadFailed(WebCore::ResourceError&&) final;
     void usePreload() final;
 
@@ -97,7 +97,7 @@ private:
     bool m_isDownload { false };
     RefPtr<WebCore::FetchEvent> m_event;
     Function<void()> m_cancelledCallback;
-    WebCore::ResourceResponse m_preloadResponse;
+    std::optional<WebCore::ResourceResponse::CrossThreadData> m_preloadResponse;
     WebCore::ResourceError m_preloadError;
 };
 


### PR DESCRIPTION
#### c41dfa79a5859286d096783b4e996d97177f8056
<pre>
imported/w3c/web-platform-tests/service-workers/service-worker/navigation-sets-cookie.https.html is flaky crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250486">https://bugs.webkit.org/show_bug.cgi?id=250486</a>
rdar://104138207

Reviewed by Youenn Fablet.

Have WebServiceWorkerFetchTaskClient keep the preloadResponse as a CrossThreadData
instead of a ResourceResponse. m_preloadResponse gets initialized on the service
worker thread but the WebServiceWorkerFetchTaskClient object always gets destroyed
on the main thread. A ResourceResponse contains AtomStrings and thus cannot be
destroyed on another thread than the one it got constructed on.

* Source/WebCore/workers/service/context/ServiceWorkerFetch.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::navigationPreloadIsReady):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
(WebKit::WebServiceWorkerFetchTaskClient::setFetchEvent):
(WebKit::WebServiceWorkerFetchTaskClient::navigationPreloadIsReady):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h:

Canonical link: <a href="https://commits.webkit.org/258847@main">https://commits.webkit.org/258847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3419ca0abe99d631fc0e643ad24b9bad2630c26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112340 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172544 "Hash b3419ca0 for PR 8577 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3119 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95313 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37795 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79525 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26315 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2762 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45817 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7548 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3240 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->