### PR TITLE
Fix bugzilla CSS to not unintentionally set font properties on all inputs

### DIFF
--- a/Websites/bugs.webkit.org/skins/standard/global.css
+++ b/Websites/bugs.webkit.org/skins/standard/global.css
@@ -12,7 +12,7 @@
         color: #000;
         background: #fff url("global/body-back.gif") repeat-x;
     }
-    body, td, th, input, dt, #titles {
+    body, td, th, input:not([type=button], [type=submit], [type=reset]), dt, #titles {
         font-family: Verdana, sans-serif;
         font-size: small;
     }


### PR DESCRIPTION
#### 2477f9376ca67439105885b4a5d7d6e9f7a4da5d
<pre>
Fix bugzilla CSS to not unintentionally set font properties on all inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=250531">https://bugs.webkit.org/show_bug.cgi?id=250531</a>
rdar://104193389

Reviewed by Alexey Proskuryakov.

<a href="https://commits.webkit.org/258754@main">https://commits.webkit.org/258754@main</a> made font properties apply to input[type=button|reset|submit] like other browsers do.

This CSS rule was making submit buttons bigger than other controls unintentionally, since it was only meant for text inputs.
The inconsistency is also visible in other browsers, notably with the font-family difference between select and button inputs.

* Websites/bugs.webkit.org/skins/standard/global.css:
(body, td, th, input:not([type=button], [type=submit], [type=reset]), dt, #titles):
(body, td, th, input, dt, #titles): Deleted.

Canonical link: <a href="https://commits.webkit.org/258857@main">https://commits.webkit.org/258857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac7a2adb58cb67c164ac98b39d774dbdea157d31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12268 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112390 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3170 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95365 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108916 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5678 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5845 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7596 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3243 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->