### PR TITLE
Remove incorrect FIXME about HTMLPreElement.width type

### DIFF
--- a/Source/WebCore/html/HTMLPreElement.idl
+++ b/Source/WebCore/html/HTMLPreElement.idl
@@ -24,8 +24,6 @@
 [
     Exposed=Window
 ] interface HTMLPreElement : HTMLElement {
-    // FIXME: DOM spec says that width should be of type DOMString
-    // see http://bugs.webkit.org/show_bug.cgi?id=8992
     [CEReactions=NotNeeded, Reflect] attribute long width;
 };
 


### PR DESCRIPTION
#### a37a7d6fcf2a410fda1d473e05beb6f9e6b958d9
<pre>
Remove incorrect FIXME about HTMLPreElement.width type

Remove incorrect FIXME about HTMLPreElement.width type
<a href="https://bugs.webkit.org/show_bug.cgi?id=250274">https://bugs.webkit.org/show_bug.cgi?id=250274</a>

Reviewed by Aditya Keerthi.

This patch is to remove incorrect FIXME, which mentions about &apos;width&apos; attribute
to be DOMString and referring to old bug. While using the test case from reference bug,
&apos;width&apos; attribute is &apos;number&apos; type and same as other browsers (Firefox &amp; Chrome).

Hence, it is an incorrect comment and this patch is to remove it.

* Source/WebCore/html/HTMLPreElement.idl: Remove &apos;FIXME&apos;

Canonical link: <a href="https://commits.webkit.org/258838@main">https://commits.webkit.org/258838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4e78e4fc90dd049d0ea49918a6e7c6842f9bcaf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112350 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3129 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95323 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108875 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93369 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24913 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5643 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26319 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2771 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6079 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7558 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->