### PR TITLE
Data written via FileSystemSyncAccessHandle disappears after creating new FileSystemFileHandle

### DIFF
--- a/LayoutTests/storage/filesystemaccess/file-handle-getfile-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/file-handle-getfile-expected.txt
@@ -4,6 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS readText is fileContent
+PASS newReadText is fileContent
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/storage/filesystemaccess/file-handle-getfile-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/file-handle-getfile-worker-expected.txt
@@ -6,6 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 Starting worker: resources/file-handle-getfile.js
 PASS [Worker] writeSize is writeBuffer.byteLength
 PASS [Worker] readText is fileContent
+PASS [Worker] newReadText is fileContent
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/storage/filesystemaccess/resources/file-handle-getfile.js
+++ b/LayoutTests/storage/filesystemaccess/resources/file-handle-getfile.js
@@ -5,7 +5,7 @@ if (this.importScripts) {
 
 description("This test checks getFile() of FileSystemFileHandle.");
 
-var rootHandle, fileHandle, fileObject, writeSize, writeBuffer, fileContent;
+var rootHandle, fileHandle, fileObject, readText, newFileHandle, newFileObject, newReadText, writeSize, writeBuffer, fileContet;
 
 async function read(file) 
 {
@@ -44,6 +44,11 @@ async function test()
         fileObject = await fileHandle.getFile();
         readText = await read(fileObject);
         shouldBe("readText", "fileContent");
+
+        newFileHandle = await rootHandle.getFileHandle("file-handle-getfile.txt", { "create" : false });
+        newFileObject = await newFileHandle.getFile();
+        newReadText = await read(newFileObject);
+        shouldBe("newReadText", "fileContent");
 
         finishTest();
     } catch (error) {

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<FileSystemStorageHandle> FileSystemStorageHandle::create(FileSys
         canAccess = FileSystem::makeAllDirectories(path);
         break;
     case FileSystemStorageHandle::Type::File:
-        if (auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::Write); FileSystem::isHandleValid(handle)) {
+        if (auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite); FileSystem::isHandleValid(handle)) {
             FileSystem::closeFile(handle);
             canAccess = true;
         }


### PR DESCRIPTION
#### 60a6090b410679b744f83e3bdb196189354c148f
<pre>
Data written via FileSystemSyncAccessHandle disappears after creating new FileSystemFileHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=250495">https://bugs.webkit.org/show_bug.cgi?id=250495</a>
rdar://104187327

Reviewed by Chris Dumez.

FileSystem::openFile truncates file when mode is FileOpenMode::Write.

* LayoutTests/storage/filesystemaccess/file-handle-getfile-expected.txt:
* LayoutTests/storage/filesystemaccess/file-handle-getfile-worker-expected.txt:
* LayoutTests/storage/filesystemaccess/resources/file-handle-getfile.js:
(async test):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::create):

Canonical link: <a href="https://commits.webkit.org/258876@main">https://commits.webkit.org/258876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67a0f290774c2f9134329943fe671473ec3bd0aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112381 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172579 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3161 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110604 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37824 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5669 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26341 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2791 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45844 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6102 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7587 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->