### PR TITLE
Fix compiler errors with GCC-12 [GCC] with libwebrtc (USE_GSTREAMER_WEBRTC=FALSE)

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -446,6 +446,8 @@ static std::optional<RTCErrorDetailType> toRTCErrorDetailType(webrtc::RTCErrorDe
     case webrtc::RTCErrorDetailType::NONE:
         return { };
     };
+
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 RefPtr<RTCError> toRTCError(const webrtc::RTCError& rtcError)

--- a/Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp
+++ b/Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp
@@ -275,6 +275,8 @@ webrtc::PeerConnectionInterface::SignalingState MockLibWebRTCPeerConnection::sig
     case RTCSignalingState::Closed:
         return SignalingState::kClosed;
     }
+
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 void MockLibWebRTCPeerConnection::SetLocalDescription(std::unique_ptr<webrtc::SessionDescriptionInterface> sessionDescription, rtc::scoped_refptr<webrtc::SetLocalDescriptionObserverInterface> observer)


### PR DESCRIPTION
#### d1d4a86a623f5b951e582aad8518f2cc9b4b4401
<pre>
Fix compiler errors with GCC-12 [GCC] with libwebrtc (USE_GSTREAMER_WEBRTC=FALSE)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250562">https://bugs.webkit.org/show_bug.cgi?id=250562</a>

Reviewed by Philippe Normand.

With GCC version 12.2.0 the compiler stops with:
  error: control reaches end of non-void function [-Werror=return-type]
when building these files, at least since commit
9def6e6f0258ddd9171d32bec2fffb684dbc7b8b.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::toRTCErrorDetailType):
* Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp:
(WebCore::MockLibWebRTCPeerConnection::signaling_state):

Canonical link: <a href="https://commits.webkit.org/258871@main">https://commits.webkit.org/258871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/722eacc3604adab3cf5fb7ca753a7a76e0148968

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12339 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112461 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172658 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3243 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95439 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108988 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37895 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92084 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5742 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2857 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11902 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6097 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7661 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->