### PR TITLE
[CISupport] Autoinstall buildbot dependencies

### DIFF
--- a/Tools/CISupport/buildbot-cmd
+++ b/Tools/CISupport/buildbot-cmd
@@ -1,0 +1,57 @@
+#!/usr/bin/python3
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a modified version of the setuptools "easy install" entrypoint
+# https://github.com/pypa/setuptools/blob/main/setuptools/command/easy_install.py#L2058
+
+import os
+import re
+import sys
+
+scripts = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Scripts')
+if os.path.isdir(os.path.join(scripts, 'webkitpy')):
+    sys.path.insert(0, scripts)
+    import webkitpy
+    from webkitpy.autoinstalled import buildbot
+
+try:
+    from importlib.metadata import distribution
+except ImportError:
+    try:
+        from importlib_metadata import distribution
+    except ImportError:
+        from pkg_resources import load_entry_point
+
+
+def importlib_load_entry_point(spec, group, name):
+    dist_name, _, _ = spec.partition('==')
+    matches = (
+        entry_point
+        for entry_point in distribution(dist_name).entry_points
+        if entry_point.group == group and entry_point.name == name
+    )
+    return next(matches).load()
+
+
+globals().setdefault('load_entry_point', importlib_load_entry_point)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2430,7 +2430,7 @@ class ReRunWebKitPerlTests(RunWebKitPerlTests):
 class RunBuildWebKitOrgUnitTests(shell.ShellCommandNewStyle):
     name = 'build-webkit-org-unit-tests'
     description = ['build-webkit-unit-tests running']
-    command = ['python3', 'runUnittests.py', 'build-webkit-org']
+    command = ['python3', 'runUnittests.py', 'build-webkit-org', '--autoinstall']
 
     def __init__(self, **kwargs):
         super().__init__(workdir='build/Tools/CISupport', timeout=2 * 60, logEnviron=False, **kwargs)
@@ -2444,7 +2444,7 @@ class RunBuildWebKitOrgUnitTests(shell.ShellCommandNewStyle):
 class RunEWSUnitTests(shell.ShellCommandNewStyle):
     name = 'ews-unit-tests'
     description = ['ews-unit-tests running']
-    command = ['python3', 'runUnittests.py', 'ews-build']
+    command = ['python3', 'runUnittests.py', 'ews-build', '--autoinstall']
 
     def __init__(self, **kwargs):
         super().__init__(workdir='build/Tools/CISupport', timeout=2 * 60, logEnviron=False, **kwargs)
@@ -2458,7 +2458,7 @@ class RunEWSUnitTests(shell.ShellCommandNewStyle):
 class RunBuildbotCheckConfig(shell.ShellCommand):
     name = 'buildbot-check-config'
     description = ['buildbot-checkconfig running']
-    command = ['buildbot', 'checkconfig']
+    command = ['python3', '../buildbot-cmd', 'checkconfig']
     directory = 'build/Tools/CISupport/ews-build'
     timeout = 2 * 60
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -839,7 +839,7 @@ class TestRunBuildbotCheckConfigForEWS(BuildStepMixinAdditions, unittest.TestCas
             ExpectShell(workdir='build/Tools/CISupport/ews-build',
                         timeout=120,
                         logEnviron=False,
-                        command=['buildbot', 'checkconfig'],
+                        command=['python3', '../buildbot-cmd', 'checkconfig'],
                         env={'LC_CTYPE': 'en_US.UTF-8'}
                         )
             + 0,
@@ -853,7 +853,7 @@ class TestRunBuildbotCheckConfigForEWS(BuildStepMixinAdditions, unittest.TestCas
             ExpectShell(workdir='build/Tools/CISupport/ews-build',
                         timeout=120,
                         logEnviron=False,
-                        command=['buildbot', 'checkconfig'],
+                        command=['python3', '../buildbot-cmd', 'checkconfig'],
                         env={'LC_CTYPE': 'en_US.UTF-8'}
                         )
             + ExpectShell.log('stdio', stdout='Configuration Errors:  builder(s) iOS-14-Debug-Build-EWS have no schedulers to drive them')
@@ -877,7 +877,7 @@ class TestRunBuildbotCheckConfigForBuildWebKit(BuildStepMixinAdditions, unittest
             ExpectShell(workdir='build/Tools/CISupport/build-webkit-org',
                         timeout=120,
                         logEnviron=False,
-                        command=['buildbot', 'checkconfig'],
+                        command=['python3', '../buildbot-cmd', 'checkconfig'],
                         env={'LC_CTYPE': 'en_US.UTF-8'}
                         )
             + 0,
@@ -891,7 +891,7 @@ class TestRunBuildbotCheckConfigForBuildWebKit(BuildStepMixinAdditions, unittest
             ExpectShell(workdir='build/Tools/CISupport/build-webkit-org',
                         timeout=120,
                         logEnviron=False,
-                        command=['buildbot', 'checkconfig'],
+                        command=['python3', '../buildbot-cmd', 'checkconfig'],
                         env={'LC_CTYPE': 'en_US.UTF-8'}
                         )
             + ExpectShell.log('stdio', stdout='Configuration Errors:  builder(s) Apple-iOS-14-Release-Build have no schedulers to drive them')
@@ -915,7 +915,7 @@ class TestRunEWSUnitTests(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         logEnviron=False,
-                        command=['python3', 'runUnittests.py', 'ews-build'],
+                        command=['python3', 'runUnittests.py', 'ews-build', '--autoinstall'],
                         )
             + 0,
         )
@@ -928,7 +928,7 @@ class TestRunEWSUnitTests(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         logEnviron=False,
-                        command=['python3', 'runUnittests.py', 'ews-build'],
+                        command=['python3', 'runUnittests.py', 'ews-build', '--autoinstall'],
                         )
             + ExpectShell.log('stdio', stdout='Unhandled Error. Traceback (most recent call last): Keys in cmd missing from expectation: [logfiles.json]')
             + 2,
@@ -987,7 +987,7 @@ class TestRunBuildWebKitOrgUnitTests(BuildStepMixinAdditions, unittest.TestCase)
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         logEnviron=False,
-                        command=['python3', 'runUnittests.py', 'build-webkit-org'],
+                        command=['python3', 'runUnittests.py', 'build-webkit-org', '--autoinstall'],
                         )
             + 0,
         )
@@ -1000,7 +1000,7 @@ class TestRunBuildWebKitOrgUnitTests(BuildStepMixinAdditions, unittest.TestCase)
             ExpectShell(workdir='build/Tools/CISupport',
                         timeout=120,
                         logEnviron=False,
-                        command=['python3', 'runUnittests.py', 'build-webkit-org'],
+                        command=['python3', 'runUnittests.py', 'build-webkit-org', '--autoinstall'],
                         )
             + ExpectShell.log('stdio', stdout='Unhandled Error. Traceback (most recent call last): Keys in cmd missing from expectation: [logfiles.json]')
             + 2,

--- a/Tools/CISupport/runUnittests.py
+++ b/Tools/CISupport/runUnittests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import argparse
 import os
 import sys
 import unittest
@@ -9,10 +10,6 @@ This is the equivalent of running:
     python -m unittest discover --start-directory {test_discovery_path} --pattern {UNIT_TEST_PATTERN}
 """
 
-# This is work-around for https://bugs.webkit.org/show_bug.cgi?id=222361
-from buildbot.process.buildstep import BuildStep
-BuildStep.warn_deprecated_if_oldstyle_subclass = lambda self, name: None
-
 UNIT_TEST_PATTERN = '*_unittest.py'
 
 
@@ -21,14 +18,44 @@ def run_unittests(test_discovery_path):
     results = unittest.TextTestRunner(buffer=True).run(test_suite)
     if results.failures or results.errors:
         raise RuntimeError('Test failures or errors were generated during this test run.')
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run Python unit tests for our various build masters',
+    )
+    parser.add_argument(
+        'path', nargs=1,
+        help='Relative path of directory to run Python unit tests in',
+    )
+    parser.add_argument(
+        '--autoinstall',
+        help='Opt in to using autoinstall for buildbot packages',
+        action='store_true',
+        dest='autoinstall',
+        default=False,
+    )
+
+    args = parser.parse_args()
+    if not args.path:
+        args.path = [os.path.dirname(__file__)]
+
+    path = os.path.abspath(args.path[0])
+    assert os.path.isdir(path), '{} is not a directory. Please specify a valid directory'.format(path)
+
+    scripts = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Scripts')
+    if args.autoinstall and os.path.isdir(os.path.join(scripts, 'webkitpy')):
+        sys.path.insert(0, scripts)
+        import webkitpy
+        from webkitpy.autoinstalled import buildbot
+
+    # This is work-around for https://bugs.webkit.org/show_bug.cgi?id=222361
+    from buildbot.process.buildstep import BuildStep
+    BuildStep.warn_deprecated_if_oldstyle_subclass = lambda self, name: None
+
+    return run_unittests(path)
 
 
 if __name__ == '__main__':
-    try:
-        relative_path = sys.argv[1]
-    except IndexError:
-        relative_path = os.path.dirname(__file__)
-
-    path = os.path.abspath(relative_path)
-    assert os.path.isdir(path), '{} is not a directory. Please specify a valid directory'.format(path)
-    run_unittests(path)
+    sys.exit(main())

--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -23,16 +23,31 @@
 import sys
 
 from webkitscmpy import AutoInstall, Package, Version
+from webkitpy.autoinstalled import twisted
 
-AutoInstall.register(Package('autobahn', Version(20, 7, 1)))
-AutoInstall.register(Package('buildbot', Version(2, 10, 1)))
-AutoInstall.register(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil'))
-AutoInstall.register(Package('jinja2', Version(2, 11, 2), pypi_name='Jinja2'))
-AutoInstall.register(Package('jwt', Version(1, 7, 1), pypi_name='PyJWT'))
-AutoInstall.register(Package('pyyaml', Version(5, 3, 1), pypi_name='PyYAML'))
-AutoInstall.register(Package('sqlalchemy', Version(1, 3, 20), pypi_name='SQLAlchemy'))
-AutoInstall.register(Package('sqlalchemy-migrate', Version(0, 13, 0)))
-AutoInstall.register(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
-AutoInstall.register(Package('txaio', Version(20, 4, 1)))
+AutoInstall.install(Package('attrs', Version(21, 4, 0)))
+AutoInstall.install(Package('autobahn', Version(20, 7, 1)))
+AutoInstall.install(Package('automat', Version(20, 2, 0), pypi_name='Automat'))
+AutoInstall.install(Package('constantly', Version(15, 1, 0)))
+AutoInstall.install(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil'))
+AutoInstall.install(Package('decorator', Version(5, 1, 1)))
+AutoInstall.install(Package('future', Version(0, 18, 2)))
+AutoInstall.install(Package('hyperlink', Version(21, 0, 0)))
+AutoInstall.install(Package('incremental', Version(21, 3, 0)))
+AutoInstall.install(Package('jinja2', Version(2, 11, 3), pypi_name='Jinja2'))
+AutoInstall.install(Package('pbr', Version(5, 9, 0)))
+AutoInstall.install(Package('PyHamcrest', Version(2, 0, 3)))
+AutoInstall.install(Package('PyJWT', Version(1, 7, 1), pypi_name='PyJWT', aliases=['jwt']))
+AutoInstall.install(Package('pyyaml', Version(5, 3, 1), pypi_name='PyYAML'))
+AutoInstall.install(Package('sqlalchemy', Version(1, 3, 20), pypi_name='SQLAlchemy'))
+AutoInstall.install(Package('sqlalchemy-migrate', Version(0, 13, 0)))
+AutoInstall.install(Package('sqlparse', Version(0, 4, 2)))
+AutoInstall.install(Package('Tempita', Version(0, 4, 0)))
+AutoInstall.install(Package('txaio', Version(20, 4, 1)))
+
+AutoInstall.install(Package('buildbot', Version(2, 10, 5)))
+AutoInstall.install(Package('buildbot-worker', Version(2, 10, 5)))
+
+from buildbot import statistics
 
 sys.modules[__name__] = __import__('buildbot')

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -24,9 +24,18 @@ import sys
 
 from webkitscmpy import AutoInstall, Package, Version
 
-AutoInstall.register(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
-AutoInstall.register(Package('constantly', Version(15, 1, 0), pypi_name='constantly'))
-AutoInstall.register(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
-AutoInstall.register(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
+AutoInstall.install(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
+AutoInstall.install(Package('constantly', Version(15, 1, 0), pypi_name='constantly'))
+AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
+AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
+
+AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
+AutoInstall.install(Package('cryptography', Version(36, 0, 2), wheel=True))
+AutoInstall.install(Package('bcrypt', Version(4), wheel=True))
+AutoInstall.install(Package('cffi', Version(1, 15, 1), wheel=True))
+AutoInstall.install(Package('pycparser', Version(2, 21), wheel=True))
+
+from twisted.protocols.tls import TLSMemoryBIOFactory
+from twisted.python import threadpool
 
 sys.modules[__name__] = __import__('twisted')


### PR DESCRIPTION
#### a5d5c85284959ecd6d331a19c75b69d0e548e0de
<pre>
[CISupport] Autoinstall buildbot dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=250604">https://bugs.webkit.org/show_bug.cgi?id=250604</a>
&lt;rdar://problem/104246259&gt;

Reviewed by Aakash Jain.

Instead of relying on machine running our unit tests having buildbot
installed, we should rely on webkitpy&apos;s autoinstaller.

* Tools/CISupport/buildbot-cmd: Added.
* Tools/CISupport/ews-build/steps.py:
(RunBuildbotCheckConfig): Invoke local &apos;buildbot-cmd&apos; script.
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/CISupport/runUnittests.py: Import buildbot from webkitpy if
autoinstall is enabled.
* Tools/Scripts/webkitpy/autoinstalled/buildbot.py: Update dependencies,
install instead of just register libraries.
* Tools/Scripts/webkitpy/autoinstalled/twisted.py: Ditto.

Canonical link: <a href="https://commits.webkit.org/262159@main">https://commits.webkit.org/262159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ec55094c6241f8c9ba7722da0538dab866edfdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/808 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/832 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/1102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/797 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/880 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/915 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/1102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/816 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/880 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1042 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/880 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/1042 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1042 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/915 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/795 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/835 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/780 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/837 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/81 "Built successfully and passed tests") | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/837 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->