### PR TITLE
WASM Tail Calls do not support SIMD

### DIFF
--- a/JSTests/wasm/stress/4g-memory-cage.js
+++ b/JSTests/wasm/stress/4g-memory-cage.js
@@ -15,4 +15,4 @@ async function test() {
     assert.eq(test(42), 42);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/f32-tuple-jsapi-exported.js
+++ b/JSTests/wasm/stress/f32-tuple-jsapi-exported.js
@@ -18,4 +18,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/f32-tuple-jsapi.js
+++ b/JSTests/wasm/stress/f32-tuple-jsapi.js
@@ -21,4 +21,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/i64-call.js
+++ b/JSTests/wasm/stress/i64-call.js
@@ -21,4 +21,4 @@ async function test() {
         throw new Error();
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js
+++ b/JSTests/wasm/stress/js-wasm-call-many-return-types-on-stack-no-args.js
@@ -60,4 +60,4 @@ async function test() {
     ]);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/js-wasm-js-varying-arities.js
+++ b/JSTests/wasm/stress/js-wasm-js-varying-arities.js
@@ -63,4 +63,4 @@ async function test () {
     }
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/local-ref.js
+++ b/JSTests/wasm/stress/local-ref.js
@@ -12,4 +12,4 @@ async function test() {
     `);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/loop-more-args-than-results.js
+++ b/JSTests/wasm/stress/loop-more-args-than-results.js
@@ -20,4 +20,4 @@ async function test() {
         throw new Error();
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
+++ b/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
@@ -19,4 +19,4 @@ async function test() {
     }, WebAssembly.RuntimeError, `Out of bounds memory access`);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/multi-value-i64.js
+++ b/JSTests/wasm/stress/multi-value-i64.js
@@ -83,4 +83,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/null-memory-cage-explicit.js
+++ b/JSTests/wasm/stress/null-memory-cage-explicit.js
@@ -15,4 +15,4 @@ async function test() {
     assert.eq(test(42), -1);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/null-memory-cage.js
+++ b/JSTests/wasm/stress/null-memory-cage.js
@@ -14,4 +14,4 @@ async function test() {
     assert.eq(test(42), 42);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/osr-entry-with-loop-arguments.js
+++ b/JSTests/wasm/stress/osr-entry-with-loop-arguments.js
@@ -26,4 +26,4 @@ async function test() {
         throw new Error("Expected 100000, but got: " + result);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/set-local-enclosed-stack.js
+++ b/JSTests/wasm/stress/set-local-enclosed-stack.js
@@ -43,4 +43,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/simd-call.js
+++ b/JSTests/wasm/stress/simd-call.js
@@ -1,0 +1,41 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param $sz i32) (result i64)
+        (f32.const 1337)
+        (f32.const 1)
+        (f32.const 2)
+        (f32.const 3)
+        (f32.const 4)
+        (f32.const 5)
+        (f32.const 6)
+        (f32.const 7)
+        (f32.const 8)
+        (f32.const 9)
+        (v128.const f32x4 0 0 0 10)
+        (return (call $f))
+        (drop)
+    )
+
+    (func $f (param f32) (param f32) (param f32) (param f32) (param f32) (param f32) (param f32) (param f32) (param $i0 f32) (param $i1 f32) (param $i2 v128) (result i64)
+        (i64.add
+            (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i2)))
+            (i64.trunc_f32_s (local.get $i0)))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test, test2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 8n + 10n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-const-spill.js
+++ b/JSTests/wasm/stress/simd-const-spill.js
@@ -125,4 +125,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-const.js
+++ b/JSTests/wasm/stress/simd-const.js
@@ -27,4 +27,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-exception.js
+++ b/JSTests/wasm/stress/simd-exception.js
@@ -59,4 +59,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-load.js
+++ b/JSTests/wasm/stress/simd-load.js
@@ -66,4 +66,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-osr-many-vectors.js
+++ b/JSTests/wasm/stress/simd-osr-many-vectors.js
@@ -59,4 +59,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-osr.js
+++ b/JSTests/wasm/stress/simd-osr.js
@@ -40,4 +40,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-register-allocation.js
+++ b/JSTests/wasm/stress/simd-register-allocation.js
@@ -52,4 +52,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-tail-call-simple.js
+++ b/JSTests/wasm/stress/simd-tail-call-simple.js
@@ -1,0 +1,73 @@
+//@ requireOptions("--useWebAssemblyTailCalls=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $call_same_size (export "call_same_size") (param f64) (param f64) (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (return_call $callee_same_size))
+    (func $callee_same_size (param $i v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i))) (i64.const 42)))
+
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (f32.const 1) (f32x4.splat)
+      (f32.const 2) (f32x4.splat)
+      (f32.const 3) (f32x4.splat)
+      (f32.const 4) (f32x4.splat)
+      (f32.const 5) (f32x4.splat)
+      (f32.const 6) (f32x4.splat)
+      (f32.const 7) (f32x4.splat)
+      (f32.const 8)
+      (f32.const 9) (f32x4.splat)
+      (return_call $callee_same_size_with_stack))
+    (func $callee_same_size_with_stack (param $i0 v128) (param $i1 v128) (param $i2 v128) (param $i3 v128) (param $i4 v128) (param $i5 v128) (param $i6 v128) (param $i7 v128) (param $i8 f32) (param $i9 v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i9))) (i64.trunc_f32_s (local.get $i8))))
+    
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (f32.const 1) (f32x4.splat)
+      (f32.const 2) (f32x4.splat)
+      (f32.const 3) (f32x4.splat)
+      (f32.const 4) (f32x4.splat)
+      (f32.const 5) (f32x4.splat)
+      (f32.const 6) (f32x4.splat)
+      (f32.const 7) (f32x4.splat)
+      (f32.const 8)
+      (f32.const 90) (f32x4.splat)
+      (return_call $callee_bigger_with_stack))
+    (func $callee_bigger_with_stack (param $i0 v128) (param $i1 v128) (param $i2 v128) (param $i3 v128) (param $i4 v128) (param $i5 v128) (param $i6 v128) (param $i7 v128) (param $i8 f32) (param $i9 v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i9))) (i64.trunc_f32_s (local.get $i8))))
+
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64)  (param f64) (param f64) (param f64) (param f64)  (param $i11 f32) (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (f32.const 1) (f32x4.splat)
+      (f32.const 2) (f32x4.splat)
+      (f32.const 3) (f32x4.splat)
+      (f32.const 4) (f32x4.splat)
+      (f32.const 5) (f32x4.splat)
+      (f32.const 6) (f32x4.splat)
+      (f32.const 7) (f32x4.splat)
+      (f32.const 8)
+      (f32.const 90) (f32x4.splat)
+      (return_call $callee_smaller_with_stack))
+    (func $callee_smaller_with_stack (param $i0 v128) (param $i1 v128) (param $i2 v128) (param $i3 v128) (param $i4 v128) (param $i5 v128) (param $i6 v128) (param $i7 v128) (param $i8 f32) (param $i9 v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i9))) (i64.trunc_f32_s (local.get $i8))))
+  )
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 8n)
+        assert.eq(call_bigger_with_stack(), 90n + 8n)
+        assert.eq(call_smaller_with_stack(), 90n + 8n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -26,4 +26,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-tiny-loop.js
+++ b/JSTests/wasm/stress/simd-tiny-loop.js
@@ -26,4 +26,4 @@ async function test() {
     }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-unreachable.js
+++ b/JSTests/wasm/stress/simd-unreachable.js
@@ -13728,4 +13728,4 @@ async function test() {
   }
 }
 
-assert.asyncTest(test())
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/table-grow-table-size.js
+++ b/JSTests/wasm/stress/table-grow-table-size.js
@@ -18,4 +18,4 @@ async function test() {
     assert.eq(size(), 42);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/tail-call-js.js
+++ b/JSTests/wasm/stress/tail-call-js.js
@@ -1,0 +1,75 @@
+//@ requireOptions("--useWebAssemblyTailCalls=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (import "m" "callee_same_size" (func $callee_same_size (param $i f32) (result i64)))
+    (import "m" "callee_same_size_with_stack" (func $callee_same_size_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (import "m" "callee_bigger_with_stack" (func $callee_bigger_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (import "m" "callee_smaller_with_stack" (func $callee_smaller_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+
+    (func $call_same_size (export "call_same_size") (result i64)
+      (f32.const 1337)
+      (return_call $callee_same_size))
+
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 9)
+      (return_call $callee_same_size_with_stack))
+
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_bigger_with_stack))
+
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (param $i10 f32) (param $i11 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_smaller_with_stack))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, { m: {
+      callee_same_size: (i) => { return BigInt(i) + 42n },
+      callee_same_size_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+      callee_bigger_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11) => { return BigInt(i9) + BigInt(i2) },
+      callee_smaller_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+    } }, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 2n)
+        assert.eq(call_bigger_with_stack(), 90n + 2n)
+        assert.eq(call_smaller_with_stack(), 90n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-simple.js
+++ b/JSTests/wasm/stress/tail-call-simple.js
@@ -1,0 +1,73 @@
+//@ requireOptions("--useWebAssemblyTailCalls=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $call_same_size (export "call_same_size") (result i64)
+      (f32.const 1337)
+      (return_call $callee_same_size))
+    (func $callee_same_size (param $i f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i)) (i64.const 42)))
+
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 9)
+      (return_call $callee_same_size_with_stack))
+    (func $callee_same_size_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i9)) (i64.trunc_f32_s (local.get $i2))))
+    
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_bigger_with_stack))
+    (func $callee_bigger_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i9)) (i64.trunc_f32_s (local.get $i2))))
+
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (param $i10 f32) (param $i11 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_smaller_with_stack))
+    (func $callee_smaller_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i9)) (i64.trunc_f32_s (local.get $i2))))
+  )
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 2n)
+        assert.eq(call_bigger_with_stack(), 90n + 2n)
+        assert.eq(call_smaller_with_stack(), 90n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/top-most-enclosing-stack.js
+++ b/JSTests/wasm/stress/top-most-enclosing-stack.js
@@ -29,4 +29,4 @@ async function test() {
         throw new Error();
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/trunc-int-min-minus-one.js
+++ b/JSTests/wasm/stress/trunc-int-min-minus-one.js
@@ -28,4 +28,4 @@ async function test() {
     assert.throws(() => truncU(NaN), WebAssembly.RuntimeError, `Out of bounds Trunc operation (evaluating 'func(...args)')`);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/wasm-js-call-many-return-types-on-stack-no-args.js
+++ b/JSTests/wasm/stress/wasm-js-call-many-return-types-on-stack-no-args.js
@@ -61,4 +61,4 @@ async function test() {
     ]);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/wasm-js-multi-value-exception-in-iterator.js
+++ b/JSTests/wasm/stress/wasm-js-multi-value-exception-in-iterator.js
@@ -125,4 +125,4 @@ async function test() {
     ]);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/wasm-wasm-call-indirect-many-return-types-on-stack.js
+++ b/JSTests/wasm/stress/wasm-wasm-call-indirect-many-return-types-on-stack.js
@@ -81,4 +81,4 @@ async function test() {
     ]);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/wasm-wasm-call-many-return-types-on-stack-no-args.js
+++ b/JSTests/wasm/stress/wasm-wasm-call-many-return-types-on-stack-no-args.js
@@ -60,4 +60,4 @@ async function test() {
     ]);
 }
 
-assert.asyncTest(test());
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -55,7 +55,7 @@ static void stdFunctionCallback(Probe::Context& context)
     
 void MacroAssembler::probeDebug(Function<void(Probe::Context&)> func)
 {
-    probe(tagCFunction<JITProbePtrTag>(stdFunctionCallback), new Function<void(Probe::Context&)>(WTFMove(func)));
+    probe(tagCFunction<JITProbePtrTag>(stdFunctionCallback), new Function<void(Probe::Context&)>(WTFMove(func)), SavedFPWidth::SaveVectors);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -2171,6 +2171,11 @@ public:
 
     // This leaks memory. Must not be used for production.
     JS_EXPORT_PRIVATE void probeDebug(Function<void(Probe::Context&)>);
+    template<bool B> void probeDebugIf(Function<void(Probe::Context&)> func)
+    {
+        if constexpr (B)
+            probeDebug(WTFMove(func));
+    }
 
     // Let's you print from your JIT generated code.
     // See comments in MacroAssemblerPrinter.h for examples of how to use this.

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -835,6 +835,7 @@ asm (
 
 void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth savedFPWidth)
 {
+    JIT_COMMENT(*this, "probe_start");
     sub64(TrustedImm32(sizeof(IncomingProbeRecord)), sp);
 
     storePair64(x24, x25, sp, TrustedImm32(offsetof(IncomingProbeRecord, x24)));
@@ -852,6 +853,7 @@ void MacroAssembler::probe(Probe::Function function, void* arg, SavedFPWidth sav
 
     // ctiMasmProbeTrampoline should have restored every register except for lr and the sp.
     load64(Address(sp, offsetof(LRRestorationRecord, lr)), lr);
+    JIT_COMMENT(*this, "probe_end after this add");
     add64(TrustedImm32(sizeof(LRRestorationRecord)), sp);
 }
 

--- a/Source/JavaScriptCore/b3/air/AirStackAllocation.cpp
+++ b/Source/JavaScriptCore/b3/air/AirStackAllocation.cpp
@@ -44,8 +44,11 @@ template<typename Collection>
 void updateFrameSizeBasedOnStackSlotsImpl(Code& code, const Collection& collection)
 {
     unsigned frameSize = 0;
-    for (StackSlot* slot : collection)
+    for (StackSlot* slot : collection) {
+        if (slot->offsetFromFP() > 0)
+            continue;
         frameSize = std::max(frameSize, static_cast<unsigned>(-slot->offsetFromFP()));
+    }
     code.setFrameSize(WTF::roundUpToMultipleOf(stackAlignmentBytes(), frameSize) + stackAdjustmentForAlignment());
 }
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
@@ -265,7 +265,7 @@ public:
 
     // Calls
     CallPatchpointData WARN_UNUSED_RETURN emitCallPatchpoint(BasicBlock*, B3::Type, const ResultList&, const Vector<TypedTmp>& tmpArgs, const CallInformation&, Vector<ConstrainedTmp> patchArgs = { });
-    CallPatchpointData WARN_UNUSED_RETURN emitTailCallPatchpoint(BasicBlock*, const Checked<int32_t>& tailCallStackOffsetFromFP, const Vector<ArgumentLocation>&, const Vector<TypedTmp>& tmpArgs, Vector<ConstrainedTmp> patchArgs = { });
+    CallPatchpointData WARN_UNUSED_RETURN emitTailCallPatchpoint(BasicBlock* block, CallInformation wasmCallerInfoAsCallee, CallInformation wasmCalleeInfoAsCallee, const Vector<TypedTmp>& tmpArgSourceLocations, Vector<ConstrainedTmp> patchArgs = { });
 
     PartialResult addShift(Type, B3::Air::Opcode, ExpressionType value, ExpressionType shift, ExpressionType& result);
     PartialResult addShift64(B3::Air::Opcode, ExpressionType value, ExpressionType shift, ExpressionType& result);


### PR DESCRIPTION
#### 5e849874b69f08c869f994e29d462edc5d0b82fc
<pre>
WASM Tail Calls do not support SIMD
<a href="https://bugs.webkit.org/show_bug.cgi?id=250272">https://bugs.webkit.org/show_bug.cgi?id=250272</a>

Reviewed by NOBODY (OOPS!).

Clean up the tail calls code so that we never need to use the frame size.
Also remove the stack check elision optimization for now since it is untested.

TODO WIP

Tests
SIMD tests
Test clobbering header

* Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp:
(JSC::Wasm::AirIRGenerator32::emitTailCallPatchpoint):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitTailCallPatchpoint):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::AirIRGeneratorBase):
(JSC::Wasm::ExpressionType&gt;::addCall):
(JSC::Wasm::ExpressionType&gt;::emitIndirectCall):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitIndirectCall):
(JSC::Wasm::B3IRGenerator::createTailCallPatchpoint):
(JSC::Wasm::B3IRGenerator::addCall):
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::prepareForTailCall):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e9e188ee1728a7776383e7b16f50c24c2922f33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/104173 "The change is no longer eligible for processing.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/13265 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37090 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/113383 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/14333 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/4180 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96399 "The change is no longer eligible for processing.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112443 "The change is no longer eligible for processing.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/109943 "The change is no longer eligible for processing.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/14333 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37090 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96399 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/14333 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37090 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96399 "The change is no longer eligible for processing.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94217 "The change is no longer eligible for processing.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6629 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37090 "The change is no longer eligible for processing.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/90759 "The change is no longer eligible for processing.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4402 "The change is no longer eligible for processing.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6764 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/4180 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/90759 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12773 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37090 "The change is no longer eligible for processing.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/99370 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8546 "The change is no longer eligible for processing.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/99370 "The change is no longer eligible for processing.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->