### PR TITLE
[iOS] Update the Network process sandbox from telemetry

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -49,10 +49,18 @@
 
 (allow socket-option-set
     (require-all
+        (socket-option-level IPPROTO_IPV6)
+        (socket-option-name 27 61)))
+
+(allow socket-option-set
+    (require-all
         (socket-option-level SOL_SOCKET)
         (socket-option-name
+            SO_NECP_LISTENUUID
             SO_NOSIGPIPE
-            SO_RCVBUF)))
+            SO_RCVBUF
+            SO_REUSEADDR
+            SO_REUSEPORT)))
 #endif
 
 (allow system-privilege (with grant)


### PR DESCRIPTION
#### de0e2987d384c5a939f6e3a26e1465c0b07074a7
<pre>
[iOS] Update the Network process sandbox from telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=250528">https://bugs.webkit.org/show_bug.cgi?id=250528</a>
rdar://problem/104193989

Reviewed by Chris Dumez.

Update the Network process sandbox on iOS from telemetry.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:

Canonical link: <a href="https://commits.webkit.org/258879@main">https://commits.webkit.org/258879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992e4b6675b9c69168bd9315ce2c30c8e1a357c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112384 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3164 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110606 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79563 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26346 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2792 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45849 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7590 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3248 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->