### PR TITLE
Improve test coverage font-face src

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
@@ -2,6 +2,9 @@
 PASS Check that src: url("foo.ttf") is valid
 PASS Check that src: url("foo.ttf"), url("bar.ttf") is valid
 PASS Check that src: url("foo.ttf") format() is invalid
+PASS Check that src: url("foo.ttf") dummy() is invalid
+PASS Check that src: url("foo.ttf") format("woff") dummy() is invalid
+PASS Check that src: url("foo.ttf") dummy() format("woff") is invalid
 PASS Check that src: url("foo.ttf") format("collection") is valid
 PASS Check that src: url("foo.ttf") format("opentype") is valid
 PASS Check that src: url("foo.ttf") format("truetype") is valid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format.html
@@ -13,6 +13,12 @@
     { src: 'url("foo.ttf"), url("bar.ttf")', valid: true },
     // Empty format() is not valid
     { src: 'url("foo.ttf") format()', valid: false },
+    // Garbage data instead of format() is not valid
+    { src: 'url("foo.ttf") dummy()', valid: false },
+    // Garbage data following valid format() is not valid
+    { src: 'url("foo.ttf") format("woff") dummy()', valid: false },
+    // Garbage data preceding valid format() is not valid
+    { src: 'url("foo.ttf") dummy() format("woff")', valid: false },
     // Quoted strings in format()
     { src: 'url("foo.ttf") format("collection")', valid: true },
     { src: 'url("foo.ttf") format("opentype")', valid: true },

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local-expected.txt
@@ -1,4 +1,6 @@
 
+PASS Check that src: local(A) dummy() is invalid
+PASS Check that src: dummy() local(A) is invalid
 PASS Check that src: local(  A  ) is valid
 PASS Check that src: local(A B) is valid
 PASS Check that src: local(A    B) is valid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local.html
@@ -8,6 +8,10 @@
 <script>
   const sheet = testStyle.sheet;
   tests = [
+    // Gargbage data following valid local() is not valid
+    { src:'local(A) dummy()', valid:false},
+    // Gargbage data preceding valid local() is not valid
+    { src:'dummy() local(A)', valid:false},
     // Unquoted collapsing space
     { src:'local(  A  )', valid:true },
     { src:'local(A B)', valid:true },


### PR DESCRIPTION
#### 2a70c7ae40ada3e5ad52c38414dbc3515a1013b6
<pre>
Improve test coverage font-face src
<a href="https://bugs.webkit.org/show_bug.cgi?id=250566">https://bugs.webkit.org/show_bug.cgi?id=250566</a>
rdar://104220145

In wpt, we are not testing some invalid cases like where garbage data follows valid data in a component.

Reviewed by Myles C. Maxfield.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-local.html:

Canonical link: <a href="https://commits.webkit.org/258878@main">https://commits.webkit.org/258878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd9c1ae1625a84c06af9e1d9103963102bba1887

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12354 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112476 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172673 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3258 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110674 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109003 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37910 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92096 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79639 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5757 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2871 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11917 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6103 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7676 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->