### PR TITLE
Safari Content Blocker doesn't support :has() selector

### DIFF
--- a/LayoutTests/http/tests/contentextensions/css-display-none.html
+++ b/LayoutTests/http/tests/contentextensions/css-display-none.html
@@ -6,5 +6,7 @@
 <p class="hidden_global2">This text should not be visible once the global css selector is applied.</p>
 <p class="hidden">This text should not be visible once the particular css selector is applied.</p>
 <p class="hidden_Ž">This text should not be visible once the particular css selector with non-ascii characters is applied.</p>
+<div><p class="hidden_hasTestMatchingEverything">This text should not be visible once the global css selector with :has is applied.</p></div>
+<div><p class="hidden_hasTestNotMatchingEverything">This text should not be visible once the particular css selector with :has is applied.</p></div>
 <p class="not_hidden">This text should be visible.</p>
 </body>

--- a/LayoutTests/http/tests/contentextensions/css-display-none.html.json
+++ b/LayoutTests/http/tests/contentextensions/css-display-none.html.json
@@ -37,6 +37,24 @@
     },
     {
         "action": {
+            "type": "css-display-none",
+            "selector": "div:has(.hidden_hasTestNotMatchingEverything)"
+        },
+        "trigger": {
+            "url-filter": ".*css-display-none.html"
+        }
+    },
+    {
+        "action": {
+            "type": "css-display-none",
+            "selector": "div:has(.hidden_hasTestMatchingEverything)"
+        },
+        "trigger": {
+            "url-filter": ".*"
+        }
+    },
+    {
+        "action": {
             "type": "ignore-previous-rules"
         },
         "trigger": {

--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -26,7 +26,9 @@
 #include "config.h"
 #include "ContentExtension.h"
 
+#include "CSSParserContext.h"
 #include "CompiledContentExtension.h"
+#include "ContentExtensionParser.h"
 #include "ContentExtensionsBackend.h"
 #include "StyleSheetContents.h"
 #include <wtf/text/StringBuilder.h>
@@ -98,7 +100,7 @@ void ContentExtension::compileGlobalDisplayNoneStyleSheet()
     css.append(ContentExtensionsBackend::displayNoneCSSRule());
     css.append('}');
 
-    m_globalDisplayNoneStyleSheet = StyleSheetContents::create();
+    m_globalDisplayNoneStyleSheet = StyleSheetContents::create(contentExtensionCSSParserContext());
     m_globalDisplayNoneStyleSheet->setIsUserStyleSheet(true);
     if (!m_globalDisplayNoneStyleSheet->parseString(css.toString()))
         m_globalDisplayNoneStyleSheet = nullptr;

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -206,9 +206,15 @@ bool isValidCSSSelector(const String& selector)
 {
     ASSERT(isMainThread());
     ProcessWarming::initializeNames();
-    CSSParserContext context(HTMLQuirksMode);
-    CSSParser parser(context);
+    CSSParser parser(contentExtensionCSSParserContext());
     return !!parser.parseSelector(selector);
+}
+
+WebCore::CSSParserContext contentExtensionCSSParserContext()
+{
+    WebCore::CSSParserContext context(HTMLQuirksMode);
+    context.hasPseudoClassEnabled = true;
+    return context;
 }
 
 static std::optional<Expected<Action, std::error_code>> loadAction(const JSON::Object& ruleObject, const String& urlFilter)

--- a/Source/WebCore/contentextensions/ContentExtensionParser.h
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.h
@@ -34,12 +34,16 @@
 
 namespace WebCore {
 
+struct CSSParserContext;
+
 namespace ContentExtensions {
 
 class ContentExtensionRule;
 
 WEBCORE_EXPORT Expected<Vector<ContentExtensionRule>, std::error_code> parseRuleList(const String&);
 WEBCORE_EXPORT bool isValidCSSSelector(const String&);
+
+CSSParserContext contentExtensionCSSParserContext();
 
 } // namespace ContentExtensions
 } // namespace WebCore

--- a/Source/WebCore/contentextensions/ContentExtensionStyleSheet.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionStyleSheet.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(CONTENT_EXTENSIONS)
 
 #include "CSSStyleSheet.h"
+#include "ContentExtensionParser.h"
 #include "ContentExtensionsBackend.h"
 #include "Document.h"
 #include "StyleSheetContents.h"
@@ -38,7 +39,7 @@ namespace WebCore {
 namespace ContentExtensions {
 
 ContentExtensionStyleSheet::ContentExtensionStyleSheet(Document& document)
-    : m_styleSheet(CSSStyleSheet::create(StyleSheetContents::create(), document))
+    : m_styleSheet(CSSStyleSheet::create(StyleSheetContents::create(contentExtensionCSSParserContext()), document))
 {
     m_styleSheet->contents().setIsUserStyleSheet(true);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -29,6 +29,7 @@
 
 #include "Utilities.h"
 #include <JavaScriptCore/InitializeThreading.h>
+#include <WebCore/CSSParserContext.h>
 #include <WebCore/CombinedURLFilters.h>
 #include <WebCore/CommonAtomStrings.h>
 #include <WebCore/ContentExtensionActions.h>


### PR DESCRIPTION
#### 355ce06ba535bdf2ce87a0f130d67ff866930649
<pre>
Safari Content Blocker doesn&apos;t support :has() selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=250609">https://bugs.webkit.org/show_bug.cgi?id=250609</a>
rdar://103976010

Reviewed by Antti Koivisto and Alex Christensen.

When creating the CSSParsers for content blocker parsing and compilation, make sure to opt
into hasPseudoClassEnabled so selectors like :has work. The places this was needed were:
- ContentExtensionParser (for parsing the rules)
- ContentExtension (for the global display none rules)
- ContentExtensionStyleSheet (for the other display none rules)

Also update the contentextensions css-display-none test to test this functionality.

* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::compileGlobalDisplayNoneStyleSheet):
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::isValidCSSSelector):

Canonical link: <a href="https://commits.webkit.org/259068@main">https://commits.webkit.org/259068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba3c1daaea86e1a7306e7ab43fce6c84e60f84c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113085 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3868 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112194 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109630 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93852 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25461 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6331 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6496 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6235 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8265 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->