### PR TITLE
[JSC] Atomics.waitAsync should be invocable from the main thread

### DIFF
--- a/LayoutTests/js/Atomics-waitasync-invocable-on-main-thread-expected.txt
+++ b/LayoutTests/js/Atomics-waitasync-invocable-on-main-thread-expected.txt
@@ -1,0 +1,11 @@
+Test to ensure Atomics.waitAsync is invocable on the main thread
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+PASS Atomics.waitAsync can return immediately from the main thread
+

--- a/LayoutTests/js/Atomics-waitasync-invocable-on-main-thread.html
+++ b/LayoutTests/js/Atomics-waitasync-invocable-on-main-thread.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+    <head>
+        <script src="../resources/js-test-pre.js"></script>
+    </head>
+    <body>
+        <script src =../resources/testharness.js></script>
+        <script src =../resources/testharnessreport.js></script>
+        <script>
+        description("Test to ensure Atomics.waitAsync is invocable on the main thread");
+
+        promise_test(async t => {
+            const buffer = new SharedArrayBuffer(1024);
+            const array = new Int32Array(buffer);
+            await Atomics.waitAsync(array, 0, 1).value;
+        }, "Atomics.waitAsync can return immediately from the main thread");
+
+        </script>
+        <script src="../resources/js-test-post.js"></script>
+    </body>
+</html>

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -449,14 +449,13 @@ JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, u
     if (!std::isnan(timeoutInMilliseconds))
         timeout = std::max(Seconds::fromMilliseconds(timeoutInMilliseconds), 0_s);
 
-    if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread()) {
-        throwTypeError(globalObject, scope, makeString("Atomics."_s,
-            (type == AtomicsWaitType::Async ? "waitAsync"_s : "wait"_s), " cannot be called from the current thread."_s));
-        return { };
-    }
-
     if (type == AtomicsWaitType::Async)
         return WaiterListManager::singleton().waitAsync(globalObject, vm, ptr, expectedValue, timeout);
+
+    if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread()) {
+        throwTypeError(globalObject, scope, "Atomics.wait cannot be called from the current thread."_s);
+        return { };
+    }
 
     auto result = WaiterListManager::singleton().waitSync(vm, ptr, expectedValue, timeout);
     switch (result) {


### PR DESCRIPTION
#### 9259434c015156e882dd760a0a0355c5c5d9e3c4
<pre>
[JSC] Atomics.waitAsync should be invocable from the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=250518">https://bugs.webkit.org/show_bug.cgi?id=250518</a>

Reviewed by Keith Miller.

According to the current proposed spec [1], async atomic waits are not
restricted to threads with `AgentCanSuspend()`--so, Atomics.waitAsync should not
throw a TypeError for this reason. I&apos;ve added a (very simple) test to this
effect.

So, we should delay the check for `isAtomicsWaitAllowedOnCurrentThread` until after we know
the wait is known to be synchronous.

If there&apos;s an implementation reason we shouldn&apos;t do this, let me know, but I
couldn&apos;t find one.

[1] <a href="https://tc39.es/proposal-atomics-wait-async/#sec-dowait">https://tc39.es/proposal-atomics-wait-async/#sec-dowait</a>

* LayoutTests/js/Atomics-waitasync-invocable-on-main-thread-expected.txt: Added.
* LayoutTests/js/Atomics-waitasync-invocable-on-main-thread.html: Added.
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::atomicsWaitImpl):

Canonical link: <a href="https://commits.webkit.org/258856@main">https://commits.webkit.org/258856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c17747c67d27a6dc0ef74f5eb4e07a2d12e901b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112362 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172560 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3141 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95334 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37811 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79540 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/93283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26327 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89686 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3370 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2778 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29727 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45830 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98278 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6087 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7568 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20709 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->