### PR TITLE
Rename Image::hasSingleSecurityOrigin to Image::renderingTaintsOrigin.

### DIFF
--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -161,7 +161,7 @@ static bool taintsOrigin(CachedImage& cachedImage)
     if (image->sourceURL().protocolIsData())
         return false;
 
-    if (!image->hasSingleSecurityOrigin())
+    if (image->renderingTaintsOrigin())
         return true;
 
     if (!cachedImage.isCORSSameOrigin())

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -104,21 +104,21 @@ DestinationColorSpace CanvasRenderingContext::colorSpace() const
     return DestinationColorSpace::SRGB();
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const CanvasPattern* pattern)
+bool CanvasRenderingContext::taintsOrigin(const CanvasPattern* pattern)
 {
     if (m_canvas.originClean() && pattern && !pattern->originClean())
         return true;
     return false;
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const CanvasBase* sourceCanvas)
+bool CanvasRenderingContext::taintsOrigin(const CanvasBase* sourceCanvas)
 {
     if (m_canvas.originClean() && sourceCanvas && !sourceCanvas->originClean())
         return true;
     return false;
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const HTMLImageElement* element)
+bool CanvasRenderingContext::taintsOrigin(const HTMLImageElement* element)
 {
     if (!element || !m_canvas.originClean())
         return false;
@@ -134,9 +134,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const HTMLImageElement* element)
     if (image->sourceURL().protocolIsData())
         return false;
 
-    // FIXME: SVG image shouldn't taint the canvas if their cross-origin data says not to.
-    // https://bugs.webkit.org/show_bug.cgi?id=248437
-    if (image->isSVGImage() && !image->hasSingleSecurityOrigin())
+    if (image->renderingTaintsOrigin())
         return true;
 
     if (cachedImage->isCORSCrossOrigin())
@@ -148,7 +146,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const HTMLImageElement* element)
     return false;
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const HTMLVideoElement* video)
+bool CanvasRenderingContext::taintsOrigin(const HTMLVideoElement* video)
 {
 #if ENABLE(VIDEO)
     if (!video || !m_canvas.originClean())
@@ -167,7 +165,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const HTMLVideoElement* video)
     return false;
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const ImageBitmap* imageBitmap)
+bool CanvasRenderingContext::taintsOrigin(const ImageBitmap* imageBitmap)
 {
     if (!imageBitmap || !m_canvas.originClean())
         return false;
@@ -175,7 +173,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const ImageBitmap* imageBitmap)
     return !imageBitmap->originClean();
 }
 
-bool CanvasRenderingContext::wouldTaintOrigin(const URL& url)
+bool CanvasRenderingContext::taintsOrigin(const URL& url)
 {
     if (!m_canvas.originClean())
         return false;
@@ -188,7 +186,7 @@ bool CanvasRenderingContext::wouldTaintOrigin(const URL& url)
 
 void CanvasRenderingContext::checkOrigin(const URL& url)
 {
-    if (wouldTaintOrigin(url))
+    if (taintsOrigin(url))
         m_canvas.setOriginTainted();
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -94,16 +94,16 @@ public:
 
 protected:
     explicit CanvasRenderingContext(CanvasBase&);
-    bool wouldTaintOrigin(const CanvasPattern*);
-    bool wouldTaintOrigin(const CanvasBase*);
-    bool wouldTaintOrigin(const HTMLImageElement*);
-    bool wouldTaintOrigin(const HTMLVideoElement*);
-    bool wouldTaintOrigin(const ImageBitmap*);
-    bool wouldTaintOrigin(const URL&);
+    bool taintsOrigin(const CanvasPattern*);
+    bool taintsOrigin(const CanvasBase*);
+    bool taintsOrigin(const HTMLImageElement*);
+    bool taintsOrigin(const HTMLVideoElement*);
+    bool taintsOrigin(const ImageBitmap*);
+    bool taintsOrigin(const URL&);
 
     template<class T> void checkOrigin(const T* arg)
     {
-        if (wouldTaintOrigin(arg))
+        if (taintsOrigin(arg))
             m_canvas.setOriginTainted();
     }
     void checkOrigin(const URL&);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5368,7 +5368,7 @@ ExceptionOr<bool> WebGLRenderingContextBase::validateHTMLImageElement(const char
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid image");
         return false;
     }
-    if (wouldTaintOrigin(image))
+    if (taintsOrigin(image))
         return Exception { SecurityError };
     return true;
 }
@@ -5379,7 +5379,7 @@ ExceptionOr<bool> WebGLRenderingContextBase::validateHTMLCanvasElement(const cha
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "no canvas");
         return false;
     }
-    if (wouldTaintOrigin(canvas))
+    if (taintsOrigin(canvas))
         return Exception { SecurityError };
     return true;
 }
@@ -5392,7 +5392,7 @@ ExceptionOr<bool> WebGLRenderingContextBase::validateHTMLVideoElement(const char
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "no video");
         return false;
     }
-    if (wouldTaintOrigin(video))
+    if (taintsOrigin(video))
         return Exception { SecurityError };
     return true;
 }

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -78,8 +78,6 @@ public:
 
     void updateFromSettings(const Settings&);
 
-    bool hasSingleSecurityOrigin() const override { return true; }
-
     EncodedDataStatus dataChanged(bool allDataReceived) override;
     unsigned decodedSize() const { return m_source->decodedSize(); }
 

--- a/Source/WebCore/platform/graphics/GeneratedImage.h
+++ b/Source/WebCore/platform/graphics/GeneratedImage.h
@@ -32,8 +32,6 @@ namespace WebCore {
 
 class GeneratedImage : public Image {
 public:
-    bool hasSingleSecurityOrigin() const override { return true; }
-
     void setContainerSize(const FloatSize& size) override { m_size = size; }
     bool usesContainerSize() const override { return true; }
     bool hasRelativeWidth() const override { return true; }

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -102,9 +102,10 @@ public:
     virtual bool currentFrameKnownToBeOpaque() const = 0;
     virtual bool isAnimated() const { return false; }
 
-    // Derived classes should override this if they can assure that 
-    // the image contains only resources from its own security origin.
-    virtual bool hasSingleSecurityOrigin() const { return false; }
+    // Derived classes should override this if their rendering could leak
+    // cross-origin data (outside of the resource itself, which undergoes
+    // a CORS cross-origin check).
+    virtual bool renderingTaintsOrigin() const { return false; }
 
     WEBCORE_EXPORT static Image& nullImage();
     bool isNull() const { return size().isEmpty(); }

--- a/Source/WebCore/platform/graphics/cg/PDFDocumentImage.h
+++ b/Source/WebCore/platform/graphics/cg/PDFDocumentImage.h
@@ -68,8 +68,6 @@ private:
 
     String filenameExtension() const override;
 
-    bool hasSingleSecurityOrigin() const override { return true; }
-
     EncodedDataStatus dataChanged(bool allDataReceived) override;
 
     void destroyDecodedData(bool /*destroyAll*/ = true) override;

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -63,12 +63,12 @@ SVGFEImageElement::~SVGFEImageElement()
     clearResourceReferences();
 }
 
-bool SVGFEImageElement::hasSingleSecurityOrigin() const
+bool SVGFEImageElement::renderingTaintsOrigin() const
 {
     if (!m_cachedImage)
-        return true;
+        return false;
     auto* image = m_cachedImage->image();
-    return !image || image->hasSingleSecurityOrigin();
+    return image && image->renderingTaintsOrigin();
 }
 
 void SVGFEImageElement::clearResourceReferences()

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -35,7 +35,7 @@ public:
 
     virtual ~SVGFEImageElement();
 
-    bool hasSingleSecurityOrigin() const;
+    bool renderingTaintsOrigin() const;
 
     const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -59,7 +59,7 @@ Ref<SVGImageElement> SVGImageElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new SVGImageElement(tagName, document));
 }
 
-bool SVGImageElement::hasSingleSecurityOrigin() const
+bool SVGImageElement::renderingTaintsOrigin() const
 {
     const RenderImageResource* resource = nullptr;
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
@@ -72,10 +72,10 @@ bool SVGImageElement::hasSingleSecurityOrigin() const
     }
 
     if (!resource || !resource->cachedImage())
-        return true;
+        return false;
 
     auto* image = resource->cachedImage()->image();
-    return !image || image->hasSingleSecurityOrigin();
+    return image && image->renderingTaintsOrigin();
 }
 
 void SVGImageElement::parseAttribute(const QualifiedName& name, const AtomString& value)

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -32,7 +32,7 @@ class SVGImageElement final : public SVGGraphicsElement, public SVGURIReference 
 public:
     static Ref<SVGImageElement> create(const QualifiedName&, Document&);
 
-    bool hasSingleSecurityOrigin() const;
+    bool renderingTaintsOrigin() const;
     const AtomString& imageSourceURL() const final;
 
     const SVGLengthValue& x() const { return m_x->currentValue(); }

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -93,30 +93,30 @@ inline RefPtr<SVGSVGElement> SVGImage::rootElement() const
     return DocumentSVG::rootElement(*m_page->mainFrame().document());
 }
 
-bool SVGImage::hasSingleSecurityOrigin() const
+bool SVGImage::renderingTaintsOrigin() const
 {
     auto rootElement = this->rootElement();
     if (!rootElement)
-        return true;
+        return false;
 
     // FIXME: Once foreignObject elements within SVG images are updated to not leak cross-origin data
     // (e.g., visited links, spellcheck) we can remove the SVGForeignObjectElement check here and
-    // research if we can remove the Image::hasSingleSecurityOrigin mechanism entirely.
+    // research if we can remove the Image::renderingTaintsOrigin mechanism entirely.
     for (auto& element : descendantsOfType<SVGElement>(*rootElement)) {
         if (is<SVGForeignObjectElement>(element))
-            return false;
+            return true;
         if (is<SVGImageElement>(element)) {
-            if (!downcast<SVGImageElement>(element).hasSingleSecurityOrigin())
-                return false;
+            if (downcast<SVGImageElement>(element).renderingTaintsOrigin())
+                return true;
         } else if (is<SVGFEImageElement>(element)) {
-            if (!downcast<SVGFEImageElement>(element).hasSingleSecurityOrigin())
-                return false;
+            if (downcast<SVGFEImageElement>(element).renderingTaintsOrigin())
+                return true;
         }
     }
 
     // Because SVG image rendering disallows external resources and links,
     // these images effectively are restricted to a single security origin.
-    return true;
+    return false;
 }
 
 void SVGImage::setContainerSize(const FloatSize& size)

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -50,7 +50,7 @@ public:
     bool isSVGImage() const final { return true; }
     FloatSize size(ImageOrientation = ImageOrientation::FromImage) const final { return m_intrinsicSize; }
 
-    bool hasSingleSecurityOrigin() const final;
+    bool renderingTaintsOrigin() const final;
 
     bool hasRelativeWidth() const final;
     bool hasRelativeHeight() const final;


### PR DESCRIPTION
#### 5cfdacb9f77cffe585529fa7a25afc82234403c9
<pre>
Rename Image::hasSingleSecurityOrigin to Image::renderingTaintsOrigin.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250540">https://bugs.webkit.org/show_bug.cgi?id=250540</a>
&lt;rdar://102738351&gt;

Reviewed by Darin Adler.

There&apos;s only two entry points to this function, and one of them (CanvasRenderingContext) only calls it when the image is a SVGImage.

The only interesting implementation of this (SVGImage) is not related to multiple origins (or CORS at all), but instead to SVG foreign object possibly tainting the &lt;canvas&gt; in a different way (by drawing visited colours, spellcheck etc).

This renames the function to renderingTaintsOrigin, since that more accurately reflects the behaviour. It also swaps the meaning in the process, and removes lots of overloads which aren&apos;t needed.

The only (potential) behaviour change is that the ImageBitmap callsite (which didn&apos;t have an isSVGImage check) will now definitely only affect SVGImages instead of other types (which implicitly returned false for hasSingleSecurity origin by not overloading the function). I believe that was the intent of the change which added the check to the other callsite (and that returning false for !SVG was a missing impl bug), and this was just missed.

* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::taintsOrigin):
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::taintsOrigin):
(WebCore::CanvasRenderingContext::checkOrigin):
(WebCore::CanvasRenderingContext::wouldTaintOrigin): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::checkOrigin):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::validateHTMLImageElement):
(WebCore::WebGLRenderingContextBase::validateHTMLCanvasElement):
(WebCore::WebGLRenderingContextBase::validateHTMLVideoElement):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/GeneratedImage.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::renderingTaintsOrigin const):
(WebCore::Image::hasSingleSecurityOrigin const): Deleted.
* Source/WebCore/platform/graphics/cg/PDFDocumentImage.h:
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::renderingTaintsOrigin const):
(WebCore::SVGFEImageElement::hasSingleSecurityOrigin const): Deleted.
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::renderingTaintsOrigin const):
(WebCore::SVGImageElement::hasSingleSecurityOrigin const): Deleted.
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::renderingTaintsOrigin const):
(WebCore::SVGImage::hasSingleSecurityOrigin const): Deleted.
* Source/WebCore/svg/graphics/SVGImage.h:

Canonical link: <a href="https://commits.webkit.org/258969@main">https://commits.webkit.org/258969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42ac29d13933f1fc00922e6c942211755f82e7d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112731 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172941 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3517 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95751 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111912 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10500 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25162 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26565 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6177 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6161 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7932 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->