### PR TITLE
ASSERTION FAILED: !m_objectStoresByName.contains(objectStore->info().name()) in MemoryIDBBackingStore.cpp

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-expected.txt
@@ -1,0 +1,21 @@
+This test verifies renaming object store can be reverted succesfully if version change transaction aborts.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+openRequest = indexedDB.open(dbname);
+request = event.target;
+transaction = request.transaction;
+database = request.result;
+objectStore = database.createObjectStore('os1');
+database.deleteObjectStore('os1');
+objectStore2 = database.createObjectStore('os2')
+objectStore2.name = 'os1';
+objectStore2.put(1, 1).onsuccess = () => { transaction.abort(); }
+newOpenRequest = indexedDB.open(dbname);
+newDatabase = newOpenRequest.result;
+PASS newDatabase.objectStoreNames.length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-private-expected.txt
@@ -1,0 +1,21 @@
+This test verifies renaming object store can be reverted succesfully if version change transaction aborts.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+openRequest = indexedDB.open(dbname);
+request = event.target;
+transaction = request.transaction;
+database = request.result;
+objectStore = database.createObjectStore('os1');
+database.deleteObjectStore('os1');
+objectStore2 = database.createObjectStore('os2')
+objectStore2.name = 'os1';
+objectStore2.put(1, 1).onsuccess = () => { transaction.abort(); }
+newOpenRequest = indexedDB.open(dbname);
+newDatabase = newOpenRequest.result;
+PASS newDatabase.objectStoreNames.length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-private.html
+++ b/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/objectstore-rename-abort.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort.html
+++ b/LayoutTests/storage/indexeddb/modern/objectstore-rename-abort.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/objectstore-rename-abort.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/resources/objectstore-rename-abort.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/objectstore-rename-abort.js
@@ -1,0 +1,36 @@
+description("This test verifies renaming object store can be reverted succesfully if version change transaction aborts.");
+
+setDBNameFromPath();
+function openDatabase()
+{
+    evalAndLog("openRequest = indexedDB.open(dbname);");
+    openRequest.onupgradeneeded = onDatabaseUpgradeNeeded;
+    openRequest.onsuccess = unexpectedSuccessCallback;
+}
+
+function onDatabaseUpgradeNeeded()
+{
+    evalAndLog("request = event.target;");
+    evalAndLog("transaction = request.transaction;");
+    transaction.onabort = onTransactionAbort;
+    evalAndLog("database = request.result;");
+    evalAndLog("objectStore = database.createObjectStore('os1');");
+    evalAndLog("database.deleteObjectStore('os1');");
+    evalAndLog("objectStore2 = database.createObjectStore('os2')");
+    evalAndLog("objectStore2.name = 'os1';");
+    evalAndLog("objectStore2.put(1, 1).onsuccess = () => { transaction.abort(); }");
+}
+
+function onTransactionAbort()
+{
+    database.close();
+    evalAndLog("newOpenRequest = indexedDB.open(dbname);");
+    newOpenRequest.onupgradeneeded = (event) => {
+        evalAndLog("newDatabase = newOpenRequest.result;");
+        shouldBe("newDatabase.objectStoreNames.length", "0");
+    }
+    newOpenRequest.onerror = unexpectedErrorCallback;
+    newOpenRequest.onsuccess = finishJSTest;
+}
+
+openDatabase();

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -216,7 +216,7 @@ void MemoryBackingStoreTransaction::abort()
     m_originalIndexNames.clear();
 
     for (const auto& iterator : m_originalObjectStoreNames)
-        iterator.key->rename(iterator.value);
+        m_backingStore.renameObjectStoreForVersionChangeAbort(*iterator.key, iterator.value);
     m_originalObjectStoreNames.clear();
 
     for (const auto& objectStore : m_versionChangeAddedObjectStores)

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -310,6 +310,18 @@ IDBError MemoryIDBBackingStore::renameIndex(const IDBResourceIdentifier& transac
     return IDBError { };
 }
 
+void MemoryIDBBackingStore::renameObjectStoreForVersionChangeAbort(MemoryObjectStore& objectStore, const String& oldName)
+{
+    LOG(IndexedDB, "MemoryIDBBackingStore::renameObjectStoreForVersionChangeAbort");
+
+    auto identifier = objectStore.info().identifier();
+    auto currentName = objectStore.info().name();
+    m_objectStoresByName.remove(currentName);
+    m_objectStoresByName.set(oldName, &objectStore);
+    m_databaseInfo->renameObjectStore(identifier, oldName);
+    objectStore.rename(oldName);
+}
+
 void MemoryIDBBackingStore::removeObjectStoreForVersionChangeAbort(MemoryObjectStore& objectStore)
 {
     LOG(IndexedDB, "MemoryIDBBackingStore::removeObjectStoreForVersionChangeAbort");

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -47,6 +47,7 @@ public:
     uint64_t databaseVersion() final;
     void setDatabaseInfo(const IDBDatabaseInfo&);
 
+    void renameObjectStoreForVersionChangeAbort(MemoryObjectStore&, const String& oldName);
     void removeObjectStoreForVersionChangeAbort(MemoryObjectStore&);
     void restoreObjectStoreForVersionChangeAbort(Ref<MemoryObjectStore>&&);
     void handleLowMemoryWarning() final { };


### PR DESCRIPTION
#### 3d97acaa9a17dee8595bc0f1d32644f20b07dbe4
<pre>
ASSERTION FAILED: !m_objectStoresByName.contains(objectStore-&gt;info().name()) in MemoryIDBBackingStore.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=250617">https://bugs.webkit.org/show_bug.cgi?id=250617</a>
rdar://problem/99381891

Reviewed by Youenn Fablet.

When transaction is aborted and object store renaming operation is reverted, m_objectStoresByName in
MemoryIDBBackingStore should be updated accordingly (i.e. map the object store to the name used before renaming).
Otherwise, the wrong mapping can confuse the other operations in the tranaction abort.

Test: storage/indexeddb/modern/objectstore-rename-abort-private.html
      storage/indexeddb/modern/objectstore-rename-abort.html

* LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/objectstore-rename-abort-private.html: Added.
* LayoutTests/storage/indexeddb/modern/objectstore-rename-abort.html: Added.
* LayoutTests/storage/indexeddb/modern/resources/objectstore-rename-abort.js: Added.
(openDatabase):
(onDatabaseUpgradeNeeded):
(onTransactionAbort):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::renameObjectStoreForVersionChangeAbort):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:

Canonical link: <a href="https://commits.webkit.org/258996@main">https://commits.webkit.org/258996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a57172b5c20371aa0c994cb5df00e4b08852a901

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112822 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3601 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111988 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109360 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25239 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6080 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6261 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46151 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6181 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8013 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->