### PR TITLE
Using `rotate: x` and `transform: rotate(x)` yields different behavior with SVG

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "rotate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: 100px 100px;
+    rotate: 180deg;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "rotate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: 100px 100px;
+    rotate: 180deg;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "rotate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="match" href="rotate-animation-on-svg-ref.html">
+
+<style>
+
+@keyframes rotate-animation {
+    from { rotate: 0; }
+    to   { rotate: 180deg; }
+}
+
+svg {
+    width: 400px;
+    height: 400px;
+    overflow: visible;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: 100px 100px;
+    animation: rotate-animation 1ms linear forwards;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+
+<script>
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    document.documentElement.classList.remove("reftest-wait");
+})();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "scale" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    scale: 2;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "scale" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    scale: 2;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "scale" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="match" href="scale-animation-on-svg-ref.html">
+
+<style>
+
+@keyframes scale-animation {
+    from { scale: 1; }
+    to   { scale: 2; }
+}
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    animation: scale-animation 1ms linear forwards;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+
+<script>
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    document.documentElement.classList.remove("reftest-wait");
+})();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "translate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    translate: 100px 100px;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animating the "translate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+
+<style>
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 200px;
+    height: 200px;
+    transform-origin: top left;
+    translate: 100px 100px;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<title>Animating the "translate" property on an SVG element</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+<link rel="match" href="translate-animation-on-svg-ref.html">
+
+<style>
+
+@keyframes translate-animation {
+    from { translate: 0 0; }
+    to   { translate: 100px 100px; }
+}
+
+svg {
+    width: 400px;
+    height: 400px;
+}
+
+rect {
+    width: 100px;
+    height: 100px;
+    transform-origin: top left;
+    animation: translate-animation 1ms linear forwards;
+}
+
+</style>
+</head>
+<body>
+<svg><rect></rect></svg>
+
+<script>
+
+(async function() {
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    document.documentElement.classList.remove("reftest-wait");
+})();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -712,6 +712,8 @@ public:
     ScaleTransformOperation* scale() const { return m_rareNonInheritedData->scale.get(); }
     TranslateTransformOperation* translate() const { return m_rareNonInheritedData->translate.get(); }
 
+    bool affectsTransform() const { return hasTransform() || offsetPath() || rotate() || scale() || translate(); }
+
     TextEmphasisFill textEmphasisFill() const { return static_cast<TextEmphasisFill>(m_rareInheritedData->textEmphasisFill); }
     TextEmphasisMark textEmphasisMark() const;
     const AtomString& textEmphasisCustomMark() const { return m_rareInheritedData->textEmphasisCustomMark; }

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGModelObject.cpp
@@ -105,7 +105,7 @@ void LegacyRenderSVGModelObject::styleDidChange(StyleDifference diff, const Rend
 {
     if (diff == StyleDifference::Layout) {
         setNeedsBoundariesUpdate();
-        if (style().hasTransform() || (oldStyle && oldStyle->hasTransform()))
+        if (style().affectsTransform() || (oldStyle && oldStyle->affectsTransform()))
             setNeedsTransformUpdate();
     }
     RenderElement::styleDidChange(diff, oldStyle);


### PR DESCRIPTION
#### 540afd68832196a977584e05afc0a139f564063f
<pre>
Using `rotate: x` and `transform: rotate(x)` yields different behavior with SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=250387">https://bugs.webkit.org/show_bug.cgi?id=250387</a>

Reviewed by Simon Fraser.

Check whether any transform-related property changed in LegacyRenderSVGModelObject::styleDidChange()
to determine whether an SVG element&apos;s needs to update its transform. To support this we add a new
RenderStyle::affectsTransform() method which returns true when any of the RenderStyle data
structures related to the &quot;transform&quot;, &quot;scale&quot;, &quot;rotate&quot;, &quot;translate&quot; and &quot;offset&quot; CSS properties
are non-empty or defined.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-on-svg.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/scale-animation-on-svg.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/translate-animation-on-svg.html: Added.
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::affectsTransform const):
* Source/WebCore/rendering/svg/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/258882@main">https://commits.webkit.org/258882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f88b229dcd167a9980ee4db4fc9603d3429d3c9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12346 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112468 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172665 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3250 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110668 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108995 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37906 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92089 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79635 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5749 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2864 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11909 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7668 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->