### PR TITLE
CSP 3: Update Content Security Policy when header sent as part of a 304 response

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/304-response-should-update-csp.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/304-response-should-update-csp.sub-expected.txt
@@ -2,6 +2,6 @@
 
 PASS Test that the first frame uses nonce abc
 PASS Test that the first frame does not use nonce def
-FAIL Test that the second frame uses nonce def assert_unreached: Unexpected message received Reached unreachable code
-FAIL Test that the second frame does not use nonce abc assert_unreached: Unexpected message received Reached unreachable code
+PASS Test that the second frame uses nonce def
+PASS Test that the second frame does not use nonce abc
 

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -68,6 +68,9 @@ static constexpr ASCIILiteral headerPrefixesToIgnoreAfterRevalidation[] = {
 
 static inline bool shouldUpdateHeaderAfterRevalidation(const String& header)
 {
+    if (header.startsWithIgnoringASCIICase("content-security-"_s))
+        return true;
+
     for (auto& headerToIgnore : headersToIgnoreAfterRevalidation) {
         if (equalIgnoringASCIICase(header, headerToIgnore))
             return false;


### PR DESCRIPTION
#### 9bcb547791aa90dfe8715b041f14e374c42f5199
<pre>
CSP 3: Update Content Security Policy when header sent as part of a 304 response
<a href="https://bugs.webkit.org/show_bug.cgi?id=244637">https://bugs.webkit.org/show_bug.cgi?id=244637</a>
rdar://99405897

Reviewed by Brent Fulgham.

We ignore any headers with the &quot;Content-&quot; prefix in a 304 response. This change
special-cases the Content-Security-Policy and Content-Security-Policy-Report-Only
headers to be included in the cached response. This has the effect of updating the
cache entry&apos;s CSP if the server sends a new CSP in a 304 response.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/304-response-should-update-csp.sub-expected.txt:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::shouldUpdateHeaderAfterRevalidation):

Canonical link: <a href="https://commits.webkit.org/258931@main">https://commits.webkit.org/258931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cffa6da61c2da57abcf1b800c1fca7eadb6e1182

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112505 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172705 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3293 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110768 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37938 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26381 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2898 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6139 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7704 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->