### PR TITLE
IPC stream buffer interface allows creating npot buffer sizes

### DIFF
--- a/LayoutTests/ipc/stream-buffer-read-write.html
+++ b/LayoutTests/ipc/stream-buffer-read-write.html
@@ -15,8 +15,8 @@ if (window.IPC) {
     let dataWriteSuccess = false;
 
     const testBytes = Uint8Array.from({length: 16}, (x, i) => i + 0x41);
-    const bufferSize = 272;
-    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSize);
+    const bufferSizeLog2 = 4;
+    const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
     streamConnection.open();
 
     let streamBuffer = streamConnection.streamBuffer();

--- a/LayoutTests/ipc/stream-check-autoreleasepool.html
+++ b/LayoutTests/ipc/stream-check-autoreleasepool.html
@@ -8,10 +8,10 @@ promise_test(async t => {
     if (!window.IPC)
         return;
     const defaultTimeout = 1000;
-    const bufferSize = 400;
+    const bufferSizeLog2 = 9;
     const streamTesterID = 447;
     for (const processTarget of IPC.processTargets) {
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSize);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },

--- a/LayoutTests/ipc/stream-sync-reply-shared-memory.html
+++ b/LayoutTests/ipc/stream-sync-reply-shared-memory.html
@@ -7,10 +7,10 @@
 setup({ single_test: true });
 if (window.IPC) { // For compiles with !ENABLE(IPC_TESTING_API)
     const defaultTimeout = 1000;
-    const bufferSize = 400;
+    const bufferSizeLog2 = 9;
     const streamTesterID = 447;
     for (const processTarget of IPC.processTargets) {
-        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSize);
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
         streamConnection.open();
         IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
             { type: 'uint64_t', value: streamTesterID },

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -64,7 +64,7 @@ public:
     };
 
     // The messages from the server are delivered to the caller through the passed IPC::MessageReceiver.
-    static StreamConnectionPair create(size_t bufferSize);
+    static StreamConnectionPair create(unsigned bufferSizeLog2);
 
     ~StreamClientConnection();
 
@@ -98,7 +98,7 @@ public:
     Connection& connectionForTesting();
 
 private:
-    StreamClientConnection(Ref<Connection>, size_t bufferSize);
+    StreamClientConnection(Ref<Connection>, unsigned bufferSizeLog2);
 
     struct Span {
         uint8_t* data;

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -39,10 +39,11 @@ static Ref<WebKit::SharedMemory> createMemory(size_t size)
     return memory.releaseNonNull();
 }
 
-StreamConnectionBuffer::StreamConnectionBuffer(size_t memorySize)
-    : m_dataSize(memorySize - headerSize())
-    , m_sharedMemory(createMemory(memorySize))
+StreamConnectionBuffer::StreamConnectionBuffer(unsigned dataSizeLog2)
+    : m_dataSize(static_cast<size_t>(1u) << dataSizeLog2)
+    , m_sharedMemory(createMemory(m_dataSize + headerSize()))
 {
+    ASSERT(dataSizeLog2 < 31u); // Currently expected to be not that big, and offset to fit in size_t with the tag bits.
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(sharedMemorySizeIsValid(m_sharedMemory->size()));
 }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -71,7 +71,7 @@ class Encoder;
 class StreamConnectionBuffer {
     WTF_MAKE_NONCOPYABLE(StreamConnectionBuffer);
 public:
-    explicit StreamConnectionBuffer(size_t memorySize);
+    explicit StreamConnectionBuffer(unsigned dataSizeLog2);
     StreamConnectionBuffer(StreamConnectionBuffer&&);
     ~StreamConnectionBuffer();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -48,7 +48,6 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static constexpr size_t defaultStreamSize = 1 << 21;
 static constexpr size_t readPixelsInlineSizeLimit = 64 * KB;
 
 namespace {
@@ -74,7 +73,8 @@ RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy(IPC::Connection& conn
     : GraphicsContextGL(attributes)
     , m_videoFrameObjectHeapProxy(WTFMove(videoFrameObjectHeapProxy))
 {
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultStreamSize);
+    constexpr unsigned connectionBufferSizeLog2 = 21;
+    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
     m_streamConnection = WTFMove(clientConnection);
     m_connection = &connection;
     m_connection->send(Messages::GPUConnectionToWebProcess::CreateGraphicsContextGL(attributes, m_graphicsContextGLIdentifier, renderingBackend, WTFMove(serverConnectionHandle)), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -80,8 +80,8 @@ RemoteRenderingBackendProxy::~RemoteRenderingBackendProxy()
 void RemoteRenderingBackendProxy::ensureGPUProcessConnection()
 {
     if (!m_streamConnection) {
-        static constexpr auto connectionBufferSize = 1 << 21;
-        auto [streamConnection, serverHandle] = IPC::StreamClientConnection::create(connectionBufferSize);
+        static constexpr auto connectionBufferSizeLog2 = 21;
+        auto [streamConnection, serverHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
         m_streamConnection = WTFMove(streamConnection);
         m_streamConnection->open(*this, m_dispatcher);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -40,14 +40,14 @@
 
 namespace WebKit {
 
-static constexpr size_t defaultStreamSize = 1 << 21;
 
 RemoteGPUProxy::RemoteGPUProxy(GPUProcessConnection& gpuProcessConnection, WebGPU::ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, RenderingBackendIdentifier renderingBackend)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
     , m_gpuProcessConnection(&gpuProcessConnection)
 {
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultStreamSize);
+    constexpr size_t connectionBufferSizeLog2 = 21;
+    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
     m_streamConnection = WTFMove(clientConnection);
     m_gpuProcessConnection->addClient(*this);
     m_gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteGPU(identifier, renderingBackend, WTFMove(serverConnectionHandle)), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2457,12 +2457,12 @@ JSValueRef JSIPC::createStreamClientConnection(JSContextRef context, JSObjectRef
         return JSValueMakeUndefined(context);
     }
 
-    auto bufferSize = argumentCount ? convertToUint64(toJS(globalObject, arguments[0])) : std::optional<uint64_t> { };
-    if (!bufferSize) {
+    auto bufferSizeLog2 = argumentCount ? convertToUint64(toJS(globalObject, arguments[0])) : std::optional<uint64_t> { };
+    if (!bufferSizeLog2) {
         *exception = createTypeError(context, "Must specify the size"_s);
         return JSValueMakeUndefined(context);
     }
-    auto connectionPair = IPC::StreamClientConnection::create(*bufferSize);
+    auto connectionPair = IPC::StreamClientConnection::create(*bufferSizeLog2);
     auto& vm = globalObject->vm();
     auto scope = DECLARE_CATCH_SCOPE(vm);
     JSC::JSObject* connectionPairObject = JSC::constructEmptyArray(globalObject, nullptr);

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
@@ -32,9 +32,13 @@ namespace TestWebKitAPI {
 
 TEST(StreamConnectionBufferTests, CreateWorks)
 {
-    IPC::StreamConnectionBuffer b(5000);
+    IPC::StreamConnectionBuffer b(8);
     EXPECT_NE(b.data(), nullptr);
-    EXPECT_LT(b.dataSize(), 5000u);
+    EXPECT_EQ(b.dataSize(), 256u);
+
+    IPC::StreamConnectionBuffer b2(24);
+    EXPECT_NE(b2.data(), nullptr);
+    EXPECT_EQ(b2.dataSize(), 16777216u);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -171,7 +171,8 @@ public:
     void SetUp() override
     {
         WTF::initializeMainThread();
-        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(10000);
+        constexpr unsigned bufferSizeLog2 = 14;
+        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(bufferSizeLog2);
         auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), *m_workQueue);
         m_clientConnection = WTFMove(clientConnection);
         m_serverConnection = WTFMove(serverConnection);


### PR DESCRIPTION
#### b3f9762fcd0a0e27240fb9153817166be4297403
<pre>
IPC stream buffer interface allows creating npot buffer sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250557">https://bugs.webkit.org/show_bug.cgi?id=250557</a>
rdar://104217729

Reviewed by Antti Koivisto.

Non-power of two buffer sizes are problematic because the circular buffer
algorithm benefits from using power of two buffers. The property will
be used in future commits.

Use log2 number in the API to enforce that only power-of-two buffers
are used.

Additionally, the API was taking in the shared memory buffer size. Since
the header is an implementation detail of the communciation buffer, change
the implementation to take in the expected data size and adjust the size in
the implementation.

* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
(IPC::StreamClientConnection::StreamClientConnection):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::StreamConnectionBuffer):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::RemoteGPUProxy):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::createStreamClientConnection):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:

Canonical link: <a href="https://commits.webkit.org/258911@main">https://commits.webkit.org/258911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7e356a95489e7215edc0153a83f18a010e530db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112519 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172719 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3307 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110782 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10314 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37946 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79671 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5796 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26392 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5971 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2912 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6124 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7723 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->