### PR TITLE
[GameController] Correctly handle magnitude values passed to GamepadHapticActuator.playEffect()

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -31,6 +31,7 @@
 #import "GameControllerHapticEngines.h"
 #import "GamepadEffectParameters.h"
 #import "Logging.h"
+#import <cmath>
 
 #import "CoreHapticsSoftLink.h"
 
@@ -38,15 +39,10 @@ namespace WebCore {
 
 static double magnitudeToIntensity(double magnitude)
 {
-    if (magnitude <= 0)
-        return 0;
-
-    // Magnitude is a value in the [0; 1] range. Intensity has the same range but with
-    // GameController, intensities below 0.1 don't register. To address this, we scale
-    // the magnitude to be in the [0.1; 1] range.
-    constexpr double newRange = 0.9;
-    constexpr double newMinimum = 0.1;
-    return (std::min(magnitude, 1.0) * newRange) + newMinimum;
+    // GameController doesn't use the intensity as-is and values below 0.1 would end up
+    // not triggering any gamepad vibration. Per GameController developers, we should
+    // pass sqrt(magnitude) to address this issue.
+    return std::sqrt(std::clamp<double>(magnitude, 0, 1));
 }
 
 std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)


### PR DESCRIPTION
#### 7ad0df2f473f50c09f2782e7cd12fdb44111d66f
<pre>
[GameController] Correctly handle magnitude values passed to GamepadHapticActuator.playEffect()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250616">https://bugs.webkit.org/show_bug.cgi?id=250616</a>

Reviewed by Youenn Fablet.

Correctly handle magnitude values passed to GamepadHapticActuator.playEffect()
when passing them to the GameController framework.

We noticed different Gamepad vibration results between Safari and Chrome for
the same magnitude values. One obvious difference was that values below 0.1
didn&apos;t result in any vibration in Safari but did in Chrome.

In 258874@main, I made an attempt to address this by scaling the input
magnitude (in the range [0; 1]) to be in the range [0.1; 1] in order to
always get a vibration if the magnitude value is not zero.

However, I have since heard back from GameController developers who have
indicating that we should be using the square root of the magnitude,
instead of the raw magnitude value. This is due to the fact that the
GameController framework doesn&apos;t use the input value as-is internally.

I am therefore updating our code to use the suggested approach. I have
validated on XBox Cloud that the level of vibration feels similar between
Safari and Chrome.

* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::magnitudeToIntensity):

Canonical link: <a href="https://commits.webkit.org/258988@main">https://commits.webkit.org/258988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83d3fa9bfecae2eae302b935dfe1d550f6dd6bc6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112561 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172764 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3351 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95542 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111239 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37979 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26417 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2947 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45925 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7768 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3281 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->