### PR TITLE
Page scrolls more than one screenful when pressing Space or Fn+Down

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1012,22 +1012,6 @@ static bool executeRemoveFormat(Frame& frame, Event*, EditorCommandSource, const
     return true;
 }
 
-static bool executeScrollPageBackward(Frame& frame, Event*, EditorCommandSource, const String&)
-{
-    if (frame.eventHandler().shouldUseSmoothKeyboardScrollingForFocusedScrollableArea())
-        return frame.eventHandler().keyboardScrollRecursively(ScrollDirection::ScrollUp, ScrollGranularity::Page, nullptr);
-
-    return frame.eventHandler().logicalScrollRecursively(ScrollBlockDirectionBackward, ScrollGranularity::Page);
-}
-
-static bool executeScrollPageForward(Frame& frame, Event*, EditorCommandSource, const String&)
-{
-    if (frame.eventHandler().shouldUseSmoothKeyboardScrollingForFocusedScrollableArea())
-        return frame.eventHandler().keyboardScrollRecursively(ScrollDirection::ScrollDown, ScrollGranularity::Page, nullptr);
-
-    return frame.eventHandler().logicalScrollRecursively(ScrollBlockDirectionForward, ScrollGranularity::Page);
-}
-
 static bool executeScrollLineUp(Frame& frame, Event*, EditorCommandSource, const String&)
 {
     return frame.eventHandler().scrollRecursively(ScrollUp, ScrollGranularity::Line);
@@ -1771,8 +1755,6 @@ static const CommandMap& createCommandMap()
         { "Print"_s, { executePrint, supported, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "Redo"_s, { executeRedo, supported, enabledRedo, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "RemoveFormat"_s, { executeRemoveFormat, supported, enabledRangeInEditableText, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
-        { "ScrollPageBackward"_s, { executeScrollPageBackward, supportedFromMenuOrKeyBinding, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
-        { "ScrollPageForward"_s, { executeScrollPageForward, supportedFromMenuOrKeyBinding, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "ScrollLineUp"_s, { executeScrollLineUp, supportedFromMenuOrKeyBinding, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "ScrollLineDown"_s, { executeScrollLineDown, supportedFromMenuOrKeyBinding, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "ScrollToBeginningOfDocument"_s, { executeScrollToBeginningOfDocument, supportedFromMenuOrKeyBinding, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -366,7 +366,7 @@ public:
     
     WEBCORE_EXPORT void selectClosestContextualWordOrLinkFromHitTestResult(const HitTestResult&, AppendTrailingWhitespace);
 
-    bool keyboardScrollRecursively(std::optional<ScrollDirection>, std::optional<ScrollGranularity>, Node*);
+    bool keyboardScrollRecursively(std::optional<ScrollDirection>, std::optional<ScrollGranularity>, Node*, bool isKeyRepeat);
     WEBCORE_EXPORT bool shouldUseSmoothKeyboardScrollingForFocusedScrollableArea();
 
 private:
@@ -389,14 +389,13 @@ private:
     bool handleMousePressEventDoubleClick(const MouseEventWithHitTestResults&);
     bool handleMousePressEventTripleClick(const MouseEventWithHitTestResults&);
 
-    bool keyboardScroll(std::optional<ScrollDirection>, std::optional<ScrollGranularity>, Node*);
-    bool beginKeyboardScrollGesture(KeyboardScrollingAnimator*, ScrollDirection, ScrollGranularity);
+    bool keyboardScroll(std::optional<ScrollDirection>, std::optional<ScrollGranularity>, Node*, bool isKeyRepeat);
+    bool beginKeyboardScrollGesture(KeyboardScrollingAnimator*, ScrollDirection, ScrollGranularity, bool isKeyRepeat);
     void stopKeyboardScrolling();
-    bool startKeyboardScrollAnimationOnDocument(ScrollDirection, ScrollGranularity);
-    bool startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection, ScrollGranularity, RenderBox*);
-    bool startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(ScrollDirection, ScrollGranularity, RenderBox*);
-    bool startKeyboardScrollAnimationOnEnclosingScrollableContainer(ScrollDirection, ScrollGranularity, Node*);
-    bool focusedScrollableAreaShouldUseSmoothKeyboardScrolling();
+    bool startKeyboardScrollAnimationOnDocument(ScrollDirection, ScrollGranularity, bool isKeyRepeat);
+    bool startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection, ScrollGranularity, RenderBox*, bool isKeyRepeat);
+    bool startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(ScrollDirection, ScrollGranularity, RenderBox*, bool isKeyRepeat);
+    bool startKeyboardScrollAnimationOnEnclosingScrollableContainer(ScrollDirection, ScrollGranularity, Node*, bool isKeyRepeat);
 
 #if ENABLE(DRAG_SUPPORT)
     bool handleMouseDraggedEvent(const MouseEventWithHitTestResults&, CheckDragHysteresis = ShouldCheckDragHysteresis);

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -196,7 +196,7 @@ std::optional<KeyboardScroll> KeyboardScrollingAnimator::makeKeyboardScroll(Scro
     return scroll;
 }
 
-bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direction, ScrollGranularity granularity)
+bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direction, ScrollGranularity granularity, bool isKeyRepeat)
 {
     auto scroll = makeKeyboardScroll(direction, granularity);
     if (!scroll)
@@ -208,7 +208,7 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
     if (!rubberbandableDirections().at(boxSideForDirection(direction)))
         return false;
 
-    if (granularity == ScrollGranularity::Document) {
+    if (granularity == ScrollGranularity::Document || (!isKeyRepeat && granularity == ScrollGranularity::Page)) {
         m_scrollableArea.endKeyboardScroll(false);
         auto newPosition = IntPoint(m_scrollableArea.scrollAnimator().currentPosition() + scroll->offset);
         m_scrollableArea.scrollAnimator().scrollToPositionWithAnimation(newPosition);

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -56,7 +56,7 @@ class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimato
 public:
     KeyboardScrollingAnimator(ScrollableArea&);
 
-    bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity);
+    bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity, bool isKeyRepeat);
     void handleKeyUpEvent();
     WEBCORE_EXPORT void stopScrollingImmediately();
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2577,8 +2577,6 @@ static const SelectorNameMap& selectorExceptionMap()
         { @selector(pageDownAndModifySelection:), "MovePageDownAndModifySelection"_s },
         { @selector(pageUp:), "MovePageUp"_s },
         { @selector(pageUpAndModifySelection:), "MovePageUpAndModifySelection"_s },
-        { @selector(scrollPageDown:), "ScrollPageForward"_s },
-        { @selector(scrollPageUp:), "ScrollPageBackward"_s },
         { @selector(_pasteAsQuotation:), "PasteAsQuotation"_s },
     };
 


### PR DESCRIPTION
#### 8984da7400104156ff59e1b95adee4349f22a451
<pre>
Page scrolls more than one screenful when pressing Space or Fn+Down
<a href="https://bugs.webkit.org/show_bug.cgi?id=250598">https://bugs.webkit.org/show_bug.cgi?id=250598</a>
rdar://104152802

Reviewed by Simon Fraser.

Before event handler driven smooth keyboard scrolling, pressing and holding the
spacebar or page up/down keys would do the following sequence of actions:

1. Scroll down the page by a &quot;screenful&quot;.
2. On Cocoa platforms, the scrolling mechanism would wait until the `keyRepeatInterval`
has passed.
3. After the interval has passed, it would continue consistently page scrolling until
the key is released.

With the introduction of event handler driven smooth keyboard scrolling, step two
was omitted. However, because smooth scrolling was slower than previously, the behavior
was effectively unchanged, as the slowness of the scrolling compensated for what would
have been the key repeat interval.

After <a href="https://github.com/WebKit/WebKit/pull/8318">https://github.com/WebKit/WebKit/pull/8318</a>, smooth scrolling was adjusted which
caused its velocity to increase. As a result, the lack of a delay was now noticable,
and page scrolling would scroll more than a &quot;screenful&quot; unless preisely one key event was sent.

This PR adjusts smooth scrolling such that the smooth keyboard scroll animation only
starts after the `keyRepeatInterval`, with the first part of the entire scroll behaving the
same as it did prior to smooth keyboard scrolling.

Note that this will apply to only spacebar and page up / down scrolling, and not arrow key
scrolling.

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeScrollPageBackward):
(WebCore::executeScrollPageForward):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultKeyboardEventHandler):
(WebCore::EventHandler::defaultKeyboardScrollEventHandler):
(WebCore::EventHandler::defaultPageUpDownEventHandler):
(WebCore::EventHandler::defaultSpaceEventHandler):
(WebCore::EventHandler::beginKeyboardScrollGesture):
(WebCore::EventHandler::startKeyboardScrollAnimationOnDocument):
(WebCore::EventHandler::startKeyboardScrollAnimationOnRenderBoxLayer):
(WebCore::EventHandler::startKeyboardScrollAnimationOnRenderBoxAndItsAncestors):
(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):
(WebCore::EventHandler::keyboardScrollRecursively):
(WebCore::EventHandler::keyboardScroll):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
* Source/WebCore/platform/KeyboardScrollingAnimator.h:

Canonical link: <a href="https://commits.webkit.org/259146@main">https://commits.webkit.org/259146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e71a7d0691af8b40eaaba2eb74e389806d23ecf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113225 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173533 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4022 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96246 "Reverted pull request changes (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112315 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38603 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26969 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3509 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6299 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8399 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->