### PR TITLE
Encapsulate CAAnimation keyPath in a struct for IPC

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -258,7 +258,7 @@ private:
 #if ENABLE(MODEL_ELEMENT)
     virtual Ref<PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner);
 #endif
-    virtual Ref<PlatformCAAnimation> createPlatformCAAnimation(PlatformCAAnimation::AnimationType, const String& keyPath);
+    virtual Ref<PlatformCAAnimation> createPlatformCAAnimation(PlatformCAAnimation::AnimationType, PlatformCAAnimation::KeyPath&&);
 
     PlatformCALayer* primaryLayer() const { return m_structuralLayer.get() ? m_structuralLayer.get() : m_layer.get(); }
     PlatformCALayer* hostLayerForSublayers() const;
@@ -278,9 +278,9 @@ private:
     bool createFilterAnimationsFromKeyframes(const KeyframeValueList&, const Animation*, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
 
     // Return autoreleased animation (use RetainPtr?)
-    Ref<PlatformCAAnimation> createBasicAnimation(const Animation*, const String& keyPath, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
-    Ref<PlatformCAAnimation> createKeyframeAnimation(const Animation*, const String&, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
-    Ref<PlatformCAAnimation> createSpringAnimation(const Animation*, const String&, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
+    Ref<PlatformCAAnimation> createBasicAnimation(const Animation*, PlatformCAAnimation::KeyPath&&, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
+    Ref<PlatformCAAnimation> createKeyframeAnimation(const Animation*, PlatformCAAnimation::KeyPath&&, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
+    Ref<PlatformCAAnimation> createSpringAnimation(const Animation*, PlatformCAAnimation::KeyPath&&, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
     void setupAnimation(PlatformCAAnimation*, const Animation*, bool additive, bool keyframesShouldUseAnimationWideTimingFunction);
     
     const TimingFunction& timingFunctionForAnimationValue(const AnimationValue&, const Animation&, bool keyframesShouldUseAnimationWideTimingFunction);

--- a/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
@@ -42,6 +42,7 @@ public:
     WEBCORE_EXPORT static void setBlendingFiltersOnLayer(PlatformLayer*, const BlendMode);
     static bool isAnimatedFilterProperty(FilterOperation::Type);
     static const char* animatedFilterPropertyName(FilterOperation::Type);
+    static FilterOperation::Type filterOperationTypeFromAnimatedFilterPropertyName(const String&);
 
     WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation*);
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
@@ -48,7 +48,7 @@ void setHasExplicitBeginTime(CAAnimation *, bool);
 
 class PlatformCAAnimationCocoa final : public PlatformCAAnimation {
 public:
-    static Ref<PlatformCAAnimation> create(AnimationType, const String& keyPath);
+    static Ref<PlatformCAAnimation> create(AnimationType, KeyPath&&);
     WEBCORE_EXPORT static Ref<PlatformCAAnimation> create(PlatformAnimationRef);
 
     virtual ~PlatformCAAnimationCocoa();
@@ -59,7 +59,7 @@ public:
 
     PlatformAnimationRef platformAnimation() const;
     
-    String keyPath() const override;
+    const KeyPath& keyPath() const override;
     
     CFTimeInterval beginTime() const override;
     void setBeginTime(CFTimeInterval) override;
@@ -128,10 +128,11 @@ public:
     void copyAnimationsFrom(const PlatformCAAnimation&) final;
 
 private:
-    PlatformCAAnimationCocoa(AnimationType, const String& keyPath);
+    PlatformCAAnimationCocoa(AnimationType, KeyPath&&);
     PlatformCAAnimationCocoa(PlatformAnimationRef);
 
     RetainPtr<CAAnimation> m_animation;
+    KeyPath m_keyPath;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -390,17 +390,35 @@ bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::Type type)
 const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::Type type)
 {
     switch (type) {
-    case FilterOperation::Type::Grayscale: return "inputAmount";
-    case FilterOperation::Type::Sepia:return "inputColorMatrix";
-    case FilterOperation::Type::Saturate: return "inputAmount";
-    case FilterOperation::Type::HueRotate: return "inputAngle";
-    case FilterOperation::Type::Invert: return "inputColorMatrix";
-    case FilterOperation::Type::Opacity: return "inputColorMatrix";
-    case FilterOperation::Type::Brightness: return "inputColorMatrix";
-    case FilterOperation::Type::Contrast: return "inputColorMatrix";
-    case FilterOperation::Type::Blur: return "inputRadius";
-    default: return "";
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Saturate:
+        return "inputAmount";
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Opacity:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
+        return "inputColorMatrix";
+    case FilterOperation::Type::HueRotate:
+        return "inputAngle";
+    case FilterOperation::Type::Blur:
+        return "inputRadius";
+    default:
+        return "";
     }
+}
+
+FilterOperation::Type PlatformCAFilters::filterOperationTypeFromAnimatedFilterPropertyName(const String& animatedFilterPropertyName)
+{
+    if (animatedFilterPropertyName == "inputAmount"_s)
+        return FilterOperation::Type::Grayscale;
+    if (animatedFilterPropertyName == "inputColorMatrix"_s)
+        return FilterOperation::Type::Sepia;
+    if (animatedFilterPropertyName == "inputAngle"_s)
+        return FilterOperation::Type::HueRotate;
+    if (animatedFilterPropertyName == "inputRadius"_s)
+        return FilterOperation::Type::Blur;
+    return FilterOperation::Type::None;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class PlatformCAAnimationWin final : public PlatformCAAnimation {
 public:
-    static Ref<PlatformCAAnimation> create(AnimationType, const String& keyPath);
+    static Ref<PlatformCAAnimation> create(AnimationType, KeyPath&&);
 
     virtual ~PlatformCAAnimationWin();
 
@@ -47,7 +47,7 @@ public:
 
     PlatformAnimationRef platformAnimation() const;
     
-    String keyPath() const override;
+    const KeyPath& keyPath() const override;
     
     CFTimeInterval beginTime() const override;
     void setBeginTime(CFTimeInterval) override;
@@ -116,9 +116,10 @@ public:
     void copyAnimationsFrom(const PlatformCAAnimation&) final;
 
 private:
-    PlatformCAAnimationWin(AnimationType, const String& keyPath);
+    PlatformCAAnimationWin(AnimationType, KeyPath&&);
 
     RetainPtr<CACFAnimationRef> m_animation;
+    KeyPath m_keyPath;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2614,3 +2614,18 @@ enum class WebCore::AutocapitalizeType : uint8_t {
     Sentences,
     AllCharacters
 };
+
+header: <WebCore/GraphicsLayerClient.h>
+[CustomHeader] enum class WebCore::AnimatedProperty : uint8_t {
+    Invalid,
+    Translate,
+    Scale,
+    Rotate,
+    Transform,
+    Opacity,
+    BackgroundColor,
+    Filter,
+#if ENABLE(FILTERS_LEVEL_2)
+    WebkitBackdropFilter
+#endif
+};

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.cpp
@@ -78,9 +78,9 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(Ref<WebCore::M
 }
 #endif
 
-Ref<PlatformCAAnimation> GraphicsLayerCARemote::createPlatformCAAnimation(PlatformCAAnimation::AnimationType type, const String& keyPath)
+Ref<PlatformCAAnimation> GraphicsLayerCARemote::createPlatformCAAnimation(PlatformCAAnimation::AnimationType type, PlatformCAAnimation::KeyPath&& keyPath)
 {
-    return PlatformCAAnimationRemote::create(type, keyPath);
+    return PlatformCAAnimationRemote::create(type, WTFMove(keyPath));
 }
 
 void GraphicsLayerCARemote::moveToContext(RemoteLayerTreeContext& context)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -50,7 +50,7 @@ private:
 #if ENABLE(MODEL_ELEMENT)
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, WebCore::PlatformCALayerClient* owner) override;
 #endif
-    Ref<WebCore::PlatformCAAnimation> createPlatformCAAnimation(WebCore::PlatformCAAnimation::AnimationType, const String& keyPath) override;
+    Ref<WebCore::PlatformCAAnimation> createPlatformCAAnimation(WebCore::PlatformCAAnimation::AnimationType, WebCore::PlatformCAAnimation::KeyPath&&) override;
 
     // PlatformCALayerRemote can't currently proxy directly composited image contents, so opt out of this optimization.
     bool shouldDirectlyCompositeImage(WebCore::Image*) const override { return false; }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -47,7 +47,7 @@ class RemoteLayerTreeHost;
 
 class PlatformCAAnimationRemote final : public WebCore::PlatformCAAnimation {
 public:
-    static Ref<PlatformCAAnimation> create(AnimationType, const String& keyPath);
+    static Ref<PlatformCAAnimation> create(AnimationType, KeyPath&&);
 
     virtual ~PlatformCAAnimationRemote() { }
 
@@ -55,7 +55,7 @@ public:
 
     Ref<PlatformCAAnimation> copy() const override;
 
-    String keyPath() const override;
+    const KeyPath& keyPath() const override;
 
     CFTimeInterval beginTime() const override;
     void setBeginTime(CFTimeInterval) override;
@@ -129,7 +129,6 @@ public:
 
     void didStart(CFTimeInterval beginTime) { m_properties.beginTime = beginTime; }
 
-
     using KeyframeValue = std::variant<float, WebCore::Color, WebCore::FloatPoint3D, WebCore::TransformationMatrix, RefPtr<WebCore::FilterOperation>>;
 
     struct Properties {
@@ -153,7 +152,7 @@ public:
         void encode(IPC::Encoder&) const;
         static std::optional<Properties> decode(IPC::Decoder&);
 
-        String keyPath;
+        PlatformCAAnimation::KeyPath keyPath;
         PlatformCAAnimation::AnimationType animationType;
 
         CFTimeInterval beginTime;
@@ -187,7 +186,7 @@ public:
     static void updateLayerAnimations(CALayer *, RemoteLayerTreeHost*, const AnimationsList& animationsToAdd, const HashSet<String>& animationsToRemove);
 
 private:
-    PlatformCAAnimationRemote(AnimationType, const String& keyPath);
+    PlatformCAAnimationRemote(AnimationType, KeyPath&&);
 
     Properties m_properties;
 };

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -329,8 +329,10 @@
 		51A587851D2739E3004BA9AF /* IndexedDBDatabaseProcessKill-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51A587821D272EB5004BA9AF /* IndexedDBDatabaseProcessKill-1.html */; };
 		51B1EE961C80FAEF0064FB98 /* IndexedDBPersistence-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE941C80FADD0064FB98 /* IndexedDBPersistence-1.html */; };
 		51B1EE971C80FAEF0064FB98 /* IndexedDBPersistence-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE951C80FADD0064FB98 /* IndexedDBPersistence-2.html */; };
+		51BB6B86296E931F0059B107 /* test-mse.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BB6B7E296E8FFD0059B107 /* test-mse.webm */; };
 		51BCEE4E1C84F53B0042C82E /* IndexedDBMultiProcess-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4C1C84F52C0042C82E /* IndexedDBMultiProcess-1.html */; };
 		51BCEE4F1C84F53B0042C82E /* IndexedDBMultiProcess-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4D1C84F52C0042C82E /* IndexedDBMultiProcess-2.html */; };
+		51C234CF2970E13500E35C4B /* test-mse-audio.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C234C72970E11400E35C4B /* test-mse-audio.webm */; };
 		51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */; };
 		51CD1C721B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51CD1C711B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html */; };
 		51DB16CE1F085137001FA4C5 /* WebViewIconLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */; };
@@ -521,6 +523,7 @@
 		6BF4A683239ED4CD00E2F45B /* LoggedInStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6BF4A682239ED4CD00E2F45B /* LoggedInStatus.cpp */; };
 		6BFD294C1D5E6C1D008EC968 /* HashCountedSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A38D7E51C752D5F004F157D /* HashCountedSet.cpp */; };
 		712E4BC125DDC52A0007201C /* AnimationFrameRate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */; };
+		713E32F929742224007CDE30 /* PlatformCAAnimationKeyPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 713E32F129742224007CDE30 /* PlatformCAAnimationKeyPath.cpp */; };
 		71E88C4124B5299C00665160 /* ShareSheetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 71E88C4024B5299C00665160 /* ShareSheetTests.mm */; };
 		71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
 		725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
@@ -995,8 +998,6 @@
 		CD57779D211CE91F001B371E /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
 		CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53219E910AA00CF1835 /* file-with-mse.html */; };
 		CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
-		51C234CF2970E13500E35C4B /* test-mse-audio.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C234C72970E11400E35C4B /* test-mse-audio.webm */; };
-		51BB6B86296E931F0059B107 /* test-mse.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BB6B7E296E8FFD0059B107 /* test-mse.webm */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
 		CD758A6F20572EA00071834A /* video-with-paused-audio-and-playing-muted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */; };
 		CD78E11E1DB7EE2A0014A2DE /* FullscreenDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */; };
@@ -2411,10 +2412,12 @@
 		51B1EE951C80FADD0064FB98 /* IndexedDBPersistence-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBPersistence-2.html"; sourceTree = "<group>"; };
 		51B40D9D23AC960E00E05241 /* AsyncFunction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AsyncFunction.mm; sourceTree = "<group>"; };
 		51B454EB1B4E236B0085EAA6 /* WebViewCloseInsideDidFinishLoadForFrame.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebViewCloseInsideDidFinishLoadForFrame.mm; sourceTree = "<group>"; };
+		51BB6B7E296E8FFD0059B107 /* test-mse.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.webm"; sourceTree = "<group>"; };
 		51BCEE491C84F4AF0042C82E /* IndexedDBMultiProcess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IndexedDBMultiProcess.mm; sourceTree = "<group>"; };
 		51BCEE4C1C84F52C0042C82E /* IndexedDBMultiProcess-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBMultiProcess-1.html"; sourceTree = "<group>"; };
 		51BCEE4D1C84F52C0042C82E /* IndexedDBMultiProcess-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBMultiProcess-2.html"; sourceTree = "<group>"; };
 		51BE9E652376089500B4E117 /* MediaType.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaType.mm; sourceTree = "<group>"; };
+		51C234C72970E11400E35C4B /* test-mse-audio.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse-audio.webm"; sourceTree = "<group>"; };
 		51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "WKURLSchemeHandler-1.mm"; sourceTree = "<group>"; };
 		51C8E1A41F26AC5400BF731B /* ResourceLoadStatistics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ResourceLoadStatistics.mm; sourceTree = "<group>"; };
 		51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = EmptyGrandfatheredResourceLoadStatistics.plist; sourceTree = "<group>"; };
@@ -2682,6 +2685,7 @@
 		6B9ABE112086952F00D75DE6 /* HTTPParsers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPParsers.cpp; sourceTree = "<group>"; };
 		6BF4A682239ED4CD00E2F45B /* LoggedInStatus.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LoggedInStatus.cpp; sourceTree = "<group>"; };
 		712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AnimationFrameRate.cpp; sourceTree = "<group>"; };
+		713E32F129742224007CDE30 /* PlatformCAAnimationKeyPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformCAAnimationKeyPath.cpp; sourceTree = "<group>"; };
 		71E88C4024B5299C00665160 /* ShareSheetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ShareSheetTests.mm; sourceTree = "<group>"; };
 		71E88C4324B533EC00665160 /* img-with-base64-url.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "img-with-base64-url.html"; sourceTree = "<group>"; };
 		725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = AdditionalSupportedImageTypes.html; sourceTree = "<group>"; };
@@ -3186,8 +3190,6 @@
 		CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "video-with-audio-and-web-audio.html"; sourceTree = "<group>"; };
 		CD59F53219E910AA00CF1835 /* file-with-mse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-mse.html"; sourceTree = "<group>"; };
 		CD59F53319E910BC00CF1835 /* test-mse.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.mp4"; sourceTree = "<group>"; };
-		51BB6B7E296E8FFD0059B107 /* test-mse.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.webm"; sourceTree = "<group>"; };
-		51C234C72970E11400E35C4B /* test-mse-audio.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse-audio.webm"; sourceTree = "<group>"; };
 		CD5FF4962162E27E004BD86F /* ISOBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBox.cpp; sourceTree = "<group>"; };
 		CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "video-with-paused-audio-and-playing-muted.html"; sourceTree = "<group>"; };
 		CD78E11A1DB7EA360014A2DE /* FullscreenDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenDelegate.mm; sourceTree = "<group>"; };
@@ -5541,6 +5543,7 @@
 				510A667A27D2FC7A00D22629 /* CoreMediaUtilities.mm */,
 				751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */,
 				41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */,
+				713E32F129742224007CDE30 /* PlatformCAAnimationKeyPath.cpp */,
 				57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */,
 				5769C50A1D9B0001000847FB /* SerializedCryptoKeyWrap.mm */,
 				A17991861E1C994E00A505ED /* SharedBuffer.mm */,
@@ -6390,6 +6393,7 @@
 				7CCE7F0A1A411AE600447C4C /* PasteboardNotifications.mm in Sources */,
 				7C83E0531D0A643A00FEBCF3 /* PendingAPIRequestURL.cpp in Sources */,
 				E325C90723E3870200BC7D3B /* PictureInPictureSupport.mm in Sources */,
+				713E32F929742224007CDE30 /* PlatformCAAnimationKeyPath.cpp in Sources */,
 				7CCE7EA61A411A0F00447C4C /* PlatformUtilitiesMac.mm in Sources */,
 				7CCE7EA71A411A1300447C4C /* PlatformWebViewMac.mm in Sources */,
 				F4010B8324DA267F00A876E2 /* PoseAsClass.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformCAAnimationKeyPath.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformCAAnimationKeyPath.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/PlatformCAAnimation.h>
+
+namespace TestWebKitAPI {
+
+TEST(PlatformCAAnimation, KeyPathSinglePropertyConstructor)
+{
+    WebCore::PlatformCAAnimation::KeyPath keyPath { WebCore::AnimatedProperty::Transform };
+    EXPECT_EQ(keyPath.animatedProperty, WebCore::AnimatedProperty::Transform);
+    EXPECT_EQ(keyPath.filterOperationType, WebCore::FilterOperation::Type::None);
+    EXPECT_EQ(keyPath.index, 0);
+}
+
+TEST(PlatformCAAnimation, KeyPathFullConstructor)
+{
+    WebCore::PlatformCAAnimation::KeyPath keyPath { WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Invert, 2 };
+    EXPECT_EQ(keyPath.animatedProperty, WebCore::AnimatedProperty::Filter);
+    EXPECT_EQ(keyPath.filterOperationType, WebCore::FilterOperation::Type::Invert);
+    EXPECT_EQ(keyPath.index, 2);
+}
+
+TEST(PlatformCAAnimation, KeyPathStringRepresentation)
+{
+    WebCore::PlatformCAAnimation::KeyPath translate { WebCore::AnimatedProperty::Translate };
+    EXPECT_STREQ(translate.string().ascii().data(), "transform");
+
+    WebCore::PlatformCAAnimation::KeyPath scale { WebCore::AnimatedProperty::Scale };
+    EXPECT_STREQ(scale.string().ascii().data(), "transform");
+
+    WebCore::PlatformCAAnimation::KeyPath rotate { WebCore::AnimatedProperty::Rotate };
+    EXPECT_STREQ(rotate.string().ascii().data(), "transform");
+
+    WebCore::PlatformCAAnimation::KeyPath transform { WebCore::AnimatedProperty::Transform };
+    EXPECT_STREQ(transform.string().ascii().data(), "transform");
+
+    WebCore::PlatformCAAnimation::KeyPath opacity { WebCore::AnimatedProperty::Opacity };
+    EXPECT_STREQ(opacity.string().ascii().data(), "opacity");
+
+    WebCore::PlatformCAAnimation::KeyPath backgroundColor { WebCore::AnimatedProperty::BackgroundColor };
+    EXPECT_STREQ(backgroundColor.string().ascii().data(), "backgroundColor");
+
+    WebCore::PlatformCAAnimation::KeyPath filter { WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Grayscale, 2 };
+    EXPECT_STREQ(filter.string().ascii().data(), "filters.filter_2.inputAmount");
+
+#if ENABLE(FILTERS_LEVEL_2)
+    WebCore::PlatformCAAnimation::KeyPath backdropFilter { WebCore::AnimatedProperty::WebkitBackdropFilter };
+    EXPECT_STREQ(backdropFilter.string().ascii().data(), "backdropFilters");
+#endif
+}
+
+static void testKeyPathStringRountrip(const WebCore::PlatformCAAnimation::KeyPath& src)
+{
+    WebCore::PlatformCAAnimation::KeyPath keyPath { src.string() };
+    EXPECT_EQ(src.animatedProperty, keyPath.animatedProperty);
+    EXPECT_EQ(src.filterOperationType, keyPath.filterOperationType);
+    EXPECT_EQ(src.index, keyPath.index);
+}
+
+TEST(PlatformCAAnimation, KeyPathStringConstructor)
+{
+    testKeyPathStringRountrip({ WebCore::AnimatedProperty::Transform });
+    testKeyPathStringRountrip({ WebCore::AnimatedProperty::Opacity });
+    testKeyPathStringRountrip({ WebCore::AnimatedProperty::BackgroundColor });
+    testKeyPathStringRountrip({ WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Grayscale, 2 });
+    testKeyPathStringRountrip({ WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Sepia, 22 });
+#if ENABLE(FILTERS_LEVEL_2)
+    testKeyPathStringRountrip({ WebCore::AnimatedProperty::WebkitBackdropFilter });
+#endif
+}
+
+}


### PR DESCRIPTION
#### 3b2b3f84ecda5ffdb18a931905a3dc5e31d62821
<pre>
Encapsulate CAAnimation keyPath in a struct for IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=250510">https://bugs.webkit.org/show_bug.cgi?id=250510</a>
rdar://102433824

Reviewed by NOBODY (OOPS!).

We use CAAnimation subclasses to perform certain type of animations that can be accelerated on Cocoa
ports. On iOS, we run those animations in the UIProcess where the target CALayer objects are hosted.
The `keyPath` for each of those animations is encoded and transmitted to the UIProcess as a string.
However, the way these key paths are handled by Core Animation, unexpected strings with certain symbols,
such as `dealloc`, could wreak havoc and compromise the UIProcess.

We now encapsulate animation key paths in a new PlatformCALayer::KeyPath struct which we encode to send
to the UIProcess, ensuring that only valid key paths can be created and sent over IPC.

In this patch we replace all call chains leading to the creation of a PlatformCAAnimation to use one of
those new KeyPath structs instead of a String.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createPlatformCAAnimation):
(WebCore::GraphicsLayerCA::updateAnimations):
(WebCore::GraphicsLayerCA::createAnimationFromKeyframes):
(WebCore::GraphicsLayerCA::appendToUncommittedAnimations):
(WebCore::GraphicsLayerCA::createBasicAnimation):
(WebCore::GraphicsLayerCA::createKeyframeAnimation):
(WebCore::GraphicsLayerCA::createSpringAnimation):
(WebCore::propertyIdToString): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp:
(WebCore::PlatformCAAnimation::KeyPath::KeyPath):
(WebCore::PlatformCAAnimation::KeyPath::string const):
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h:
(WebCore::PlatformCAAnimation::KeyPath::KeyPath):
(WebCore::PlatformCAAnimation::KeyPath::encode const):
(WebCore::PlatformCAAnimation::KeyPath::decode):
* Source/WebCore/platform/graphics/ca/PlatformCAFilters.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::PlatformCAAnimationCocoa::create):
(WebCore::PlatformCAAnimationCocoa::PlatformCAAnimationCocoa):
(WebCore::PlatformCAAnimationCocoa::copy const):
(WebCore::PlatformCAAnimationCocoa::keyPath const):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::animatedFilterPropertyName):
(WebCore::PlatformCAFilters::filterOperationTypeFromAnimatedFilterPropertyName):
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp:
(PlatformCAAnimationWin::create):
(PlatformCAAnimationWin::PlatformCAAnimationWin):
(PlatformCAAnimationWin::copy const):
(PlatformCAAnimationWin::keyPath const):
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.cpp:
(WebKit::GraphicsLayerCARemote::createPlatformCAAnimation):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::Properties::encode const):
(WebKit::PlatformCAAnimationRemote::create):
(WebKit::PlatformCAAnimationRemote::copy const):
(WebKit::PlatformCAAnimationRemote::PlatformCAAnimationRemote):
(WebKit::PlatformCAAnimationRemote::keyPath const):
(WebKit::createAnimation):
(WebKit::operator&lt;&lt;):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/PlatformCAAnimationKeyPath.cpp: Added.
(TestWebKitAPI::TEST):
(TestWebKitAPI::testKeyPathStringRountrip):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b2b3f84ecda5ffdb18a931905a3dc5e31d62821

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112648 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172855 "Hash 3b2b3f84 for PR 8587 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3436 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111806 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93516 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38057 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79788 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5922 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26494 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3022 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46003 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7854 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->