### PR TITLE
Make FilterOperation::OperationType an enum class

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -1493,7 +1493,7 @@ private:
 
         auto listContainsReference = [](auto& filterOperations) {
             return filterOperations.operations().findIf([](auto& filterOperation) {
-                return filterOperation->type() == FilterOperation::OperationType::REFERENCE;
+                return filterOperation->type() == FilterOperation::Type::Reference;
             }) != notFound;
         };
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1026,62 +1026,62 @@ Ref<CSSValue> ComputedStyleExtractor::valueForFilter(const RenderStyle& style, c
     for (Vector<RefPtr<FilterOperation>>::const_iterator it = filterOperations.operations().begin(); it != end; ++it) {
         FilterOperation& filterOperation = **it;
 
-        if (filterOperation.type() == FilterOperation::REFERENCE) {
+        if (filterOperation.type() == FilterOperation::Type::Reference) {
             ReferenceFilterOperation& referenceOperation = downcast<ReferenceFilterOperation>(filterOperation);
             list->append(cssValuePool.createValue(referenceOperation.url(), CSSUnitType::CSS_URI));
         } else {
             RefPtr<CSSFunctionValue> filterValue;
             switch (filterOperation.type()) {
-            case FilterOperation::GRAYSCALE: {
+            case FilterOperation::Type::Grayscale: {
                 filterValue = CSSFunctionValue::create(CSSValueGrayscale);
                 filterValue->append(cssValuePool.createValue(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::SEPIA: {
+            case FilterOperation::Type::Sepia: {
                 filterValue = CSSFunctionValue::create(CSSValueSepia);
                 filterValue->append(cssValuePool.createValue(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::SATURATE: {
+            case FilterOperation::Type::Saturate: {
                 filterValue = CSSFunctionValue::create(CSSValueSaturate);
                 filterValue->append(cssValuePool.createValue(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::HUE_ROTATE: {
+            case FilterOperation::Type::HueRotate: {
                 filterValue = CSSFunctionValue::create(CSSValueHueRotate);
                 filterValue->append(cssValuePool.createValue(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_DEG));
                 break;
             }
-            case FilterOperation::INVERT: {
+            case FilterOperation::Type::Invert: {
                 filterValue = CSSFunctionValue::create(CSSValueInvert);
                 filterValue->append(cssValuePool.createValue(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::APPLE_INVERT_LIGHTNESS: {
+            case FilterOperation::Type::AppleInvertLightness: {
                 filterValue = CSSFunctionValue::create(CSSValueAppleInvertLightness);
                 break;
             }
-            case FilterOperation::OPACITY: {
+            case FilterOperation::Type::Opacity: {
                 filterValue = CSSFunctionValue::create(CSSValueOpacity);
                 filterValue->append(cssValuePool.createValue(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::BRIGHTNESS: {
+            case FilterOperation::Type::Brightness: {
                 filterValue = CSSFunctionValue::create(CSSValueBrightness);
                 filterValue->append(cssValuePool.createValue(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::CONTRAST: {
+            case FilterOperation::Type::Contrast: {
                 filterValue = CSSFunctionValue::create(CSSValueContrast);
                 filterValue->append(cssValuePool.createValue(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount(), CSSUnitType::CSS_NUMBER));
                 break;
             }
-            case FilterOperation::BLUR: {
+            case FilterOperation::Type::Blur: {
                 filterValue = CSSFunctionValue::create(CSSValueBlur);
                 filterValue->append(adjustLengthForZoom(downcast<BlurFilterOperation>(filterOperation).stdDeviation(), style, adjust));
                 break;
             }
-            case FilterOperation::DROP_SHADOW: {
+            case FilterOperation::Type::DropShadow: {
                 DropShadowFilterOperation& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
                 filterValue = CSSFunctionValue::create(CSSValueDropShadow);
                 // We want our computed style to look like that of a text shadow (has neither spread nor inset style).

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -570,7 +570,7 @@ static bool fragmentNeedsColorTransformed(ReplacementFragment& fragment, const P
 
         const auto& colorFilter = editableRootRenderer->style().appleColorFilter();
         for (const auto& colorFilterOperation : colorFilter.operations()) {
-            if (colorFilterOperation->type() != FilterOperation::APPLE_INVERT_LIGHTNESS)
+            if (colorFilterOperation->type() != FilterOperation::Type::AppleInvertLightness)
                 return false;
         }
     }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3585,7 +3585,7 @@ bool GraphicsLayerCA::createFilterAnimationsFromKeyframes(const KeyframeValueLis
 
     // FIXME: We can't currently hardware animate shadows.
     for (int i = 0; i < numAnimations; ++i) {
-        if (operations.at(i)->type() == FilterOperation::DROP_SHADOW)
+        if (operations.at(i)->type() == FilterOperation::Type::DropShadow)
             return false;
     }
 
@@ -3891,7 +3891,7 @@ bool GraphicsLayerCA::setFilterAnimationEndpoints(const KeyframeValueList& value
     return true;
 }
 
-bool GraphicsLayerCA::setFilterAnimationKeyframes(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* keyframeAnim, int functionIndex, FilterOperation::OperationType filterOp, bool keyframesShouldUseAnimationWideTimingFunction)
+bool GraphicsLayerCA::setFilterAnimationKeyframes(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* keyframeAnim, int functionIndex, FilterOperation::Type filterOp, bool keyframesShouldUseAnimationWideTimingFunction)
 {
     Vector<float> keyTimes;
     Vector<RefPtr<FilterOperation>> values;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -292,7 +292,7 @@ private:
     bool setTransformAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction);
     
     bool setFilterAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex);
-    bool setFilterAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, FilterOperation::OperationType, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool setFilterAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, FilterOperation::Type, bool keyframesShouldUseAnimationWideTimingFunction);
 
     bool isRunningTransformAnimation() const;
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
@@ -40,13 +40,13 @@ class PlatformCAFilters {
 public:
     WEBCORE_EXPORT static void setFiltersOnLayer(PlatformLayer*, const FilterOperations&);
     WEBCORE_EXPORT static void setBlendingFiltersOnLayer(PlatformLayer*, const BlendMode);
-    static bool isAnimatedFilterProperty(FilterOperation::OperationType);
-    static const char* animatedFilterPropertyName(FilterOperation::OperationType);
+    static bool isAnimatedFilterProperty(FilterOperation::Type);
+    static const char* animatedFilterPropertyName(FilterOperation::Type);
 
     WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation*);
 
     // A null operation indicates that we should make a "no-op" filter of the given type.
-    static RetainPtr<NSValue> colorMatrixValueForFilter(FilterOperation::OperationType, const FilterOperation*);
+    static RetainPtr<NSValue> colorMatrixValueForFilter(FilterOperation::Type, const FilterOperation*);
 };
 
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -61,12 +61,12 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
         auto filterName = makeString("filter_", i++);
         auto& filterOperation = *operationPtr;
         switch (filterOperation.type()) {
-        case FilterOperation::DEFAULT:
-        case FilterOperation::REFERENCE:
-        case FilterOperation::NONE:
+        case FilterOperation::Type::Default:
+        case FilterOperation::Type::Reference:
+        case FilterOperation::Type::None:
             ASSERT_NOT_REACHED();
             return nil;
-        case FilterOperation::DROP_SHADOW: {
+        case FilterOperation::Type::DropShadow: {
             // FIXME: For now assume drop shadow is the last filter, put it on the layer.
             // <rdar://problem/10959969> Handle case where drop-shadow is not the last filter.
             const auto& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
@@ -76,28 +76,28 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             [layer setShadowOpacity:1];
             return nil;
         }
-        case FilterOperation::GRAYSCALE: {
+        case FilterOperation::Type::Grayscale: {
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMonochrome];
             [filter setValue:[NSNumber numberWithFloat:colorMatrixOperation.amount()] forKey:@"inputAmount"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::SEPIA: {
+        case FilterOperation::Type::Sepia: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::SATURATE: {
+        case FilterOperation::Type::Saturate: {
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorSaturate];
             [filter setValue:[NSNumber numberWithFloat:colorMatrixOperation.amount()] forKey:@"inputAmount"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::HUE_ROTATE: {
+        case FilterOperation::Type::HueRotate: {
             const auto& colorMatrixOperation = downcast<BasicColorMatrixFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorHueRotate];
             [filter setValue:[NSNumber numberWithFloat:deg2rad(colorMatrixOperation.amount())] forKey:@"inputAngle"];
@@ -105,38 +105,38 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::INVERT: {
+        case FilterOperation::Type::Invert: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::APPLE_INVERT_LIGHTNESS:
-            ASSERT_NOT_REACHED(); // APPLE_INVERT_LIGHTNESS is only used in -apple-color-filter.
+        case FilterOperation::Type::AppleInvertLightness:
+            ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
             break;
-        case FilterOperation::OPACITY: {
+        case FilterOperation::Type::Opacity: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::BRIGHTNESS: {
+        case FilterOperation::Type::Brightness: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::CONTRAST: {
+        case FilterOperation::Type::Contrast: {
             RetainPtr<NSValue> colorMatrixValue = PlatformCAFilters::colorMatrixValueForFilter(filterOperation.type(), &filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterColorMatrix];
             [filter setValue:colorMatrixValue.get() forKey:@"inputColorMatrix"];
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::BLUR: {
+        case FilterOperation::Type::Blur: {
             const auto& blurOperation = downcast<BlurFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterGaussianBlur];
             [filter setValue:[NSNumber numberWithFloat:floatValueForLength(blurOperation.stdDeviation(), 0)] forKey:@"inputRadius"];
@@ -147,7 +147,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             [filter setName:filterName];
             return filter;
         }
-        case FilterOperation::PASSTHROUGH:
+        case FilterOperation::Type::Passthrough:
             return nil;
         }
         ASSERT_NOT_REACHED();
@@ -162,7 +162,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
 
 RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperation* operation)
 {
-    FilterOperation::OperationType type = operation->type();
+    FilterOperation::Type type = operation->type();
     RetainPtr<id> value;
     
     if (is<DefaultFilterOperation>(*operation)) {
@@ -171,10 +171,10 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
     }
     
     switch (type) {
-    case FilterOperation::DEFAULT:
+    case FilterOperation::Type::Default:
         ASSERT_NOT_REACHED();
         break;
-    case FilterOperation::GRAYSCALE: {
+    case FilterOperation::Type::Grayscale: {
         // CAFilter: inputAmount
         double amount = 0;
         if (operation)
@@ -183,12 +183,12 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         value = @(amount);
         break;
     }
-    case FilterOperation::SEPIA: {
+    case FilterOperation::Type::Sepia: {
         // CAFilter: inputColorMatrix
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
         break;
     }
-    case FilterOperation::SATURATE: {
+    case FilterOperation::Type::Saturate: {
         // CAFilter: inputAmount
         double amount = 1;
         if (operation)
@@ -197,7 +197,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         value = @(amount);
         break;
     }
-    case FilterOperation::HUE_ROTATE: {
+    case FilterOperation::Type::HueRotate: {
         // Hue rotate CAFilter: inputAngle
         double amount = 0;
         if (operation)
@@ -207,32 +207,32 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         value = @(amount);
         break;
     }
-    case FilterOperation::INVERT: {
+    case FilterOperation::Type::Invert: {
         // CAFilter: inputColorMatrix
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
         break;
     }
-    case FilterOperation::APPLE_INVERT_LIGHTNESS:
-            ASSERT_NOT_REACHED(); // APPLE_INVERT_LIGHTNESS is only used in -apple-color-filter.
+    case FilterOperation::Type::AppleInvertLightness:
+        ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
         break;
-    case FilterOperation::OPACITY: {
+    case FilterOperation::Type::Opacity: {
         // Opacity CAFilter: inputColorMatrix
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
         break;
     }
     
-    case FilterOperation::BRIGHTNESS: {
+    case FilterOperation::Type::Brightness: {
         // Brightness CAFilter: inputColorMatrix
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
         break;
     }
 
-    case FilterOperation::CONTRAST: {
+    case FilterOperation::Type::Contrast: {
         // Contrast CAFilter: inputColorMatrix
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
         break;
     }
-    case FilterOperation::BLUR: {
+    case FilterOperation::Type::Blur: {
         // CAFilter: inputRadius
         double amount = 0;
         if (operation)
@@ -268,33 +268,33 @@ static CAColorMatrix caColorMatrixFromColorMatrix(const ColorMatrix<5, 4>& color
     };
 }
 
-RetainPtr<NSValue> PlatformCAFilters::colorMatrixValueForFilter(FilterOperation::OperationType type, const FilterOperation* filterOperation)
+RetainPtr<NSValue> PlatformCAFilters::colorMatrixValueForFilter(FilterOperation::Type type, const FilterOperation* filterOperation)
 {
     switch (type) {
-    case FilterOperation::SEPIA: {
+    case FilterOperation::Type::Sepia: {
         float amount = filterOperation ? downcast<BasicColorMatrixFilterOperation>(*filterOperation).amount() : 0;
         auto sepiaMatrix = sepiaColorMatrix(amount);
         return [NSValue valueWithCAColorMatrix:caColorMatrixFromColorMatrix(sepiaMatrix)];
     }
-    case FilterOperation::INVERT: {
+    case FilterOperation::Type::Invert: {
         float amount = filterOperation ? downcast<BasicComponentTransferFilterOperation>(*filterOperation).amount() : 0;
         auto invertMatrix = invertColorMatrix(amount);
         return [NSValue valueWithCAColorMatrix:caColorMatrixFromColorMatrix(invertMatrix)];
     }
-    case FilterOperation::APPLE_INVERT_LIGHTNESS:
-        ASSERT_NOT_REACHED(); // APPLE_INVERT_LIGHTNESS is only used in -apple-color-filter.
+    case FilterOperation::Type::AppleInvertLightness:
+        ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
         return nullptr;
-    case FilterOperation::OPACITY: {
+    case FilterOperation::Type::Opacity: {
         float amount = filterOperation ? downcast<BasicComponentTransferFilterOperation>(filterOperation)->amount() : 1;
         auto opacityMatrix = opacityColorMatrix(amount);
         return [NSValue valueWithCAColorMatrix:caColorMatrixFromColorMatrix(opacityMatrix)];
     }
-    case FilterOperation::CONTRAST: {
+    case FilterOperation::Type::Contrast: {
         float amount = filterOperation ? downcast<BasicComponentTransferFilterOperation>(filterOperation)->amount() : 1;
         auto contrastMatrix = contrastColorMatrix(amount);
         return [NSValue valueWithCAColorMatrix:caColorMatrixFromColorMatrix(contrastMatrix)];
     }
-    case FilterOperation::BRIGHTNESS: {
+    case FilterOperation::Type::Brightness: {
         float amount = filterOperation ? downcast<BasicComponentTransferFilterOperation>(filterOperation)->amount() : 1;
         auto brightnessMatrix = brightnessColorMatrix(amount);
         return [NSValue valueWithCAColorMatrix:caColorMatrixFromColorMatrix(brightnessMatrix)];
@@ -369,36 +369,36 @@ void PlatformCAFilters::setBlendingFiltersOnLayer(PlatformLayer* layer, const Bl
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::OperationType type)
+bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::Type type)
 {
     switch (type) {
-    case FilterOperation::GRAYSCALE:
-    case FilterOperation::SEPIA:
-    case FilterOperation::SATURATE:
-    case FilterOperation::HUE_ROTATE:
-    case FilterOperation::INVERT:
-    case FilterOperation::OPACITY:
-    case FilterOperation::BRIGHTNESS:
-    case FilterOperation::CONTRAST:
-    case FilterOperation::BLUR:
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Saturate:
+    case FilterOperation::Type::HueRotate:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Opacity:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
+    case FilterOperation::Type::Blur:
         return true;
     default:
         return false;
     }
 }
 
-const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::OperationType type)
+const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::Type type)
 {
     switch (type) {
-    case FilterOperation::GRAYSCALE: return "inputAmount";
-    case FilterOperation::SEPIA:return "inputColorMatrix";
-    case FilterOperation::SATURATE: return "inputAmount";
-    case FilterOperation::HUE_ROTATE: return "inputAngle";
-    case FilterOperation::INVERT: return "inputColorMatrix";
-    case FilterOperation::OPACITY: return "inputColorMatrix";
-    case FilterOperation::BRIGHTNESS: return "inputColorMatrix";
-    case FilterOperation::CONTRAST: return "inputColorMatrix";
-    case FilterOperation::BLUR: return "inputRadius";
+    case FilterOperation::Type::Grayscale: return "inputAmount";
+    case FilterOperation::Type::Sepia:return "inputColorMatrix";
+    case FilterOperation::Type::Saturate: return "inputAmount";
+    case FilterOperation::Type::HueRotate: return "inputAngle";
+    case FilterOperation::Type::Invert: return "inputColorMatrix";
+    case FilterOperation::Type::Opacity: return "inputColorMatrix";
+    case FilterOperation::Type::Brightness: return "inputColorMatrix";
+    case FilterOperation::Type::Contrast: return "inputColorMatrix";
+    case FilterOperation::Type::Blur: return "inputRadius";
     default: return "";
     }
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -882,9 +882,9 @@ bool PlatformCALayerCocoa::filtersCanBeComposited(const FilterOperations& filter
     for (unsigned i = 0; i < filters.size(); ++i) {
         const FilterOperation* filterOperation = filters.at(i);
         switch (filterOperation->type()) {
-        case FilterOperation::REFERENCE:
+        case FilterOperation::Type::Reference:
             return false;
-        case FilterOperation::DROP_SHADOW:
+        case FilterOperation::Type::DropShadow:
             // FIXME: For now we can only handle drop-shadow is if it's last in the list
             if (i < (filters.size() - 1))
                 return false;

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAFiltersWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAFiltersWin.cpp
@@ -35,13 +35,13 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
     // Hardware filter animation not implemented on Windows.
 }
 
-bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::OperationType)
+bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::Type)
 {
     // Hardware filter animation not implemented on Windows.
     return false;
 }
 
-const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::OperationType)
+const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::Type)
 {
     // Hardware filter animation not implemented on Windows.
     return "";

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -33,11 +33,6 @@
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
 
-// Annoyingly, wingdi.h #defines this.
-#ifdef PASSTHROUGH
-#undef PASSTHROUGH
-#endif
-
 namespace WebCore {
 
 // CSS Filters
@@ -50,22 +45,22 @@ struct ResourceLoaderOptions;
 
 class FilterOperation : public ThreadSafeRefCounted<FilterOperation> {
 public:
-    enum OperationType {
-        REFERENCE, // url(#somefilter)
-        GRAYSCALE,
-        SEPIA,
-        SATURATE,
-        HUE_ROTATE,
-        INVERT,
-        APPLE_INVERT_LIGHTNESS,
-        OPACITY,
-        BRIGHTNESS,
-        CONTRAST,
-        BLUR,
-        DROP_SHADOW,
-        PASSTHROUGH,
-        DEFAULT,
-        NONE
+    enum class Type : uint8_t {
+        Reference, // url(#somefilter)
+        Grayscale,
+        Sepia,
+        Saturate,
+        HueRotate,
+        Invert,
+        AppleInvertLightness,
+        Opacity,
+        Brightness,
+        Contrast,
+        Blur,
+        DropShadow,
+        Passthrough,
+        Default,
+        None
     };
 
     virtual ~FilterOperation() = default;
@@ -83,16 +78,16 @@ public:
     virtual bool transformColor(SRGBA<float>&) const { return false; }
     virtual bool inverseTransformColor(SRGBA<float>&) const { return false; }
 
-    OperationType type() const { return m_type; }
+    Type type() const { return m_type; }
 
     bool isBasicColorMatrixFilterOperation() const
     {
-        return m_type == GRAYSCALE || m_type == SEPIA || m_type == SATURATE || m_type == HUE_ROTATE;
+        return m_type == Type::Grayscale || m_type == Type::Sepia || m_type == Type::Saturate || m_type == Type::HueRotate;
     }
 
     bool isBasicComponentTransferFilterOperation() const
     {
-        return m_type == INVERT || m_type == BRIGHTNESS || m_type == CONTRAST || m_type == OPACITY;
+        return m_type == Type::Invert || m_type == Type::Brightness || m_type == Type::Contrast || m_type == Type::Opacity;
     }
 
     bool isSameType(const FilterOperation& o) const { return o.type() == m_type; }
@@ -109,19 +104,19 @@ public:
     virtual bool shouldBeRestrictedBySecurityOrigin() const { return false; }
 
 protected:
-    FilterOperation(OperationType type)
+    FilterOperation(Type type)
         : m_type(type)
     {
     }
 
     double blendAmounts(double from, double to, const BlendingContext&) const;
 
-    OperationType m_type;
+    Type m_type;
 };
 
 class WEBCORE_EXPORT DefaultFilterOperation : public FilterOperation {
 public:
-    static Ref<DefaultFilterOperation> create(OperationType representedType)
+    static Ref<DefaultFilterOperation> create(Type representedType)
     {
         return adoptRef(*new DefaultFilterOperation(representedType));
     }
@@ -131,18 +126,18 @@ public:
         return adoptRef(*new DefaultFilterOperation(representedType()));
     }
 
-    OperationType representedType() const { return m_representedType; }
+    Type representedType() const;
 
 private:
     bool operator==(const FilterOperation&) const override;
 
-    DefaultFilterOperation(OperationType representedType)
-        : FilterOperation(DEFAULT)
+    DefaultFilterOperation(Type representedType)
+        : FilterOperation(Type::Default)
         , m_representedType(representedType)
     {
     }
 
-    OperationType m_representedType;
+    Type m_representedType;
 };
 
 class PassthroughFilterOperation : public FilterOperation {
@@ -164,7 +159,7 @@ private:
     }
 
     PassthroughFilterOperation()
-        : FilterOperation(PASSTHROUGH)
+        : FilterOperation(Type::Passthrough)
     {
     }
 };
@@ -209,11 +204,11 @@ private:
     std::unique_ptr<CachedSVGDocumentReference> m_cachedSVGDocumentReference;
 };
 
-// GRAYSCALE, SEPIA, SATURATE and HUE_ROTATE are variations on a basic color matrix effect.
-// For HUE_ROTATE, the angle of rotation is stored in m_amount.
+// Grayscale, Sepia, Saturate and HueRotate are variations on a basic color matrix effect.
+// For HueRotate, the angle of rotation is stored in m_amount.
 class WEBCORE_EXPORT BasicColorMatrixFilterOperation : public FilterOperation {
 public:
-    static Ref<BasicColorMatrixFilterOperation> create(double amount, OperationType type)
+    static Ref<BasicColorMatrixFilterOperation> create(double amount, Type type)
     {
         return adoptRef(*new BasicColorMatrixFilterOperation(amount, type));
     }
@@ -232,7 +227,7 @@ private:
 
     double passthroughAmount() const;
 
-    BasicColorMatrixFilterOperation(double amount, OperationType type)
+    BasicColorMatrixFilterOperation(double amount, Type type)
         : FilterOperation(type)
         , m_amount(amount)
     {
@@ -244,10 +239,10 @@ private:
     double m_amount;
 };
 
-// INVERT, BRIGHTNESS, CONTRAST and OPACITY are variations on a basic component transfer effect.
+// Invert, Brightness, Contrast and Opacity are variations on a basic component transfer effect.
 class WEBCORE_EXPORT BasicComponentTransferFilterOperation : public FilterOperation {
 public:
-    static Ref<BasicComponentTransferFilterOperation> create(double amount, OperationType type)
+    static Ref<BasicComponentTransferFilterOperation> create(double amount, Type type)
     {
         return adoptRef(*new BasicComponentTransferFilterOperation(amount, type));
     }
@@ -259,7 +254,7 @@ public:
 
     double amount() const { return m_amount; }
 
-    bool affectsOpacity() const override { return m_type == OPACITY; }
+    bool affectsOpacity() const override;
 
     RefPtr<FilterOperation> blend(const FilterOperation* from, const BlendingContext&, bool blendToPassthrough = false) override;
 
@@ -268,7 +263,7 @@ private:
 
     double passthroughAmount() const;
 
-    BasicComponentTransferFilterOperation(double amount, OperationType type)
+    BasicComponentTransferFilterOperation(double amount, Type type)
         : FilterOperation(type)
         , m_amount(amount)
     {
@@ -298,7 +293,7 @@ private:
     bool operator==(const FilterOperation&) const final;
 
     InvertLightnessFilterOperation()
-        : FilterOperation(APPLE_INVERT_LIGHTNESS)
+        : FilterOperation(Type::AppleInvertLightness)
     {
     }
 
@@ -329,7 +324,7 @@ private:
     bool operator==(const FilterOperation&) const override;
 
     BlurFilterOperation(Length stdDeviation)
-        : FilterOperation(BLUR)
+        : FilterOperation(Type::Blur)
         , m_stdDeviation(WTFMove(stdDeviation))
     {
     }
@@ -367,7 +362,7 @@ private:
     bool operator==(const FilterOperation&) const override;
 
     DropShadowFilterOperation(const IntPoint& location, int stdDeviation, const Color& color)
-        : FilterOperation(DROP_SHADOW)
+        : FilterOperation(Type::DropShadow)
         , m_location(location)
         , m_stdDeviation(stdDeviation)
         , m_color(color)
@@ -391,35 +386,35 @@ SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
     static bool isType(const WebCore::FilterOperation& operation) { return operation.predicate; } \
 SPECIALIZE_TYPE_TRAITS_END()
 
-SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(DefaultFilterOperation, type() == WebCore::FilterOperation::DEFAULT)
-SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(PassthroughFilterOperation, type() == WebCore::FilterOperation::PASSTHROUGH)
-SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(ReferenceFilterOperation, type() == WebCore::FilterOperation::REFERENCE)
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(DefaultFilterOperation, type() == WebCore::FilterOperation::Type::Default)
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(PassthroughFilterOperation, type() == WebCore::FilterOperation::Type::Passthrough)
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(ReferenceFilterOperation, type() == WebCore::FilterOperation::Type::Reference)
 SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(BasicColorMatrixFilterOperation, isBasicColorMatrixFilterOperation())
 SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(BasicComponentTransferFilterOperation, isBasicComponentTransferFilterOperation())
-SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(InvertLightnessFilterOperation, type() == WebCore::FilterOperation::APPLE_INVERT_LIGHTNESS)
-SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(BlurFilterOperation, type() == WebCore::FilterOperation::BLUR)
-SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(DropShadowFilterOperation, type() == WebCore::FilterOperation::DROP_SHADOW)
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(InvertLightnessFilterOperation, type() == WebCore::FilterOperation::Type::AppleInvertLightness)
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(BlurFilterOperation, type() == WebCore::FilterOperation::Type::Blur)
+SPECIALIZE_TYPE_TRAITS_FILTEROPERATION(DropShadowFilterOperation, type() == WebCore::FilterOperation::Type::DropShadow)
 
 namespace WTF {
 
-template<> struct EnumTraits<WebCore::FilterOperation::OperationType> {
+template<> struct EnumTraits<WebCore::FilterOperation::Type> {
     using values = EnumValues<
-        WebCore::FilterOperation::OperationType,
-        WebCore::FilterOperation::OperationType::REFERENCE,
-        WebCore::FilterOperation::OperationType::GRAYSCALE,
-        WebCore::FilterOperation::OperationType::SEPIA,
-        WebCore::FilterOperation::OperationType::SATURATE,
-        WebCore::FilterOperation::OperationType::HUE_ROTATE,
-        WebCore::FilterOperation::OperationType::INVERT,
-        WebCore::FilterOperation::OperationType::APPLE_INVERT_LIGHTNESS,
-        WebCore::FilterOperation::OperationType::OPACITY,
-        WebCore::FilterOperation::OperationType::BRIGHTNESS,
-        WebCore::FilterOperation::OperationType::CONTRAST,
-        WebCore::FilterOperation::OperationType::BLUR,
-        WebCore::FilterOperation::OperationType::DROP_SHADOW,
-        WebCore::FilterOperation::OperationType::PASSTHROUGH,
-        WebCore::FilterOperation::OperationType::DEFAULT,
-        WebCore::FilterOperation::OperationType::NONE
+        WebCore::FilterOperation::Type,
+        WebCore::FilterOperation::Type::Reference,
+        WebCore::FilterOperation::Type::Grayscale,
+        WebCore::FilterOperation::Type::Sepia,
+        WebCore::FilterOperation::Type::Saturate,
+        WebCore::FilterOperation::Type::HueRotate,
+        WebCore::FilterOperation::Type::Invert,
+        WebCore::FilterOperation::Type::AppleInvertLightness,
+        WebCore::FilterOperation::Type::Opacity,
+        WebCore::FilterOperation::Type::Brightness,
+        WebCore::FilterOperation::Type::Contrast,
+        WebCore::FilterOperation::Type::Blur,
+        WebCore::FilterOperation::Type::DropShadow,
+        WebCore::FilterOperation::Type::Passthrough,
+        WebCore::FilterOperation::Type::Default,
+        WebCore::FilterOperation::Type::None
     >;
 };
 

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -61,7 +61,7 @@ bool FilterOperations::operationsMatch(const FilterOperations& other) const
 bool FilterOperations::hasReferenceFilter() const
 {
     for (auto& operation : m_operations) {
-        if (operation->type() == FilterOperation::REFERENCE)
+        if (operation->type() == FilterOperation::Type::Reference)
             return true;
     }
     return false;
@@ -72,7 +72,7 @@ IntOutsets FilterOperations::outsets() const
     IntOutsets totalOutsets;
     for (auto& operation : m_operations) {
         switch (operation->type()) {
-        case FilterOperation::BLUR: {
+        case FilterOperation::Type::Blur: {
             auto& blurOperation = downcast<BlurFilterOperation>(*operation);
             float stdDeviation = floatValueForLength(blurOperation.stdDeviation(), 0);
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
@@ -80,7 +80,7 @@ IntOutsets FilterOperations::outsets() const
             totalOutsets += outsets;
             break;
         }
-        case FilterOperation::DROP_SHADOW: {
+        case FilterOperation::Type::DropShadow: {
             auto& dropShadowOperation = downcast<DropShadowFilterOperation>(*operation);
             float stdDeviation = dropShadowOperation.stdDeviation();
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
@@ -94,7 +94,7 @@ IntOutsets FilterOperations::outsets() const
             totalOutsets += outsets;
             break;
         }
-        case FilterOperation::REFERENCE:
+        case FilterOperation::Type::Reference:
             ASSERT_NOT_REACHED();
             break;
         default:

--- a/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp
@@ -181,20 +181,20 @@ void BitmapTextureGL::updatePendingContents(const IntRect& targetRect, const Int
 }
 #endif
 
-static unsigned getPassesRequiredForFilter(FilterOperation::OperationType type)
+static unsigned getPassesRequiredForFilter(FilterOperation::Type type)
 {
     switch (type) {
-    case FilterOperation::GRAYSCALE:
-    case FilterOperation::SEPIA:
-    case FilterOperation::SATURATE:
-    case FilterOperation::HUE_ROTATE:
-    case FilterOperation::INVERT:
-    case FilterOperation::BRIGHTNESS:
-    case FilterOperation::CONTRAST:
-    case FilterOperation::OPACITY:
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Saturate:
+    case FilterOperation::Type::HueRotate:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
+    case FilterOperation::Type::Opacity:
         return 1;
-    case FilterOperation::BLUR:
-    case FilterOperation::DROP_SHADOW:
+    case FilterOperation::Type::Blur:
+    case FilterOperation::Type::DropShadow:
         // We use two-passes (vertical+horizontal) for blur and drop-shadow.
         return 2;
     default:
@@ -231,7 +231,7 @@ RefPtr<BitmapTexture> BitmapTextureGL::applyFilters(TextureMapper& textureMapper
                 intermediateSurface = texmapGL.acquireTextureFromPool(contentSize(), BitmapTexture::SupportsAlpha);
             texmapGL.bindSurface(intermediateSurface.get());
             texmapGL.drawFiltered(*resultSurface.get(), spareSurface.get(), *filter, j);
-            if (!j && filter->type() == FilterOperation::DROP_SHADOW) {
+            if (!j && filter->type() == FilterOperation::Type::DropShadow) {
                 spareSurface = resultSurface;
                 resultSurface = nullptr;
             }

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
@@ -598,7 +598,7 @@ bool GraphicsLayerTextureMapper::filtersCanBeComposited(const FilterOperations& 
         return false;
 
     for (const auto& filterOperation : filters.operations()) {
-        if (filterOperation->type() == FilterOperation::REFERENCE)
+        if (filterOperation->type() == FilterOperation::Type::Reference)
             return false;
     }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
@@ -310,28 +310,28 @@ void TextureMapperGL::drawNumber(int number, const Color& color, const FloatPoin
 #endif
 }
 
-static TextureMapperShaderProgram::Options optionsForFilterType(FilterOperation::OperationType type, unsigned pass)
+static TextureMapperShaderProgram::Options optionsForFilterType(FilterOperation::Type type, unsigned pass)
 {
     switch (type) {
-    case FilterOperation::GRAYSCALE:
+    case FilterOperation::Type::Grayscale:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::GrayscaleFilter };
-    case FilterOperation::SEPIA:
+    case FilterOperation::Type::Sepia:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::SepiaFilter };
-    case FilterOperation::SATURATE:
+    case FilterOperation::Type::Saturate:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::SaturateFilter };
-    case FilterOperation::HUE_ROTATE:
+    case FilterOperation::Type::HueRotate:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::HueRotateFilter };
-    case FilterOperation::INVERT:
+    case FilterOperation::Type::Invert:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::InvertFilter };
-    case FilterOperation::BRIGHTNESS:
+    case FilterOperation::Type::Brightness:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::BrightnessFilter };
-    case FilterOperation::CONTRAST:
+    case FilterOperation::Type::Contrast:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::ContrastFilter };
-    case FilterOperation::OPACITY:
+    case FilterOperation::Type::Opacity:
         return { TextureMapperShaderProgram::TextureRGB, TextureMapperShaderProgram::OpacityFilter };
-    case FilterOperation::BLUR:
+    case FilterOperation::Type::Blur:
         return { TextureMapperShaderProgram::BlurFilter };
-    case FilterOperation::DROP_SHADOW:
+    case FilterOperation::Type::DropShadow:
         if (!pass)
             return { TextureMapperShaderProgram::AlphaBlur };
         return { TextureMapperShaderProgram::AlphaBlur, TextureMapperShaderProgram::ContentTexture, TextureMapperShaderProgram::SolidColor };
@@ -379,19 +379,19 @@ static void prepareFilterProgram(TextureMapperShaderProgram& program, const Filt
     glUseProgram(program.programID());
 
     switch (operation.type()) {
-    case FilterOperation::GRAYSCALE:
-    case FilterOperation::SEPIA:
-    case FilterOperation::SATURATE:
-    case FilterOperation::HUE_ROTATE:
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Saturate:
+    case FilterOperation::Type::HueRotate:
         glUniform1f(program.filterAmountLocation(), static_cast<const BasicColorMatrixFilterOperation&>(operation).amount());
         break;
-    case FilterOperation::INVERT:
-    case FilterOperation::BRIGHTNESS:
-    case FilterOperation::CONTRAST:
-    case FilterOperation::OPACITY:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
+    case FilterOperation::Type::Opacity:
         glUniform1f(program.filterAmountLocation(), static_cast<const BasicComponentTransferFilterOperation&>(operation).amount());
         break;
-    case FilterOperation::BLUR: {
+    case FilterOperation::Type::Blur: {
         const BlurFilterOperation& blur = static_cast<const BlurFilterOperation&>(operation);
         FloatSize radius;
 
@@ -405,7 +405,7 @@ static void prepareFilterProgram(TextureMapperShaderProgram& program, const Filt
         glUniform1fv(program.gaussianKernelLocation(), GaussianKernelHalfWidth, gaussianKernel());
         break;
     }
-    case FilterOperation::DROP_SHADOW: {
+    case FilterOperation::Type::DropShadow: {
         const DropShadowFilterOperation& shadow = static_cast<const DropShadowFilterOperation&>(operation);
         glUniform1fv(program.gaussianKernelLocation(), GaussianKernelHalfWidth, gaussianKernel());
         switch (pass) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -536,7 +536,7 @@ bool CoordinatedGraphicsLayer::filtersCanBeComposited(const FilterOperations& fi
         return false;
 
     for (const auto& filterOperation : filters.operations()) {
-        if (filterOperation->type() == FilterOperation::REFERENCE)
+        if (filterOperation->type() == FilterOperation::Type::Reference)
             return false;
     }
 
@@ -1392,7 +1392,7 @@ bool CoordinatedGraphicsLayer::shouldHaveBackingStore() const
 
     // Check if there's a filter that sets the opacity to zero.
     bool hasOpacityZeroFilter = notFound != filters().operations().findIf([&](const auto& operation) {
-        return operation->type() == FilterOperation::OperationType::OPACITY && !downcast<BasicComponentTransferFilterOperation>(*operation).amount();
+        return operation->type() == FilterOperation::Type::Opacity && !downcast<BasicComponentTransferFilterOperation>(*operation).amount();
     });
 
     // If there's a filter that sets opacity to 0 and the filters are not being animated, the layer is invisible.

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -226,51 +226,51 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
 
     for (auto& operation : operations.operations()) {
         switch (operation->type()) {
-        case FilterOperation::APPLE_INVERT_LIGHTNESS:
-            ASSERT_NOT_REACHED(); // APPLE_INVERT_LIGHTNESS is only used in -apple-color-filter.
+        case FilterOperation::Type::AppleInvertLightness:
+            ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
             break;
 
-        case FilterOperation::BLUR:
+        case FilterOperation::Type::Blur:
             function = createBlurEffect(downcast<BlurFilterOperation>(*operation), clipOperation());
             break;
 
-        case FilterOperation::BRIGHTNESS:
+        case FilterOperation::Type::Brightness:
             function = createBrightnessEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
             break;
 
-        case FilterOperation::CONTRAST:
+        case FilterOperation::Type::Contrast:
             function = createContrastEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
             break;
 
-        case FilterOperation::DROP_SHADOW:
+        case FilterOperation::Type::DropShadow:
             function = createDropShadowEffect(downcast<DropShadowFilterOperation>(*operation));
             break;
 
-        case FilterOperation::GRAYSCALE:
+        case FilterOperation::Type::Grayscale:
             function = createGrayScaleEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
             break;
 
-        case FilterOperation::HUE_ROTATE:
+        case FilterOperation::Type::HueRotate:
             function = createHueRotateEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
             break;
 
-        case FilterOperation::INVERT:
+        case FilterOperation::Type::Invert:
             function = createInvertEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
             break;
 
-        case FilterOperation::OPACITY:
+        case FilterOperation::Type::Opacity:
             function = createOpacityEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
             break;
 
-        case FilterOperation::SATURATE:
+        case FilterOperation::Type::Saturate:
             function = createSaturateEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
             break;
 
-        case FilterOperation::SEPIA:
+        case FilterOperation::Type::Sepia:
             function = createSepiaEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
             break;
 
-        case FilterOperation::REFERENCE:
+        case FilterOperation::Type::Reference:
             function = createReferenceFilter(*this, downcast<ReferenceFilterOperation>(*operation), renderer, preferredFilterRenderingModes, targetBoundingBox, destinationContext);
             break;
 
@@ -375,7 +375,7 @@ bool CSSFilter::isIdentity(RenderElement& renderer, const FilterOperations& oper
         return false;
 
     for (auto& operation : operations.operations()) {
-        if (operation->type() == FilterOperation::REFERENCE) {
+        if (operation->type() == FilterOperation::Type::Reference) {
             if (!isIdentityReferenceFilter(downcast<ReferenceFilterOperation>(*operation), renderer))
                 return false;
             continue;
@@ -393,7 +393,7 @@ IntOutsets CSSFilter::calculateOutsets(RenderElement& renderer, const FilterOper
     IntOutsets outsets;
 
     for (auto& operation : operations.operations()) {
-        if (operation->type() == FilterOperation::REFERENCE) {
+        if (operation->type() == FilterOperation::Type::Reference) {
             outsets += calculateReferenceFilterOutsets(downcast<ReferenceFilterOperation>(*operation), renderer, targetBoundingBox);
             continue;
         }

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -108,7 +108,7 @@ Vector<std::pair<AtomString, QualifiedName>> ReferencedSVGResources::referencedS
         const auto& filterOperations = style.filter();
         for (auto& operation : filterOperations.operations()) {
             auto& filterOperation = *operation;
-            if (filterOperation.type() == FilterOperation::REFERENCE) {
+            if (filterOperation.type() == FilterOperation::Type::Reference) {
                 const auto& referenceFilterOperation = downcast<ReferenceFilterOperation>(filterOperation);
                 if (!referenceFilterOperation.fragment().isEmpty())
                     referencedResources.append({ referenceFilterOperation.fragment(), SVGNames::filterTag });

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2837,7 +2837,7 @@ bool RenderStyle::hasReferenceFilterOnly() const
     if (!hasFilter())
         return false;
     auto& filterOperations = m_rareNonInheritedData->filter->operations;
-    return filterOperations.size() == 1 && filterOperations.at(0)->type() == FilterOperation::REFERENCE;
+    return filterOperations.size() == 1 && filterOperations.at(0)->type() == FilterOperation::Type::Reference;
 }
 
 float RenderStyle::outlineWidth() const

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -623,7 +623,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
         const FilterOperations& filterOperations = style.filter();
         if (filterOperations.size() == 1) {
             const FilterOperation& filterOperation = *filterOperations.at(0);
-            if (filterOperation.type() == FilterOperation::REFERENCE) {
+            if (filterOperation.type() == FilterOperation::Type::Reference) {
                 const auto& referenceFilterOperation = downcast<ReferenceFilterOperation>(filterOperation);
                 AtomString id = SVGURIReference::fragmentIdentifierFromIRIString(referenceFilterOperation.url(), renderer.document());
                 if (RenderSVGResourceFilter* filter = getRenderSVGResourceById<RenderSVGResourceFilter>(renderer.document(), id)) {

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -240,7 +240,7 @@ bool SVGResources::buildCachedResources(const RenderElement& renderer, const Ren
             const FilterOperations& filterOperations = style.filter();
             if (filterOperations.size() == 1) {
                 const FilterOperation& filterOperation = *filterOperations.at(0);
-                if (filterOperation.type() == FilterOperation::REFERENCE) {
+                if (filterOperation.type() == FilterOperation::Type::Reference) {
                     const auto& referenceFilterOperation = downcast<ReferenceFilterOperation>(filterOperation);
                     AtomString id = SVGURIReference::fragmentIdentifierFromIRIString(referenceFilterOperation.url(), element.document());
                     if (setFilter(getRenderSVGResourceById<RenderSVGResourceFilter>(document, id)))

--- a/Source/WebCore/style/FilterOperationsBuilder.cpp
+++ b/Source/WebCore/style/FilterOperationsBuilder.cpp
@@ -38,38 +38,38 @@ namespace WebCore {
 
 namespace Style {
 
-static FilterOperation::OperationType filterOperationForType(CSSValueID type)
+static FilterOperation::Type filterOperationForType(CSSValueID type)
 {
     switch (type) {
     case CSSValueUrl:
-        return FilterOperation::REFERENCE;
+        return FilterOperation::Type::Reference;
     case CSSValueGrayscale:
-        return FilterOperation::GRAYSCALE;
+        return FilterOperation::Type::Grayscale;
     case CSSValueSepia:
-        return FilterOperation::SEPIA;
+        return FilterOperation::Type::Sepia;
     case CSSValueSaturate:
-        return FilterOperation::SATURATE;
+        return FilterOperation::Type::Saturate;
     case CSSValueHueRotate:
-        return FilterOperation::HUE_ROTATE;
+        return FilterOperation::Type::HueRotate;
     case CSSValueInvert:
-        return FilterOperation::INVERT;
+        return FilterOperation::Type::Invert;
     case CSSValueAppleInvertLightness:
-        return FilterOperation::APPLE_INVERT_LIGHTNESS;
+        return FilterOperation::Type::AppleInvertLightness;
     case CSSValueOpacity:
-        return FilterOperation::OPACITY;
+        return FilterOperation::Type::Opacity;
     case CSSValueBrightness:
-        return FilterOperation::BRIGHTNESS;
+        return FilterOperation::Type::Brightness;
     case CSSValueContrast:
-        return FilterOperation::CONTRAST;
+        return FilterOperation::Type::Contrast;
     case CSSValueBlur:
-        return FilterOperation::BLUR;
+        return FilterOperation::Type::Blur;
     case CSSValueDropShadow:
-        return FilterOperation::DROP_SHADOW;
+        return FilterOperation::Type::DropShadow;
     default:
         break;
     }
     ASSERT_NOT_REACHED();
-    return FilterOperation::NONE;
+    return FilterOperation::Type::None;
 }
 
 std::optional<FilterOperations> createFilterOperations(const Document& document, RenderStyle& style, const CSSToLengthConversionData& cssToLengthConversionData, const CSSValue& inValue)
@@ -101,12 +101,12 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
             continue;
 
         auto& filterValue = downcast<CSSFunctionValue>(currentValue.get());
-        FilterOperation::OperationType operationType = filterOperationForType(filterValue.name());
+        auto operationType = filterOperationForType(filterValue.name());
 
         // Check that all parameters are primitive values, with the
         // exception of drop shadow which has a CSSShadowValue parameter.
         const CSSPrimitiveValue* firstValue = nullptr;
-        if (operationType != FilterOperation::DROP_SHADOW) {
+        if (operationType != FilterOperation::Type::DropShadow) {
             bool haveNonPrimitiveValue = false;
             for (unsigned j = 0; j < filterValue.length(); ++j) {
                 if (!is<CSSPrimitiveValue>(*filterValue.itemWithoutBoundsCheck(j))) {
@@ -121,9 +121,9 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
         }
 
         switch (operationType) {
-        case FilterOperation::GRAYSCALE:
-        case FilterOperation::SEPIA:
-        case FilterOperation::SATURATE: {
+        case FilterOperation::Type::Grayscale:
+        case FilterOperation::Type::Sepia:
+        case FilterOperation::Type::Saturate: {
             double amount = 1;
             if (filterValue.length() == 1) {
                 amount = firstValue->doubleValue();
@@ -134,7 +134,7 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
             operations.operations().append(BasicColorMatrixFilterOperation::create(amount, operationType));
             break;
         }
-        case FilterOperation::HUE_ROTATE: {
+        case FilterOperation::Type::HueRotate: {
             double angle = 0;
             if (filterValue.length() == 1)
                 angle = firstValue->computeDegrees();
@@ -142,10 +142,10 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
             operations.operations().append(BasicColorMatrixFilterOperation::create(angle, operationType));
             break;
         }
-        case FilterOperation::INVERT:
-        case FilterOperation::BRIGHTNESS:
-        case FilterOperation::CONTRAST:
-        case FilterOperation::OPACITY: {
+        case FilterOperation::Type::Invert:
+        case FilterOperation::Type::Brightness:
+        case FilterOperation::Type::Contrast:
+        case FilterOperation::Type::Opacity: {
             double amount = 1;
             if (filterValue.length() == 1) {
                 amount = firstValue->doubleValue();
@@ -156,11 +156,11 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
             operations.operations().append(BasicComponentTransferFilterOperation::create(amount, operationType));
             break;
         }
-        case FilterOperation::APPLE_INVERT_LIGHTNESS: {
+        case FilterOperation::Type::AppleInvertLightness: {
             operations.operations().append(InvertLightnessFilterOperation::create());
             break;
         }
-        case FilterOperation::BLUR: {
+        case FilterOperation::Type::Blur: {
             Length stdDeviation = Length(0, LengthType::Fixed);
             if (filterValue.length() >= 1)
                 stdDeviation = convertToFloatLength(firstValue, cssToLengthConversionData);
@@ -170,7 +170,7 @@ std::optional<FilterOperations> createFilterOperations(const Document& document,
             operations.operations().append(BlurFilterOperation::create(stdDeviation));
             break;
         }
-        case FilterOperation::DROP_SHADOW: {
+        case FilterOperation::Type::DropShadow: {
             if (filterValue.length() != 1)
                 return std::nullopt;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -821,39 +821,39 @@ void ArgumentCoder<FilterOperation>::encode(Encoder& encoder, const FilterOperat
     encoder << filter.type();
 
     switch (filter.type()) {
-    case FilterOperation::NONE:
-    case FilterOperation::REFERENCE:
+    case FilterOperation::Type::None:
+    case FilterOperation::Type::Reference:
         ASSERT_NOT_REACHED();
         return;
-    case FilterOperation::GRAYSCALE:
-    case FilterOperation::SEPIA:
-    case FilterOperation::SATURATE:
-    case FilterOperation::HUE_ROTATE:
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Saturate:
+    case FilterOperation::Type::HueRotate:
         encoder << downcast<BasicColorMatrixFilterOperation>(filter).amount();
         return;
-    case FilterOperation::INVERT:
-    case FilterOperation::OPACITY:
-    case FilterOperation::BRIGHTNESS:
-    case FilterOperation::CONTRAST:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Opacity:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
         encoder << downcast<BasicComponentTransferFilterOperation>(filter).amount();
         return;
-    case FilterOperation::APPLE_INVERT_LIGHTNESS:
-        ASSERT_NOT_REACHED(); // APPLE_INVERT_LIGHTNESS is only used in -apple-color-filter.
+    case FilterOperation::Type::AppleInvertLightness:
+        ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
         return;
-    case FilterOperation::BLUR:
+    case FilterOperation::Type::Blur:
         encoder << downcast<BlurFilterOperation>(filter).stdDeviation();
         return;
-    case FilterOperation::DROP_SHADOW: {
+    case FilterOperation::Type::DropShadow: {
         const auto& dropShadowFilter = downcast<DropShadowFilterOperation>(filter);
         encoder << dropShadowFilter.location();
         encoder << dropShadowFilter.stdDeviation();
         encoder << dropShadowFilter.color();
         return;
     }
-    case FilterOperation::DEFAULT:
+    case FilterOperation::Type::Default:
         encoder << downcast<DefaultFilterOperation>(filter).representedType();
         return;
-    case FilterOperation::PASSTHROUGH:
+    case FilterOperation::Type::Passthrough:
         return;
     }
 
@@ -862,46 +862,46 @@ void ArgumentCoder<FilterOperation>::encode(Encoder& encoder, const FilterOperat
 
 bool decodeFilterOperation(Decoder& decoder, RefPtr<FilterOperation>& filter)
 {
-    FilterOperation::OperationType type;
+    FilterOperation::Type type;
     if (!decoder.decode(type))
         return false;
 
     switch (type) {
-    case FilterOperation::NONE:
-    case FilterOperation::REFERENCE:
+    case FilterOperation::Type::None:
+    case FilterOperation::Type::Reference:
         ASSERT_NOT_REACHED();
         return false;
-    case FilterOperation::GRAYSCALE:
-    case FilterOperation::SEPIA:
-    case FilterOperation::SATURATE:
-    case FilterOperation::HUE_ROTATE: {
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Saturate:
+    case FilterOperation::Type::HueRotate: {
         double amount;
         if (!decoder.decode(amount))
             return false;
         filter = BasicColorMatrixFilterOperation::create(amount, type);
         return true;
     }
-    case FilterOperation::INVERT:
-    case FilterOperation::OPACITY:
-    case FilterOperation::BRIGHTNESS:
-    case FilterOperation::CONTRAST: {
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Opacity:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast: {
         double amount;
         if (!decoder.decode(amount))
             return false;
         filter = BasicComponentTransferFilterOperation::create(amount, type);
         return true;
     }
-    case FilterOperation::APPLE_INVERT_LIGHTNESS:
-        ASSERT_NOT_REACHED(); // APPLE_INVERT_LIGHTNESS is only used in -apple-color-filter.
+    case FilterOperation::Type::AppleInvertLightness:
+        ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
         return false;
-    case FilterOperation::BLUR: {
+    case FilterOperation::Type::Blur: {
         Length stdDeviation;
         if (!decoder.decode(stdDeviation))
             return false;
         filter = BlurFilterOperation::create(stdDeviation);
         return true;
     }
-    case FilterOperation::DROP_SHADOW: {
+    case FilterOperation::Type::DropShadow: {
         IntPoint location;
         int stdDeviation;
         Color color;
@@ -914,14 +914,14 @@ bool decodeFilterOperation(Decoder& decoder, RefPtr<FilterOperation>& filter)
         filter = DropShadowFilterOperation::create(location, stdDeviation, color);
         return true;
     }
-    case FilterOperation::DEFAULT: {
-        FilterOperation::OperationType representedType;
+    case FilterOperation::Type::Default: {
+        FilterOperation::Type representedType;
         if (!decoder.decode(representedType))
             return false;
         filter = DefaultFilterOperation::create(representedType);
         return true;
     }
-    case FilterOperation::PASSTHROUGH:
+    case FilterOperation::Type::Passthrough:
         filter = PassthroughFilterOperation::create();
         return true;
     }

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -442,7 +442,7 @@ static bool filtersCanBeComposited(const FilterOperations& filters)
     if (!filters.size())
         return false;
     for (const auto& filterOperation : filters.operations()) {
-        if (filterOperation->type() == FilterOperation::REFERENCE)
+        if (filterOperation->type() == FilterOperation::Type::Reference)
             return false;
     }
     return true;


### PR DESCRIPTION
#### dffcbbe951fc5f5f777fb0279e4cc43b7823d617
<pre>
Make FilterOperation::OperationType an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250519">https://bugs.webkit.org/show_bug.cgi?id=250519</a>

Reviewed by Alex Christensen.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForFilter):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::fragmentNeedsColorTransformed):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createFilterAnimationsFromKeyframes):
(WebCore::GraphicsLayerCA::setFilterAnimationKeyframes):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCAFilters.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::setFiltersOnLayer):
(WebCore::PlatformCAFilters::filterValueForOperation):
(WebCore::PlatformCAFilters::colorMatrixValueForFilter):
(WebCore::PlatformCAFilters::isAnimatedFilterProperty):
(WebCore::PlatformCAFilters::animatedFilterPropertyName):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::filtersCanBeComposited):
* Source/WebCore/platform/graphics/ca/win/PlatformCAFiltersWin.cpp:
(PlatformCAFilters::isAnimatedFilterProperty):
(PlatformCAFilters::animatedFilterPropertyName):
* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
(WebCore::DefaultFilterOperation::representedType const):
(WebCore::ReferenceFilterOperation::ReferenceFilterOperation):
(WebCore::FilterOperation::blendAmounts const):
(WebCore::BasicColorMatrixFilterOperation::isIdentity const):
(WebCore::BasicColorMatrixFilterOperation::transformColor const):
(WebCore::BasicColorMatrixFilterOperation::passthroughAmount const):
(WebCore::BasicComponentTransferFilterOperation::isIdentity const):
(WebCore::BasicComponentTransferFilterOperation::transformColor const):
(WebCore::BasicComponentTransferFilterOperation::passthroughAmount const):
(WebCore::BasicComponentTransferFilterOperation::affectsOpacity const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/filters/FilterOperation.h:
(WebCore::FilterOperation::type const):
(WebCore::FilterOperation::isBasicColorMatrixFilterOperation const):
(WebCore::FilterOperation::isBasicComponentTransferFilterOperation const):
(WebCore::FilterOperation::FilterOperation):
(WebCore::PassthroughFilterOperation::PassthroughFilterOperation):
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::hasReferenceFilter const):
(WebCore::FilterOperations::outsets const):
* Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp:
(WebCore::getPassesRequiredForFilter):
(WebCore::BitmapTextureGL::applyFilters):
* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp:
(WebCore::GraphicsLayerTextureMapper::filtersCanBeComposited const):
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::optionsForFilterType):
(WebCore::prepareFilterProgram):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::filtersCanBeComposited const):
(WebCore::CoordinatedGraphicsLayer::shouldHaveBackingStore const):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::buildFilterFunctions):
(WebCore::CSSFilter::isIdentity):
(WebCore::CSSFilter::calculateOutsets):
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedSVGResourceIDs):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hasReferenceFilterOnly const):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeResources):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/style/FilterOperationsBuilder.cpp:
(WebCore::Style::filterOperationForType):
(WebCore::Style::createFilterOperations):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;FilterOperation&gt;::encode):
(IPC::decodeFilterOperation):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::filtersCanBeComposited):

Canonical link: <a href="https://commits.webkit.org/258864@main">https://commits.webkit.org/258864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da4673aa5fd2b7957fa3da6441abeee525080b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112371 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172569 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3150 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110597 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5659 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26337 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2785 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45840 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7576 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3244 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->