### PR TITLE
[WGSL] Start implementing the codegen

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -40,18 +40,6 @@ Expected<void, Error> Visitor::result()
     return m_expectedError;
 }
 
-template<typename T> void Visitor::checkErrorAndVisit(T& x)
-{
-    if (!hasError())
-        visit(x);
-}
-
-template<typename T> void Visitor::maybeCheckErrorAndVisit(T* x)
-{
-    if (!hasError() && x)
-        visit(*x);
-}
-
 // Shader Module
 
 void Visitor::visit(ShaderModule& shaderModule)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -88,8 +88,17 @@ public:
     bool hasError() const;
     Expected<void, Error> result();
 
-    template<typename T> void checkErrorAndVisit(T&);
-    template<typename T> void maybeCheckErrorAndVisit(T*);
+    template<typename T> void checkErrorAndVisit(T& x)
+    {
+        if (!hasError())
+            visit(x);
+    }
+
+    template<typename T> void maybeCheckErrorAndVisit(T* x)
+    {
+        if (!hasError() && x)
+            visit(*x);
+    }
 
 protected:
     void setError(Error error)

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MetalCodeGenerator.h"
+
+#include "AST.h"
+#include "MetalFunctionWriter.h"
+#include <wtf/DataLog.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace WGSL {
+
+namespace Metal {
+
+static constexpr bool dumpMetalCode = false;
+
+static StringView metalCodePrologue()
+{
+    return StringView {
+        "#include <metal_stdlib>\n"
+        "\n"
+        "using namespace metal;\n"
+        "\n"_s
+    };
+
+}
+
+static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
+{
+    if (dumpMetalCode) {
+        dataLogLn("Generated Metal code:");
+        dataLogLn(stringBuilder.toString());
+    }
+}
+
+RenderMetalCode generateMetalCode(AST::ShaderModule& module)
+{
+    StringBuilder stringBuilder;
+    stringBuilder.append(metalCodePrologue());
+
+    auto metalFunctionEntryPoints = Metal::emitMetalFunctions(stringBuilder, module);
+
+    dumpMetalCodeIfNeeded(stringBuilder);
+
+    return { WTFMove(stringBuilder), WTFMove(metalFunctionEntryPoints.mangledVertexEntryPointName), WTFMove(metalFunctionEntryPoints.mangledFragmentEntryPointName) };
+}
+
+} // namespace Metal
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/StringBuilder.h>
+
+namespace WGSL {
+
+namespace AST {
+class ShaderModule;
+}
+
+namespace Metal {
+
+struct RenderMetalCode {
+    StringBuilder metalSource;
+    String mangledVertexEntryPointName;
+    String mangledFragmentEntryPointName;
+};
+
+// Can't fail. Any failure checks need to be done earlier, in the backend-agnostic part of the compiler.
+RenderMetalCode generateMetalCode(AST::ShaderModule&);
+
+} // namespace Metal
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MetalFunctionWriter.h"
+
+#include "AST.h"
+#include "ASTStringDumper.h"
+#include "ASTVisitor.h"
+#include <wtf/DataLog.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/SetForScope.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace WGSL {
+
+namespace Metal {
+
+class FunctionDefinitionWriter : public AST::Visitor {
+public:
+    FunctionDefinitionWriter(StringBuilder& stringBuilder)
+        : m_stringBuilder(stringBuilder)
+    {
+    }
+
+    virtual ~FunctionDefinitionWriter() = default;
+
+    void visit(AST::ShaderModule&) override;
+
+    void visit(AST::Attribute&) override;
+    void visit(AST::BuiltinAttribute&) override;
+    void visit(AST::LocationAttribute&) override;
+    void visit(AST::StageAttribute&) override;
+
+    void visit(AST::FunctionDecl&) override;
+    void visit(AST::StructDecl&) override;
+    void visit(AST::VariableDecl&) override;
+
+    void visit(AST::Expression&) override;
+    void visit(AST::AbstractFloatLiteral&) override;
+    void visit(AST::AbstractIntLiteral&) override;
+    void visit(AST::ArrayAccess&) override;
+    void visit(AST::CallableExpression&) override;
+    void visit(AST::Float32Literal&) override;
+    void visit(AST::IdentifierExpression&) override;
+    void visit(AST::Int32Literal&) override;
+    void visit(AST::StructureAccess&) override;
+    void visit(AST::UnaryExpression&) override;
+
+    void visit(AST::Statement&) override;
+    void visit(AST::AssignmentStatement&) override;
+    void visit(AST::ReturnStatement&) override;
+
+    void visit(AST::TypeDecl&) override;
+    void visit(AST::ArrayType&) override;
+    void visit(AST::NamedType&) override;
+    void visit(AST::ParameterizedType&) override;
+
+    void visit(AST::Parameter&) override;
+
+    StringBuilder& m_stringBuilder;
+    Indentation<4> m_indent { 0 };
+};
+
+void FunctionDefinitionWriter::visit(AST::ShaderModule& shaderModule)
+{
+    AST::Visitor::visit(shaderModule);
+}
+
+void FunctionDefinitionWriter::visit(AST::FunctionDecl& functionDefinition)
+{
+    // FIXME: visit return attributes
+    ASSERT(functionDefinition.maybeReturnType());
+    for (auto& attribute : functionDefinition.attributes()) {
+        checkErrorAndVisit(attribute);
+        m_stringBuilder.append(" ");
+    }
+    checkErrorAndVisit(*functionDefinition.maybeReturnType());
+    m_stringBuilder.append(" ", functionDefinition.name(), "(");
+    bool first = true;
+    for (auto& parameter : functionDefinition.parameters()) {
+        if (!first)
+            m_stringBuilder.append(", ");
+        checkErrorAndVisit(parameter);
+        first = false;
+    }
+    m_stringBuilder.append(")\n");
+    m_stringBuilder.append("{\n");
+    IndentationScope scope(m_indent);
+    checkErrorAndVisit(functionDefinition.body());
+    m_stringBuilder.append("}\n\n");
+}
+
+void FunctionDefinitionWriter::visit(AST::StructDecl& structDecl)
+{
+    // FIXME: visit struct attributes
+    m_stringBuilder.append(m_indent, "struct ", structDecl.name(), " {\n");
+    {
+        IndentationScope scope(m_indent);
+        for (auto& member : structDecl.members()) {
+            m_stringBuilder.append(m_indent);
+            visit(member.type());
+            m_stringBuilder.append(" ", member.name());
+            for (auto &attribute : member.attributes()) {
+                m_stringBuilder.append(" ");
+                visit(attribute);
+            }
+            m_stringBuilder.append(";\n");
+        }
+    }
+    m_stringBuilder.append(m_indent, "};\n\n");
+}
+
+void FunctionDefinitionWriter::visit(AST::VariableDecl& variableDecl)
+{
+    ASSERT(variableDecl.maybeTypeDecl());
+
+    visit(*variableDecl.maybeTypeDecl());
+    m_stringBuilder.append(" ", variableDecl.name());
+    if (variableDecl.maybeInitializer()) {
+        m_stringBuilder.append(" = ");
+        visit(*variableDecl.maybeInitializer());
+    }
+}
+
+void FunctionDefinitionWriter::visit(AST::Attribute& attribute)
+{
+    AST::Visitor::visit(attribute);
+}
+
+void FunctionDefinitionWriter::visit(AST::BuiltinAttribute& builtin)
+{
+    // FIXME: we should replace this with something more efficient, like a trie
+    if (builtin.name() == "vertex_index"_s) {
+        m_stringBuilder.append("[[vertex_id]]");
+        return;
+    }
+
+    if (builtin.name() == "position"_s) {
+        m_stringBuilder.append("[[position]]");
+        return;
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
+void FunctionDefinitionWriter::visit(AST::StageAttribute& stage)
+{
+    switch (stage.stage()) {
+    case AST::StageAttribute::Stage::Vertex:
+        m_stringBuilder.append("[[vertex]]");
+        break;
+    case AST::StageAttribute::Stage::Fragment:
+        m_stringBuilder.append("[[fragment]]");
+        break;
+    case AST::StageAttribute::Stage::Compute:
+        m_stringBuilder.append("[[compute]]");
+        break;
+    }
+}
+
+void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
+{
+    m_stringBuilder.append("[[attribute(", location.location(), ")]]");
+}
+
+void FunctionDefinitionWriter::visit(AST::TypeDecl& type)
+{
+    AST::Visitor::visit(type);
+}
+
+void FunctionDefinitionWriter::visit(AST::ArrayType& type)
+{
+    ASSERT(type.maybeElementType());
+    ASSERT(type.maybeElementCount());
+    m_stringBuilder.append("array<");
+    visit(*type.maybeElementType());
+    m_stringBuilder.append(", ");
+    visit(*type.maybeElementCount());
+    m_stringBuilder.append(">");
+}
+
+void FunctionDefinitionWriter::visit(AST::NamedType& type)
+{
+    if (type.name() == "i32"_s)
+        m_stringBuilder.append("int");
+    else if (type.name() == "f32"_s)
+        m_stringBuilder.append("float");
+    else if (type.name() == "u32"_s)
+        m_stringBuilder.append("unsigned");
+    else
+        m_stringBuilder.append(type.name());
+}
+
+void FunctionDefinitionWriter::visit(AST::ParameterizedType& type)
+{
+    switch (type.base()) {
+    case AST::ParameterizedType::Base::Vec2:
+        m_stringBuilder.append("vec<");
+        visit(type.elementType());
+        m_stringBuilder.append(", 2>");
+        break;
+    case AST::ParameterizedType::Base::Vec3:
+        m_stringBuilder.append("vec<");
+        visit(type.elementType());
+        m_stringBuilder.append(", 3>");
+        break;
+    case AST::ParameterizedType::Base::Vec4:
+        m_stringBuilder.append("vec<");
+        visit(type.elementType());
+        m_stringBuilder.append(", 4>");
+        break;
+
+    // FIXME: Implement the following types
+    case AST::ParameterizedType::Base::Mat2x2:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat2x3:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat2x4:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat3x2:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat3x3:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat3x4:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat4x2:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat4x3:
+        ASSERT_NOT_REACHED();
+        break;
+    case AST::ParameterizedType::Base::Mat4x4:
+        break;
+    }
+}
+
+void FunctionDefinitionWriter::visit(AST::Parameter& parameter)
+{
+    visit(parameter.type());
+    m_stringBuilder.append(" ", parameter.name());
+    for (auto& attribute : parameter.attributes()) {
+        m_stringBuilder.append(" ");
+        checkErrorAndVisit(attribute);
+    }
+}
+
+void FunctionDefinitionWriter::visit(AST::Expression& expression)
+{
+    AST::Visitor::visit(expression);
+}
+
+void FunctionDefinitionWriter::visit(AST::CallableExpression& call)
+{
+    bool first = true;
+    if (call.target().kind() == AST::Node::Kind::ArrayType) {
+        m_stringBuilder.append("{\n");
+        {
+            IndentationScope scope(m_indent);
+            for (auto& argument : call.arguments()) {
+                m_stringBuilder.append(m_indent);
+                visit(argument);
+                m_stringBuilder.append(",\n");
+                first = false;
+            }
+        }
+        m_stringBuilder.append(m_indent, "}");
+    } else {
+        visit(call.target());
+        m_stringBuilder.append("(");
+        for (auto& argument : call.arguments()) {
+            if (!first)
+                m_stringBuilder.append(", ");
+            visit(argument);
+            first = false;
+        }
+        m_stringBuilder.append(")");
+    }
+}
+
+void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
+{
+    switch (unary.operation()) {
+    case AST::UnaryOperation::Negate:
+        m_stringBuilder.append("-");
+    }
+    visit(unary.expression());
+}
+
+void FunctionDefinitionWriter::visit(AST::ArrayAccess& access)
+{
+    visit(access.base());
+    m_stringBuilder.append("[");
+    visit(access.index());
+    m_stringBuilder.append("]");
+}
+
+void FunctionDefinitionWriter::visit(AST::IdentifierExpression& identifier)
+{
+    m_stringBuilder.append(identifier.identifier());
+}
+
+void FunctionDefinitionWriter::visit(AST::StructureAccess& access)
+{
+    visit(access.base());
+    m_stringBuilder.append(".", access.fieldName());
+}
+
+void FunctionDefinitionWriter::visit(AST::AbstractIntLiteral& literal)
+{
+    // FIXME: this might not serialize all values correctly
+    m_stringBuilder.append(literal.value());
+}
+
+void FunctionDefinitionWriter::visit(AST::Int32Literal& literal)
+{
+    // FIXME: this might not serialize all values correctly
+    m_stringBuilder.append(literal.value());
+}
+
+void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
+{
+    // FIXME: this might not serialize all values correctly
+    m_stringBuilder.append(literal.value());
+}
+
+void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
+{
+    // FIXME: this might not serialize all values correctly
+    m_stringBuilder.append(literal.value());
+}
+
+void FunctionDefinitionWriter::visit(AST::Statement& statement)
+{
+    if (statement.kind() != AST::Node::Kind::CompoundStatement)
+        m_stringBuilder.append(m_indent);
+
+    AST::Visitor::visit(statement);
+
+    if (statement.kind() != AST::Node::Kind::CompoundStatement)
+        m_stringBuilder.append(";\n");
+}
+
+void FunctionDefinitionWriter::visit(AST::AssignmentStatement& assignment)
+{
+    if (assignment.maybeLhs()) {
+        visit(*assignment.maybeLhs());
+        m_stringBuilder.append(" = ");
+    }
+    visit(assignment.rhs());
+}
+
+void FunctionDefinitionWriter::visit(AST::ReturnStatement& statement)
+{
+    m_stringBuilder.append("return");
+    if (statement.maybeExpression()) {
+        m_stringBuilder.append(" ");
+        visit(*statement.maybeExpression());
+    }
+}
+
+RenderMetalFunctionEntryPoints emitMetalFunctions(StringBuilder& stringBuilder, AST::ShaderModule& module)
+{
+    FunctionDefinitionWriter functionDefinitionWriter(stringBuilder);
+    functionDefinitionWriter.visit(module);
+
+    // FIXME: return the actual entry points
+    return { String(""_s), String(""_s) };
+}
+
+} // namespace Metal
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/StringBuilder.h>
+
+namespace WGSL {
+
+namespace AST {
+class ShaderModule;
+}
+
+namespace Metal {
+
+struct RenderMetalFunctionEntryPoints {
+    String mangledVertexEntryPointName;
+    String mangledFragmentEntryPointName;
+};
+RenderMetalFunctionEntryPoints emitMetalFunctions(StringBuilder&, AST::ShaderModule&);
+
+} // namespace Metal
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -476,6 +476,10 @@ Expected<AST::FunctionDecl, Error> Parser<Lexer>::parseFunctionDecl(AST::Attribu
     while (current().m_type != TokenType::ParenRight) {
         PARSE(parameter, Parameter);
         parameters.append(makeUniqueRef<AST::Parameter>(WTFMove(parameter)));
+        if (current().m_type == TokenType::Comma)
+            consume();
+        else
+            break;
     }
     CONSUME_TYPE(ParenRight);
 

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WGSL.h"
 
+#include "Metal/MetalCodeGenerator.h"
 #include "Parser.h"
 
 namespace WGSL {
@@ -54,19 +55,19 @@ SuccessfulCheck::SuccessfulCheck(Vector<Warning>&& messages, UniqueRef<AST::Shad
 
 SuccessfulCheck::~SuccessfulCheck() = default;
 
-PrepareResult prepare(const AST::ShaderModule& ast, const HashMap<String, PipelineLayout>& pipelineLayouts)
+PrepareResult prepare(AST::ShaderModule& ast, const HashMap<String, PipelineLayout>& pipelineLayouts)
 {
-    UNUSED_PARAM(ast);
     UNUSED_PARAM(pipelineLayouts);
-    return { String(), { } };
+    Metal::RenderMetalCode metalCode = Metal::generateMetalCode(ast);
+    return { metalCode.metalSource.toString(), { } };
 }
 
-PrepareResult prepare(const AST::ShaderModule& ast, const String& entryPointName, const std::optional<PipelineLayout>& pipelineLayouts)
+PrepareResult prepare(AST::ShaderModule& ast, const String& entryPointName, const std::optional<PipelineLayout>& pipelineLayouts)
 {
-    UNUSED_PARAM(ast);
     UNUSED_PARAM(entryPointName);
     UNUSED_PARAM(pipelineLayouts);
-    return { String(), { } };
+    Metal::RenderMetalCode metalCode = Metal::generateMetalCode(ast);
+    return { metalCode.metalSource.toString(), { } };
 }
 
 }

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -204,7 +204,7 @@ struct PrepareResult {
 
 // These are not allowed to fail.
 // All failures must have already been caught in check().
-PrepareResult prepare(const AST::ShaderModule&, const HashMap<String, PipelineLayout>&);
-PrepareResult prepare(const AST::ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
+PrepareResult prepare(AST::ShaderModule&, const HashMap<String, PipelineLayout>&);
+PrepareResult prepare(AST::ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -84,6 +84,10 @@
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
+		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
+		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
+		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
+		979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B5297018290050EA2C /* MetalFunctionWriter.cpp */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
 
@@ -324,6 +328,10 @@
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
+		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
+		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
+		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
+		979240B5297018290050EA2C /* MetalFunctionWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalFunctionWriter.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -596,6 +604,7 @@
 			isa = PBXGroup;
 			children = (
 				33EA185C27BC193D00A1DD52 /* AST */,
+				979240B1297018290050EA2C /* Metal */,
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
@@ -679,6 +688,17 @@
 			path = AST;
 			sourceTree = "<group>";
 		};
+		979240B1297018290050EA2C /* Metal */ = {
+			isa = PBXGroup;
+			children = (
+				979240B4297018290050EA2C /* MetalCodeGenerator.cpp */,
+				979240B2297018290050EA2C /* MetalCodeGenerator.h */,
+				979240B5297018290050EA2C /* MetalFunctionWriter.cpp */,
+				979240B3297018290050EA2C /* MetalFunctionWriter.h */,
+			);
+			path = Metal;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -728,6 +748,8 @@
 				3A1337E828FBD56400F29B73 /* ASTVisitor.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
+				979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */,
+				979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */,
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
 				66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */,
 				338BB2D227B6B63F00E066AB /* SourceSpan.h in Headers */,
@@ -926,6 +948,8 @@
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
+				979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */,
+				979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -39,7 +39,7 @@ struct LibraryCreationResult {
     WGSL::Reflection::EntryPointInformation entryPointInformation; // FIXME(PERFORMANCE): This is big. Don't copy this around.
 };
 
-static std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const ShaderModule& shaderModule, const PipelineLayout& pipelineLayout, const String& entryPoint, NSString *label)
+static std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, ShaderModule& shaderModule, const PipelineLayout& pipelineLayout, const String& entryPoint, NSString *label)
 {
     if (shaderModule.library()) {
         if (const auto* pipelineLayoutHint = shaderModule.pipelineLayoutHint(entryPoint)) {
@@ -50,7 +50,7 @@ static std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, 
         }
     }
 
-    const auto* ast = shaderModule.ast();
+    auto* ast = shaderModule.ast();
     if (!ast)
         return std::nullopt;
 
@@ -147,7 +147,7 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
     if (descriptor.nextInChain || descriptor.compute.nextInChain)
         return ComputePipeline::createInvalid(*this);
 
-    const ShaderModule& shaderModule = WebGPU::fromAPI(descriptor.compute.module);
+    ShaderModule& shaderModule = WebGPU::fromAPI(descriptor.compute.module);
     const PipelineLayout& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
     auto label = fromAPI(descriptor.label);
 

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -65,7 +65,7 @@ public:
     static WGSL::PipelineLayout convertPipelineLayout(const PipelineLayout&);
     static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label);
 
-    const WGSL::AST::ShaderModule* ast() const;
+    WGSL::AST::ShaderModule* ast() const;
 
     const PipelineLayout* pipelineLayoutHint(const String&) const;
     const WGSL::Reflection::EntryPointInformation* entryPointInformation(const String&) const;

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -300,13 +300,13 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
     return { { } };
 }
 
-const WGSL::AST::ShaderModule* ShaderModule::ast() const
+WGSL::AST::ShaderModule* ShaderModule::ast() const
 {
-    return WTF::switchOn(m_checkResult, [&](const WGSL::SuccessfulCheck& successfulCheck) -> const WGSL::AST::ShaderModule* {
+    return WTF::switchOn(m_checkResult, [&](const WGSL::SuccessfulCheck& successfulCheck) -> WGSL::AST::ShaderModule* {
         return successfulCheck.ast.ptr();
-    }, [&](const WGSL::FailedCheck&) -> const WGSL::AST::ShaderModule* {
+    }, [&](const WGSL::FailedCheck&) -> WGSL::AST::ShaderModule* {
         return nullptr;
-    }, [](std::monostate) -> const WGSL::AST::ShaderModule* {
+    }, [](std::monostate) -> WGSL::AST::ShaderModule* {
         ASSERT_NOT_REACHED();
         return nullptr;
     });

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
@@ -30,9 +30,9 @@ async function helloTriangle() {
 /*
     FIXME: Use WGSL once compiler is brought up
     const wgslSource = `
-                     @vertex fn main(@builtin(vertex_index) VertexIndex: u32) -> @builtin(position) vec4<f32>
+                     @vertex fn vsmain(@builtin(vertex_index) VertexIndex: u32) -> @builtin(position) vec4<f32>
                      {
-                         var pos = array<vec2<f32>, 3>(
+                         var pos: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                              vec2<f32>( 0.0,  0.5),
                              vec2<f32>(-0.5, -0.5),
                              vec2<f32>( 0.5, -0.5)
@@ -40,7 +40,7 @@ async function helloTriangle() {
                          return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
                      }
 
-                     @fragment fn main() -> @location(0) vec4<f32>
+                     @fragment fn fsmain() -> @location(0) vec4<f32>
                      {
                          return vec4<f32>(1.0, 0.0, 0.0, 1.0);
                      }


### PR DESCRIPTION
#### 06f047e2888cd627f37a1f74ade3447292e54021
<pre>
[WGSL] Start implementing the codegen
<a href="https://bugs.webkit.org/show_bug.cgi?id=250555">https://bugs.webkit.org/show_bug.cgi?id=250555</a>
&lt;rdar://problem/104217343&gt;

Reviewed by Myles C. Maxfield.

A initial naive codegen implementation, just enough to show the red triangle on the screen.

* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp: Added.
(WGSL::Metal::metalCodePrologue):
(WGSL::Metal::dumpMetalCodeIfNeeded):
(WGSL::Metal::generateMetalCode):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h: Added.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp: Added.
(WGSL::Metal::FunctionDefinitionWriter::FunctionDefinitionWriter):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitMetalFunctions):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h: Added.
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStructMember):
(WGSL::Parser&lt;Lexer&gt;::parseFunctionDecl):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepare):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::createLibrary):
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::ast const):
* Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js:
(async helloTriangle):

Canonical link: <a href="https://commits.webkit.org/259070@main">https://commits.webkit.org/259070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33bfadb53c7083a116a16fbc4557f6cdc6d31465

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112952 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3735 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112085 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38411 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80061 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3275 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46271 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6239 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8136 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->