### PR TITLE
Make MockGamepadProvider robust so that it doesn't end up crashing the test runner

### DIFF
--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -29,6 +29,8 @@
 
 #include "GamepadProvider.h"
 #include "MockGamepad.h"
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -59,6 +61,9 @@ private:
     void gamepadInputActivity();
 
     Vector<PlatformGamepad*> m_connectedGamepadVector;
+    // FIXME: Use HashMap<WeakPtr<GamepadProviderClient>, HashSet<WeakPtr<PlatformGamepad>>>
+    // after deriving GamepadProviderClient and PlatformGamepad from CanMakeWeakPtr
+    HashMap<GamepadProviderClient*, HashSet<PlatformGamepad*>>  m_invisibleGamepadsForClient;
     Vector<std::unique_ptr<MockGamepad>> m_mockGamepadVector;
 
     bool m_shouldScheduleActivityCallback { true };


### PR DESCRIPTION
#### feab6de8fb5ee04b52a859ee7066266258c13b30
<pre>
Make MockGamepadProvider robust so that it doesn&apos;t end up crashing the test runner
<a href="https://bugs.webkit.org/show_bug.cgi?id=250605">https://bugs.webkit.org/show_bug.cgi?id=250605</a>
rdar://104165858

Reviewed by David Kilzer.

This change adds more state to MockGamepadProvider so that it can track the gamepads
that were connected before the GamepadProviderClient starts monitoring. Before this change,
a simple snippet like:
&lt;script&gt;
  testRunner.setMockGamepadDetails(0);
  testRunner.connectMockGamepad(0);
  addEventListener(&apos;gamepadconnected&apos;, () =&gt; {});
&lt;/script&gt;

would crash the test runner.

* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::startMonitoringGamepads):
(WebCore::MockGamepadProvider::stopMonitoringGamepads):
(WebCore::MockGamepadProvider::connectMockGamepad):
(WebCore::MockGamepadProvider::disconnectMockGamepad):
* Source/WebCore/testing/MockGamepadProvider.h:

Canonical link: <a href="https://commits.webkit.org/259411@main">https://commits.webkit.org/259411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44a3ee8ef441ec3d7fa28ebc10c0c468177a05e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114070 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174272 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4804 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112984 "Built successfully") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39125 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26225 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27585 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7325 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6488 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9112 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->