### PR TITLE
OffscreenCanvas WebGL doesn't fire the context lost event.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3959,6 +3959,9 @@ webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html [ Pass ]
 webgl/2.0.y/conformance2/transform_feedback/simultaneous_binding.html [ Pass ]
 webgl/1.0.x/conformance/extensions/oes-vertex-array-object.html [ Pass ]
 
+webgl/2.0.y/conformance/offscreencanvas [ Pass ]
+webgl/2.0.y/conformance2/offscreencanvas [ Pass ]
+
 # Explicitly turn on conformance test until all of webgl/2.0.y is enabled
 webgl/2.0.y/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/ext-texture-norm16.html [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1806,6 +1806,18 @@ imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canva
 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html [ Skip ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html [ Skip ]
+webgl/2.0.y/conformance/offscreencanvas/context-creation-worker.html [ Skip ]
+webgl/2.0.y/conformance/offscreencanvas/context-lost-restored-worker.html [ Skip ]
+webgl/2.0.y/conformance/offscreencanvas/context-lost-worker.html [ Skip ]
+webgl/2.0.y/conformance/offscreencanvas/methods-worker.html [ Skip ]
+webgl/2.0.y/conformance/offscreencanvas/offscreencanvas-timer-query.html [ Skip ]
+webgl/2.0.y/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html [ Skip ]
+webgl/2.0.y/conformance2/offscreencanvas/context-creation-worker.html [ Skip ]
+webgl/2.0.y/conformance2/offscreencanvas/methods-2-worker.html [ Skip ]
+webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-query.html [ Skip ]
+webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-sync.html [ Skip ]
+webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-timer-query.html [ Skip ]
+webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html [ Skip ]
 
 webkit.org/b/251187 [ Debug ] imported/w3c/web-platform-tests/fetch/api/redirect/redirect-back-to-original-origin.any.html [ Pass Crash ]
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntSize.h"
+#include "TaskSource.h"
 #include <wtf/HashSet.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
@@ -37,6 +38,7 @@ class CanvasBase;
 class CanvasObserver;
 class CanvasRenderingContext;
 class Element;
+class Event;
 class GraphicsClient;
 class GraphicsContext;
 class GraphicsContextStateSaver;
@@ -119,6 +121,9 @@ public:
     WEBCORE_EXPORT static size_t maxActivePixelMemory();
     WEBCORE_EXPORT static void setMaxPixelMemoryForTesting(std::optional<size_t>);
     WEBCORE_EXPORT static void setMaxCanvasAreaForTesting(std::optional<size_t>);
+
+    virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
+    virtual void dispatchEvent(Event&) = 0;
 
 protected:
     explicit CanvasBase(IntSize);

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -67,6 +67,9 @@ public:
 
     void replayDisplayList(GraphicsContext*) const;
 
+    void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final { };
+    void dispatchEvent(Event&) final { }
+
     using RefCounted::ref;
     using RefCounted::deref;
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -1062,6 +1062,16 @@ bool HTMLCanvasElement::isControlledByOffscreen() const
     return m_context && m_context->isPlaceholder();
 }
 
+void HTMLCanvasElement::queueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
+{
+    ActiveDOMObject::queueTaskKeepingObjectAlive(*this, source, WTFMove(task));
+}
+
+void HTMLCanvasElement::dispatchEvent(Event& event)
+{
+    Node::dispatchEvent(event);
+}
+
 WebCoreOpaqueRoot root(HTMLCanvasElement* canvas)
 {
     return root(static_cast<Node*>(canvas));

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -141,6 +141,9 @@ public:
 #endif
     WEBCORE_EXPORT void setAvoidIOSurfaceSizeCheckInWebProcessForTesting();
 
+    void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
+    void dispatchEvent(Event&) final;
+
 private:
     HTMLCanvasElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -32,6 +32,7 @@
 #include "CanvasRenderingContext.h"
 #include "Chrome.h"
 #include "Document.h"
+#include "EventDispatcher.h"
 #include "HTMLCanvasElement.h"
 #include "ImageBitmap.h"
 #include "ImageBitmapRenderingContext.h"
@@ -100,7 +101,9 @@ bool OffscreenCanvas::enabledForContext(ScriptExecutionContext& context)
 
 Ref<OffscreenCanvas> OffscreenCanvas::create(ScriptExecutionContext& scriptExecutionContext, unsigned width, unsigned height)
 {
-    return adoptRef(*new OffscreenCanvas(scriptExecutionContext, width, height));
+    auto canvas = adoptRef(*new OffscreenCanvas(scriptExecutionContext, width, height));
+    canvas->suspendIfNeeded();
+    return canvas;
 }
 
 Ref<OffscreenCanvas> OffscreenCanvas::create(ScriptExecutionContext& scriptExecutionContext, std::unique_ptr<DetachedOffscreenCanvas>&& detachedCanvas)
@@ -120,6 +123,7 @@ Ref<OffscreenCanvas> OffscreenCanvas::create(ScriptExecutionContext& scriptExecu
         }
     });
 
+    clone->suspendIfNeeded();
     return clone;
 }
 
@@ -127,12 +131,13 @@ Ref<OffscreenCanvas> OffscreenCanvas::create(ScriptExecutionContext& scriptExecu
 {
     auto offscreen = adoptRef(*new OffscreenCanvas(scriptExecutionContext, canvas.width(), canvas.height()));
     offscreen->setPlaceholderCanvas(canvas);
+    offscreen->suspendIfNeeded();
     return offscreen;
 }
 
 OffscreenCanvas::OffscreenCanvas(ScriptExecutionContext& scriptExecutionContext, unsigned width, unsigned height)
-    : CanvasBase(IntSize(width, height))
-    , ContextDestructionObserver(&scriptExecutionContext)
+    : ActiveDOMObject(&scriptExecutionContext)
+    , CanvasBase(IntSize(width, height))
     , m_placeholderData(PlaceholderData::create())
 {
 }
@@ -337,8 +342,8 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
     }
 
 #if ENABLE(WEBGL)
-    if (is<WebGLRenderingContext>(*m_context)) {
-        auto webGLContext = &downcast<WebGLRenderingContext>(*m_context);
+    if (is<WebGLRenderingContextBase>(*m_context)) {
+        auto webGLContext = &downcast<WebGLRenderingContextBase>(*m_context);
 
         // FIXME: We're supposed to create an ImageBitmap using the backing
         // store from this canvas (or its context), but for now we'll just
@@ -565,6 +570,17 @@ void OffscreenCanvas::reset()
 
     notifyObserversCanvasResized();
     scheduleCommitToPlaceholderCanvas();
+}
+
+
+void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
+{
+    ActiveDOMObject::queueTaskKeepingObjectAlive(*this, source, WTFMove(task));
+}
+
+void OffscreenCanvas::dispatchEvent(Event& event)
+{
+    EventDispatcher::dispatchEvent({ this }, event);
 }
 
 }

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(OFFSCREEN_CANVAS)
 
+#include "ActiveDOMObject.h"
 #include "AffineTransform.h"
 #include "CanvasBase.h"
 #include "ContextDestructionObserver.h"
@@ -97,7 +98,7 @@ private:
     WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_placeholderCanvas;
 };
 
-class OffscreenCanvas final : public RefCounted<OffscreenCanvas>, public CanvasBase, public EventTarget, private ContextDestructionObserver {
+class OffscreenCanvas final : public ActiveDOMObject, public RefCounted<OffscreenCanvas>, public CanvasBase, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(OffscreenCanvas);
 public:
 
@@ -147,6 +148,10 @@ public:
 
     void commitToPlaceholderCanvas();
 
+    const char* activeDOMObjectName() const final { return "OffscreenCanvas"_s; }
+
+    void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
+    void dispatchEvent(Event&) final;
     using RefCounted::ref;
     using RefCounted::deref;
 

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -46,6 +46,7 @@ enum OffscreenRenderingContextType
 };
 
 [
+    ActiveDOMObject,
     GenerateIsReachable=Impl,
     EnabledBySetting=OffscreenCanvasEnabled,
     Conditional=OFFSCREEN_CANVAS,

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5514,18 +5514,14 @@ void WebGLRenderingContextBase::vertexAttribfvImpl(const char* functionName, GCG
 
 void WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent()
 {
-    auto* canvas = htmlCanvas();
-    if (!canvas)
-        return;
-
     // It is safe to capture |this| because we keep the canvas element alive and it owns |this|.
-    queueTaskKeepingObjectAlive(*canvas, TaskSource::WebGL, [this, canvas] {
+    canvasBase().queueTaskKeepingObjectAlive(TaskSource::WebGL, [this] {
         if (isContextStopped())
             return;
         if (!isContextLost())
             return;
         auto event = WebGLContextEvent::create(eventNames().webglcontextlostEvent, Event::CanBubble::No, Event::IsCancelable::Yes, emptyString());
-        canvas->dispatchEvent(event);
+        canvasBase().dispatchEvent(event);
         m_contextLostState->restoreRequested = event->defaultPrevented();
         if (m_contextLostState->mode == RealLostContext && m_contextLostState->restoreRequested)
             m_restoreTimer.startOneShot(0_s);
@@ -5566,12 +5562,8 @@ void WebGLRenderingContextBase::maybeRestoreContext()
     setupFlags();
     initializeNewContext();
 
-    auto* canvas = htmlCanvas();
-    if (!canvas)
-        return;
-
     if (!isContextLost()) {
-        canvas->dispatchEvent(WebGLContextEvent::create(eventNames().webglcontextrestoredEvent, Event::CanBubble::No, Event::IsCancelable::Yes, emptyString()));
+        canvasBase().dispatchEvent(WebGLContextEvent::create(eventNames().webglcontextrestoredEvent, Event::CanBubble::No, Event::IsCancelable::Yes, emptyString()));
         // Notify the render layer to reconfigure the structure of the backing. This causes the backing to
         // start using the new layer contents display delegate from the new context.
         notifyCanvasContentChanged();

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -99,11 +99,7 @@ bool WebGLSync::isSignaled() const
 
 void WebGLSync::scheduleAllowCacheUpdate(WebGLRenderingContextBase& context)
 {
-    auto* canvas = context.htmlCanvas();
-    if (!canvas)
-        return;
-
-    context.queueTaskKeepingObjectAlive(*canvas, TaskSource::WebGL, [protectedThis = Ref { *this }]() {
+    context.canvasBase().queueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }]() {
         protectedThis->m_allowCacheUpdate = true;
     });
 }


### PR DESCRIPTION
#### 903910f95dd36fc7cbc660fb96daab4df0372a07
<pre>
OffscreenCanvas WebGL doesn&apos;t fire the context lost event.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250532">https://bugs.webkit.org/show_bug.cgi?id=250532</a>
&lt;rdar://104198422&gt;

Reviewed by Ryosuke Niwa.

Adds support for dispatching the event to OffscreenCanvas too, and enables the WebGL tests that cover this.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::queueTaskKeepingObjectAlive):
(WebCore::HTMLCanvasElement::dispatchEvent):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::create):
(WebCore::OffscreenCanvas::OffscreenCanvas):
(WebCore::OffscreenCanvas::transferToImageBitmap):
(WebCore::OffscreenCanvas::queueTaskKeepingObjectAlive):
(WebCore::OffscreenCanvas::dispatchEvent):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::scheduleAllowCacheUpdate):

Canonical link: <a href="https://commits.webkit.org/260924@main">https://commits.webkit.org/260924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20462a309cbbeeb86c5b5625b541fd41d2906e59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/109950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/42639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/113901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/20518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10244 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102212 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/115699 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43493 "Found 2 new test failures: webgl/2.0.y/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html, webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30146 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85317 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/11758 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/31487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12383 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/17751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7575 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14176 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->