### PR TITLE
[@property] Rules in shadow trees should be ignored.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL @property rules in shadow trees should have no effect assert_equals: expected "calc(1px + 1px)" but got "2px"
+PASS @property rules in shadow trees should have no effect
 

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -37,6 +37,7 @@
 #include "CSSVariableData.h"
 #include "ConstantPropertyMap.h"
 #include "CustomPropertyRegistry.h"
+#include "Document.h"
 #include "RenderStyle.h"
 #include "StyleBuilder.h"
 #include "StyleResolver.h"

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -54,11 +54,6 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
     RefPtr<CSSCustomPropertyValue> initialValue;
     if (!descriptor.initialValue.isNull()) {
         CSSTokenizer tokenizer(descriptor.initialValue);
-        auto styleResolver = Style::Resolver::create(document);
-
-        // We need to initialize this so that we can successfully parse computationally dependent values (like em units).
-        // We don't actually need the values to be accurate, since they will be rejected later anyway
-        auto style = styleResolver->defaultStyleForElement(nullptr);
 
         HashSet<CSSPropertyID> dependencies;
         CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, true /* isInitial */, dependencies, tokenizer.tokenRange(), strictCSSParserContext());
@@ -66,10 +61,11 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
         if (!dependencies.isEmpty())
             return Exception { SyntaxError, "The given initial value must be computationally independent."_s };
 
-        auto parentStyle = RenderStyle::clone(*style);
-        Style::Builder dummyBuilder(*style, { document, parentStyle }, { }, { });
+        // We don't need to provide a real context style since only computationally independent values are allowed (no 'em' etc).
+        auto placeholderStyle = RenderStyle::create();
+        Style::Builder builder { placeholderStyle, { document, RenderStyle::defaultStyle() }, { }, { } };
 
-        initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(descriptor.name, *syntax, tokenizer.tokenRange(), dummyBuilder.state(), { document });
+        initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(descriptor.name, *syntax, tokenizer.tokenRange(), builder.state(), { document });
 
         if (!initialValue)
             return Exception { SyntaxError, "The given initial value does not parse for the given syntax."_s };

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -41,6 +41,7 @@
 #include "CSSStyleSheet.h"
 #include "CachedResourceLoader.h"
 #include "CompositeOperation.h"
+#include "Document.h"
 #include "ElementRuleCollector.h"
 #include "Frame.h"
 #include "FrameSelection.h"
@@ -134,15 +135,21 @@ private:
     std::unique_ptr<RenderStyle> m_userAgentAppearanceStyle;
 };
 
-Ref<Resolver> Resolver::create(Document& document)
+Ref<Resolver> Resolver::create(Document& document, ScopeType scopeType)
 {
-    return adoptRef(*new Resolver(document));
+    return adoptRef(*new Resolver(document, scopeType));
 }
 
-Resolver::Resolver(Document& document)
-    : m_ruleSets(*this)
-    , m_document(document)
-    , m_matchAuthorAndUserStyles(m_document.settings().authorAndUserStylesEnabled())
+Resolver::Resolver(Document& document, ScopeType scopeType)
+    : m_document(document)
+    , m_scopeType(scopeType)
+    , m_ruleSets(*this)
+    , m_matchAuthorAndUserStyles(settings().authorAndUserStylesEnabled())
+{
+    initialize();
+}
+
+void Resolver::initialize()
 {
     UserAgentStyle::initDefaultStyleSheet();
 
@@ -152,34 +159,51 @@ Resolver::Resolver(Document& document)
     // document doesn't have documentElement
     // NOTE: this assumes that element that gets passed to styleForElement -call
     // is always from the document that owns the style selector
-    FrameView* view = m_document.view();
+    FrameView* view = document().view();
     if (view)
         m_mediaQueryEvaluator = MQ::MediaQueryEvaluator { view->mediaType() };
     else
         m_mediaQueryEvaluator = MQ::MediaQueryEvaluator { };
 
-    if (auto* documentElement = m_document.documentElement()) {
-        m_rootDefaultStyle = styleForElement(*documentElement, { m_document.initialContainingBlockStyle() }, RuleMatchingBehavior::MatchOnlyUserAgentRules).style;
+    if (auto* documentElement = document().documentElement()) {
+        m_rootDefaultStyle = styleForElement(*documentElement, { document().initialContainingBlockStyle() }, RuleMatchingBehavior::MatchOnlyUserAgentRules).style;
         // Turn off assertion against font lookups during style resolver initialization. We may need root style font for media queries.
-        m_document.fontSelector().incrementIsComputingRootStyleFont();
-        m_rootDefaultStyle->fontCascade().update(&m_document.fontSelector());
+        document().fontSelector().incrementIsComputingRootStyleFont();
+        m_rootDefaultStyle->fontCascade().update(&document().fontSelector());
         m_rootDefaultStyle->fontCascade().primaryFont();
-        m_document.fontSelector().decrementIsComputingRootStyleFont();
+        document().fontSelector().decrementIsComputingRootStyleFont();
     }
 
     if (m_rootDefaultStyle && view)
-        m_mediaQueryEvaluator = MQ::MediaQueryEvaluator { view->mediaType(), m_document, m_rootDefaultStyle.get() };
+        m_mediaQueryEvaluator = MQ::MediaQueryEvaluator { view->mediaType(), document(), m_rootDefaultStyle.get() };
 
     m_ruleSets.resetAuthorStyle();
     m_ruleSets.resetUserAgentMediaQueryStyle();
 }
 
+Resolver::~Resolver() = default;
+
+Document& Resolver::document()
+{
+    return *m_document;
+}
+
+const Document& Resolver::document() const
+{
+    return *m_document;
+}
+
+const Settings& Resolver::settings() const
+{
+    return document().settings();
+}
+
 void Resolver::addCurrentSVGFontFaceRules()
 {
-    if (m_document.svgExtensions()) {
-        auto& svgFontFaceElements = m_document.svgExtensions()->svgFontFaceElements();
+    if (document().svgExtensions()) {
+        auto& svgFontFaceElements = document().svgExtensions()->svgFontFaceElements();
         for (auto& svgFontFaceElement : svgFontFaceElements)
-            m_document.fontSelector().addFontFaceRule(svgFontFaceElement.fontFaceRule(), svgFontFaceElement.isInUserAgentShadowTree());
+            document().fontSelector().addFontFaceRule(svgFontFaceElement.fontFaceRule(), svgFontFaceElement.isInUserAgentShadowTree());
     }
 }
 
@@ -196,12 +220,7 @@ void Resolver::addKeyframeStyle(Ref<StyleRuleKeyframes>&& rule)
 {
     auto& animationName = rule->name();
     m_keyframesRuleMap.set(animationName, WTFMove(rule));
-    m_document.keyframesRuleDidChange(animationName);
-}
-
-Resolver::~Resolver()
-{
-    RELEASE_ASSERT(!m_document.isResolvingTreeStyle());
+    document().keyframesRuleDidChange(animationName);
 }
 
 static inline bool isAtShadowBoundary(const Element& element)
@@ -212,7 +231,7 @@ static inline bool isAtShadowBoundary(const Element& element)
 BuilderContext Resolver::builderContext(const State& state)
 {
     return {
-        m_document,
+        document(),
         *state.parentStyle(),
         state.rootElementStyle(),
         state.element()
@@ -482,11 +501,11 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& elem
 
 std::unique_ptr<RenderStyle> Resolver::styleForPage(int pageIndex)
 {
-    auto* documentElement = m_document.documentElement();
+    auto* documentElement = document().documentElement();
     if (!documentElement || !documentElement->renderStyle())
         return RenderStyle::createPtr();
 
-    auto state = State(*documentElement, m_document.initialContainingBlockStyle());
+    auto state = State(*documentElement, document().initialContainingBlockStyle());
 
     state.setStyle(RenderStyle::createPtr());
     state.style()->inheritFrom(*state.rootElementStyle());

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -108,7 +108,7 @@ void Scope::createDocumentResolver()
 
     SetForScope isUpdatingStyleResolver { m_isUpdatingStyleResolver, true };
 
-    m_resolver = Resolver::create(m_document);
+    m_resolver = Resolver::create(m_document, Resolver::ScopeType::Document);
 
     m_document.fontSelector().buildStarted();
 
@@ -129,7 +129,7 @@ void Scope::createOrFindSharedShadowTreeResolver()
     auto result = documentScope().m_sharedShadowTreeResolvers.ensure(WTFMove(key), [&] {
         SetForScope isUpdatingStyleResolver { m_isUpdatingStyleResolver, true };
 
-        m_resolver = Resolver::create(m_document);
+        m_resolver = Resolver::create(m_document, Resolver::ScopeType::ShadowTree);
 
         m_resolver->ruleSets().setUsesSharedUserStyle(!isForUserAgentShadowTree());
         m_resolver->appendAuthorStyleSheets(m_activeStyleSheets);


### PR DESCRIPTION
#### 997d987fd5b6f1909b9fad9c0018f383a97ed8cc
<pre>
[@property] Rules in shadow trees should be ignored.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250567">https://bugs.webkit.org/show_bug.cgi?id=250567</a>
rdar://104221943

Reviewed by Simon Fraser.

&quot;A @property is invalid if it occurs in a stylesheet inside of a shadow tree, and must be ignored.&quot;

<a href="https://drafts.css-houdini.org/css-properties-values-api/#at-property-rule">https://drafts.css-houdini.org/css-properties-values-api/#at-property-rule</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow-expected.txt:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):

No need to create a style resolver.

* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):

Fix indentation.

(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):

The actual fix. Check if we are in a shadow scope and bail.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::create):

Pass the scope as enum value (document or shadow). Due to sharing between identically styled
shadow trees we don&apos;t provide the actual Style::Scope.

(WebCore::Style::Resolver::Resolver):

Use WeakPtr for the document.

(WebCore::Style::Resolver::initialize):

Factor into a function.

(WebCore::Style::Resolver::document):
(WebCore::Style::Resolver::document const):
(WebCore::Style::Resolver::scope): Deleted.
(WebCore::Style::Resolver::scope const): Deleted.
(WebCore::Style::Resolver::~Resolver): Deleted.
* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::Resolver::scopeType const):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createDocumentResolver):
(WebCore::Style::Scope::createOrFindSharedShadowTreeResolver):

Canonical link: <a href="https://commits.webkit.org/258880@main">https://commits.webkit.org/258880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69078b64d50563644ba8061c4b6dc60377ced6c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12376 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3280 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109025 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5776 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6106 "Build is being retried. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by Simon Fraser; Validated commit message; Compiled WebKit (warnings); 14 flakes; Canonicalized commit; Pushed to pull request branch; 'git log ...'; Pushed commit to WebKit repository; Added comment on PR 8617 and added comment on bug 250567; Removed labels from pull request; Closed bug 250567") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7698 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->