### PR TITLE
Lookalike character sanitization does not work if content blockers are disabled through SPI

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -193,15 +193,6 @@ StyleSheetContents* ContentExtensionsBackend::globalDisplayNoneStyleSheet(const 
     return contentExtension ? contentExtension->globalDisplayNoneStyleSheet() : nullptr;
 }
 
-static void sanitizeLookalikeCharactersIfNecessary(ContentRuleListResults& results, const Page& page, const URL& url, OptionSet<ResourceType> type)
-{
-    if (!type.contains(ResourceType::Document))
-        return;
-
-    if (auto adjustedURL = page.chrome().client().sanitizeLookalikeCharacters(url); adjustedURL != url)
-        results.summary.redirectActions.append({ { RedirectAction::URLAction { adjustedURL.string() } }, adjustedURL });
-}
-
 ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(Page& page, const URL& url, OptionSet<ResourceType> resourceType, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom)
 {
     Document* currentDocument = nullptr;
@@ -231,8 +222,6 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
     ContentRuleListResults results;
     if (page.httpsUpgradeEnabled())
         makeSecureIfNecessary(results, url, redirectFrom);
-    if (mainFrameContext)
-        sanitizeLookalikeCharactersIfNecessary(results, page, url, resourceType);
     results.results.reserveInitialCapacity(actions.size());
     for (const auto& actionsFromContentRuleList : actions) {
         const String& contentRuleListIdentifier = actionsFromContentRuleList.contentRuleListIdentifier;


### PR DESCRIPTION
#### b922a9d45b8ac1d34f73a38ad7f8e073b0ccebd7
<pre>
Lookalike character sanitization does not work if content blockers are disabled through SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=250608">https://bugs.webkit.org/show_bug.cgi?id=250608</a>

Reviewed by Tim Horton.

Allow lookalike character sanitization to remain active even if content blockers are disabled via
`-[WKWebpagePreferences _setContentBlockersEnabled:NO]`, by hoisting the logic out of
`ContentExtensionsBackend::processContentRuleListsForLoad` and into the call site in
`UserContentProvider` instead. This allows us to apply these adjustments, even in the case where
`contentRuleListsEnabled(initiatingDocumentLoader)` return `false`.

Changes covered by a new API test.

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
(WebCore::ContentExtensions::sanitizeLookalikeCharactersIfNecessary): Deleted.
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::sanitizeLookalikeCharactersIfNeeded):

Move this from `ContentExtensionsBackend` to `UserContentProvider`. No other change in behavior.

(WebCore::UserContentProvider::processContentRuleListsForLoad):

Canonical link: <a href="https://commits.webkit.org/258908@main">https://commits.webkit.org/258908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18da6ea5d2d126adafa477284c778b4f6309d087

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112547 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172750 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3336 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111061 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10336 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37966 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24999 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26404 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45910 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6122 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7753 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->