### PR TITLE
Fix internal watchOS build

### DIFF
--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -127,6 +127,10 @@ static bool ignoreWatchdogForDebugging = false;
     _fullscreenInterface = *fullscreenInterface;
 }
 
+#if PLATFORM(WATCHOS)
+IGNORE_WARNINGS_BEGIN("deprecated-implementations")
+#endif
+
 - (void)playerViewControllerWillStartPictureInPicture:(AVPlayerViewController *)playerViewController
 {
     UNUSED_PARAM(playerViewController);
@@ -200,6 +204,10 @@ static VideoFullscreenInterfaceAVKit::ExitFullScreenReason convertToExitFullScre
     if (self.fullscreenInterface)
         self.fullscreenInterface->prepareForPictureInPictureStopWithCompletionHandler(completionHandler);
 }
+
+#if PLATFORM(WATCHOS)
+IGNORE_WARNINGS_END
+#endif
 
 - (BOOL)playerViewControllerShouldStartPictureInPictureFromInlineWhenEnteringBackground:(AVPlayerViewController *)playerViewController
 {

--- a/Source/WebKit/Platform/spi/watchos/PepperUICoreSPI.h
+++ b/Source/WebKit/Platform/spi/watchos/PepperUICoreSPI.h
@@ -29,6 +29,7 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
+IGNORE_WARNINGS_BEGIN("undef")
 #import <PepperUICore/PUICActionController.h>
 #import <PepperUICore/PUICActionController_Private.h>
 #import <PepperUICore/PUICActionGroup.h>
@@ -50,6 +51,7 @@
 #import <PepperUICore/PUICTableViewCell.h>
 #import <PepperUICore/UIDevice+PUICAdditions.h>
 #import <PepperUICore/UIScrollView+PUICAdditionsPrivate.h>
+IGNORE_WARNINGS_END
 
 #if HAVE(QUICKBOARD_COLLECTION_VIEWS)
 #import <PepperUICore/PUICQuickboardListCollectionViewItemCell.h>


### PR DESCRIPTION
#### 06560a63a201799695a7339d262da780e6360b25
<pre>
Fix internal watchOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=250611">https://bugs.webkit.org/show_bug.cgi?id=250611</a>
rdar://104249009

Unreviewed.

Some things were deprecated, some headers have #if SOMETHING without defining SOMETHING.

* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
* Source/WebKit/Platform/spi/watchos/PepperUICoreSPI.h:

Canonical link: <a href="https://commits.webkit.org/258910@main">https://commits.webkit.org/258910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3928b1a727a32da47198dfa81219ac66b5118ffa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112569 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3359 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95550 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111311 "Failed to checkout and rebase branch from PR 8650") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109108 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5845 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6018 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12000 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7776 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3262 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->