### PR TITLE
[webkitscmpy] Provide programatic way to review PR

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.10.10',
+    version='5.11.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 10, 10)
+version = Version(5, 11, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,7 +25,7 @@ import re
 import time
 
 import json as jsonlib
-from webkitbugspy import mocks as bmocks
+from webkitbugspy import mocks as bmocks, Issue
 from webkitcorepy import mocks
 from webkitscmpy import Commit, remote as scmremote
 
@@ -435,6 +435,26 @@ class GitHub(bmocks.GitHub):
                     return mocks.Response.fromJson({
                         key: value for key, value in candidate.items() if key not in ('requested_reviews', 'reviews')
                     }, url=url)
+
+            return mocks.Response.fromJson(
+                dict(message='Not found'),
+                url=url,
+                status_code=404,
+            )
+
+        # Add review
+        if method == 'POST' and auth and stripped_url.startswith(pr_base) and stripped_url.endswith('/reviews'):
+            for candidate in self.pull_requests:
+                if stripped_url.split('/')[5] != str(candidate['number']):
+                    continue
+                candidate['reviews'].append(
+                    dict(user=dict(login=auth.username), state=json.get('event', 'COMMENT')),
+                )
+                if 'body' in json:
+                    self.issues[candidate['number']]['comments'].append(
+                        Issue.Comment(user=self.users.get(auth.username), timestamp=int(time.time()), content=json['body']),
+                    )
+                return mocks.Response.fromJson(candidate['reviews'])
 
             return mocks.Response.fromJson(
                 dict(message='Not found'),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -207,6 +207,11 @@ class PullRequest(object):
         if self._comments is None and self.generator:
             self._comments = list(self.generator.comments(self))
         return self._comments
+
+    def review(self, comment=None, approve=None):
+        if not self.generator:
+            raise self.Exception('No associated pull-request generator')
+        return self.generator.review(self, comment=comment, approve=approve)
 
     def __repr__(self):
         return 'PR {}{}'.format(self.number, ' | {}'.format(self.title) if self.title else '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,6 +52,9 @@ class Scm(ScmBase):
             raise NotImplementedError()
 
         def comments(self, pull_request):
+            raise NotImplementedError()
+
+        def review(self, pull_request, comment=None, approve=None):
             raise NotImplementedError()
 
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1505,6 +1505,17 @@ Reviewed by NOBODY (OOPS!).
             pr.open()
             self.assertTrue(pr.opened)
 
+    def test_review(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(pr.approvers, [Contributor('Eager Reviewer', ['ereviewer@webkit.org'])])
+            self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
+
+            pr.review(comment='Looks good!', approve=True)
+            self.assertEqual(pr.comments[-1].content, 'Looks good!')
+            self.assertEqual(len(pr.approvers), 2)
+
 
 class TestNetworkPullRequestBitBucket(unittest.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'
@@ -1622,3 +1633,20 @@ Reviewed by NOBODY (OOPS!).
             self.assertFalse(pr.opened)
             pr.open()
             self.assertTrue(pr.opened)
+
+    def test_whoami(self):
+        with self.webserver():
+            repo = remote.BitBucket(self.remote)
+            self.assertEqual(repo.whoami(), 'timcommitter')
+
+    def test_review(self):
+        with self.webserver():
+            repo = remote.BitBucket(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(pr.approvers, [Contributor('Eager Reviewer', ['ereviewer@webkit.org'])])
+            self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
+
+            pr.review(comment='Looks good!', approve=True)
+
+            self.assertEqual(pr.comments[-1].content, 'Looks good!')
+            self.assertEqual(len(pr.approvers), 2)


### PR DESCRIPTION
#### b9ce13f0fd8bf798a32723657255a677650bd54b
<pre>
[webkitscmpy] Provide programatic way to review PR
<a href="https://bugs.webkit.org/show_bug.cgi?id=250533">https://bugs.webkit.org/show_bug.cgi?id=250533</a>
rdar://104199059

Reviewed by Elliott Williams.

Add a &quot;review&quot; function that allows programs to approve and rejects PRs
with a comment.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request): Handle &quot;whoami&quot; requests, add reviewers and give Bitbucket
users usernames when returning.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.request): Handle requests to add reviews.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.review): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.comment): Return pull request object to indicate success.
(BitBucket.PRGenerator.review): Set review status on PR and optionally make a comment.
(BitBucket.whoami): Return the Bitbucket username of the current user.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.review): Add a review to the specified PR.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.PRGenerator.review): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/259056@main">https://commits.webkit.org/259056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b4b774cc5aaff8e1b022f81bc8ffbdf5d074d1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103806 "Failed to checkout and rebase branch from PR 8598") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/12923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/113032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/107756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3818 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96054 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109579 "Failed to checkout and rebase branch from PR 8598") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/107290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6280 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6448 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/102679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3309 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->