### PR TITLE
[GTK][WPE] Stop using legacy download client

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.h
@@ -17,11 +17,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef WebKitDownloadClient_h
-#define WebKitDownloadClient_h
+#pragma once
 
-#include "WebKitWebContext.h"
+#include "DownloadProxy.h"
+#include "WebKitDownload.h"
+#include <wtf/glib/GRefPtr.h>
 
-void attachDownloadClientToContext(WebKitWebContext*);
+void attachDownloadClientToDownload(GRefPtr<WebKitDownload>&&, WebKit::DownloadProxy&);
 
-#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownloadPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownloadPrivate.h
@@ -19,15 +19,16 @@
 
 #pragma once
 
+#include "DownloadProxy.h"
 #include "WebKitDownload.h"
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/glib/GRefPtr.h>
 
-WebKitDownload* webkitDownloadCreate(WebKit::DownloadProxy*);
+GRefPtr<WebKitDownload> webkitDownloadCreate(WebKit::DownloadProxy&, WebKitWebView* = nullptr);
 void webkitDownloadStarted(WebKitDownload*);
 bool webkitDownloadIsCancelled(WebKitDownload*);
 void webkitDownloadSetResponse(WebKitDownload*, WebKitURIResponse*);
-void webkitDownloadSetWebView(WebKitDownload*, WebKitWebView*);
 void webkitDownloadNotifyProgress(WebKitDownload*, guint64 bytesReceived);
 void webkitDownloadFailed(WebKitDownload*, const WebCore::ResourceError&);
 void webkitDownloadCancelled(WebKitDownload*);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
@@ -24,10 +24,12 @@
 #include "APINavigationClient.h"
 #include "FrameInfoData.h"
 #include "WebKitBackForwardListPrivate.h"
+#include "WebKitDownloadPrivate.h"
 #include "WebKitNavigationPolicyDecisionPrivate.h"
 #include "WebKitPrivate.h"
 #include "WebKitResponsePolicyDecisionPrivate.h"
 #include "WebKitURIResponsePrivate.h"
+#include "WebKitWebContextPrivate.h"
 #include "WebKitWebViewPrivate.h"
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
@@ -151,6 +153,24 @@ private:
     {
         GRefPtr<WebKitPolicyDecision> decision = adoptGRef(webkitResponsePolicyDecisionCreate(WTFMove(navigationResponse), WTFMove(listener)));
         webkitWebViewMakePolicyDecision(m_webView, WEBKIT_POLICY_DECISION_TYPE_RESPONSE, decision.get());
+    }
+
+    void navigationActionDidBecomeDownload(WebPageProxy&, API::NavigationAction&, DownloadProxy& downloadProxy) override
+    {
+        auto download = webkitDownloadCreate(downloadProxy, m_webView);
+        webkitWebContextDownloadStarted(webkit_web_view_get_context(m_webView), download.get());
+    }
+
+    void navigationResponseDidBecomeDownload(WebPageProxy&, API::NavigationResponse&, DownloadProxy& downloadProxy) override
+    {
+        auto download = webkitDownloadCreate(downloadProxy, m_webView);
+        webkitWebContextDownloadStarted(webkit_web_view_get_context(m_webView), download.get());
+    }
+
+    void contextMenuDidCreateDownload(WebPageProxy&, DownloadProxy& downloadProxy) override
+    {
+        auto download = webkitDownloadCreate(downloadProxy, m_webView);
+        webkitWebContextDownloadStarted(webkit_web_view_get_context(m_webView), download.get());
     }
 
     WebKitWebView* m_webView;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "DownloadProxy.h"
 #include "WebKitUserContentManager.h"
 #include "WebKitWebContext.h"
 #include "WebKitWebsitePolicies.h"
@@ -33,9 +32,6 @@
 #include <WebCore/ResourceRequest.h>
 
 WebKit::WebProcessPool& webkitWebContextGetProcessPool(WebKitWebContext*);
-WebKitDownload* webkitWebContextGetOrCreateDownload(WebKit::DownloadProxy*);
-WebKitDownload* webkitWebContextStartDownload(WebKitWebContext*, const char* uri, WebKit::WebPageProxy*);
-void webkitWebContextRemoveDownload(WebKit::DownloadProxy*);
 void webkitWebContextDownloadStarted(WebKitWebContext*, WebKitDownload*);
 void webkitWebContextCreatePageForWebView(WebKitWebContext*, WebKitWebView*, WebKitUserContentManager*, WebKitWebView*, WebKitWebsitePolicies*);
 void webkitWebContextWebViewDestroyed(WebKitWebContext*, WebKitWebView*);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -74,7 +74,6 @@ std::optional<WebKitScriptDialogType> webkitWebViewGetCurrentScriptDialogType(We
 void webkitWebViewMakePermissionRequest(WebKitWebView*, WebKitPermissionRequest*);
 void webkitWebViewMakePolicyDecision(WebKitWebView*, WebKitPolicyDecisionType, WebKitPolicyDecision*);
 void webkitWebViewMouseTargetChanged(WebKitWebView*, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEventModifier>);
-void webkitWebViewHandleDownloadRequest(WebKitWebView*, WebKit::DownloadProxy*);
 void webkitWebViewPrintFrame(WebKitWebView*, WebKit::WebFrameProxy*);
 WebKit::WebKitWebResourceLoadManager* webkitWebViewGetWebResourceLoadManager(WebKitWebView*);
 void webkitWebViewResourceLoadStarted(WebKitWebView*, WebKitWebResource*, WebCore::ResourceRequest&&);

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -373,12 +373,6 @@ void PageClientImpl::didPerformDragControllerAction()
 }
 #endif
 
-void PageClientImpl::handleDownloadRequest(DownloadProxy& download)
-{
-    if (WEBKIT_IS_WEB_VIEW(m_viewWidget))
-        webkitWebViewHandleDownloadRequest(WEBKIT_WEB_VIEW(m_viewWidget), &download);
-}
-
 void PageClientImpl::didCommitLoadForMainFrame(const String& /* mimeType */, bool /* useCustomContentProvider */ )
 {
     webkitWebViewBaseResetClickCounter(WEBKIT_WEB_VIEW_BASE(m_viewWidget));

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -113,7 +113,6 @@ private:
     void exitAcceleratedCompositingMode() override;
     void updateAcceleratedCompositingMode(const LayerTreeContext&) override;
 
-    void handleDownloadRequest(DownloadProxy&) override;
     void didChangeContentSize(const WebCore::IntSize&) override;
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
     void didStartProvisionalLoadForMainFrame() override;

--- a/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
@@ -49,7 +49,6 @@ public:
     virtual bool isGLibBasedAPI() { return false; }
 
     virtual void frameDisplayed(WKWPE::View&) { }
-    virtual void handleDownloadRequest(WKWPE::View&, WebKit::DownloadProxy&) { }
     virtual void willStartLoad(WKWPE::View&) { }
     virtual void didChangePageID(WKWPE::View&) { }
     virtual void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&& completionHandler) { completionHandler(WebKit::UserMessage()); }

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -129,11 +129,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
 {
 }
 
-void PageClientImpl::handleDownloadRequest(DownloadProxy& download)
-{
-    m_view.handleDownloadRequest(download);
-}
-
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)
 {
 }

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -84,7 +84,6 @@ private:
     void toolTipChanged(const String&, const String&) override;
 
     void didCommitLoadForMainFrame(const String&, bool) override;
-    void handleDownloadRequest(DownloadProxy&) override;
 
     void didChangeContentSize(const WebCore::IntSize&) override;
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -339,11 +339,6 @@ void View::frameDisplayed()
     m_client->frameDisplayed(*this);
 }
 
-void View::handleDownloadRequest(DownloadProxy& download)
-{
-    m_client->handleDownloadRequest(*this, download);
-}
-
 void View::willStartLoad()
 {
     m_client->willStartLoad(*this);

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.h
@@ -53,7 +53,6 @@ struct CompositionUnderline;
 }
 
 namespace WebKit {
-class DownloadProxy;
 class TouchGestureController;
 class WebKitWebResourceLoadManager;
 class WebPageGroup;
@@ -76,7 +75,6 @@ public:
     // Client methods
     void setClient(std::unique_ptr<API::ViewClient>&&);
     void frameDisplayed();
-    void handleDownloadRequest(WebKit::DownloadProxy&);
     void willStartLoad();
     void didChangePageID();
     void didReceiveUserMessage(WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&);

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
@@ -33,7 +33,6 @@ class IntRect;
 }
 
 namespace WebKit {
-class DownloadProxy;
 class WebKitPopupMenu;
 class WebKitWebResourceLoadManager;
 struct WebPopupItem;
@@ -51,7 +50,6 @@ private:
     bool isGLibBasedAPI() override { return true; }
 
     void frameDisplayed(WKWPE::View&) override;
-    void handleDownloadRequest(WKWPE::View&, WebKit::DownloadProxy&) override;
     void willStartLoad(WKWPE::View&) override;
     void didChangePageID(WKWPE::View&) override;
     void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&) override;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -145,7 +145,6 @@ enum class UndoOrRedo : bool;
 enum class TapHandlingResult : uint8_t;
 
 class ContextMenuContextData;
-class DownloadProxy;
 class DrawingAreaProxy;
 class NativeWebGestureEvent;
 class NativeWebKeyboardEvent;
@@ -276,8 +275,6 @@ public:
     virtual void removeAllPDFHUDs() = 0;
 #endif
     
-    virtual void handleDownloadRequest(DownloadProxy&) = 0;
-
     virtual bool handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) { return false; }
     virtual bool showShareSheet(const WebCore::ShareDataWithParsedURL&, WTF::CompletionHandler<void (bool)>&&) { return false; }
     virtual void showContactPicker(const WebCore::ContactsRequestData&, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&& completionHandler) { completionHandler(std::nullopt); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3698,7 +3698,6 @@ void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* 
         }
 
         downloadID = download.downloadID();
-        handleDownloadRequest(download);
         m_decidePolicyForResponseRequest = { };
     }
     
@@ -6745,11 +6744,6 @@ void WebPageProxy::setMayStartMediaWhenInWindow(bool mayStartMedia)
         return;
 
     send(Messages::WebPage::SetMayStartMediaWhenInWindow(mayStartMedia));
-}
-
-void WebPageProxy::handleDownloadRequest(DownloadProxy& download)
-{
-    pageClient().handleDownloadRequest(download);
 }
 
 void WebPageProxy::resumeDownload(const API::Data& resumeData, const String& path, CompletionHandler<void(DownloadProxy*)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1437,7 +1437,6 @@ public:
 
     WebPageCreationParameters creationParameters(WebProcessProxy&, DrawingAreaProxy&, RefPtr<API::WebsitePolicies>&& = nullptr);
 
-    void handleDownloadRequest(DownloadProxy&);
     void resumeDownload(const API::Data& resumeData, const String& path, CompletionHandler<void(DownloadProxy*)>&&);
     void downloadRequest(WebCore::ResourceRequest&&, CompletionHandler<void(DownloadProxy*)>&&);
     void dataTaskWithRequest(WebCore::ResourceRequest&&, CompletionHandler<void(API::DataTask&)>&&);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1203,7 +1203,6 @@ DownloadProxy& WebProcessPool::download(WebsiteDataStore& dataStore, WebPageProx
 
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     if (initiatingPage) {
-        initiatingPage->handleDownloadRequest(downloadProxy);
 #if ENABLE(APP_BOUND_DOMAINS)
         isAppBound = initiatingPage->isTopFrameNavigatingToAppBoundDomain();
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -90,7 +90,6 @@ private:
     void didStartProvisionalLoadForMainFrame() override;
     void didFailProvisionalLoadForMainFrame() override;
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
-    void handleDownloadRequest(DownloadProxy&) override;
     void didChangeContentSize(const WebCore::IntSize&) override;
     void setCursor(const WebCore::Cursor&) override;
     void setCursorHiddenUntilMouseMoves(bool) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -31,7 +31,6 @@
 #import "APIData.h"
 #import "ApplicationStateTracker.h"
 #import "DataReference.h"
-#import "DownloadProxy.h"
 #import "DrawingAreaProxy.h"
 #import "EndowmentStateTracker.h"
 #import "FrameInfoData.h"
@@ -263,10 +262,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
     [m_webView _hidePasswordView];
     [m_webView _setHasCustomContentView:useCustomContentProvider loadedMIMEType:mimeType];
     [m_contentView _didCommitLoadForMainFrame];
-}
-
-void PageClientImpl::handleDownloadRequest(DownloadProxy&)
-{
 }
 
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -91,7 +91,6 @@ private:
     void toolTipChanged(const String& oldToolTip, const String& newToolTip) override;
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
     void didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, const IPC::DataReference&) override;
-    void handleDownloadRequest(DownloadProxy&) override;
     void didChangeContentSize(const WebCore::IntSize&) override;
     void setCursor(const WebCore::Cursor&) override;
     void setCursorHiddenUntilMouseMoves(bool) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -31,7 +31,6 @@
 #import "APIHitTestResult.h"
 #import "AppKitSPI.h"
 #import "DataReference.h"
-#import "DownloadProxy.h"
 #import "DrawingAreaProxy.h"
 #import "Logging.h"
 #import "NativeWebGestureEvent.h"
@@ -290,10 +289,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
 }
 
 void PageClientImpl::didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, const IPC::DataReference& dataReference)
-{
-}
-
-void PageClientImpl::handleDownloadRequest(DownloadProxy&)
 {
 }
 

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -107,10 +107,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
     notImplemented();
 }
 
-void PageClientImpl::handleDownloadRequest(DownloadProxy&)
-{
-}
-
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize& size)
 {
     notImplemented();

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -82,8 +82,6 @@ private:
 
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
 
-    void handleDownloadRequest(DownloadProxy&) override;
-
     void didChangeContentSize(const WebCore::IntSize&) override;
 
     void setCursor(const WebCore::Cursor&) override;

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -237,11 +237,6 @@ void PageClientImpl::didChangeContentSize(const IntSize& size)
     notImplemented();
 }
 
-void PageClientImpl::handleDownloadRequest(DownloadProxy& download)
-{
-    notImplemented();
-}
-
 void PageClientImpl::didCommitLoadForMainFrame(const String& /* mimeType */, bool /* useCustomContentProvider */ )
 {
     notImplemented();

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -99,7 +99,6 @@ private:
     void exitAcceleratedCompositingMode() override;
     void updateAcceleratedCompositingMode(const LayerTreeContext&) override;
 
-    void handleDownloadRequest(DownloadProxy&) override;
     void didChangeContentSize(const WebCore::IntSize&) override;
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
     void didFirstVisuallyNonEmptyLayoutForMainFrame() override;


### PR DESCRIPTION
#### 7a5daf3137d24451085c7c65573bc787e5aac772
<pre>
[GTK][WPE] Stop using legacy download client
<a href="https://bugs.webkit.org/show_bug.cgi?id=250570">https://bugs.webkit.org/show_bug.cgi?id=250570</a>

Reviewed by Michael Catanzaro.

Move to use the new one, attached to the download object instead of the context.

* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
(webkitDownloadCreate):
(webkitDownloadFailed):
(webkitDownloadFinished):
(webkit_download_cancel):
(webkitDownloadSetWebView): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp:
(attachDownloadClientToDownload):
(attachDownloadClientToContext): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.h:
* Source/WebKit/UIProcess/API/glib/WebKitDownloadPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextConstructed):
(webkitWebContextDispose):
(webkit_web_context_download_uri):
(downloadsMap): Deleted.
(webkitWebContextGetOrCreateDownload): Deleted.
(webkitWebContextStartDownload): Deleted.
(webkitWebContextRemoveDownload): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_download_uri):
(webkitWebViewHandleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/APIViewClient.h:
(API::ViewClient::frameDisplayed):
(API::ViewClient::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
(WKWPE::View::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/API/wpe/WPEView.h:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::download):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
(WebKit::PageClientImpl::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
(WebKit::PageClientImpl::handleDownloadRequest): Deleted.
* Source/WebKit/UIProcess/win/PageClientImpl.h:

Canonical link: <a href="https://commits.webkit.org/258927@main">https://commits.webkit.org/258927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1902e6aa18b7cef32e899e63ea0e7d4c2dd78ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36350 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112622 "Updated wpe dependencies (failure)") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3410 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111473 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79765 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26469 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6070 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45978 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6135 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7828 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->