### PR TITLE
[@property] Fix the test to allow 'default' as an initial value for '*' syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -17,6 +17,7 @@ PASS syntax:'*', initialValue:'([ brackets ]) { yay (??)}' is valid
 PASS syntax:'*', initialValue:'yep 'this is valid too'' is valid
 PASS syntax:'*', initialValue:'unmatched opening bracket is valid :(' is valid
 PASS syntax:'*', initialValue:'"' is valid
+PASS syntax:'*', initialValue:'default' is valid
 PASS syntax:'<length>', initialValue:'0' is valid
 PASS syntax:'<length>', initialValue:'10px /*:)*/' is valid
 PASS syntax:'<length>', initialValue:' calc(-2px)' is valid
@@ -124,7 +125,6 @@ PASS syntax:'*', initialValue:'inherit' is invalid
 PASS syntax:'*', initialValue:'unset' is invalid
 PASS syntax:'*', initialValue:'revert' is invalid
 PASS syntax:'*', initialValue:'revert-layer' is invalid
-FAIL syntax:'*', initialValue:'default' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
 PASS syntax:'<custom-ident>', initialValue:'initial' is invalid
 PASS syntax:'<custom-ident>', initialValue:'inherit' is invalid
 PASS syntax:'<custom-ident>', initialValue:'unset' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html
@@ -41,6 +41,7 @@ assert_valid("*", "([ brackets ]) { yay (??)}");
 assert_valid("*", "yep 'this is valid too'");
 assert_valid("*", "unmatched opening bracket is valid :(");
 assert_valid("*", '"');
+assert_valid("*", "default");
 
 assert_valid("<length>", "0");
 assert_valid("<length>", "10px /*:)*/");
@@ -154,16 +155,14 @@ assert_invalid("<color>|REVert", "red");
 assert_invalid("<integer>|deFAUlt", "1");
 
 // Invalid initialValue
-// The 6 tests that follow are not clearly backed by the specification,
-// but (at least other than the one for 'default') they're probably a
-// good idea and we should change the spec.  See
+// The 5 tests that follow are not clearly backed by the specification,
+// but they're probably a good idea and we should change the spec. See
 // https://github.com/w3c/css-houdini-drafts/issues/1076 .
 assert_invalid("*", "initial");
 assert_invalid("*", "inherit");
 assert_invalid("*", "unset");
 assert_invalid("*", "revert");
 assert_invalid("*", "revert-layer");
-assert_invalid("*", "default");
 // ... end possibly-invalid tests.
 assert_invalid("<custom-ident>", "initial");
 assert_invalid("<custom-ident>", "inherit");


### PR DESCRIPTION
#### f5656e4975af3dd4265d6f41f353319606d22459
<pre>
[@property] Fix the test to allow &apos;default&apos; as an initial value for &apos;*&apos; syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=250571">https://bugs.webkit.org/show_bug.cgi?id=250571</a>
rdar://104223391

Reviewed by Simon Fraser.

Value &apos;default&apos; is not legal as a custom identifier but it is not a css-wide keyword (<a href="https://www.w3.org/TR/css-values-3/#custom-idents).">https://www.w3.org/TR/css-values-3/#custom-idents).</a>
With &apos;*&apos; syntax the value is just a pile of parser tokens and shouldn&apos;t be interpreted until someone tries to use it, beyond
recognizing the css-wide keywords.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html:

Canonical link: <a href="https://commits.webkit.org/258881@main">https://commits.webkit.org/258881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6a26a56723e5e78020ea5a36861568dd0653cd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12378 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172698 "Build is being retried. Recent messages:Pull request contains relevant changes; Deleted stale build files; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); 11 flakes 7 failures; Running; 7 flakes 8 failures; archiving test results; Reverted pull request changes; validate-change running; Compiled WebKit (warnings); layout-tests (failure); Running; Passed layout tests") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/13413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3282 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/110755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109027 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/13413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/13413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5952 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/11938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6108 "Build is being retried. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by Simon Fraser; Validated commit message; Compiled WebKit (warnings); 16 flakes; Canonicalized commit; Pushed to pull request branch; Updated pull request; Pushed commit to WebKit repository; Added comment on PR 8621 and added comment on bug 250571; Removed labels from pull request; Closed bug 250571") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7700 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->