### PR TITLE
Make AnimationPropertyID an enum class

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -612,7 +612,7 @@ FloatRect GraphicsLayer::adjustCoverageRectForMovement(const FloatRect& coverage
     return unionRect(coverageRect, expandedRect);
 }
 
-String GraphicsLayer::animationNameForTransition(AnimatedPropertyID property)
+String GraphicsLayer::animationNameForTransition(AnimatedProperty property)
 {
     // | is not a valid identifier character in CSS, so this can never conflict with a keyframe identifier.
     return makeString("-|transition", static_cast<int>(property), '-');
@@ -694,9 +694,9 @@ static inline const FilterOperations& filterOperationsAt(const KeyframeValueList
 int GraphicsLayer::validateFilterOperations(const KeyframeValueList& valueList)
 {
 #if ENABLE(FILTERS_LEVEL_2)
-    ASSERT(valueList.property() == AnimatedPropertyFilter || valueList.property() == AnimatedPropertyWebkitBackdropFilter);
+    ASSERT(valueList.property() == AnimatedProperty::Filter || valueList.property() == AnimatedProperty::WebkitBackdropFilter);
 #else
-    ASSERT(valueList.property() == AnimatedPropertyFilter);
+    ASSERT(valueList.property() == AnimatedProperty::Filter);
 #endif
 
     if (valueList.size() < 2)

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -201,7 +201,7 @@ private:
 // FIXME: Should be moved to its own header file.
 class KeyframeValueList {
 public:
-    explicit KeyframeValueList(AnimatedPropertyID property)
+    explicit KeyframeValueList(AnimatedProperty property)
         : m_property(property)
     {
     }
@@ -231,7 +231,7 @@ public:
         m_values.swap(other.m_values);
     }
 
-    AnimatedPropertyID property() const { return m_property; }
+    AnimatedProperty property() const { return m_property; }
 
     size_t size() const { return m_values.size(); }
     const AnimationValue& at(size_t i) const { return *m_values.at(i); }
@@ -241,7 +241,7 @@ public:
 
 protected:
     Vector<std::unique_ptr<const AnimationValue>> m_values;
-    AnimatedPropertyID m_property;
+    AnimatedProperty m_property;
 };
 
 // GraphicsLayer is an abstraction for a rendering surface with backing store,
@@ -488,7 +488,7 @@ public:
     WEBCORE_EXPORT virtual void setEventRegion(EventRegion&&);
 
     // Transitions are identified by a special animation name that cannot clash with a keyframe identifier.
-    static String animationNameForTransition(AnimatedPropertyID);
+    static String animationNameForTransition(AnimatedProperty);
 
     // Return true if the animation is handled by the compositing system.
     virtual bool addAnimation(const KeyframeValueList&, const FloatSize& /*boxSize*/, const Animation*, const String& /*animationName*/, double /*timeOffset*/)  { return false; }

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -40,6 +40,20 @@ class GraphicsLayer;
 class IntPoint;
 class IntRect;
 
+enum class AnimatedProperty : uint8_t {
+    Invalid,
+    Translate,
+    Scale,
+    Rotate,
+    Transform,
+    Opacity,
+    BackgroundColor,
+    Filter,
+#if ENABLE(FILTERS_LEVEL_2)
+    WebkitBackdropFilter,
+#endif
+};
+
 enum class GraphicsLayerPaintingPhase {
     Background            = 1 << 0,
     Foreground            = 1 << 1,
@@ -49,25 +63,6 @@ enum class GraphicsLayerPaintingPhase {
     CompositedScroll      = 1 << 5,
     ChildClippingMask     = 1 << 6,
 };
-
-enum AnimatedPropertyID {
-    AnimatedPropertyInvalid,
-    AnimatedPropertyTranslate,
-    AnimatedPropertyScale,
-    AnimatedPropertyRotate,
-    AnimatedPropertyTransform,
-    AnimatedPropertyOpacity,
-    AnimatedPropertyBackgroundColor,
-    AnimatedPropertyFilter,
-#if ENABLE(FILTERS_LEVEL_2)
-    AnimatedPropertyWebkitBackdropFilter,
-#endif
-};
-
-inline bool animatedPropertyIsTransformOrRelated(AnimatedPropertyID property)
-{
-    return property == AnimatedPropertyTransform || property == AnimatedPropertyTranslate || property == AnimatedPropertyScale || property == AnimatedPropertyRotate;
-}
 
 enum class PlatformLayerTreeAsTextFlags : uint8_t {
     Debug = 1 << 0,
@@ -136,7 +131,7 @@ public:
 
     virtual void logFilledVisibleFreshTile(unsigned) { };
 
-    virtual TransformationMatrix transformMatrixForProperty(AnimatedPropertyID) const { return { }; }
+    virtual TransformationMatrix transformMatrixForProperty(AnimatedProperty) const { return { }; }
 
 #ifndef NDEBUG
     // RenderLayerBacking overrides this to verify that it is not

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -255,29 +255,34 @@ static PlatformCAAnimation::ValueFunctionType getValueFunctionNameForTransformOp
     }
 }
 
-static ASCIILiteral propertyIdToString(AnimatedPropertyID property)
+static ASCIILiteral propertyIdToString(AnimatedProperty property)
 {
     switch (property) {
-    case AnimatedPropertyTranslate:
-    case AnimatedPropertyScale:
-    case AnimatedPropertyRotate:
-    case AnimatedPropertyTransform:
+    case AnimatedProperty::Translate:
+    case AnimatedProperty::Scale:
+    case AnimatedProperty::Rotate:
+    case AnimatedProperty::Transform:
         return "transform"_s;
-    case AnimatedPropertyOpacity:
+    case AnimatedProperty::Opacity:
         return "opacity"_s;
-    case AnimatedPropertyBackgroundColor:
+    case AnimatedProperty::BackgroundColor:
         return "backgroundColor"_s;
-    case AnimatedPropertyFilter:
+    case AnimatedProperty::Filter:
         return "filters"_s;
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter:
+    case AnimatedProperty::WebkitBackdropFilter:
         return "backdropFilters"_s;
 #endif
-    case AnimatedPropertyInvalid:
+    case AnimatedProperty::Invalid:
         ASSERT_NOT_REACHED();
     }
     ASSERT_NOT_REACHED();
     return { };
+}
+
+static bool animatedPropertyIsTransformOrRelated(AnimatedProperty property)
+{
+    return property == AnimatedProperty::Transform || property == AnimatedProperty::Translate || property == AnimatedProperty::Scale || property == AnimatedProperty::Rotate;
 }
 
 static bool animationHasStepsTimingFunction(const KeyframeValueList& valueList, const Animation* anim)
@@ -719,9 +724,9 @@ void GraphicsLayerCA::moveOrCopyAnimations(MoveOrCopy operation, PlatformCALayer
 {
     for (auto& animationGroup : m_animationGroups) {
         if ((animatedPropertyIsTransformOrRelated(animationGroup.m_property)
-            || animationGroup.m_property == AnimatedPropertyOpacity
-            || animationGroup.m_property == AnimatedPropertyBackgroundColor
-            || animationGroup.m_property == AnimatedPropertyFilter))
+            || animationGroup.m_property == AnimatedProperty::Opacity
+            || animationGroup.m_property == AnimatedProperty::BackgroundColor
+            || animationGroup.m_property == AnimatedProperty::Filter))
             moveOrCopyLayerAnimation(operation, animationGroup.animationIdentifier(), animationGroup.computedBeginTime(), fromLayer, toLayer);
     }
 }
@@ -1121,12 +1126,12 @@ bool GraphicsLayerCA::addAnimation(const KeyframeValueList& valueList, const Flo
     bool createdAnimations = false;
     if (animatedPropertyIsTransformOrRelated(valueList.property()))
         createdAnimations = createTransformAnimationsFromKeyframes(valueList, anim, animationName, Seconds { timeOffset }, boxSize, keyframesShouldUseAnimationWideTimingFunction);
-    else if (valueList.property() == AnimatedPropertyFilter) {
+    else if (valueList.property() == AnimatedProperty::Filter) {
         if (supportsAcceleratedFilterAnimations())
             createdAnimations = createFilterAnimationsFromKeyframes(valueList, anim, animationName, Seconds { timeOffset }, keyframesShouldUseAnimationWideTimingFunction);
     }
 #if ENABLE(FILTERS_LEVEL_2)
-    else if (valueList.property() == AnimatedPropertyWebkitBackdropFilter) {
+    else if (valueList.property() == AnimatedProperty::WebkitBackdropFilter) {
         if (supportsAcceleratedFilterAnimations())
             createdAnimations = createFilterAnimationsFromKeyframes(valueList, anim, animationName, Seconds { timeOffset }, keyframesShouldUseAnimationWideTimingFunction);
     }
@@ -3090,7 +3095,7 @@ void GraphicsLayerCA::updateAnimations()
     auto infiniteDuration = std::numeric_limits<double>::max();
     auto currentTime = Seconds(CACurrentMediaTime());
 
-    auto addAnimationGroup = [&](AnimatedPropertyID property, const Vector<RefPtr<PlatformCAAnimation>>& animations) {
+    auto addAnimationGroup = [&](AnimatedProperty property, const Vector<RefPtr<PlatformCAAnimation>>& animations) {
         auto caAnimationGroup = createPlatformCAAnimation(PlatformCAAnimation::Group, emptyString());
         caAnimationGroup->setDuration(infiniteDuration);
         caAnimationGroup->setAnimations(animations);
@@ -3125,7 +3130,7 @@ void GraphicsLayerCA::updateAnimations()
     };
 
     enum class TransformationMatrixSource { UseIdentityMatrix, AskClient };
-    auto makeBaseValueTransformAnimation = [&](AnimatedPropertyID property, TransformationMatrixSource matrixSource = TransformationMatrixSource::AskClient, Seconds beginTimeOfEarliestPropertyAnimation = 0_s) -> LayerPropertyAnimation* {
+    auto makeBaseValueTransformAnimation = [&](AnimatedProperty property, TransformationMatrixSource matrixSource = TransformationMatrixSource::AskClient, Seconds beginTimeOfEarliestPropertyAnimation = 0_s) -> LayerPropertyAnimation* {
         // A base value transform animation can either be set to the identity matrix or to read the underlying
         // value from the GraphicsLayerClient. If we didn't explicitly ask for an identity matrix, we can skip
         // the addition of this base value transform animation since it will be a no-op.
@@ -3151,7 +3156,7 @@ void GraphicsLayerCA::updateAnimations()
         return &m_baseValueTransformAnimations.last();
     };
 
-    auto addBaseValueTransformAnimation = [&](AnimatedPropertyID property, TransformationMatrixSource matrixSource = TransformationMatrixSource::AskClient, Seconds beginTimeOfEarliestPropertyAnimation = 0_s) {
+    auto addBaseValueTransformAnimation = [&](AnimatedProperty property, TransformationMatrixSource matrixSource = TransformationMatrixSource::AskClient, Seconds beginTimeOfEarliestPropertyAnimation = 0_s) {
         // Additivity will depend on the source of the matrix, if it was explicitly provided as an identity matrix, it
         // is the initial base value transform animation and must override the current transform value for this layer.
         // Otherwise, it is meant to apply the underlying value for one specific transform-related property and be additive
@@ -3194,16 +3199,16 @@ void GraphicsLayerCA::updateAnimations()
 
     for (auto& animation : m_animations) {
         switch (animation.m_property) {
-        case AnimatedPropertyTranslate:
+        case AnimatedProperty::Translate:
             translateAnimation = &animation;
             break;
-        case AnimatedPropertyScale:
+        case AnimatedProperty::Scale:
             scaleAnimation = &animation;
             break;
-        case AnimatedPropertyRotate:
+        case AnimatedProperty::Rotate:
             rotateAnimation = &animation;
             break;
-        case AnimatedPropertyTransform:
+        case AnimatedProperty::Transform:
             // In the case of animations targeting the "transform" CSS property, there may be several
             // animations created for a single KeyframeEffect, one for each transform component. In that
             // case the animation index starts at 0 and increases for each component. If we encounter an
@@ -3214,15 +3219,15 @@ void GraphicsLayerCA::updateAnimations()
                 transformAnimations.clear();
             transformAnimations.append(&animation);
             break;
-        case AnimatedPropertyOpacity:
-        case AnimatedPropertyBackgroundColor:
-        case AnimatedPropertyFilter:
+        case AnimatedProperty::Opacity:
+        case AnimatedProperty::BackgroundColor:
+        case AnimatedProperty::Filter:
 #if ENABLE(FILTERS_LEVEL_2)
-        case AnimatedPropertyWebkitBackdropFilter:
+        case AnimatedProperty::WebkitBackdropFilter:
 #endif
             addLeafAnimation(animation);
             break;
-        case AnimatedPropertyInvalid:
+        case AnimatedProperty::Invalid:
             ASSERT_NOT_REACHED();
         }
     }
@@ -3240,9 +3245,9 @@ void GraphicsLayerCA::updateAnimations()
     if (!translateAnimations.isEmpty() || !scaleAnimations.isEmpty() || !rotateAnimations.isEmpty() || !transformAnimations.isEmpty()) {
         // Start with a base identity transform to override the transform applied to the layer and have a
         // sound base to add animations on top of with additivity enabled.
-        addBaseValueTransformAnimation(AnimatedPropertyTransform, TransformationMatrixSource::UseIdentityMatrix);
+        addBaseValueTransformAnimation(AnimatedProperty::Transform, TransformationMatrixSource::UseIdentityMatrix);
 
-        auto addAnimationsForProperty = [&](const Vector<LayerPropertyAnimation*>& animations, AnimatedPropertyID property) {
+        auto addAnimationsForProperty = [&](const Vector<LayerPropertyAnimation*>& animations, AnimatedProperty property) {
             if (animations.isEmpty()) {
                 addBaseValueTransformAnimation(property);
                 return;
@@ -3280,10 +3285,10 @@ void GraphicsLayerCA::updateAnimations()
             addAnimationGroup(property, caAnimations);
         };
 
-        addAnimationsForProperty(transformAnimations, AnimatedPropertyTransform);
-        addAnimationsForProperty(scaleAnimations, AnimatedPropertyScale);
-        addAnimationsForProperty(rotateAnimations, AnimatedPropertyRotate);
-        addAnimationsForProperty(translateAnimations, AnimatedPropertyTranslate);
+        addAnimationsForProperty(transformAnimations, AnimatedProperty::Transform);
+        addAnimationsForProperty(scaleAnimations, AnimatedProperty::Scale);
+        addAnimationsForProperty(rotateAnimations, AnimatedProperty::Rotate);
+        addAnimationsForProperty(translateAnimations, AnimatedProperty::Translate);
     }
 }
 
@@ -3416,7 +3421,7 @@ static bool isKeyframe(const KeyframeValueList& list)
 
 bool GraphicsLayerCA::createAnimationFromKeyframes(const KeyframeValueList& valueList, const Animation* animation, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction)
 {
-    ASSERT(!animatedPropertyIsTransformOrRelated(valueList.property()) && (!supportsAcceleratedFilterAnimations() || valueList.property() != AnimatedPropertyFilter));
+    ASSERT(!animatedPropertyIsTransformOrRelated(valueList.property()) && (!supportsAcceleratedFilterAnimations() || valueList.property() != AnimatedProperty::Filter));
 
     bool valuesOK;
     
@@ -3567,9 +3572,9 @@ bool GraphicsLayerCA::appendToUncommittedAnimations(const KeyframeValueList& val
 bool GraphicsLayerCA::createFilterAnimationsFromKeyframes(const KeyframeValueList& valueList, const Animation* animation, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction)
 {
 #if ENABLE(FILTERS_LEVEL_2)
-    ASSERT(valueList.property() == AnimatedPropertyFilter || valueList.property() == AnimatedPropertyWebkitBackdropFilter);
+    ASSERT(valueList.property() == AnimatedProperty::Filter || valueList.property() == AnimatedProperty::WebkitBackdropFilter);
 #else
-    ASSERT(valueList.property() == AnimatedPropertyFilter);
+    ASSERT(valueList.property() == AnimatedProperty::Filter);
 #endif
 
     int listIndex = validateFilterOperations(valueList);
@@ -3686,7 +3691,7 @@ bool GraphicsLayerCA::setAnimationEndpoints(const KeyframeValueList& valueList, 
     unsigned toIndex = forwards;
     
     switch (valueList.property()) {
-    case AnimatedPropertyOpacity: {
+    case AnimatedProperty::Opacity: {
         basicAnim->setFromValue(static_cast<const FloatAnimationValue&>(valueList.at(fromIndex)).value());
         basicAnim->setToValue(static_cast<const FloatAnimationValue&>(valueList.at(toIndex)).value());
         break;
@@ -3713,7 +3718,7 @@ bool GraphicsLayerCA::setAnimationKeyframes(const KeyframeValueList& valueList, 
         keyTimes.append(forwards ? curValue.keyTime() : (1 - curValue.keyTime()));
 
         switch (valueList.property()) {
-        case AnimatedPropertyOpacity: {
+        case AnimatedProperty::Opacity: {
             const FloatAnimationValue& floatValue = static_cast<const FloatAnimationValue&>(curValue);
             values.append(floatValue.value());
             break;
@@ -3969,13 +3974,13 @@ PlatformCALayer* GraphicsLayerCA::layerForSuperlayer() const
     return m_structuralLayer ? m_structuralLayer.get() : m_layer.get();
 }
 
-PlatformCALayer* GraphicsLayerCA::animatedLayer(AnimatedPropertyID property) const
+PlatformCALayer* GraphicsLayerCA::animatedLayer(AnimatedProperty property) const
 {
     switch (property) {
-    case AnimatedPropertyBackgroundColor:
+    case AnimatedProperty::BackgroundColor:
         return m_contentsLayer.get();
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter:
+    case AnimatedProperty::WebkitBackdropFilter:
         // FIXME: Should be just m_backdropLayer.get(). Also, add an ASSERT(m_backdropLayer) here when https://bugs.webkit.org/show_bug.cgi?id=145322 is fixed.
         return m_backdropLayer ? m_backdropLayer.get() : primaryLayer();
 #endif
@@ -3992,12 +3997,12 @@ GraphicsLayerCA::LayerMap* GraphicsLayerCA::primaryLayerClones() const
     return m_structuralLayer ? &m_layerClones->structuralLayerClones : &m_layerClones->primaryLayerClones;
 }
 
-GraphicsLayerCA::LayerMap* GraphicsLayerCA::animatedLayerClones(AnimatedPropertyID property) const
+GraphicsLayerCA::LayerMap* GraphicsLayerCA::animatedLayerClones(AnimatedProperty property) const
 {
     if (!m_layerClones)
         return nullptr;
 
-    return (property == AnimatedPropertyBackgroundColor) ? &m_layerClones->contentsLayerClones : primaryLayerClones();
+    return (property == AnimatedProperty::BackgroundColor) ? &m_layerClones->contentsLayerClones : primaryLayerClones();
 }
 
 void GraphicsLayerCA::updateRootRelativeScale()
@@ -4223,19 +4228,19 @@ void GraphicsLayerCA::dumpInnerLayer(TextStream& ts, PlatformCALayer* layer, Opt
     ts << indent << ")\n";
 }
 
-static TextStream& operator<<(TextStream& textStream, AnimatedPropertyID propertyID)
+static TextStream& operator<<(TextStream& textStream, AnimatedProperty propertyID)
 {
     switch (propertyID) {
-    case AnimatedPropertyInvalid: textStream << "invalid"; break;
-    case AnimatedPropertyTranslate: textStream << "translate"; break;
-    case AnimatedPropertyScale: textStream << "scale"; break;
-    case AnimatedPropertyRotate: textStream << "rotate"; break;
-    case AnimatedPropertyTransform: textStream << "transform"; break;
-    case AnimatedPropertyOpacity: textStream << "opacity"; break;
-    case AnimatedPropertyBackgroundColor: textStream << "background-color"; break;
-    case AnimatedPropertyFilter: textStream << "filter"; break;
+    case AnimatedProperty::Invalid: textStream << "invalid"; break;
+    case AnimatedProperty::Translate: textStream << "translate"; break;
+    case AnimatedProperty::Scale: textStream << "scale"; break;
+    case AnimatedProperty::Rotate: textStream << "rotate"; break;
+    case AnimatedProperty::Transform: textStream << "transform"; break;
+    case AnimatedProperty::Opacity: textStream << "opacity"; break;
+    case AnimatedProperty::BackgroundColor: textStream << "background-color"; break;
+    case AnimatedProperty::Filter: textStream << "filter"; break;
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter: textStream << "backdrop-filter"; break;
+    case AnimatedProperty::WebkitBackdropFilter: textStream << "backdrop-filter"; break;
 #endif
     }
     return textStream;
@@ -4867,25 +4872,25 @@ double GraphicsLayerCA::backingStoreMemoryEstimate() const
     return m_layer->backingStoreBytesPerPixel() * size().width() * m_layer->contentsScale() * size().height() * m_layer->contentsScale();
 }
 
-static String animatedPropertyIDAsString(AnimatedPropertyID property)
+static String animatedPropertyIDAsString(AnimatedProperty property)
 {
     switch (property) {
-    case AnimatedPropertyTranslate:
-    case AnimatedPropertyScale:
-    case AnimatedPropertyRotate:
-    case AnimatedPropertyTransform:
+    case AnimatedProperty::Translate:
+    case AnimatedProperty::Scale:
+    case AnimatedProperty::Rotate:
+    case AnimatedProperty::Transform:
         return "transform"_s;
-    case AnimatedPropertyOpacity:
+    case AnimatedProperty::Opacity:
         return "opacity"_s;
-    case AnimatedPropertyBackgroundColor:
+    case AnimatedProperty::BackgroundColor:
         return "background-color"_s;
-    case AnimatedPropertyFilter:
+    case AnimatedProperty::Filter:
         return "filter"_s;
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter:
+    case AnimatedProperty::WebkitBackdropFilter:
         return "backdrop-filter"_s;
 #endif
-    case AnimatedPropertyInvalid:
+    case AnimatedProperty::Invalid:
         return "invalid"_s;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -263,14 +263,14 @@ private:
     PlatformCALayer* primaryLayer() const { return m_structuralLayer.get() ? m_structuralLayer.get() : m_layer.get(); }
     PlatformCALayer* hostLayerForSublayers() const;
     PlatformCALayer* layerForSuperlayer() const;
-    PlatformCALayer* animatedLayer(AnimatedPropertyID) const;
+    PlatformCALayer* animatedLayer(AnimatedProperty) const;
 
     typedef String CloneID; // Identifier for a given clone, based on original/replica branching down the tree.
     static bool isReplicatedRootClone(const CloneID& cloneID) { return cloneID[0U] & 1; }
 
     typedef HashMap<CloneID, RefPtr<PlatformCALayer>> LayerMap;
     LayerMap* primaryLayerClones() const;
-    LayerMap* animatedLayerClones(AnimatedPropertyID) const;
+    LayerMap* animatedLayerClones(AnimatedProperty) const;
     static void clearClones(LayerMap&);
 
     bool createAnimationFromKeyframes(const KeyframeValueList&, const Animation*, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
@@ -490,7 +490,7 @@ private:
     // a single transition or keyframe animation, so index is used to distinguish these.
     enum class PlayState { Playing, PlayPending, Paused, PausePending };
     struct LayerPropertyAnimation {
-        LayerPropertyAnimation(Ref<PlatformCAAnimation>&& caAnimation, const String& animationName, AnimatedPropertyID property, int index, Seconds timeOffset)
+        LayerPropertyAnimation(Ref<PlatformCAAnimation>&& caAnimation, const String& animationName, AnimatedProperty property, int index, Seconds timeOffset)
             : m_animation(WTFMove(caAnimation))
             , m_name(animationName)
             , m_property(property)
@@ -508,7 +508,7 @@ private:
 
         RefPtr<PlatformCAAnimation> m_animation;
         String m_name;
-        AnimatedPropertyID m_property;
+        AnimatedProperty m_property;
         int m_index;
         Seconds m_timeOffset { 0_s };
         std::optional<Seconds> m_beginTime;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
@@ -141,7 +141,7 @@ static const TimingFunction& timingFunctionForAnimationValue(const AnimationValu
 
 static KeyframeValueList createThreadsafeKeyFrames(const KeyframeValueList& originalKeyframes, const FloatSize& boxSize)
 {
-    if (originalKeyframes.property() != AnimatedPropertyTransform)
+    if (originalKeyframes.property() != AnimatedProperty::Transform)
         return originalKeyframes;
 
     // Currently translation operations are the only transform operations that store a non-fixed
@@ -306,15 +306,15 @@ Seconds Animation::computeTotalRunningTime(MonotonicTime time)
 void Animation::applyInternal(ApplicationResult& applicationResults, const AnimationValue& from, const AnimationValue& to, float progress)
 {
     switch (m_keyframes.property()) {
-    case AnimatedPropertyTransform:
+    case AnimatedProperty::Transform:
         applicationResults.transform = applyTransformAnimation(static_cast<const TransformAnimationValue&>(from).value(), static_cast<const TransformAnimationValue&>(to).value(), progress, m_boxSize);
         return;
-    case AnimatedPropertyOpacity:
+    case AnimatedProperty::Opacity:
         applicationResults.opacity = applyOpacityAnimation((static_cast<const FloatAnimationValue&>(from).value()), (static_cast<const FloatAnimationValue&>(to).value()), progress);
         return;
-    case AnimatedPropertyFilter:
+    case AnimatedProperty::Filter:
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter:
+    case AnimatedProperty::WebkitBackdropFilter:
 #endif
         applicationResults.filters = applyFilterAnimation(static_cast<const FilterAnimationValue&>(from).value(), static_cast<const FilterAnimationValue&>(to).value(), progress, m_boxSize);
         return;
@@ -338,7 +338,7 @@ void Animations::remove(const String& name)
     });
 }
 
-void Animations::remove(const String& name, AnimatedPropertyID property)
+void Animations::remove(const String& name, AnimatedProperty property)
 {
     m_animations.removeAllMatching([&name, property] (const Animation& animation) {
         return animation.name() == name && animation.keyframes().property() == property;
@@ -379,7 +379,7 @@ void Animations::applyKeepingInternalState(Animation::ApplicationResult& applica
         animation.applyKeepingInternalState(applicationResults, time);
 }
 
-bool Animations::hasActiveAnimationsOfType(AnimatedPropertyID type) const
+bool Animations::hasActiveAnimationsOfType(AnimatedProperty type) const
 {
     return std::any_of(m_animations.begin(), m_animations.end(),
         [&type](const Animation& animation) {

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h
@@ -40,7 +40,7 @@ public:
     };
 
     Animation()
-        : m_keyframes(WebCore::AnimatedPropertyInvalid)
+        : m_keyframes(WebCore::AnimatedProperty::Invalid)
     { }
     Animation(const String&, const WebCore::KeyframeValueList&, const WebCore::FloatSize&, const WebCore::Animation&, MonotonicTime, Seconds, AnimationState);
 
@@ -84,7 +84,7 @@ public:
 
     void add(const Animation&);
     void remove(const String& name);
-    void remove(const String& name, WebCore::AnimatedPropertyID);
+    void remove(const String& name, WebCore::AnimatedProperty);
     void pause(const String&, Seconds);
     void suspend(MonotonicTime);
     void resume();
@@ -98,7 +98,7 @@ public:
     Vector<Animation>& animations() { return m_animations; }
 
     bool hasRunningAnimations() const;
-    bool hasActiveAnimationsOfType(WebCore::AnimatedPropertyID type) const;
+    bool hasActiveAnimationsOfType(WebCore::AnimatedProperty type) const;
 
 private:
     Vector<Animation> m_animations;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
@@ -609,10 +609,10 @@ bool GraphicsLayerTextureMapper::addAnimation(const KeyframeValueList& valueList
 {
     ASSERT(!keyframesName.isEmpty());
 
-    if (!anim || anim->isEmptyOrZeroDuration() || valueList.size() < 2 || (valueList.property() != AnimatedPropertyTransform && valueList.property() != AnimatedPropertyOpacity))
+    if (!anim || anim->isEmptyOrZeroDuration() || valueList.size() < 2 || (valueList.property() != AnimatedProperty::Transform && valueList.property() != AnimatedProperty::Opacity))
         return false;
 
-    if (valueList.property() == AnimatedPropertyFilter) {
+    if (valueList.property() == AnimatedProperty::Filter) {
         int listIndex = validateFilterOperations(valueList);
         if (listIndex < 0)
             return false;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1388,7 +1388,7 @@ void CoordinatedGraphicsLayer::computeTransformedVisibleRect()
 bool CoordinatedGraphicsLayer::shouldHaveBackingStore() const
 {
     // If the CSS opacity value is 0 and there's no animation over the opacity property, the layer is invisible.
-    bool isInvisibleBecauseOpacityZero = !opacity() && !m_animations.hasActiveAnimationsOfType(AnimatedPropertyOpacity);
+    bool isInvisibleBecauseOpacityZero = !opacity() && !m_animations.hasActiveAnimationsOfType(AnimatedProperty::Opacity);
 
     // Check if there's a filter that sets the opacity to zero.
     bool hasOpacityZeroFilter = notFound != filters().operations().findIf([&](const auto& operation) {
@@ -1396,14 +1396,14 @@ bool CoordinatedGraphicsLayer::shouldHaveBackingStore() const
     });
 
     // If there's a filter that sets opacity to 0 and the filters are not being animated, the layer is invisible.
-    isInvisibleBecauseOpacityZero |= hasOpacityZeroFilter && !m_animations.hasActiveAnimationsOfType(AnimatedPropertyFilter);
+    isInvisibleBecauseOpacityZero |= hasOpacityZeroFilter && !m_animations.hasActiveAnimationsOfType(AnimatedProperty::Filter);
 
     return drawsContent() && contentsAreVisible() && !m_size.isEmpty() && !isInvisibleBecauseOpacityZero;
 }
 
 bool CoordinatedGraphicsLayer::selfOrAncestorHasActiveTransformAnimation() const
 {
-    if (m_animations.hasActiveAnimationsOfType(AnimatedPropertyTransform))
+    if (m_animations.hasActiveAnimationsOfType(AnimatedProperty::Transform))
         return true;
 
     if (!parent())
@@ -1432,9 +1432,9 @@ bool CoordinatedGraphicsLayer::addAnimation(const KeyframeValueList& valueList, 
 
     switch (valueList.property()) {
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter:
+    case AnimatedProperty::WebkitBackdropFilter:
 #endif
-    case AnimatedPropertyFilter: {
+    case AnimatedProperty::Filter: {
         int listIndex = validateFilterOperations(valueList);
         if (listIndex < 0)
             return false;
@@ -1444,8 +1444,8 @@ bool CoordinatedGraphicsLayer::addAnimation(const KeyframeValueList& valueList, 
             return false;
         break;
     }
-    case AnimatedPropertyOpacity:
-    case AnimatedPropertyTransform:
+    case AnimatedProperty::Opacity:
+    case AnimatedProperty::Transform:
         break;
     default:
         return false;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3860,14 +3860,14 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& anim
     if (!hasOpacity && !hasRotate && !hasScale && !hasTranslate && !hasTransform && !hasFilter && !hasBackdropFilter)
         return false;
 
-    KeyframeValueList rotateVector(AnimatedPropertyRotate);
-    KeyframeValueList scaleVector(AnimatedPropertyScale);
-    KeyframeValueList translateVector(AnimatedPropertyTranslate);
-    KeyframeValueList transformVector(AnimatedPropertyTransform);
-    KeyframeValueList opacityVector(AnimatedPropertyOpacity);
-    KeyframeValueList filterVector(AnimatedPropertyFilter);
+    KeyframeValueList rotateVector(AnimatedProperty::Rotate);
+    KeyframeValueList scaleVector(AnimatedProperty::Scale);
+    KeyframeValueList translateVector(AnimatedProperty::Translate);
+    KeyframeValueList transformVector(AnimatedProperty::Transform);
+    KeyframeValueList opacityVector(AnimatedProperty::Opacity);
+    KeyframeValueList filterVector(AnimatedProperty::Filter);
 #if ENABLE(FILTERS_LEVEL_2)
-    KeyframeValueList backdropFilterVector(AnimatedPropertyWebkitBackdropFilter);
+    KeyframeValueList backdropFilterVector(AnimatedProperty::WebkitBackdropFilter);
 #endif
 
     for (auto& currentKeyframe : keyframes) {
@@ -4014,68 +4014,68 @@ LayoutRect RenderLayerBacking::compositedBoundsIncludingMargin() const
     return boundsIncludingMargin;
 }
 
-CSSPropertyID RenderLayerBacking::graphicsLayerToCSSProperty(AnimatedPropertyID property)
+CSSPropertyID RenderLayerBacking::graphicsLayerToCSSProperty(AnimatedProperty property)
 {
     CSSPropertyID cssProperty = CSSPropertyInvalid;
     switch (property) {
-    case AnimatedPropertyTranslate:
+    case AnimatedProperty::Translate:
         cssProperty = CSSPropertyTranslate;
         break;
-    case AnimatedPropertyScale:
+    case AnimatedProperty::Scale:
         cssProperty = CSSPropertyScale;
         break;
-    case AnimatedPropertyRotate:
+    case AnimatedProperty::Rotate:
         cssProperty = CSSPropertyRotate;
         break;
-    case AnimatedPropertyTransform:
+    case AnimatedProperty::Transform:
         cssProperty = CSSPropertyTransform;
         break;
-    case AnimatedPropertyOpacity:
+    case AnimatedProperty::Opacity:
         cssProperty = CSSPropertyOpacity;
         break;
-    case AnimatedPropertyBackgroundColor:
+    case AnimatedProperty::BackgroundColor:
         cssProperty = CSSPropertyBackgroundColor;
         break;
-    case AnimatedPropertyFilter:
+    case AnimatedProperty::Filter:
         cssProperty = CSSPropertyFilter;
         break;
 #if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedPropertyWebkitBackdropFilter:
+    case AnimatedProperty::WebkitBackdropFilter:
         cssProperty = CSSPropertyWebkitBackdropFilter;
         break;
 #endif
-    case AnimatedPropertyInvalid:
+    case AnimatedProperty::Invalid:
         ASSERT_NOT_REACHED();
     }
     return cssProperty;
 }
 
-AnimatedPropertyID RenderLayerBacking::cssToGraphicsLayerProperty(CSSPropertyID cssProperty)
+AnimatedProperty RenderLayerBacking::cssToGraphicsLayerProperty(CSSPropertyID cssProperty)
 {
     switch (cssProperty) {
     case CSSPropertyTranslate:
-        return AnimatedPropertyTranslate;
+        return AnimatedProperty::Translate;
     case CSSPropertyScale:
-        return AnimatedPropertyScale;
+        return AnimatedProperty::Scale;
     case CSSPropertyRotate:
-        return AnimatedPropertyRotate;
+        return AnimatedProperty::Rotate;
     case CSSPropertyTransform:
-        return AnimatedPropertyTransform;
+        return AnimatedProperty::Transform;
     case CSSPropertyOpacity:
-        return AnimatedPropertyOpacity;
+        return AnimatedProperty::Opacity;
     case CSSPropertyBackgroundColor:
-        return AnimatedPropertyBackgroundColor;
+        return AnimatedProperty::BackgroundColor;
     case CSSPropertyFilter:
-        return AnimatedPropertyFilter;
+        return AnimatedProperty::Filter;
 #if ENABLE(FILTERS_LEVEL_2)
     case CSSPropertyWebkitBackdropFilter:
-        return AnimatedPropertyWebkitBackdropFilter;
+        return AnimatedProperty::WebkitBackdropFilter;
 #endif
     default:
         // It's fine if we see other css properties here; they are just not accelerated.
         break;
     }
-    return AnimatedPropertyInvalid;
+    return AnimatedProperty::Invalid;
 }
 
 CompositingLayerType RenderLayerBacking::compositingLayerType() const
@@ -4144,7 +4144,7 @@ TextStream& operator<<(TextStream& ts, const RenderLayerBacking& backing)
     return ts;
 }
 
-TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedPropertyID property) const
+TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedProperty property) const
 {
     TransformationMatrix matrix;
 
@@ -4153,13 +4153,13 @@ TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedProp
             operation->apply(matrix, snappedIntRect(m_owningLayer.rendererBorderBoxRect()).size());
     };
 
-    if (property == AnimatedPropertyTranslate)
+    if (property == AnimatedProperty::Translate)
         applyTransformOperation(renderer().style().translate());
-    else if (property == AnimatedPropertyScale)
+    else if (property == AnimatedProperty::Scale)
         applyTransformOperation(renderer().style().scale());
-    else if (property == AnimatedPropertyRotate)
+    else if (property == AnimatedProperty::Rotate)
         applyTransformOperation(renderer().style().rotate());
-    else if (property == AnimatedPropertyTransform)
+    else if (property == AnimatedProperty::Transform)
         renderer().style().transform().apply(snappedIntRect(m_owningLayer.rendererBorderBoxRect()).size(), matrix);
     else
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -251,7 +251,7 @@ public:
 
     LayoutSize subpixelOffsetFromRenderer() const { return m_subpixelOffsetFromRenderer; }
 
-    TransformationMatrix transformMatrixForProperty(AnimatedPropertyID) const final;
+    TransformationMatrix transformMatrixForProperty(AnimatedProperty) const final;
 
 #if PLATFORM(IOS_FAMILY)
     bool needsIOSDumpRenderTreeMainFrameRenderViewLayerIsAlwaysOpaqueHack(const GraphicsLayer&) const override;
@@ -394,8 +394,8 @@ private:
     
     void paintDebugOverlays(const GraphicsLayer*, GraphicsContext&);
 
-    static CSSPropertyID graphicsLayerToCSSProperty(AnimatedPropertyID);
-    static AnimatedPropertyID cssToGraphicsLayerProperty(CSSPropertyID);
+    static CSSPropertyID graphicsLayerToCSSProperty(AnimatedProperty);
+    static AnimatedProperty cssToGraphicsLayerProperty(CSSPropertyID);
 
     bool canIssueSetNeedsDisplay() const { return !paintsIntoWindow() && !paintsIntoCompositedAncestor(); }
     LayoutRect computeParentGraphicsLayerRect(const RenderLayer* compositedAncestor) const;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
@@ -179,7 +179,7 @@ void WebInspectorClient::showPaintRect(const FloatRect& rect)
     paintLayer->setSize(rect.size());
     paintLayer->setBackgroundColor(Color::red.colorWithAlphaByte(51));
 
-    KeyframeValueList fadeKeyframes(AnimatedPropertyOpacity);
+    KeyframeValueList fadeKeyframes(AnimatedProperty::Opacity);
     fadeKeyframes.insert(makeUnique<FloatAnimationValue>(0, 1));
 
     fadeKeyframes.insert(makeUnique<FloatAnimationValue>(0.25, 0));


### PR DESCRIPTION
#### 8299608484f71712ae68fc3775bc299e55f1377f
<pre>
Make AnimationPropertyID an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250520">https://bugs.webkit.org/show_bug.cgi?id=250520</a>

Reviewed by Alex Christensen.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::animationNameForTransition):
(WebCore::GraphicsLayer::validateFilterOperations):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::KeyframeValueList::KeyframeValueList):
(WebCore::KeyframeValueList::property const):
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::transformMatrixForProperty const):
(WebCore::animatedPropertyIsTransformOrRelated): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::propertyIdToString):
(WebCore::animatedPropertyIsTransformOrRelated):
(WebCore::GraphicsLayerCA::moveOrCopyAnimations):
(WebCore::GraphicsLayerCA::addAnimation):
(WebCore::GraphicsLayerCA::updateAnimations):
(WebCore::GraphicsLayerCA::createAnimationFromKeyframes):
(WebCore::GraphicsLayerCA::createFilterAnimationsFromKeyframes):
(WebCore::GraphicsLayerCA::setAnimationEndpoints):
(WebCore::GraphicsLayerCA::setAnimationKeyframes):
(WebCore::GraphicsLayerCA::animatedLayer const):
(WebCore::GraphicsLayerCA::animatedLayerClones const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
(WebCore::GraphicsLayerCA::LayerPropertyAnimation::LayerPropertyAnimation):
* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp:
(Nicosia::createThreadsafeKeyFrames):
(Nicosia::Animation::applyInternal):
(Nicosia::Animations::remove):
(Nicosia::Animations::hasActiveAnimationsOfType const):
* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h:
(Nicosia::Animation::Animation):
* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp:
(WebCore::GraphicsLayerTextureMapper::addAnimation):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::shouldHaveBackingStore const):
(WebCore::CoordinatedGraphicsLayer::selfOrAncestorHasActiveTransformAnimation const):
(WebCore::CoordinatedGraphicsLayer::addAnimation):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::startAnimation):
(WebCore::RenderLayerBacking::graphicsLayerToCSSProperty):
(WebCore::RenderLayerBacking::cssToGraphicsLayerProperty):
(WebCore::RenderLayerBacking::transformMatrixForProperty const):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp:
(WebKit::WebInspectorClient::showPaintRect):

Canonical link: <a href="https://commits.webkit.org/258865@main">https://commits.webkit.org/258865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38fa6e3e723811a02d8d59d46fc8ceb2a399f408

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112367 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172565 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3146 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110595 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92020 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24927 "Found 2 new test failures: http/tests/security/clean-origin-css-exposed-resource-timing.html, http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79545 "Found 2 new API test failures: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5655 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26333 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2783 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45836 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7572 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3245 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->