### PR TITLE
[resultsdbpy] Use autoinstaller in unit tests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2381,7 +2381,7 @@ class RunResultsdbpyTests(shell.ShellCommandNewStyle):
     ]
 
     def __init__(self, **kwargs):
-        super(RunResultsdbpyTests, self).__init__(timeout=2 * 60, logEnviron=False, **kwargs)
+        super(RunResultsdbpyTests, self).__init__(timeout=15 * 60, logEnviron=False, **kwargs)
 
     def getResultSummary(self):
         if self.results == SUCCESS:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -931,7 +931,7 @@ class TestRunResultsdbpyTests(BuildStepMixinAdditions, unittest.TestCase):
         self.setupStep(RunResultsdbpyTests())
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=120,
+                        timeout=900,
                         logEnviron=False,
                         command=['python3', 'Tools/Scripts/libraries/resultsdbpy/resultsdbpy/run-tests', '--verbose', '--no-selenium', '--fast-tests'],
                         )
@@ -944,7 +944,7 @@ class TestRunResultsdbpyTests(BuildStepMixinAdditions, unittest.TestCase):
         self.setupStep(RunResultsdbpyTests())
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
-                        timeout=120,
+                        timeout=900,
                         logEnviron=False,
                         command=['python3', 'Tools/Scripts/libraries/resultsdbpy/resultsdbpy/run-tests', '--verbose', '--no-selenium', '--fast-tests'],
                         )

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import platform
 import sys
 
 
@@ -54,7 +55,10 @@ AutoInstall.register(Package('aioredis', Version(1, 3, 1)))
 AutoInstall.register(Package('async-timeout', Version(3, 0, 1)))
 AutoInstall.register(Package('boto3', Version(1, 16, 63), wheel=True))
 AutoInstall.register(Package('botocore', Version(1, 19, 63), wheel=True))
-AutoInstall.register(Package('cassandra', Version(3, 25, 0), pypi_name='cassandra-driver', slow_install=True))
+if platform.machine() == 'arm64':
+    AutoInstall.register(Package('cassandra', Version(3, 25, 0), pypi_name='cassandra-driver', slow_install=True))
+else:
+    AutoInstall.register(Package('cassandra', Version(3, 25, 0), pypi_name='cassandra-driver', wheel=True))
 AutoInstall.register(Package('click', Version(7, 1, 2)))
 AutoInstall.register(Package('Crypto', Version(3, 10, 1), pypi_name='pycryptodome'))
 AutoInstall.register(Package('fakeredis', Version(1, 5, 2)))

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/run-tests
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/run-tests
@@ -30,6 +30,15 @@ import os
 import sys
 import unittest
 
+module_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+tools_dir = os.path.dirname(os.path.dirname(module_dir))
+if os.path.isdir(os.path.join(tools_dir, 'webkitpy')):
+    sys.path.insert(0, tools_dir)
+    import webkitpy
+sys.path.insert(0, module_dir)
+
+import resultsdbpy
+
 from cassandra.cqlengine.management import CQLENG_ALLOW_SCHEMA_MANAGEMENT
 
 def main():


### PR DESCRIPTION
#### f71e1a38f644458a83e7c003a0a92001f2275d13
<pre>
[resultsdbpy] Use autoinstaller in unit tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=250586">https://bugs.webkit.org/show_bug.cgi?id=250586</a>
rdar://104231864

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py: cassandra driver takes about 10 minutes to install.
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py: Use wheel if possible.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/run-tests: Import webkitpy and
resultsdbpy to register autoinstaller.

Canonical link: <a href="https://commits.webkit.org/258989@main">https://commits.webkit.org/258989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b0219901138bc1206696e25986f0de4aaacd0da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112805 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3584 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95826 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/111977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10560 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107067 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25221 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26623 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3153 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/102449 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46133 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7997 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3282 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->