### PR TITLE
[WebRTC] Fix -Wunused-but-set-variable warnings in the libwebrtc project

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
@@ -76,7 +76,7 @@ WARNING_CFLAGS = $(WK_COMMON_WARNING_CFLAGS) $(WK_FIXME_WARNING_CFLAGS) -Wexit-t
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 // -Wno-unknown-warning-option added for -Wno-unused-but-set-parameter.
-WK_FIXME_WARNING_CFLAGS = -Wno-conditional-uninitialized -Wno-missing-field-initializers -Wno-sign-compare -Wno-undef -Wno-unknown-warning-option -Wno-unused-but-set-parameter -Wno-unused-but-set-variable -Wno-unused-parameter;
+WK_FIXME_WARNING_CFLAGS = -Wno-conditional-uninitialized -Wno-missing-field-initializers -Wno-sign-compare -Wno-undef -Wno-unknown-warning-option -Wno-unused-but-set-parameter -Wno-unused-parameter;
 
 ENTITLEMENTS_REQUIRED = $(ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_$(USE_INTERNAL_SDK))
 ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_ = NO;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc
@@ -172,6 +172,10 @@ absl::optional<H265PpsParser::PpsState> H265PpsParser::ParseInternal(
   // redundant_pic_cnt_present_flag: u(1)
   pps.redundant_pic_cnt_present_flag = bit_buffer->ReadBits(1);
 
+  // Ignore -Wunused-but-set-variable warnings.
+  (void)bits_tmp;
+  (void)golomb_ignored;
+
   return pps;
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
@@ -128,6 +128,7 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsUpToVui(Bitstream
   }
   // sps_seq_parameter_set_id: ue(v)
   golomb_ignored = buffer->ReadExponentialGolomb();
+  (void)golomb_ignored; // Ignore -Wunused-but-set-variable warning.
   // chrome_format_idc: ue(v)
   chroma_format_idc = buffer->ReadExponentialGolomb();
   if (chroma_format_idc == 3) {

--- a/Source/ThirdParty/libwebrtc/WebKit/libwebrtc-fix-Wunused-but-set-variable.diff
+++ b/Source/ThirdParty/libwebrtc/WebKit/libwebrtc-fix-Wunused-but-set-variable.diff
@@ -1,0 +1,27 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc
+index 6f13f3b807bb..1df2667d2eae 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc
+@@ -172,6 +172,10 @@ absl::optional<H265PpsParser::PpsState> H265PpsParser::ParseInternal(
+   // redundant_pic_cnt_present_flag: u(1)
+   pps.redundant_pic_cnt_present_flag = bit_buffer->ReadBits(1);
+ 
++  // Ignore -Wunused-but-set-variable warnings.
++  (void)bits_tmp;
++  (void)golomb_ignored;
++
+   return pps;
+ }
+ 
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
+index f4628ad63eeb..0d157624f533 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc
+@@ -128,6 +128,7 @@ absl::optional<H265SpsParser::SpsState> H265SpsParser::ParseSpsUpToVui(Bitstream
+   }
+   // sps_seq_parameter_set_id: ue(v)
+   golomb_ignored = buffer->ReadExponentialGolomb();
++  (void)golomb_ignored; // Ignore -Wunused-but-set-variable warning.
+   // chrome_format_idc: ue(v)
+   chroma_format_idc = buffer->ReadExponentialGolomb();
+   if (chroma_format_idc == 3) {


### PR DESCRIPTION
#### d9cd0e72ca7c30784f069afbc0c5617c5ff8b91d
<pre>
[WebRTC] Fix -Wunused-but-set-variable warnings in the libwebrtc project
<a href="https://bugs.webkit.org/show_bug.cgi?id=250622">https://bugs.webkit.org/show_bug.cgi?id=250622</a>
&lt;rdar://104261631&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig:
(WK_FIXME_WARNING_CFLAGS):
- Remove -Wno-unused-but-set-variable.
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc:
- Add empty statements for bits_tmp and golomb_ignored
  variables.
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_sps_parser.cc:
- Add empty statement for golomb_ignored variable.
* Source/ThirdParty/libwebrtc/WebKit/libwebrtc-fix-Wunused-but-set-variable.diff: Add.

Canonical link: <a href="https://commits.webkit.org/258956@main">https://commits.webkit.org/258956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce856db14f0f22b8eafe529fd80918c1333c0923

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112576 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172780 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3366 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111321 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37993 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79725 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26431 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2961 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45940 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7783 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3273 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->