### PR TITLE
Effectively revert 258484@main

### DIFF
--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -40,9 +40,6 @@
 #include <iosfwd>
 #include <limits>
 #include <utility>
-#include <wtf/ArgumentCoder.h>
-#include <wtf/HashFunctions.h>
-#include <wtf/HashTraits.h>
 #include <wtf/Platform.h>
 
 #if COMPILER(MSVC)
@@ -1267,78 +1264,10 @@ using UInt128 = UInt128Impl;
 using Int128 = Int128Impl;
 #endif
 
-template<> struct DefaultHash<UInt128> {
-    static unsigned hash(const UInt128& i) { return pairIntHash(intHash(static_cast<uint64_t>(i >> 64)), intHash(static_cast<uint64_t>(i))); }
-    static bool equal(const UInt128& a, const UInt128& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-template<> struct DefaultHash<Int128> {
-    static unsigned hash(const UInt128& i) { return pairIntHash(intHash(static_cast<uint64_t>(i >> 64)), intHash(static_cast<uint64_t>(i))); }
-    static bool equal(const Int128& a, const Int128& b) { return a == b; }
-    static constexpr bool safeToCompareToEmptyOrDeleted = true;
-};
-
-template<> struct HashTraits<UInt128> : GenericHashTraits<UInt128> {
-    static constexpr bool emptyValueIsZero = true;
-    static void constructDeletedValue(UInt128& slot) { slot = static_cast<UInt128>(-1); }
-    static bool isDeletedValue(UInt128 value) { return value == static_cast<UInt128>(-1); }
-};
-
-template<> struct HashTraits<Int128> : GenericHashTraits<Int128> {
-    static constexpr bool emptyValueIsZero = true;
-    static void constructDeletedValue(Int128& slot) { slot = static_cast<Int128>(-1); }
-    static bool isDeletedValue(Int128 value) { return value == static_cast<Int128>(-1); }
-};
-
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, UInt128);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, Int128);
 
 }  // namespace WTF
-
-namespace IPC {
-template<> struct ArgumentCoder<WTF::UInt128> {
-    template<typename Encoder> static void encode(Encoder& encoder, const WTF::UInt128& i)
-    {
-        encoder << static_cast<uint64_t>(i >> 64);
-        encoder << static_cast<uint64_t>(i);
-    }
-    template<typename Decoder> static std::optional<WTF::UInt128> decode(Decoder& decoder)
-    {
-        std::optional<uint64_t> high;
-        decoder >> high;
-        if (!high)
-            return std::nullopt;
-
-        std::optional<uint64_t> low;
-        decoder >> low;
-        if (!low)
-            return std::nullopt;
-
-        return (static_cast<WTF::UInt128>(*high) << 64) | *low;
-    }
-};
-template<> struct ArgumentCoder<WTF::Int128> {
-    template<typename Encoder> static void encode(Encoder& encoder, const WTF::Int128& i)
-    {
-        encoder << static_cast<int64_t>(i >> 64);
-        encoder << static_cast<int64_t>(i);
-    }
-    template<typename Decoder> static std::optional<WTF::Int128> decode(Decoder& decoder)
-    {
-        std::optional<int64_t> high;
-        decoder >> high;
-        if (!high)
-            return std::nullopt;
-
-        std::optional<uint64_t> low;
-        decoder >> low;
-        if (!low)
-            return std::nullopt;
-
-        return (static_cast<WTF::Int128>(*high) << 64) | *low;
-    }
-};
-}
 
 using WTF::Int128;
 using WTF::UInt128;

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -28,7 +28,6 @@
 #include <atomic>
 #include <mutex>
 #include <wtf/HashTraits.h>
-#include <wtf/Int128.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
@@ -132,7 +131,7 @@ public:
     };
 
 private:
-    template<typename U> friend ObjectIdentifier<U> makeObjectIdentifier(UInt128);
+    template<typename U> friend ObjectIdentifier<U> makeObjectIdentifier(uint64_t);
     friend struct HashTraits<ObjectIdentifier>;
     template<typename U> friend struct ObjectIdentifierHash;
 
@@ -148,10 +147,9 @@ private:
     inline static bool m_generationProtected { false };
 };
 
-template<typename T> inline ObjectIdentifier<T> makeObjectIdentifier(UInt128 identifier)
+template<typename T> inline ObjectIdentifier<T> makeObjectIdentifier(uint64_t identifier)
 {
-    ASSERT(identifier == static_cast<uint64_t>(identifier));
-    return ObjectIdentifier<T> { static_cast<uint64_t>(identifier) };
+    return ObjectIdentifier<T> { identifier };
 }
 
 template<typename T> inline void add(Hasher& hasher, ObjectIdentifier<T> identifier)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -205,7 +205,7 @@ void NetworkProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder
 {
     ASSERT(parentProcessConnection() == &connection);
     if (parentProcessConnection() != &connection) {
-        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), decoder.destinationID());
         ASSERT_NOT_REACHED();
         return;
     }
@@ -232,7 +232,7 @@ bool NetworkProcess::didReceiveSyncMessage(IPC::Connection& connection, IPC::Dec
 {
     ASSERT(parentProcessConnection() == &connection);
     if (parentProcessConnection() != &connection) {
-        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), decoder.destinationID());
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -2109,7 +2109,7 @@ void NetworkProcess::continueWillSendRequest(DownloadID downloadID, WebCore::Res
 
 void NetworkProcess::findPendingDownloadLocation(NetworkDataTask& networkDataTask, ResponseCompletionHandler&& completionHandler, const ResourceResponse& response)
 {
-    UInt128 destinationID = networkDataTask.pendingDownloadID().toUInt64();
+    uint64_t destinationID = networkDataTask.pendingDownloadID().toUInt64();
 
     String suggestedFilename = networkDataTask.suggestedFilename();
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -62,7 +62,7 @@ std::atomic<unsigned> UnboundedSynchronousIPCScope::unboundedSynchronousIPCCount
 Lock Connection::s_connectionMapLock;
 
 struct Connection::WaitForMessageState {
-    WaitForMessageState(MessageName messageName, UInt128 destinationID, OptionSet<WaitForOption> waitForOptions)
+    WaitForMessageState(MessageName messageName, uint64_t destinationID, OptionSet<WaitForOption> waitForOptions)
         : messageName(messageName)
         , destinationID(destinationID)
         , waitForOptions(waitForOptions)
@@ -70,7 +70,7 @@ struct Connection::WaitForMessageState {
     }
 
     MessageName messageName;
-    UInt128 destinationID;
+    uint64_t destinationID;
     OptionSet<WaitForOption> waitForOptions;
     bool messageWaitingInterrupted = false;
     std::unique_ptr<Decoder> decoder;
@@ -96,7 +96,7 @@ public:
     bool processIncomingMessage(Connection& connection, std::unique_ptr<Decoder>&) WTF_REQUIRES_LOCK(connection.m_incomingMessagesLock);
 
     // Dispatch pending sync messages.
-    void dispatchMessages(Function<void(MessageName, UInt128)>&& willDispatchMessage = { });
+    void dispatchMessages(Function<void(MessageName, uint64_t)>&& willDispatchMessage = { });
 
     // Add matching pending messages to the provided MessageReceiveQueue.
     void enqueueMatchingMessages(Connection&, MessageReceiveQueue&, const ReceiverMatcher&);
@@ -221,7 +221,7 @@ bool Connection::SyncMessageState::processIncomingMessage(Connection& connection
     return true;
 }
 
-void Connection::SyncMessageState::dispatchMessages(Function<void(MessageName, UInt128)>&& willDispatchMessage)
+void Connection::SyncMessageState::dispatchMessages(Function<void(MessageName, uint64_t)>&& willDispatchMessage)
 {
     assertIsCurrent(m_dispatcher);
     {
@@ -380,7 +380,7 @@ void Connection::removeMessageReceiveQueue(const ReceiverMatcher& receiverMatche
     m_receiveQueues.remove(receiverMatcher);
 }
 
-void Connection::addWorkQueueMessageReceiver(ReceiverName receiverName, WorkQueue& workQueue, WorkQueueMessageReceiver& receiver, UInt128 destinationID)
+void Connection::addWorkQueueMessageReceiver(ReceiverName receiverName, WorkQueue& workQueue, WorkQueueMessageReceiver& receiver, uint64_t destinationID)
 {
     auto receiverMatcher = ReceiverMatcher::createWithZeroAsAnyDestination(receiverName, destinationID);
 
@@ -390,12 +390,12 @@ void Connection::addWorkQueueMessageReceiver(ReceiverName receiverName, WorkQueu
     m_receiveQueues.add(WTFMove(receiveQueue), receiverMatcher);
 }
 
-void Connection::removeWorkQueueMessageReceiver(ReceiverName receiverName, UInt128 destinationID)
+void Connection::removeWorkQueueMessageReceiver(ReceiverName receiverName, uint64_t destinationID)
 {
     removeMessageReceiveQueue(ReceiverMatcher::createWithZeroAsAnyDestination(receiverName, destinationID));
 }
 
-void Connection::addMessageReceiver(FunctionDispatcher& dispatcher, MessageReceiver& receiver, ReceiverName receiverName, UInt128 destinationID)
+void Connection::addMessageReceiver(FunctionDispatcher& dispatcher, MessageReceiver& receiver, ReceiverName receiverName, uint64_t destinationID)
 {
     auto receiverMatcher = ReceiverMatcher::createWithZeroAsAnyDestination(receiverName, destinationID);
     auto receiveQueue = makeUnique<FunctionDispatcherQueue>(dispatcher, receiver);
@@ -404,7 +404,7 @@ void Connection::addMessageReceiver(FunctionDispatcher& dispatcher, MessageRecei
     m_receiveQueues.add(WTFMove(receiveQueue), receiverMatcher);
 }
 
-void Connection::removeMessageReceiver(ReceiverName receiverName, UInt128 destinationID)
+void Connection::removeMessageReceiver(ReceiverName receiverName, uint64_t destinationID)
 {
     removeMessageReceiveQueue(ReceiverMatcher::createWithZeroAsAnyDestination(receiverName, destinationID));
 }
@@ -488,7 +488,7 @@ void Connection::markCurrentlyDispatchedMessageAsInvalid()
     m_didReceiveInvalidMessage = true;
 }
 
-UniqueRef<Encoder> Connection::createSyncMessageEncoder(MessageName messageName, UInt128 destinationID, SyncRequestID& syncRequestID)
+UniqueRef<Encoder> Connection::createSyncMessageEncoder(MessageName messageName, uint64_t destinationID, SyncRequestID& syncRequestID)
 {
     auto encoder = makeUniqueRef<Encoder>(messageName, destinationID);
 
@@ -594,7 +594,7 @@ Timeout Connection::timeoutRespectingIgnoreTimeoutsForTesting(Timeout timeout) c
     return m_ignoreTimeoutsForTesting ? Timeout::infinity() : timeout;
 }
 
-std::unique_ptr<Decoder> Connection::waitForMessage(MessageName messageName, UInt128 destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
+std::unique_ptr<Decoder> Connection::waitForMessage(MessageName messageName, uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
     if (!isValid())
         return nullptr;
@@ -654,7 +654,7 @@ std::unique_ptr<Decoder> Connection::waitForMessage(MessageName messageName, UIn
     while (true) {
         // Handle any messages that are blocked on a response from us.
         bool wasMessageToWaitForAlreadyDispatched = false;
-        m_syncState->dispatchMessages([&](auto nameOfMessageToDispatch, UInt128 destinationOfMessageToDispatch) {
+        m_syncState->dispatchMessages([&](auto nameOfMessageToDispatch, uint64_t destinationOfMessageToDispatch) {
             wasMessageToWaitForAlreadyDispatched |= messageName == nameOfMessageToDispatch && destinationID == destinationOfMessageToDispatch;
         });
 

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -242,8 +242,8 @@ public:
     // Adds a message receive queue that dispatches through WorkQueue to WorkQueueMessageReceiver.
     // Keeps the WorkQueue and the WorkQueueMessageReceiver alive. Dispatched tasks keep WorkQueueMessageReceiver alive.
     // destinationID == 0 matches all ids.
-    void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiver&, UInt128 destinationID = 0);
-    void removeWorkQueueMessageReceiver(ReceiverName, UInt128 destinationID = 0);
+    void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiver&, uint64_t destinationID = 0);
+    void removeWorkQueueMessageReceiver(ReceiverName, uint64_t destinationID = 0);
 
     // Adds a message receive queue that dispatches through FunctionDispatcher.
     // `FunctionDispatcher` will be used in any thread.
@@ -251,16 +251,16 @@ public:
     // until `removeMessageReceiver()` for same receiver name, destination id returns.
     // The caller is responsible for making sure the `MessageReceiver` is alive when the dispatched functions
     // are run.
-    void addMessageReceiver(FunctionDispatcher&, MessageReceiver&, ReceiverName, UInt128 destinationID = 0);
-    void removeMessageReceiver(ReceiverName, UInt128 destinationID = 0);
+    void addMessageReceiver(FunctionDispatcher&, MessageReceiver&, ReceiverName, uint64_t destinationID = 0);
+    void removeMessageReceiver(ReceiverName, uint64_t destinationID = 0);
 
     bool open(Client&, SerialFunctionDispatcher& = RunLoop::current());
     void invalidate();
     void markCurrentlyDispatchedMessageAsInvalid();
 
-    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
-    template<typename T> bool send(T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
-    template<typename T> static bool send(UniqueID, T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
+    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
+    template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
+    template<typename T> static bool send(UniqueID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
 
     // Sync senders should check the SendSyncResult for true/false in case they need to know if the result was really received.
     // Sync senders should hold on to the SendSyncResult in case they reference the contents of the reply via DataRefererence / ArrayReference.
@@ -291,8 +291,9 @@ public:
         }
     };
 
-    template<typename T> SendSyncResult<T> sendSync(T&& message, UInt128 destinationID, Timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { }); // Main thread only.
-    template<typename> bool waitForAndDispatchImmediately(UInt128 destinationID, Timeout, OptionSet<WaitForOption> waitForOptions = { }); // Main thread only.
+    template<typename T> SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { }); // Main thread only.
+
+    template<typename> bool waitForAndDispatchImmediately(uint64_t destinationID, Timeout, OptionSet<WaitForOption> waitForOptions = { }); // Main thread only.
     template<typename> bool waitForAsyncReplyAndDispatchImmediately(AsyncReplyID, Timeout); // Main thread only.
 
     // Thread-safe.
@@ -330,7 +331,7 @@ public:
         AsyncReplyID replyID;
     };
     bool sendMessageWithAsyncReply(UniqueRef<Encoder>&&, AsyncReplyHandler, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
-    UniqueRef<Encoder> createSyncMessageEncoder(MessageName, UInt128 destinationID, SyncRequestID&);
+    UniqueRef<Encoder> createSyncMessageEncoder(MessageName, uint64_t destinationID, SyncRequestID&);
     std::unique_ptr<Decoder> sendSyncMessage(SyncRequestID, UniqueRef<Encoder>&&, Timeout, OptionSet<SendSyncOption> sendSyncOptions);
     bool sendSyncReply(UniqueRef<Encoder>&&);
 
@@ -365,7 +366,7 @@ public:
     void setIgnoreInvalidMessageForTesting() { m_ignoreInvalidMessageForTesting = true; }
     bool ignoreInvalidMessageForTesting() const { return m_ignoreInvalidMessageForTesting; }
     void dispatchIncomingMessageForTesting(std::unique_ptr<Decoder>&&);
-    std::unique_ptr<Decoder> waitForMessageForTesting(MessageName, UInt128 destinationID, Timeout, OptionSet<WaitForOption>);
+    std::unique_ptr<Decoder> waitForMessageForTesting(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
 #endif
 
     void dispatchMessageReceiverMessage(MessageReceiver&, std::unique_ptr<Decoder>&&);
@@ -388,8 +389,8 @@ private:
     bool isIncomingMessagesThrottlingEnabled() const { return m_incomingMessagesThrottlingLevel.has_value(); }
 
     static HashMap<IPC::Connection::UniqueID, Connection*>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock);
-    
-    std::unique_ptr<Decoder> waitForMessage(MessageName, UInt128 destinationID, Timeout, OptionSet<WaitForOption>);
+
+    std::unique_ptr<Decoder> waitForMessage(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
 
     SyncRequestID makeSyncRequestID() { return SyncRequestID::generateThreadSafe(); }
     bool pushPendingSyncRequestID(SyncRequestID);
@@ -575,7 +576,7 @@ private:
 };
 
 template<typename T>
-bool Connection::send(T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+bool Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
     static_assert(!T::isSync, "Async message expected");
 
@@ -586,7 +587,7 @@ bool Connection::send(T&& message, UInt128 destinationID, OptionSet<SendOption> 
 }
 
 template<typename T>
-bool Connection::send(UniqueID connectionID, T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+bool Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
     Locker locker { s_connectionMapLock };
     auto* connection = connectionMap().get(connectionID);
@@ -596,7 +597,7 @@ bool Connection::send(UniqueID connectionID, T&& message, UInt128 destinationID,
 }
 
 template<typename T, typename C>
-Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID, OptionSet<SendOption> sendOptions)
+Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions)
 {
     static_assert(!T::isSync, "Async message expected");
     auto handler = makeAsyncReplyHandler<T>(WTFMove(completionHandler));
@@ -608,7 +609,7 @@ Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& complet
     return { };
 }
 
-template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, UInt128 destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
+template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, uint64_t destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
 {
     static_assert(T::isSync, "Sync message expected");
     SyncRequestID syncRequestID;
@@ -635,7 +636,7 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
     return result;
 }
 
-template<typename T> bool Connection::waitForAndDispatchImmediately(UInt128 destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
+template<typename T> bool Connection::waitForAndDispatchImmediately(uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
     std::unique_ptr<Decoder> decoder = waitForMessage(T::name(), destinationID, timeout, waitForOptions);
     if (!decoder)
@@ -654,8 +655,8 @@ template<typename T> bool Connection::waitForAsyncReplyAndDispatchImmediately(As
         return false;
 
     ASSERT(decoder->messageReceiverName() == ReceiverName::AsyncReply);
-    ASSERT(replyID.toUInt64() == static_cast<uint64_t>(decoder->destinationID()));
-    auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(static_cast<uint64_t>(decoder->destinationID())));
+    ASSERT(decoder->destinationID() == replyID.toUInt64());
+    auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(decoder->destinationID()));
     if (!handler) {
         ASSERT_NOT_REACHED();
         return false;
@@ -665,7 +666,7 @@ template<typename T> bool Connection::waitForAsyncReplyAndDispatchImmediately(As
 }
 
 #if ENABLE(IPC_TESTING_API)
-inline std::unique_ptr<Decoder> Connection::waitForMessageForTesting(MessageName messageName, UInt128 destinationID, Timeout timeout, OptionSet<WaitForOption> options)
+inline std::unique_ptr<Decoder> Connection::waitForMessageForTesting(MessageName messageName, uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> options)
 {
     return waitForMessage(messageName, destinationID, timeout, options);
 }

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -78,7 +78,7 @@ Decoder::Decoder(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&& b
     , m_bufferDeallocator { WTFMove(bufferDeallocator) }
     , m_attachments { WTFMove(attachments) }
 {
-    if (UNLIKELY(reinterpret_cast<uintptr_t>(m_buffer) % alignof(UInt128))) {
+    if (UNLIKELY(reinterpret_cast<uintptr_t>(m_buffer) % alignof(uint64_t))) {
         markInvalid();
         return;
     }
@@ -93,7 +93,7 @@ Decoder::Decoder(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&& b
         return;
 }
 
-Decoder::Decoder(const uint8_t* stream, size_t streamSize, UInt128 destinationID)
+Decoder::Decoder(const uint8_t* stream, size_t streamSize, uint64_t destinationID)
     : m_buffer { stream }
     , m_bufferPos { m_buffer }
     , m_bufferEnd { m_buffer + streamSize }

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -28,6 +28,7 @@
 #include "Attachment.h"
 #include "MessageNames.h"
 #include "ReceiverMatcher.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Function.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
@@ -51,7 +52,7 @@ public:
     static std::unique_ptr<Decoder> create(const uint8_t* buffer, size_t bufferSize, Vector<Attachment>&&);
     using BufferDeallocator = Function<void(const uint8_t*, size_t)>;
     static std::unique_ptr<Decoder> create(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&&, Vector<Attachment>&&);
-    Decoder(const uint8_t* stream, size_t streamSize, UInt128 destinationID);
+    Decoder(const uint8_t* stream, size_t streamSize, uint64_t destinationID);
 
     ~Decoder();
 
@@ -62,7 +63,7 @@ public:
 
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
-    UInt128 destinationID() const { return m_destinationID; }
+    uint64_t destinationID() const { return m_destinationID; }
     bool matches(const ReceiverMatcher& matcher) const { return matcher.matches(messageReceiverName(), destinationID()); }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
@@ -172,8 +173,8 @@ private:
     OptionSet<MessageFlags> m_messageFlags;
     MessageName m_messageName;
 
+    uint64_t m_destinationID;
     bool m_isAllowedWhenWaitingForSyncReplyOverride { false };
-    UInt128 m_destinationID;
 
 #if PLATFORM(MAC)
     ImportanceAssertion m_importanceAssertion;

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -63,7 +63,7 @@ static inline void freeBuffer(void* addr, size_t size)
 #endif
 }
 
-Encoder::Encoder(MessageName messageName, UInt128 destinationID)
+Encoder::Encoder(MessageName messageName, uint64_t destinationID)
     : m_messageName(messageName)
     , m_destinationID(destinationID)
 {

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -29,7 +29,6 @@
 #include "MessageNames.h"
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Forward.h>
-#include <wtf/Int128.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
@@ -43,7 +42,7 @@ template<typename, typename> struct ArgumentCoder;
 class Encoder final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    Encoder(MessageName, UInt128 destinationID);
+    Encoder(MessageName, uint64_t destinationID);
     ~Encoder();
 
     Encoder(const Encoder&) = delete;
@@ -53,7 +52,7 @@ public:
 
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
-    UInt128 destinationID() const { return m_destinationID; }
+    uint64_t destinationID() const { return m_destinationID; }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
 
@@ -98,7 +97,7 @@ private:
     OptionSet<MessageFlags>& messageFlags();
 
     MessageName m_messageName;
-    UInt128 m_destinationID;
+    uint64_t m_destinationID;
 
     uint8_t m_inlineBuffer[512];
 

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
@@ -29,7 +29,6 @@
 #include "MessageReceiveQueue.h"
 #include <variant>
 #include <wtf/HashMap.h>
-#include <wtf/Int128.h>
 
 namespace IPC {
 
@@ -53,7 +52,7 @@ public:
 private:
     using StoreType = std::variant<MessageReceiveQueue*, std::unique_ptr<MessageReceiveQueue>>;
     void addImpl(StoreType&&, const ReceiverMatcher&);
-    using QueueMap = HashMap<std::pair<uint8_t, UInt128>, StoreType>;
+    using QueueMap = HashMap<std::pair<uint8_t, uint64_t>, StoreType>;
     // Key is ReceiverName. FIXME: make it possible to use ReceiverName.
     using AnyIDQueueMap = HashMap<uint8_t, StoreType>;
     QueueMap m_queues;

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -47,7 +47,7 @@ void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, Me
     m_globalMessageReceivers.set(messageReceiverName, messageReceiver);
 }
 
-void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, UInt128 destinationID, MessageReceiver& messageReceiver)
+void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, uint64_t destinationID, MessageReceiver& messageReceiver)
 {
     ASSERT(destinationID);
     ASSERT(!m_messageReceivers.contains(std::make_pair(messageReceiverName, destinationID)));
@@ -70,7 +70,7 @@ void MessageReceiverMap::removeMessageReceiver(ReceiverName messageReceiverName)
     m_globalMessageReceivers.remove(it);
 }
 
-void MessageReceiverMap::removeMessageReceiver(ReceiverName messageReceiverName, UInt128 destinationID)
+void MessageReceiverMap::removeMessageReceiver(ReceiverName messageReceiverName, uint64_t destinationID)
 {
     auto it = m_messageReceivers.find(std::make_pair(messageReceiverName, destinationID));
     if (it == m_messageReceivers.end()) {

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.h
@@ -43,10 +43,10 @@ public:
     ~MessageReceiverMap();
 
     void addMessageReceiver(ReceiverName, MessageReceiver&);
-    void addMessageReceiver(ReceiverName, UInt128 destinationID, MessageReceiver&);
+    void addMessageReceiver(ReceiverName, uint64_t destinationID, MessageReceiver&);
 
     void removeMessageReceiver(ReceiverName);
-    void removeMessageReceiver(ReceiverName, UInt128 destinationID);
+    void removeMessageReceiver(ReceiverName, uint64_t destinationID);
     void removeMessageReceiver(MessageReceiver&);
 
     void invalidate();
@@ -58,7 +58,7 @@ private:
     // Message receivers that don't require a destination ID.
     HashMap<ReceiverName, WeakPtr<MessageReceiver>, WTF::IntHash<ReceiverName>, WTF::StrongEnumHashTraits<ReceiverName>> m_globalMessageReceivers;
 
-    HashMap<std::pair<ReceiverName, UInt128>, WeakPtr<MessageReceiver>, DefaultHash<std::pair<ReceiverName, UInt128>>, PairHashTraits<WTF::StrongEnumHashTraits<ReceiverName>, HashTraits<UInt128>>> m_messageReceivers;
+    HashMap<std::pair<ReceiverName, uint64_t>, WeakPtr<MessageReceiver>, DefaultHash<std::pair<ReceiverName, uint64_t>>, PairHashTraits<WTF::StrongEnumHashTraits<ReceiverName>, HashTraits<uint64_t>>> m_messageReceivers;
 };
 
 };

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -27,7 +27,6 @@
 
 #include <wtf/Assertions.h>
 #include "Connection.h"
-#include <wtf/Int128.h>
 #include <wtf/UniqueRef.h>
 
 namespace IPC {
@@ -41,7 +40,7 @@ public:
         return send(WTFMove(message), messageSenderDestinationID(), sendOptions);
     }
 
-    template<typename T> bool send(T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions = { })
+    template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
     {
         static_assert(!T::isSync, "Message is sync!");
 
@@ -67,7 +66,7 @@ public:
     }
 
     template<typename T>
-    SendSyncResult<T> sendSync(T&& message, UInt128 destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
+    SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
     {
         if (auto* connection = messageSenderConnection())
             return connection->sendSync(WTFMove(message), destinationID, timeout, sendSyncOptions);
@@ -90,7 +89,7 @@ public:
     }
 
     template<typename T, typename C>
-    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID, OptionSet<SendOption> sendOptions = { })
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
     {
         static_assert(!T::isSync, "Async message expected");
 

--- a/Source/WebKit/Platform/IPC/ReceiverMatcher.h
+++ b/Source/WebKit/Platform/IPC/ReceiverMatcher.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <optional>
-#include <wtf/Int128.h>
 
 namespace IPC {
 
@@ -42,27 +41,27 @@ struct ReceiverMatcher {
 
     // Matches message to specific receiver, specific destination ID.
     // Note: destinationID == 0 matches only 0 ids.
-    ReceiverMatcher(ReceiverName receiverName, UInt128 destinationID)
+    ReceiverMatcher(ReceiverName receiverName, uint64_t destinationID)
         : receiverName(receiverName)
         , destinationID(destinationID)
     {
     }
 
     // Creates a matcher from parameters where destinationID == 0 means any destintation ID. Deprecated.
-    static ReceiverMatcher createWithZeroAsAnyDestination(ReceiverName receiverName, UInt128 destinationID)
+    static ReceiverMatcher createWithZeroAsAnyDestination(ReceiverName receiverName, uint64_t destinationID)
     {
         if (destinationID)
             return ReceiverMatcher { receiverName, destinationID };
         return ReceiverMatcher { receiverName };
     }
 
-    bool matches(ReceiverName matchReceiverName, UInt128 matchDestinationID) const
+    bool matches(ReceiverName matchReceiverName, uint64_t matchDestinationID) const
     {
         return !receiverName || (*receiverName == matchReceiverName && (!destinationID || *destinationID == matchDestinationID));
     }
 
     std::optional<ReceiverName> receiverName;
-    std::optional<UInt128> destinationID;
+    std::optional<uint64_t> destinationID;
 };
 
 }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1042,7 +1042,7 @@ def generate_message_handler(receiver):
             result.append('    if (connection.connection().ignoreInvalidMessageForTesting())\n')
             result.append('        return;\n')
             result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
         result.append('}\n')
     else:
         receive_variant = receiver.name if receiver.has_attribute(LEGACY_RECEIVER_ATTRIBUTE) else ''
@@ -1063,7 +1063,7 @@ def generate_message_handler(receiver):
             result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
             result.append('        return;\n')
             result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
         result.append('}\n')
 
     if not receiver.has_attribute(STREAM_ATTRIBUTE) and (sync_messages or receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE)):
@@ -1083,7 +1083,7 @@ def generate_message_handler(receiver):
         result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
         result.append('        return false;\n')
         result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));\n')
+        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());\n')
         result.append('    return false;\n')
         result.append('}\n')
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -59,7 +59,7 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
@@ -58,7 +58,7 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -52,7 +52,7 @@ void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -131,7 +131,7 @@ void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connec
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -148,7 +148,7 @@ bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Co
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -49,7 +49,7 @@ void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection&
     if (connection.connection().ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -47,7 +47,7 @@ void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::D
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -67,7 +67,7 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
     if (connection.connection().ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -74,7 +74,7 @@ bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC:
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
     return false;
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -131,7 +131,7 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
@@ -148,7 +148,7 @@ bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, I
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
     return false;
 }
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -130,12 +130,12 @@ void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName,
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);
 }
 
-void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID, IPC::MessageReceiver& messageReceiver)
+void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, destinationID, messageReceiver);
 }
 
-void AuxiliaryProcess::removeMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID)
+void AuxiliaryProcess::removeMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID)
 {
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -66,8 +66,8 @@ public:
     void enableTermination();
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
-    void addMessageReceiver(IPC::ReceiverName, UInt128 destinationID, IPC::MessageReceiver&);
-    void removeMessageReceiver(IPC::ReceiverName, UInt128 destinationID);
+    void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);
+    void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
     void removeMessageReceiver(IPC::ReceiverName);
     void removeMessageReceiver(IPC::MessageReceiver&);
     

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -254,12 +254,12 @@ void AuxiliaryProcessProxy::addMessageReceiver(IPC::ReceiverName messageReceiver
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);
 }
 
-void AuxiliaryProcessProxy::addMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID, IPC::MessageReceiver& messageReceiver)
+void AuxiliaryProcessProxy::addMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, destinationID, messageReceiver);
 }
 
-void AuxiliaryProcessProxy::removeMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID)
+void AuxiliaryProcessProxy::removeMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID)
 {
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -60,15 +60,14 @@ public:
 
     virtual ProcessThrottler& throttler() = 0;
 
-    template<typename T> bool send(T&& message, UInt128 destinationID, OptionSet<IPC::SendOption> sendOptions = { });
+    template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions = { });
 
     template<typename T> using SendSyncResult = IPC::Connection::SendSyncResult<T>;
-    template<typename T> SendSyncResult<T> sendSync(T&& message, UInt128 destinationID, IPC::Timeout = 1_s, OptionSet<IPC::SendSyncOption> sendSyncOptions = { });
+    template<typename T> SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, IPC::Timeout = 1_s, OptionSet<IPC::SendSyncOption> sendSyncOptions = { });
 
     enum class ShouldStartProcessThrottlerActivity : bool { No, Yes };
-
     using AsyncReplyID = IPC::Connection::AsyncReplyID;
-    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&&, C&&, UInt128 destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
+    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&&, C&&, uint64_t destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
     
     template<typename T, typename U>
     bool send(T&& message, ObjectIdentifier<U> destinationID, OptionSet<IPC::SendOption> sendOptions = { })
@@ -99,8 +98,8 @@ public:
     }
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
-    void addMessageReceiver(IPC::ReceiverName, UInt128 destinationID, IPC::MessageReceiver&);
-    void removeMessageReceiver(IPC::ReceiverName, UInt128 destinationID);
+    void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);
+    void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
     void removeMessageReceiver(IPC::ReceiverName);
     
     template <typename T>
@@ -218,7 +217,7 @@ private:
 };
 
 template<typename T>
-bool AuxiliaryProcessProxy::send(T&& message, UInt128 destinationID, OptionSet<IPC::SendOption> sendOptions)
+bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions)
 {
     static_assert(!T::isSync, "Async message expected");
 
@@ -229,7 +228,7 @@ bool AuxiliaryProcessProxy::send(T&& message, UInt128 destinationID, OptionSet<I
 }
 
 template<typename T>
-AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& message, UInt128 destinationID, IPC::Timeout timeout, OptionSet<IPC::SendSyncOption> sendSyncOptions)
+AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& message, uint64_t destinationID, IPC::Timeout timeout, OptionSet<IPC::SendSyncOption> sendSyncOptions)
 {
     static_assert(T::isSync, "Sync message expected");
 
@@ -242,7 +241,7 @@ AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& mes
 }
 
 template<typename T, typename C>
-AuxiliaryProcessProxy::AsyncReplyID AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+AuxiliaryProcessProxy::AsyncReplyID AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
 {
     static_assert(!T::isSync, "Async message expected");
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1462,7 +1462,7 @@ void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, I
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);
 }
 
-void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID, IPC::MessageReceiver& messageReceiver)
+void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, destinationID, messageReceiver);
 }
@@ -1472,7 +1472,7 @@ void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName);
 }
 
-void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID)
+void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID)
 {
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -165,9 +165,9 @@ public:
     }
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
-    void addMessageReceiver(IPC::ReceiverName, UInt128 destinationID, IPC::MessageReceiver&);
+    void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);
     void removeMessageReceiver(IPC::ReceiverName);
-    void removeMessageReceiver(IPC::ReceiverName, UInt128 destinationID);
+    void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
 
     WebBackForwardCache& backForwardCache() { return m_backForwardCache.get(); }
     

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -200,8 +200,8 @@ static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef f
         return JSValueMakeUndefined(context);
 
     WebCore::FrameIdentifier frameID {
-        makeObjectIdentifier<WebCore::FrameIdentifierType>(static_cast<UInt128>(JSValueToNumber(context, arguments[0], exception))),
-        makeObjectIdentifier<WebCore::ProcessIdentifierType>(static_cast<UInt128>(JSValueToNumber(context, arguments[1], exception)))
+        makeObjectIdentifier<WebCore::FrameIdentifierType>(JSValueToNumber(context, arguments[0], exception)),
+        makeObjectIdentifier<WebCore::ProcessIdentifierType>(JSValueToNumber(context, arguments[1], exception))
     };
     uint64_t callbackID = JSValueToNumber(context, arguments[2], exception);
     if (JSValueIsString(context, arguments[3])) {

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -501,7 +501,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 namespace {
 
 struct SyncIPCMessageInfo {
-    uint64_t destinationID; // FIXME: real IPC destinationID is at the moment UInt128, but we cannot decode that from JS.
+    uint64_t destinationID;
     IPC::MessageName messageName;
     IPC::Timeout timeout;
 };
@@ -2881,13 +2881,7 @@ JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* 
     jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "description"_s), JSC::jsString(vm, String::fromLatin1(IPC::description(decoder.messageName()))));
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    JSC::JSObject* array = JSC::constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    array->putDirectIndex(globalObject, 0, JSC::JSValue(static_cast<uint64_t>(decoder.destinationID())));
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    array->putDirectIndex(globalObject, 1, JSC::JSValue(static_cast<uint64_t>(decoder.destinationID() >> 64)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "destinationID"_s), JSC::JSValue(array));
+    jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "destinationID"_s), JSC::JSValue(decoder.destinationID()));
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     if (decoder.isSyncMessage()) {

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -959,7 +959,7 @@ void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
         return;
     }
 
-    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()), static_cast<int>(getCurrentProcessID()));
+    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
 }
 
 void WebProcess::didClose(IPC::Connection& connection)

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -410,7 +410,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
     dispatchAndWait(runLoop, [&] {
         ASSERT_TRUE(openB());
         for (uint64_t i = 100u; i < 160u; ++i) {
-            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (UInt128 value) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
                 if (!value)
                     WTFLogAlways("GOT: %llu", j);
                 EXPECT_GE(value, 100u);

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 
 struct MessageInfo {
     IPC::MessageName messageName;
-    UInt128 destinationID;
+    uint64_t destinationID;
 };
 
 struct MockTestMessage1 {
@@ -50,7 +50,7 @@ struct MockTestMessageWithAsyncReply1 {
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
     std::tuple<> arguments() { return { }; }
-    using ReplyArguments = std::tuple<UInt128>;
+    using ReplyArguments = std::tuple<uint64_t>;
 };
 
 class MockConnectionClient final : public IPC::Connection::Client {

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -45,7 +45,7 @@ using TestObjectIdentifier = ObjectIdentifier<TestObjectIdentifierTag>;
 
 struct MessageInfo {
     IPC::MessageName messageName;
-    UInt128 destinationID;
+    uint64_t destinationID;
 };
 
 struct MockStreamTestMessage1 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -412,7 +412,7 @@ TEST(IPCTestingAPI, CanInterceptAlert)
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].type"].UTF8String, "String");
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].value"].UTF8String, "ok");
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[0].syncRequestID)"].UTF8String, "number");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID[0]"].intValue,
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID"].intValue,
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 
@@ -444,7 +444,7 @@ TEST(IPCTestingAPI, CanInterceptHasStorageAccess)
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"targetMessage.arguments[3].type"].UTF8String, "uint64_t");
     EXPECT_EQ([webView stringByEvaluatingJavaScript:@"targetMessage.arguments[3].value"].intValue, [webView stringByEvaluatingJavaScript:@"IPC.pageID.toString()"].intValue);
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(targetMessage.syncRequestID)"].UTF8String, "undefined");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"targetMessage.destinationID[0]"].intValue, 0);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"targetMessage.destinationID"].intValue, 0);
 }
 #endif
 
@@ -477,7 +477,7 @@ TEST(IPCTestingAPI, CanInterceptFindString)
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].type"].UTF8String, "uint32_t");
     EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[2].value"].intValue, 1);
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[0].syncRequestID)"].UTF8String, "undefined");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID[0]"].intValue,
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID"].intValue,
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 


### PR DESCRIPTION
#### a3ebb425ed08c8574a33c6cc5237bfcc4210e21c
<pre>
Effectively revert 258484@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=250614">https://bugs.webkit.org/show_bug.cgi?id=250614</a>
rdar://104223231

Unreviewed.

It likely caused an issue with watchOS.  Revert it and the associated fixes
while keeping everything building and running nicely.

* Source/WTF/wtf/Int128.h:
(WTF::DefaultHash&lt;UInt128&gt;::hash): Deleted.
(WTF::DefaultHash&lt;UInt128&gt;::equal): Deleted.
(WTF::DefaultHash&lt;Int128&gt;::hash): Deleted.
(WTF::DefaultHash&lt;Int128&gt;::equal): Deleted.
(WTF::HashTraits&lt;UInt128&gt;::constructDeletedValue): Deleted.
(WTF::HashTraits&lt;UInt128&gt;::isDeletedValue): Deleted.
(WTF::HashTraits&lt;Int128&gt;::constructDeletedValue): Deleted.
(WTF::HashTraits&lt;Int128&gt;::isDeletedValue): Deleted.
(IPC::ArgumentCoder&lt;WTF::UInt128&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WTF::UInt128&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;WTF::Int128&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WTF::Int128&gt;::decode): Deleted.
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::makeObjectIdentifier):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::didReceiveMessage):
(WebKit::NetworkProcess::didReceiveSyncMessage):
(WebKit::NetworkProcess::findPendingDownloadLocation):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::WaitForMessageState::WaitForMessageState):
(IPC::Connection::SyncMessageState::dispatchMessages):
(IPC::Connection::addWorkQueueMessageReceiver):
(IPC::Connection::removeWorkQueueMessageReceiver):
(IPC::Connection::addMessageReceiver):
(IPC::Connection::removeMessageReceiver):
(IPC::Connection::createSyncMessageEncoder):
(IPC::Connection::waitForMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::send):
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::waitForMessageForTesting):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::Decoder):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::destinationID const):
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::Encoder):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h:
* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::addMessageReceiver):
(IPC::MessageReceiverMap::removeMessageReceiver):
* Source/WebKit/Platform/IPC/MessageReceiverMap.h:
* Source/WebKit/Platform/IPC/MessageSender.h:
(IPC::MessageSender::send):
(IPC::MessageSender::sendSync):
(IPC::MessageSender::sendWithAsyncReply):
* Source/WebKit/Platform/IPC/ReceiverMatcher.h:
(IPC::ReceiverMatcher::ReceiverMatcher):
(IPC::ReceiverMatcher::createWithZeroAsAnyDestination):
(IPC::ReceiverMatcher::matches const):
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
(WebKit::TestWithIfMessage::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
(WebKit::TestWithImageData::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage):
(WebKit::TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
(WebKit::TestWithSemaphore::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
(WebKit::TestWithStreamBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::addMessageReceiver):
(WebKit::AuxiliaryProcess::removeMessageReceiver):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::addMessageReceiver):
(WebKit::AuxiliaryProcessProxy::removeMessageReceiver):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::send):
(WebKit::AuxiliaryProcessProxy::sendSync):
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::addMessageReceiver):
(WebKit::WebProcessPool::removeMessageReceiver):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::didReceiveMessage):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/258904@main">https://commits.webkit.org/258904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81ef599125b0f3151909058945a71277927f906d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112556 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/172759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3346 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95537 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/111213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109095 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/106829 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93460 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5832 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89892 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3568 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6005 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29772 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11987 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/45922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98488 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7763 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20752 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3260 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->