### PR TITLE
[Wasm-GC] Add missing type expansion for arrays, structs

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -171,6 +171,16 @@ function testArrayNew() {
         (array.new_canon 0 (i32.const 42) (i32.const 5)))
     )
   `);
+
+  instantiate(`
+    (module
+      ;; Test with subtype as well.
+      (type (array i32))
+      (type (sub 0 (array i32)))
+      (func (result (ref 0))
+        (array.new_canon 1 (i32.const 42) (i32.const 5)))
+    )
+  `);
 }
 
 function testArrayNewDefault() {
@@ -179,6 +189,16 @@ function testArrayNewDefault() {
       (type (array i32))
       (func (result (ref 0))
         (array.new_canon_default 0 (i32.const 5)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      ;; Test with subtype as well.
+      (type (array i32))
+      (type (sub 0 (array i32)))
+      (func (result (ref 0))
+        (array.new_canon_default 1 (i32.const 5)))
     )
   `);
 }
@@ -192,6 +212,21 @@ function testArrayGet() {
           (array.new_canon 0 (i32.const 0) (i32.const 5))
           (i32.const 3)
           (array.get 0))
+      )
+    `);
+    assert.eq(m.exports.f(), 0);
+  }
+
+  {
+    let m = instantiate(`
+      (module
+        ;; Test with a subtype as well.
+        (type (array i32))
+        (type (sub 0 (array i32)))
+        (func (export "f") (result i32)
+          (array.new_canon 1 (i32.const 0) (i32.const 5))
+          (i32.const 3)
+          (array.get 1))
       )
     `);
     assert.eq(m.exports.f(), 0);
@@ -363,6 +398,25 @@ function testArraySet() {
           (array.set 0 (global.get 0) (i32.const 3) (i32.const 84)))
         (func (export "get") (param i32) (result i32)
           (array.get 0 (global.get 0) (local.get 0)))
+      )
+    `);
+    m.exports.init();
+    assert.eq(m.exports.get(0), 42);
+    assert.eq(m.exports.get(3), 84);
+  }
+
+  {
+    let m = instantiate(`
+      (module
+        ;; Test with a subtype as well.
+        (type (array (mut i32)))
+        (type (sub 0 (array (mut i32))))
+        (global (mut (ref null 0)) (ref.null 0))
+        (func (export "init")
+          (global.set 0 (array.new_canon 1 (i32.const 42) (i32.const 5)))
+          (array.set 1 (global.get 0) (i32.const 3) (i32.const 84)))
+        (func (export "get") (param i32) (result i32)
+          (array.get 1 (global.get 0) (local.get 0)))
       )
     `);
     m.exports.init();

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -2476,7 +2476,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addCheckedFloatingPointTruncat
 template<typename Derived, typename ExpressionType>
 auto AirIRGeneratorBase<Derived, ExpressionType>::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result) -> PartialResult
 {
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
 
     ExpressionType tmpForValue;
@@ -2492,7 +2492,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addArrayNew(uint32_t typeIndex
 template <typename Derived, typename ExpressionType>
 auto AirIRGeneratorBase<Derived, ExpressionType>::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result) -> PartialResult
 {
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
     const StorageType& elementType = arraySignature.as<ArrayType>()->elementType().type;
 
@@ -2517,7 +2517,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addArrayGet(ExtGCOpType arrayG
 {
     ASSERT(arrayGetKind == ExtGCOpType::ArrayGet || arrayGetKind == ExtGCOpType::ArrayGetS || arrayGetKind == ExtGCOpType::ArrayGetU);
 
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
     Wasm::StorageType elementType = arraySignature.as<ArrayType>()->elementType().type;
     Wasm::Type resultType = elementType.unpacked();
@@ -2606,7 +2606,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addStructNew(uint32_t typeInde
     // https://bugs.webkit.org/show_bug.cgi?id=244388
     self().emitCCall(&operationWasmStructNewEmpty, result, instanceValue(), self().addConstant(Types::I32, typeIndex));
 
-    const auto& structType = *m_info.typeSignatures[typeIndex]->template as<StructType>();
+    const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (unsigned i = 0; i < args.size(); ++i) {
         auto status = self().addStructSet(result, structType, i, args[i]);
         if (!status)
@@ -2624,7 +2624,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addStructNewDefault(uint32_t t
     // https://bugs.webkit.org/show_bug.cgi?id=244388
     self().emitCCall(&operationWasmStructNewEmpty, result, instanceValue(), self().addConstant(Types::I32, typeIndex));
 
-    const auto& structType = *m_info.typeSignatures[typeIndex]->template as<StructType>();
+    const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
         ExpressionType tmpForValue;
         if (Wasm::isRefType(structType.field(i).type))

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -2608,7 +2608,7 @@ Variable* B3IRGenerator::pushArrayNew(uint32_t typeIndex, Value* initValue, Expr
 auto B3IRGenerator::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result) -> PartialResult
 {
 #if ASSERT_ENABLED
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
     const StorageType& elementType = arraySignature.as<ArrayType>()->elementType().type;
     ASSERT(toB3Type(elementType.unpacked()) == value->type());
@@ -2631,7 +2631,7 @@ auto B3IRGenerator::addArrayNew(uint32_t typeIndex, ExpressionType size, Express
 
 auto B3IRGenerator::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result) -> PartialResult
 {
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
 
     Value* initValue;
@@ -2647,7 +2647,7 @@ auto B3IRGenerator::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, 
 
 auto B3IRGenerator::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result) -> PartialResult
 {
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
     Wasm::StorageType elementType = arraySignature.as<ArrayType>()->elementType().type;
     Wasm::Type resultType = elementType.unpacked();
@@ -2728,7 +2728,7 @@ auto B3IRGenerator::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, Ex
 auto B3IRGenerator::addArraySet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType value) -> PartialResult
 {
 #if ASSERT_ENABLED
-    Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
 #endif
 
@@ -2797,7 +2797,7 @@ auto B3IRGenerator::addStructNew(uint32_t typeIndex, Vector<ExpressionType>& arg
         instanceValue(),
         m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex));
 
-    const auto& structType = *m_info.typeSignatures[typeIndex]->template as<StructType>();
+    const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (uint32_t i = 0; i < args.size(); ++i)
         emitStructSet(structValue, i, structType, get(args[i]));
 
@@ -2816,7 +2816,7 @@ auto B3IRGenerator::addStructNewDefault(uint32_t typeIndex, ExpressionType& resu
         instanceValue(),
         m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex));
 
-    const auto& structType = *m_info.typeSignatures[typeIndex]->template as<StructType>();
+    const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
         Value* initValue;
         if (Wasm::isRefType(structType.field(i).type))

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -51,7 +51,7 @@ inline EncodedJSValue arrayNew(Instance* instance, uint32_t typeIndex, uint32_t 
 
     ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
 
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
     Wasm::FieldType fieldType = arraySignature.as<ArrayType>()->elementType();
 
@@ -102,7 +102,7 @@ inline EncodedJSValue arrayGet(Instance* instance, uint32_t typeIndex, EncodedJS
 {
 #if ASSERT_ENABLED
     ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
 #else
     UNUSED_PARAM(instance);
@@ -122,7 +122,7 @@ inline void arraySet(Instance* instance, uint32_t typeIndex, EncodedJSValue arra
     VM& vm = instance->vm();
 
 #if ASSERT_ENABLED
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex];
+    const Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
     ASSERT(arraySignature.is<ArrayType>());
 #else
     UNUSED_PARAM(typeIndex);
@@ -139,8 +139,8 @@ inline EncodedJSValue structNew(Instance* instance, uint32_t typeIndex, bool use
 {
     JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
     JSGlobalObject* globalObject = jsInstance->globalObject();
-    Ref<TypeDefinition> structTypeDefinition = instance->module().moduleInformation().typeSignatures[typeIndex];
-    const StructType& structType = *structTypeDefinition->as<StructType>();
+    const TypeDefinition& structTypeDefinition = jsInstance->instance().module().moduleInformation().typeSignatures[typeIndex]->expand();
+    const StructType& structType = *structTypeDefinition.as<StructType>();
 
     JSWebAssemblyStruct* structValue = JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex);
     RELEASE_ASSERT(structValue);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -401,7 +401,7 @@ WASM_SLOW_PATH_DECL(array_new)
     uint32_t size = READ(instruction.m_size).unboxedUInt32();
     Wasm::UseDefaultValue useDefault = static_cast<Wasm::UseDefaultValue>(instruction.m_useDefault);
 
-    Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[instruction.m_typeIndex];
+    const Wasm::TypeDefinition& arraySignature = instance->module().moduleInformation().typeSignatures[instruction.m_typeIndex]->expand();
     ASSERT(arraySignature.is<Wasm::ArrayType>());
     Wasm::StorageType elementType = arraySignature.as<Wasm::ArrayType>()->elementType().type;
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -38,7 +38,7 @@ namespace JSC {
 
 const ClassInfo JSWebAssemblyStruct::s_info = { "WebAssembly.Struct"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyStruct) };
 
-JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<Wasm::TypeDefinition>&& type)
+JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<const Wasm::TypeDefinition>&& type)
     : Base(vm, structure)
     , m_type(WTFMove(type))
     , m_payload(structType()->instancePayloadSize())
@@ -51,7 +51,7 @@ JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    Ref<Wasm::TypeDefinition> type = instance->instance().module().moduleInformation().typeSignatures[typeIndex];
+    Ref<const Wasm::TypeDefinition> type = instance->instance().module().moduleInformation().typeSignatures[typeIndex]->expand();
 
     if (!globalObject->webAssemblyEnabled()) {
         throwException(globalObject, throwScope, createEvalError(globalObject, globalObject->webAssemblyDisabledErrorMessage()));

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -70,12 +70,12 @@ public:
     uint8_t* fieldPointer(uint32_t fieldIndex);
 
 protected:
-    JSWebAssemblyStruct(VM&, Structure*, Ref<Wasm::TypeDefinition>&&);
+    JSWebAssemblyStruct(VM&, Structure*, Ref<const Wasm::TypeDefinition>&&);
     void finishCreation(VM&);
 
     // FIXME: It is possible to encode the type information in the structure field of Wasm.Struct and remove this field.
     // https://bugs.webkit.org/show_bug.cgi?id=244838
-    Ref<Wasm::TypeDefinition> m_type;
+    Ref<const Wasm::TypeDefinition> m_type;
 
     FixedVector<uint8_t> m_payload;
 };


### PR DESCRIPTION
#### 3304a1879844f73735f3109b2a3f71a75d6ee9a0
<pre>
[Wasm-GC] Add missing type expansion for arrays, structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=250489">https://bugs.webkit.org/show_bug.cgi?id=250489</a>

Reviewed by Justin Michaud.

Adds `expand()` calls where necessary to ensure that recursive/subtype
types work with array and struct operations. Also add tests to exercise
these cases.

* JSTests/wasm/gc/arrays.js:
(testArrayNewDefault):
(testArrayGet):
* JSTests/wasm/gc/structs.js:
(testStructNewDefault):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addArrayNew):
(JSC::Wasm::ExpressionType&gt;::addArrayNewDefault):
(JSC::Wasm::ExpressionType&gt;::addArrayGet):
(JSC::Wasm::ExpressionType&gt;::addStructNew):
(JSC::Wasm::ExpressionType&gt;::addStructNewDefault):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addArrayNew):
(JSC::Wasm::B3IRGenerator::addArrayNewDefault):
(JSC::Wasm::B3IRGenerator::addArrayGet):
(JSC::Wasm::B3IRGenerator::addArraySet):
(JSC::Wasm::B3IRGenerator::addStructNew):
(JSC::Wasm::B3IRGenerator::addStructNewDefault):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructTypeIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructTypeIndexAndFieldIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructFieldManipulation):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::arrayGet):
(JSC::Wasm::arraySet):
(JSC::Wasm::structNew):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
(JSC::JSWebAssemblyStruct::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/259042@main">https://commits.webkit.org/259042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f20dc1702a4ce30ff38875d954ebce7d3cfa80d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112870 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173201 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3652 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112026 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80002 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93779 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6125 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26684 "Found 1 new test failure: media/audio-session-category.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90206 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3887 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6302 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3211 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29805 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46196 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98811 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6213 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8059 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24873 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->