### PR TITLE
non-CORS Redirects to a cross-origin URI should cause video to taint <canvas>, even if the final response is same-origin.

### DIFF
--- a/LayoutTests/http/tests/security/canvas-remote-read-remote-video-allowed-redirect-expected.txt
+++ b/LayoutTests/http/tests/security/canvas-remote-read-remote-video-allowed-redirect-expected.txt
@@ -1,0 +1,16 @@
+Ensure that data can be retrieved from a canvas, even when tainted by a video resource obtained via redirection when CORS is enabled with anonymous.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Testing data retrieval on an untainted canvas:
+PASS canvas.getContext('2d').getImageData(0, 0, 100, 100) did not throw exception.
+PASS canvas.toDataURL() did not throw exception.
+
+Testing data retrieval on a canvas tainted by a remote video pattern:
+PASS context.getImageData(0, 0, 100, 100) did not throw exception.
+PASS canvas.toDataURL() did not throw exception.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/canvas-remote-read-remote-video-allowed-redirect.html
+++ b/LayoutTests/http/tests/security/canvas-remote-read-remote-video-allowed-redirect.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../media-resources/media-file.js"></script>
+    <script src="resources/canvas-video-crossorigin.js"></script>
+</head>
+<body>
+<pre id="console"></pre>
+<script>
+    description("Ensure that data can be retrieved from a canvas, even when tainted by a video resource obtained via redirection when CORS is enabled with anonymous.");
+
+    function test()
+    {
+        testDataRetrievalAllowed();
+        finishJSTest();
+    }
+
+    var video = document.createElement("video");
+    video.addEventListener("loadeddata", test);
+
+    video.crossOrigin = "anonymous";
+    var mediaFile = findMediaFile("video", "../../media/resources/test");
+    var type = mimeTypeForExtension(mediaFile.split('.').pop());
+    var url = encodeURIComponent("http://localhost:8080/security/resources/video-cross-origin-allow.py?name=" + mediaFile + "&type=" + type);
+    video.src = "/resources/redirect.py?url=" + url;
+
+    window.jsTestIsAsync = true;
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/canvas-video-crossorigin.js
+++ b/LayoutTests/http/tests/security/resources/canvas-video-crossorigin.js
@@ -20,8 +20,8 @@ function testDataRetrievalAllowed() {
     context.fillStyle = context.createPattern(video, "repeat");
     context.fillRect(0, 0, 100, 100);
 
-    shouldThrowErrorName("context.getImageData(0, 0, 100, 100)", "SecurityError");
-    shouldThrowErrorName("canvas.toDataURL()", "SecurityError");
+    shouldNotThrow("context.getImageData(0, 0, 100, 100)");
+    shouldNotThrow("canvas.toDataURL()");
 }
 
 function testDataRetrievalForbidden(description) {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub-expected.txt
@@ -4,6 +4,7 @@ CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has bee
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 
 PASS cross-origin HTMLImageElement: origin unclear getImageData
 PASS cross-origin HTMLImageElement: origin unclear 2dContext.drawImage
@@ -20,6 +21,9 @@ PASS redirected to cross-origin HTMLVideoElement: origin unclear bitmaprenderer.
 PASS redirected to same-origin HTMLVideoElement: origin unclear getImageData
 PASS redirected to same-origin HTMLVideoElement: origin unclear 2dContext.drawImage
 PASS redirected to same-origin HTMLVideoElement: origin unclear bitmaprenderer.transferFromImageBitmap
+PASS redirected to same-origin HTMLVideoElement via a cross-origin URL: origin unclear getImageData
+PASS redirected to same-origin HTMLVideoElement via a cross-origin URL: origin unclear 2dContext.drawImage
+PASS redirected to same-origin HTMLVideoElement via a cross-origin URL: origin unclear bitmaprenderer.transferFromImageBitmap
 PASS unclean HTMLCanvasElement: origin unclear getImageData
 PASS unclean HTMLCanvasElement: origin unclear 2dContext.drawImage
 PASS unclean HTMLCanvasElement: origin unclear bitmaprenderer.transferFromImageBitmap

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/resources/canvas-tests.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/resources/canvas-tests.js
@@ -196,6 +196,19 @@ function forEachCanvasSource(crossOriginUrl, sameOriginUrl, callback) {
     },
 
     {
+      name: "redirected to same-origin HTMLVideoElement via a cross-origin URL",
+      factory: () => {
+        return new Promise((resolve, reject) => {
+          const video = document.createElement("video");
+          video.oncanplaythrough = () => resolve(video);
+          video.preload = "auto";
+          video.onerror = reject;
+          video.src = "/common/redirect.py?location=" + crossOriginUrl + "/common/redirect.py?location=" + getVideoURI(sameOriginUrl + "/media/movie_300");
+        });
+      },
+    },
+
+    {
       name: "unclean HTMLCanvasElement",
       factory: () => {
         return makeImage().then(image => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
@@ -3,6 +3,7 @@ CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has bee
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 Setting fillStyle to a pattern of an unclean canvas makes the canvas origin-unclean
 
 
@@ -11,6 +12,7 @@ FAIL cross-origin SVGImageElement: Setting fillStyle to an origin-unclear patter
 PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclear pattern makes the canvas origin-unclean
 PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclear pattern makes the canvas origin-unclean
 PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclear pattern makes the canvas origin-unclean
+PASS redirected to same-origin HTMLVideoElement via a cross-origin URL: Setting fillStyle to an origin-unclear pattern makes the canvas origin-unclean
 PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclear pattern makes the canvas origin-unclean
 FAIL unclean ImageBitmap: Setting fillStyle to an origin-unclear pattern makes the canvas origin-unclean promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -444,8 +444,6 @@ http/tests/navigation/navigation-interrupted-by-fragment.html
 http/tests/security/aboutBlank/xss-DENIED-navigate-opener-document-write.html
 http/tests/security/aboutBlank/xss-DENIED-navigate-opener-javascript-url.html
 http/tests/security/aboutBlank/xss-DENIED-set-opener.html
-http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html [ Failure ]
-http/tests/security/canvas-remote-read-remote-video-allowed-with-credentials.html [ Failure ]
 http/tests/security/isolatedWorld/cross-origin-xhr.html
 http/tests/security/javascriptURL/xss-ALLOWED-from-javascript-url-window-open.html
 http/tests/security/javascriptURL/xss-ALLOWED-to-javascript-url-window-open.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -330,11 +330,6 @@ webkit.org/b/82972 plugins/multiple-plugins.html [ Pass Failure ]
 
 webkit.org/b/82979 fast/canvas/2d.text.draw.fill.maxWidth.gradient.html [ Pass Failure ]
 
-
-# No CORS support for media elements is implemented yet.
-http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html [ Failure ]
-http/tests/security/canvas-remote-read-remote-video-allowed-with-credentials.html [ Failure ]
-http/tests/security/video-cross-origin-readback.html
 http/tests/security/video-cross-origin-accessfailure.html
 
 # Random crash, like in many media tests.
@@ -1637,8 +1632,6 @@ webkit.org/b/207463 inspector/runtime/getCollectionEntries.html [ Pass Failure ]
 webkit.org/b/207046 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-currentTime.html [ Pass Failure ]
 
 webkit.org/b/207723 http/tests/contentextensions/hide-on-ping-with-ping-that-redirects.html [ Pass Failure ]
-
-webkit.org/b/207726 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html [ Pass Failure ]
 
 webkit.org/b/207978 imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing.sub.https.html [ Pass Failure ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -3594,6 +3594,7 @@ http/tests/security/XFrameOptions/x-frame-options-deny-multiple-clients.html [ F
 http/tests/security/anchor-download-allow-blob.html [ Failure ]
 http/tests/security/anchor-download-block-crossorigin.html [ Failure ]
 http/tests/security/canvas-remote-read-remote-video-redirect.html [ Crash Failure ]
+http/tests/security/canvas-remote-read-remote-video-allowed-redirect.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/form-action-src-allowed.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/form-action-src-blocked.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/form-action-src-default-ignored.html [ Failure ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -334,11 +334,6 @@ plugins/windowless_plugin_paint_test.html
 # eventSender.clearKillRing() is unimplemented
 editing/pasteboard/emacs-cntl-y-001.html
 
-# No CORS support for media elements is implemented yet.
-http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html [ Failure ]
-http/tests/security/canvas-remote-read-remote-video-allowed-with-credentials.html [ Failure ]
-http/tests/security/video-cross-origin-readback.html
-
 # Unexpected redirection happens.
 http/tests/loading/redirect-methods.html
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -133,16 +133,8 @@ void MediaElementAudioSourceNode::provideInput(AudioBus* bus, size_t framesToPro
 
 bool MediaElementAudioSourceNode::wouldTaintOrigin()
 {
-    // If the resource is redirected to another origin, treat it as tainted if the crossorigin attribute
-    // is not set. This is done for consistency with Blink.
-    if (!m_mediaElement->hasSingleSecurityOrigin() && m_mediaElement->crossOrigin().isNull())
-        return true;
-
-    if (m_mediaElement->didPassCORSAccessCheck())
-        return false;
-
     if (auto* origin = context().origin())
-        return m_mediaElement->wouldTaintOrigin(*origin);
+        return m_mediaElement->taintsOrigin(*origin);
 
     return true;
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6617,6 +6617,13 @@ double HTMLMediaElement::maxFastForwardRate() const
     return m_player ? m_player->maxFastForwardRate() : 0;
 }
 
+bool HTMLMediaElement::taintsOrigin(const SecurityOrigin& origin) const
+{
+    if (didPassCORSAccessCheck())
+        return false;
+    return m_player && m_player->isCrossOrigin(origin);
+}
+
 bool HTMLMediaElement::isFullscreen() const
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -459,9 +459,8 @@ public:
     // of one of them here.
     using HTMLElement::scriptExecutionContext;
 
-    bool hasSingleSecurityOrigin() const { return !m_player || m_player->hasSingleSecurityOrigin(); }
     bool didPassCORSAccessCheck() const { return m_player && m_player->didPassCORSAccessCheck(); }
-    bool wouldTaintOrigin(const SecurityOrigin& origin) const { return m_player && m_player->wouldTaintOrigin(origin); }
+    bool taintsOrigin(const SecurityOrigin&) const;
     
     WEBCORE_EXPORT bool isFullscreen() const override;
     bool isStandardFullscreen() const;

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -173,17 +173,7 @@ static bool taintsOrigin(CachedImage& cachedImage)
 #if ENABLE(VIDEO)
 static bool taintsOrigin(SecurityOrigin* origin, HTMLVideoElement& video)
 {
-    if (!video.hasSingleSecurityOrigin())
-        return true;
-
-    if (!video.player() || video.player()->didPassCORSAccessCheck())
-        return false;
-
-    auto url = video.currentSrc();
-    if (url.protocolIsData())
-        return false;
-
-    return !origin->canRequest(url);
+    return video.taintsOrigin(*origin);
 }
 #endif
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -152,17 +152,11 @@ bool CanvasRenderingContext::taintsOrigin(const HTMLVideoElement* video)
     if (!video || !m_canvas.originClean())
         return false;
 
-    // FIXME: video->wouldTainOrigin is incorrectly implemented, it only checks that the origin
-    // doesn't change, rather than being based on CORS cross-origin data.
-    // This is tracked in https://bugs.webkit.org/show_bug.cgi?id=242889
-    if (!video->didPassCORSAccessCheck() && video->wouldTaintOrigin(*m_canvas.securityOrigin()))
-        return true;
-
+    return video->taintsOrigin(*m_canvas.securityOrigin());
 #else
     UNUSED_PARAM(video);
-#endif
-
     return false;
+#endif
 }
 
 bool CanvasRenderingContext::taintsOrigin(const ImageBitmap* imageBitmap)

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -163,8 +163,6 @@ public:
 
     void paint(GraphicsContext&, const FloatRect&) final { }
     DestinationColorSpace colorSpace() final { return DestinationColorSpace::SRGB(); }
-
-    bool hasSingleSecurityOrigin() const final { return true; }
 };
 
 #if !RELEASE_LOG_DISABLED
@@ -1261,20 +1259,15 @@ void MediaPlayer::setShouldMaintainAspectRatio(bool maintainAspectRatio)
     m_private->setShouldMaintainAspectRatio(maintainAspectRatio);
 }
 
-bool MediaPlayer::hasSingleSecurityOrigin() const
-{
-    return m_private->hasSingleSecurityOrigin();
-}
-
 bool MediaPlayer::didPassCORSAccessCheck() const
 {
     return m_private->didPassCORSAccessCheck();
 }
 
-bool MediaPlayer::wouldTaintOrigin(const SecurityOrigin& origin) const
+bool MediaPlayer::isCrossOrigin(const SecurityOrigin& origin) const
 {
-    if (auto wouldTaint = m_private->wouldTaintOrigin(origin))
-        return *wouldTaint;
+    if (auto crossOrigin = m_private->isCrossOrigin(origin))
+        return *crossOrigin;
 
     if (m_url.protocolIsData())
         return false;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -547,9 +547,8 @@ public:
     GraphicsDeviceAdapter* graphicsDeviceAdapter() const;
 #endif
 
-    bool hasSingleSecurityOrigin() const;
     bool didPassCORSAccessCheck() const;
-    bool wouldTaintOrigin(const SecurityOrigin&) const;
+    bool isCrossOrigin(const SecurityOrigin&) const;
 
     MediaTime mediaTimeForTimeValue(const MediaTime&) const;
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -219,9 +219,8 @@ public:
 
     virtual void setShouldMaintainAspectRatio(bool) { }
 
-    virtual bool hasSingleSecurityOrigin() const { return false; }
     virtual bool didPassCORSAccessCheck() const { return false; }
-    virtual std::optional<bool> wouldTaintOrigin(const SecurityOrigin&) const { return std::nullopt; }
+    virtual std::optional<bool> isCrossOrigin(const SecurityOrigin&) const { return std::nullopt; }
 
     virtual MediaPlayer::MovieLoadType movieLoadType() const { return MediaPlayer::MovieLoadType::Unknown; }
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -493,13 +493,6 @@ bool MediaPlayerPrivateAVFoundation::supportsFullscreen() const
 #endif
 }
 
-bool MediaPlayerPrivateAVFoundation::hasSingleSecurityOrigin() const
-{
-    if (m_resolvedOrigin && m_requestedOrigin)
-        return m_resolvedOrigin->isSameSchemeHostPort(*m_requestedOrigin);
-    return false;
-}
-
 void MediaPlayerPrivateAVFoundation::setResolvedURL(URL&& resolvedURL)
 {
     m_resolvedURL = WTFMove(resolvedURL);

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -215,8 +215,6 @@ protected:
     bool supportsScanning() const override { return true; }
     unsigned long long fileSize() const override { return totalBytes(); }
 
-    bool hasSingleSecurityOrigin() const override;
-
     // Required interfaces for concrete derived classes.
     virtual void createAVAssetForURL(const URL&) = 0;
     virtual void createAVPlayer() = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -239,7 +239,7 @@ private:
     void updateVideoLayerGravity(ShouldAnimate);
 
     bool didPassCORSAccessCheck() const final;
-    std::optional<bool> wouldTaintOrigin(const SecurityOrigin&) const final;
+    std::optional<bool> isCrossOrigin(const SecurityOrigin&) const final;
 
     MediaTime getStartDate() const final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2616,12 +2616,12 @@ bool MediaPlayerPrivateAVFoundationObjC::didPassCORSAccessCheck() const
     return false;
 }
 
-std::optional<bool> MediaPlayerPrivateAVFoundationObjC::wouldTaintOrigin(const SecurityOrigin& origin) const
+std::optional<bool> MediaPlayerPrivateAVFoundationObjC::isCrossOrigin(const SecurityOrigin& origin) const
 {
     AVAssetResourceLoader *resourceLoader = m_avAsset.get().resourceLoader;
     WebCoreNSURLSession *session = (WebCoreNSURLSession *)resourceLoader.URLSession;
     if ([session isKindOfClass:[WebCoreNSURLSession class]])
-        return [session wouldTaintOrigin:origin];
+        return [session isCrossOrigin:origin];
 
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -248,7 +248,6 @@ private:
     // NOTE: Because the only way for MSE to recieve data is through an ArrayBuffer provided by
     // javascript running in the page, the video will, by necessity, always be CORS correct and
     // in the page's origin.
-    bool hasSingleSecurityOrigin() const override { return true; }
     bool didPassCORSAccessCheck() const override { return true; }
 
     MediaPlayer::MovieLoadType movieLoadType() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -155,8 +155,6 @@ private:
     void acceleratedRenderingStateChanged() final { updateLayersAsNeeded(); }
     bool supportsAcceleratedRendering() const override { return true; }
 
-    bool hasSingleSecurityOrigin() const override { return true; }
-
     MediaPlayer::MovieLoadType movieLoadType() const override { return MediaPlayer::MovieLoadType::LiveStream; }
 
     String engineDescription() const override;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -177,8 +177,7 @@ public:
     MediaTime minMediaTimeSeekable() const final { return MediaTime::zeroTime(); }
     bool didLoadingProgress() const final;
     unsigned long long totalBytes() const final;
-    bool hasSingleSecurityOrigin() const final;
-    std::optional<bool> wouldTaintOrigin(const SecurityOrigin&) const final;
+    std::optional<bool> isCrossOrigin(const SecurityOrigin&) const final;
     void simulateAudioInterruption() final;
 #if ENABLE(WEB_AUDIO)
     AudioSourceProvider* audioSourceProvider() final;
@@ -579,9 +578,6 @@ private:
     uint64_t m_httpResponseTotalSize { 0 };
     uint64_t m_networkReadPosition { 0 };
     mutable uint64_t m_readPositionAtLastDidLoadingProgress { 0 };
-
-    HashSet<RefPtr<WebCore::SecurityOrigin>> m_origins;
-    std::optional<bool> m_hasTaintedOrigin { std::nullopt };
 
     GRefPtr<GstElement> m_fpsSink { nullptr };
     uint64_t m_totalVideoFrames { 0 };

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
@@ -55,7 +55,7 @@ struct WebKitWebSrcClass {
 GType webkit_web_src_get_type(void);
 void webKitWebSrcSetMediaPlayer(WebKitWebSrc*, WebCore::MediaPlayer*, const String&);
 bool webKitSrcPassedCORSAccessCheck(WebKitWebSrc*);
-bool webKitSrcWouldTaintOrigin(WebKitWebSrc*, const WebCore::SecurityOrigin&);
+bool webKitSrcIsCrossOrigin(WebKitWebSrc*, const WebCore::SecurityOrigin&);
 
 G_END_DECLS
 

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -87,7 +87,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 @property (readonly) BOOL didPassCORSAccessChecks;
 - (void)finishTasksAndInvalidate;
 - (void)invalidateAndCancel;
-- (BOOL)wouldTaintOrigin:(const WebCore::SecurityOrigin&)origin;
+- (BOOL)isCrossOrigin:(const WebCore::SecurityOrigin&)origin;
 
 - (void)resetWithCompletionHandler:(void (^)(void))completionHandler;
 - (void)flushWithCompletionHandler:(void (^)(void))completionHandler;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -409,9 +409,8 @@ void RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged()
     m_cachedState.wirelessVideoPlaybackDisabled = m_player->wirelessVideoPlaybackDisabled();
 #endif
     m_cachedState.canSaveMediaData = m_player->canSaveMediaData();
-    m_cachedState.hasSingleSecurityOrigin = m_player->hasSingleSecurityOrigin();
     m_cachedState.didPassCORSAccessCheck = m_player->didPassCORSAccessCheck();
-    m_cachedState.wouldTaintDocumentSecurityOrigin = m_player->wouldTaintOrigin(m_configuration.documentSecurityOrigin.securityOrigin());
+    m_cachedState.documentIsCrossOrigin = m_player->isCrossOrigin(m_configuration.documentSecurityOrigin.securityOrigin());
 
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::ReadyStateChanged(m_cachedState), m_id);
 }
@@ -1109,9 +1108,9 @@ void RemoteMediaPlayerProxy::performTaskAtMediaTime(const MediaTime& taskTime, M
     }, adjustedTaskTime);
 }
 
-void RemoteMediaPlayerProxy::wouldTaintOrigin(struct WebCore::SecurityOriginData originData, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+void RemoteMediaPlayerProxy::isCrossOrigin(struct WebCore::SecurityOriginData originData, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
 {
-    completionHandler(m_player->wouldTaintOrigin(originData.securityOrigin()));
+    completionHandler(m_player->isCrossOrigin(originData.securityOrigin()));
 }
 
 void RemoteMediaPlayerProxy::setVideoPlaybackMetricsUpdateInterval(double interval)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -211,7 +211,7 @@ public:
 
     using PerformTaskAtMediaTimeCompletionHandler = CompletionHandler<void(std::optional<MediaTime>, std::optional<MonotonicTime>)>;
     void performTaskAtMediaTime(const MediaTime&, MonotonicTime, PerformTaskAtMediaTimeCompletionHandler&&);
-    void wouldTaintOrigin(struct WebCore::SecurityOriginData, CompletionHandler<void(std::optional<bool>)>&&);
+    void isCrossOrigin(struct WebCore::SecurityOriginData, CompletionHandler<void(std::optional<bool>)>&&);
 
     void setVideoPlaybackMetricsUpdateInterval(double);
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -107,7 +107,7 @@ messages -> RemoteMediaPlayerProxy NotRefCounted {
     TextTrackSetMode(WebKit::TrackPrivateRemoteIdentifier identifier, enum:uint8_t WebCore::InbandTextTrackPrivate::Mode mode)
 
     PerformTaskAtMediaTime(MediaTime mediaTime, MonotonicTime messageTime) -> (std::optional<MediaTime> mediaTime, std::optional<MonotonicTime> monotonicTime)
-    WouldTaintOrigin(struct WebCore::SecurityOriginData origin) -> (std::optional<bool> wouldTaint) Synchronous
+    IsCrossOrigin(struct WebCore::SecurityOriginData origin) -> (std::optional<bool> crossOrigin) Synchronous
 
     SetVideoPlaybackMetricsUpdateInterval(double interval)
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -332,9 +332,8 @@ private:
 
     void setShouldMaintainAspectRatio(bool) final;
 
-    bool hasSingleSecurityOrigin() const final;
     bool didPassCORSAccessCheck() const final;
-    std::optional<bool> wouldTaintOrigin(const WebCore::SecurityOrigin&) const final;
+    std::optional<bool> isCrossOrigin(const WebCore::SecurityOrigin&) const final;
 
     WebCore::MediaPlayer::MovieLoadType movieLoadType() const final;
 
@@ -456,7 +455,7 @@ private:
     HashMap<TrackPrivateRemoteIdentifier, Ref<TextTrackPrivateRemote>> m_textTracks;
 
     WebCore::SecurityOriginData m_documentSecurityOrigin;
-    mutable HashMap<WebCore::SecurityOriginData, std::optional<bool>> m_wouldTaintOriginCache;
+    mutable HashMap<WebCore::SecurityOriginData, std::optional<bool>> m_isCrossOriginCache;
 
     MediaTime m_cachedMediaTime;
     MonotonicTime m_cachedMediaTimeQueryTime;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
@@ -56,7 +56,7 @@ struct RemoteMediaPlayerState {
     double liveUpdateInterval { 0 };
     uint64_t totalBytes { 0 };
     std::optional<WebCore::VideoPlaybackQualityMetrics> videoMetrics;
-    std::optional<bool> wouldTaintDocumentSecurityOrigin { true };
+    std::optional<bool> documentIsCrossOrigin { true };
     bool paused { true };
     bool canSaveMediaData { false };
     bool hasAudio { false };
@@ -64,7 +64,6 @@ struct RemoteMediaPlayerState {
     bool hasClosedCaptions { false };
     bool hasAvailableVideoFrame { false };
     bool wirelessVideoPlaybackDisabled { false };
-    bool hasSingleSecurityOrigin { false };
     bool didPassCORSAccessCheck { false };
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
@@ -41,7 +41,7 @@ struct WebKit::RemoteMediaPlayerState {
     double liveUpdateInterval;
     uint64_t totalBytes;
     std::optional<WebCore::VideoPlaybackQualityMetrics> videoMetrics;
-    std::optional<bool> wouldTaintDocumentSecurityOrigin;
+    std::optional<bool> documentIsCrossOrigin;
     bool paused;
     bool canSaveMediaData;
     bool hasAudio;
@@ -49,7 +49,6 @@ struct WebKit::RemoteMediaPlayerState {
     bool hasClosedCaptions;
     bool hasAvailableVideoFrame;
     bool wirelessVideoPlaybackDisabled;
-    bool hasSingleSecurityOrigin;
     bool didPassCORSAccessCheck;
 }
 #endif


### PR DESCRIPTION
#### ec3e1edcb9e53c722dbac3fc483161d659ea1b1e
<pre>
non-CORS Redirects to a cross-origin URI should cause video to taint &lt;canvas&gt;, even if the final response is same-origin.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248462">https://bugs.webkit.org/show_bug.cgi?id=248462</a>
&lt;rdar://102754474&gt;

Reviewed by Jean-Yves Avenard.

This is true even if we start with a same-origin URI, redirect to a cross-origin URI and then back again to a same-origin URI.

hasSingleSecurityOrigin currently tries to track this, but it only compares the initial request URI against the response URI, not
any intermediate redirects.

This adds tracking of all redirect origins to the media player implementations of wouldTaintOrigin (and rename it to isCrossOrigin), so that
they fail if we redirected to a cross-origin URI at any point. It also ensures that we only do this if we haven&apos;t passed a CORS access check.

Moves the code for doing these checks from 3 separate callsites (CanvasRenderingContext, ImageBitmap, MediaElementAudioSourceNode) into
a single shared location (HTMLMediaElement).

Removes all the hasSingleSecurityOrigin media code, since it&apos;s no longer in use.

* LayoutTests/http/tests/security/canvas-remote-read-remote-video-allowed-redirect-expected.txt: Added.
* LayoutTests/http/tests/security/canvas-remote-read-remote-video-allowed-redirect.html: Added.

This adds a test for the change in bug 242889, which stopped us tainting for cross-origin redirects.
That&apos;s still desired, but only if CORS was requested and successful.

* LayoutTests/http/tests/security/resources/canvas-video-crossorigin.js:
(testDataRetrievalAllowed):

Fixes a test bug, where the &apos;allowed&apos; test was expecting an exception to be thrown.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/resources/canvas-tests.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt:

Add new subtest for the same-origin -&gt; cross-origin -&gt; same-origin redirect chain case.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:

Enables tests that now pass.

* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::wouldTaintOrigin):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::wouldTaintOrigin const):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::hasSingleSecurityOrigin const): Deleted.
(WebCore::HTMLMediaElement::wouldTaintOrigin const): Deleted.
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::taintsOrigin):
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::wouldTaintOrigin):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::isCrossOrigin const):
(WebCore::MediaPlayer::hasSingleSecurityOrigin const): Deleted.
(WebCore::MediaPlayer::wouldTaintOrigin const): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::isCrossOrigin const):
(WebCore::MediaPlayerPrivateInterface::hasSingleSecurityOrigin const): Deleted.
(WebCore::MediaPlayerPrivateInterface::wouldTaintOrigin const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::hasSingleSecurityOrigin const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::isCrossOrigin const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::wouldTaintOrigin const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::isCrossOrigin const):
(WebCore::MediaPlayerPrivateGStreamer::loadNextLocation):
(WebCore::MediaPlayerPrivateGStreamer::hasSingleSecurityOrigin const): Deleted.
(WebCore::MediaPlayerPrivateGStreamer::wouldTaintOrigin const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(CachedResourceStreamingClient::redirectReceived):
(webKitSrcIsCrossOrigin):
(webKitSrcWouldTaintOrigin): Deleted.
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession task:addSecurityOrigin:]):
(-[WebCoreNSURLSession isCrossOrigin:]):
(-[WebCoreNSURLSessionDataTask resource:receivedResponse:completionHandler:]):
(-[WebCoreNSURLSessionDataTask resource:receivedRedirect:request:completionHandler:]):
(-[WebCoreNSURLSession task:didReceiveResponseFromOrigin:]): Deleted.
(-[WebCoreNSURLSession wouldTaintOrigin:]): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged):
(WebKit::RemoteMediaPlayerProxy::isCrossOrigin):
(WebKit::RemoteMediaPlayerProxy::wouldTaintOrigin): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::updateCachedState):
(WebKit::MediaPlayerPrivateRemote::isCrossOrigin const):
(WebKit::MediaPlayerPrivateRemote::hasSingleSecurityOrigin const): Deleted.
(WebKit::MediaPlayerPrivateRemote::wouldTaintOrigin const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259108@main">https://commits.webkit.org/259108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6177d6332d65ebaeb494acf8302160a2ba81e1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112869 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173200 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3651 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112025 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38367 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80018 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26683 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3210 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6270 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8058 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->