### PR TITLE
Use UserContentURLPattern as the backing for WebExtensionMatchPattern.

### DIFF
--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,43 @@
 
 namespace WebCore {
 
+UserContentURLPattern::UserContentURLPattern(StringView scheme, StringView host, StringView path)
+{
+    m_scheme = scheme.toString();
+    if (m_scheme.isEmpty()) {
+        m_error = Error::MissingScheme;
+        return;
+    }
+
+    m_host = host.toString();
+    if (m_host.isEmpty()) {
+        m_error = Error::MissingHost;
+        return;
+    }
+
+    normalizeHostAndSetMatchSubdomains();
+
+    // No other '*' can occur in the host after it is normalized.
+    if (m_host.find('*') != notFound) {
+        m_error = Error::InvalidHost;
+        return;
+    }
+
+    m_path = path.toString();
+    if (!m_path.startsWith("/"_s)) {
+        m_error = Error::MissingPath;
+        return;
+    }
+
+    m_error = Error::None;
+}
+
+bool UserContentURLPattern::operator==(const UserContentURLPattern& other) const
+{
+    return this == &other || (m_error == other.m_error && m_matchSubdomains == other.m_matchSubdomains
+        && m_scheme == other.m_scheme && m_host == other.m_host && m_path == other.m_path);
+}
+
 bool UserContentURLPattern::matchesPatterns(const URL& url, const Vector<String>& allowlist, const Vector<String>& blocklist)
 {
     // In order for a URL to be a match it has to be present in the allowlist and not present in the blocklist.
@@ -61,71 +98,92 @@ bool UserContentURLPattern::matchesPatterns(const URL& url, const Vector<String>
     return matchesAllowlist && !matchesBlocklist;
 }
 
-bool UserContentURLPattern::parse(StringView pattern)
+void UserContentURLPattern::normalizeHostAndSetMatchSubdomains()
+{
+    ASSERT(!m_matchSubdomains);
+
+    if (m_host == "*"_s) {
+        // The pattern can be just '*', which means match all domains.
+        m_host = emptyString();
+        m_matchSubdomains = true;
+    } else if (m_host.startsWith("*."_s)) {
+        // The first component can be '*', which means to match all subdomains.
+        m_host = m_host.substring(2); // Length of "*."
+        m_matchSubdomains = true;
+    } else if (equalLettersIgnoringASCIICase(m_scheme, "file"_s) && equalLettersIgnoringASCIICase(m_host, "localhost"_s)) {
+        // A localhost for the file scheme is also empty string. This matches what URLParser does for URL.
+        m_host = emptyString();
+    }
+}
+
+UserContentURLPattern::Error UserContentURLPattern::parse(StringView pattern)
 {
     static constexpr ASCIILiteral schemeSeparator = "://"_s;
 
     size_t schemeEndPos = pattern.find(schemeSeparator);
     if (schemeEndPos == notFound)
-        return false;
+        return Error::MissingScheme;
 
     m_scheme = pattern.left(schemeEndPos).toString();
 
-    unsigned hostStartPos = schemeEndPos + schemeSeparator.length();
-    if (hostStartPos >= pattern.length())
-        return false;
+    bool isFileScheme = equalLettersIgnoringASCIICase(m_scheme, "file"_s);
+    size_t hostStartPos = schemeEndPos + schemeSeparator.length();
+    if (!isFileScheme && hostStartPos >= pattern.length())
+        return Error::MissingHost;
 
-    int pathStartPos = 0;
+    size_t pathStartPos = pattern.find('/', hostStartPos);
+    if (pathStartPos == notFound)
+        return Error::MissingPath;
 
-    if (equalLettersIgnoringASCIICase(m_scheme, "file"_s))
-        pathStartPos = hostStartPos;
-    else {
-        size_t hostEndPos = pattern.find('/', hostStartPos);
-        if (hostEndPos == notFound)
-            return false;
+    m_host = pattern.substring(hostStartPos, pathStartPos - hostStartPos).toString();
+    m_matchSubdomains = false;
 
-        m_host = pattern.substring(hostStartPos, hostEndPos - hostStartPos).toString();
-        m_matchSubdomains = false;
+    normalizeHostAndSetMatchSubdomains();
 
-        if (m_host == "*"_s) {
-            // The pattern can be just '*', which means match all domains.
-            m_host = emptyString();
-            m_matchSubdomains = true;
-        } else if (m_host.startsWith("*."_s)) {
-            // The first component can be '*', which means to match all subdomains.
-            m_host = m_host.substring(2); // Length of "*."
-            m_matchSubdomains = true;
-        }
-
-        // No other '*' can occur in the host.
-        if (m_host.find('*') != notFound)
-            return false;
-
-        pathStartPos = hostEndPos;
-    }
+    // No other '*' can occur in the host after it is normalized.
+    if (m_host.find('*') != notFound)
+        return Error::InvalidHost;
 
     m_path = pattern.right(pattern.length() - pathStartPos).toString();
 
-    return true;
+    return Error::None;
 }
 
-bool UserContentURLPattern::matches(const URL& test) const
+String UserContentURLPattern::originalHost() const
 {
-    if (m_invalid)
-        return false;
+    if (m_matchSubdomains && m_host.isEmpty())
+        return "*"_s;
 
-    if (m_scheme != "*"_s && !equalIgnoringASCIICase(test.protocol(), m_scheme))
-        return false;
+    if (m_matchSubdomains)
+        return makeString("*."_s, m_host);
 
-    if (!equalLettersIgnoringASCIICase(m_scheme, "file"_s) && !matchesHost(test))
-        return false;
-
-    return matchesPath(test);
+    return m_host;
 }
 
-bool UserContentURLPattern::matchesHost(const URL& test) const
+bool UserContentURLPattern::matchesScheme(const URL& url) const
 {
-    auto host = test.host();
+    ASSERT(isValid());
+
+    if (m_scheme == "*"_s)
+        return url.protocolIsInHTTPFamily();
+
+    return url.protocolIs(m_scheme);
+}
+
+bool UserContentURLPattern::matchesScheme(const UserContentURLPattern& other) const
+{
+    ASSERT(isValid());
+
+    if (m_scheme == "*"_s)
+        return other.scheme() == "*"_s || equalIgnoringASCIICase(other.scheme(), "https"_s) || equalIgnoringASCIICase(other.scheme(), "http"_s);
+
+    return equalIgnoringASCIICase(other.scheme(), m_scheme);
+}
+
+bool UserContentURLPattern::matchesHost(const String& host) const
+{
+    ASSERT(isValid());
+
     if (equalIgnoringASCIICase(host, m_host))
         return true;
 
@@ -197,15 +255,15 @@ struct MatchTester {
                 return true;
             return false;
         }
-  
+
         // Pattern is empty but not string, this is not a match.
         if (patternStringFinished())
             return false;
-        
+
         // If we don't encounter a *, then we're hosed.
         if (m_pattern[m_patternIndex] != '*')
             return false;
-        
+
         while (!testStringFinished()) {
             MatchTester nextMatch(*this);
             nextMatch.m_patternIndex++;
@@ -221,9 +279,11 @@ struct MatchTester {
     }
 };
 
-bool UserContentURLPattern::matchesPath(const URL& test) const
+bool UserContentURLPattern::matchesPath(const String& path) const
 {
-    return MatchTester(m_path, test.path()).test();
+    ASSERT(isValid());
+
+    return MatchTester(m_path, path).test();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/UserContentURLPattern.h
+++ b/Source/WebCore/page/UserContentURLPattern.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -34,34 +35,66 @@ class UserContentURLPattern {
 public:
     UserContentURLPattern() = default;
 
+    enum class Error : uint8_t {
+        None,
+        Invalid,
+        MissingScheme,
+        MissingHost,
+        InvalidHost,
+        MissingPath,
+    };
+
     explicit UserContentURLPattern(StringView pattern)
     {
-        m_invalid = !parse(pattern);
+        m_error = parse(pattern);
     }
 
-    bool isValid() const { return !m_invalid; }
+    WEBCORE_EXPORT UserContentURLPattern(StringView scheme, StringView host, StringView path);
 
-    WEBCORE_EXPORT bool matches(const URL&) const;
+    bool isValid() const { return m_error == Error::None; }
+    Error error() const { return m_error; }
+
+    template <typename T>
+    bool matches(const T& test) const
+    {
+        if (!isValid())
+            return false;
+        return matchesScheme(test) && matchesHost(test) && matchesPath(test);
+    }
 
     const String& scheme() const { return m_scheme; }
     const String& host() const { return m_host; }
     const String& path() const { return m_path; }
 
     bool matchSubdomains() const { return m_matchSubdomains; }
-    
+
+    // The host with the '*' wildcard, if matchSubdomains is true, otherwise same as host().
+    WEBCORE_EXPORT String originalHost() const;
+
+    WEBCORE_EXPORT bool matchesScheme(const URL&) const;
+    bool matchesHost(const URL& url) const { return matchesHost(url.host().toStringWithoutCopying()); }
+    bool matchesPath(const URL& url) const { return matchesPath(url.path().toStringWithoutCopying()); }
+
+    WEBCORE_EXPORT bool matchesScheme(const UserContentURLPattern&) const;
+    bool matchesHost(const UserContentURLPattern& other) const { return matchesHost(other.host()); }
+    bool matchesPath(const UserContentURLPattern& other) const { return matchesPath(other.path()); }
+
+    WEBCORE_EXPORT bool operator==(const UserContentURLPattern& other) const;
+
     static bool matchesPatterns(const URL&, const Vector<String>& allowlist, const Vector<String>& blocklist);
 
 private:
-    WEBCORE_EXPORT bool parse(StringView pattern);
+    WEBCORE_EXPORT Error parse(StringView pattern);
+    void normalizeHostAndSetMatchSubdomains();
 
-    bool matchesHost(const URL&) const;
-    bool matchesPath(const URL&) const;
+    WEBCORE_EXPORT bool matchesHost(const String&) const;
+    WEBCORE_EXPORT bool matchesPath(const String&) const;
 
     String m_scheme;
     String m_host;
     String m_path;
 
-    bool m_invalid { true };
+    Error m_error { Error::Invalid };
     bool m_matchSubdomains { false };
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -175,16 +175,22 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 - (NSString *)scheme
 {
+    if (_webExtensionMatchPattern->scheme().isNull())
+        return nil;
     return _webExtensionMatchPattern->scheme();
 }
 
 - (NSString *)host
 {
+    if (_webExtensionMatchPattern->host().isNull())
+        return nil;
     return _webExtensionMatchPattern->host();
 }
 
 - (NSString *)path
 {
+    if (_webExtensionMatchPattern->path().isNull())
+        return nil;
     return _webExtensionMatchPattern->path();
 }
 
@@ -226,6 +232,8 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensi
 
 - (BOOL)matchesURL:(NSURL *)urlToMatch options:(_WKWebExtensionMatchPatternOptions)options
 {
+    NSAssert(!(options & _WKWebExtensionMatchPatternOptionsMatchBidirectionally), @"Invalid parameter: WKWebExtensionMatchPatternOptionsMatchBidirectionally is not valid when matching a URL");
+
     return _webExtensionMatchPattern->matchesURL(urlToMatch, toImpl(options));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -551,8 +551,8 @@ static RetainPtr<TestNavigationDelegate> navigationDelegateAllowingActiveActions
     static auto delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = @{
-            @"testidentifier": [NSSet setWithObject:@"*://testhost/*"],
-            @"testidentifier2": [NSSet setWithObject:@"*://testhost/*"],
+            @"testidentifier": [NSSet setWithObject:@"testscheme://testhost/*"],
+            @"testidentifier2": [NSSet setWithObject:@"testscheme://testhost/*"],
         };
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
@@ -1126,13 +1126,13 @@ TEST_F(WKContentRuleListStoreTest, NullPatternSet)
         EXPECT_EQ(preferences._activeContentRuleListActionPatterns.count, 0u);
         switch (delegateAction) {
         case DelegateAction::AllowAll:
-            preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"*://*/*"] forKey:@"testidentifier"];
+            preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"testscheme://*/*"] forKey:@"testidentifier"];
             break;
         case DelegateAction::AllowNone:
             preferences._activeContentRuleListActionPatterns = [NSDictionary dictionary];
             break;
         case DelegateAction::AllowTestHost:
-            preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"*://testhost/*"] forKey:@"testidentifier"];
+            preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"testscheme://testhost/*"] forKey:@"testidentifier"];
             break;
         }
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
@@ -1177,7 +1177,7 @@ TEST_F(WKContentRuleListStoreTest, ExtensionPath)
 
     auto delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"*://testhost/*"] forKey:@"testidentifier"];
+        preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"testscheme://testhost/*"] forKey:@"testidentifier"];
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -1089,7 +1089,7 @@ TEST(URLSchemeHandler, DisableCORSCanvas)
     corsfailure = false;
     done = false;
 
-    configuration.get()._corsDisablingPatterns = @[@"*://*/*"];
+    configuration.get()._corsDisablingPatterns = @[@"cors://*/*"];
     {
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
@@ -144,8 +144,8 @@ TEST(WKWebExtensionMatchPattern, MatchPatternMatchesPattern)
     EXPECT_TRUE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file:///foo/bar.html")]);
     EXPECT_TRUE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file:///foo")]);
     EXPECT_TRUE([toPattern(@"file://localhost/foo*") matchesPattern:toPattern(@"file://localhost/foo")]);
-    EXPECT_FALSE([toPattern(@"file://localhost/foo*") matchesPattern:toPattern(@"file:///foo")]);
-    EXPECT_FALSE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file://localhost/foo")]);
+    EXPECT_TRUE([toPattern(@"file://localhost/foo*") matchesPattern:toPattern(@"file:///foo")]);
+    EXPECT_TRUE([toPattern(@"file:///foo*") matchesPattern:toPattern(@"file://localhost/foo")]);
     EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file:///foo/bar.html")]);
     EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file://localhost/foo/bar.html")]);
     EXPECT_TRUE([toPattern(@"file://*/foo*") matchesPattern:toPattern(@"file://test.local/foo/bar.html")]);
@@ -272,8 +272,8 @@ TEST(WKWebExtensionMatchPattern, MatchPatternMatchesURL)
     EXPECT_TRUE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file:///foo/bar.html"]]);
     EXPECT_TRUE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file:///foo"]]);
     EXPECT_TRUE([toPattern(@"file://localhost/foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo"]]);
-    EXPECT_FALSE([toPattern(@"file://localhost/foo*") matchesURL:[NSURL URLWithString:@"file:///foo"]]);
-    EXPECT_FALSE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo"]]);
+    EXPECT_TRUE([toPattern(@"file://localhost/foo*") matchesURL:[NSURL URLWithString:@"file:///foo"]]);
+    EXPECT_TRUE([toPattern(@"file:///foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo"]]);
     EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file:///foo/bar.html"]]);
     EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file://localhost/foo/bar.html"]]);
     EXPECT_TRUE([toPattern(@"file://*/foo*") matchesURL:[NSURL URLWithString:@"file://test.local/foo/bar.html"]]);
@@ -326,12 +326,15 @@ TEST(WKWebExtensionMatchPattern, MatchPatternMatchesURL)
     EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"bookmarks://"]]);
     EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:[NSURL URLWithString:@"history://"]]);
 
-    // Matches with regex special characters in pattern.
-    EXPECT_TRUE([toPattern(@"*://*/foo?bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%3Fbar"]]);
+    // Matches with regex and percent encoded special characters in pattern.
+    EXPECT_TRUE([toPattern(@"*://*/foo%3Fbar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%3Fbar"]]);
+    EXPECT_FALSE([toPattern(@"*://*/foo?bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%3Fbar"]]);
     EXPECT_FALSE([toPattern(@"*://*/foo?bar*") matchesURL:[NSURL URLWithString:@"https://example.com/fobar"]]);
-    EXPECT_TRUE([toPattern(@"*://*/foo[ba]r*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%5Bba%5Dr"]]);
+    EXPECT_TRUE([toPattern(@"*://*/foo%5Bba%5Dr*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%5Bba%5Dr"]]);
+    EXPECT_FALSE([toPattern(@"*://*/foo[ba]r*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%5Bba%5Dr"]]);
     EXPECT_FALSE([toPattern(@"*://*/foo[ba]r*") matchesURL:[NSURL URLWithString:@"https://example.com/fooar"]]);
-    EXPECT_TRUE([toPattern(@"*://*/foo|bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%7Cbar"]]);
+    EXPECT_TRUE([toPattern(@"*://*/foo%7Cbar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%7Cbar"]]);
+    EXPECT_FALSE([toPattern(@"*://*/foo|bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo%7Cbar"]]);
     EXPECT_FALSE([toPattern(@"*://*/foo|bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo"]]);
 }
 
@@ -341,7 +344,7 @@ TEST(WKWebExtensionMatchPattern, PatternDescriptions)
     EXPECT_NS_EQUAL(toPattern(@"*://*/*").description, @"*://*/*");
     EXPECT_NS_EQUAL(toPattern(@"http://*.example.com/*").description, @"http://*.example.com/*");
     EXPECT_NS_EQUAL(toPattern(@"file:///*").description, @"file:///*");
-    EXPECT_NS_EQUAL(toPattern(@"file://localhost/*").description, @"file://localhost/*");
+    EXPECT_NS_EQUAL(toPattern(@"file://localhost/*").description, @"file:///*");
 }
 
 TEST(WKWebExtensionMatchPattern, MatchesAllHosts)


### PR DESCRIPTION
#### 70c03f5cf50d47716f2ef5f2b11c6452f0a9f216
<pre>
Use UserContentURLPattern as the backing for WebExtensionMatchPattern.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250624">https://bugs.webkit.org/show_bug.cgi?id=250624</a>

Reviewed by Brian Weinstein.

WebExtensionMatchPattern has been made a thin wrapper around UserContentURLPattern by creating an internal pattern and using
UserContentURLPattern&apos;s matching methods to support WebExtensionMatchPattern&apos;s matching options (ignoring scheme, path, etc).

UserContentURLPattern now only matches HTTP-family schemes with the &apos;*&apos; scheme for Web Extensions compatibility. This change
impacted a few API tests that expected &apos;*://*/*&apos; to match custom schemes. I&apos;ve changed those tests to use the expected scheme.
Extensions and apps are not be impacted since HTTP-family URLs match like before, and only Safari specific SPIs use or expose
the UserContentURLPattern class and matching.

UserContentURLPattern now normalizes &apos;file://localhost/*&apos; to &apos;file:///*&apos; to match how URLParser parses URLs, so that matching
these URLs work universally. Additionally, hosts are now supported for file URLs, as expected by some unit tests.

Creating a pattern with the three components (scheme, host, path) is now supported.

This is significantly more efficient for WebExtensionMatchPattern. It has been observed to be 17x faster in a micro-benchmark.

* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::UserContentURLPattern::UserContentURLPattern): Added.
(WebCore::UserContentURLPattern::operator== const): Added.
(WebCore::UserContentURLPattern::normalizeHostAndSetMatchSubdomains): Added.
(WebCore::UserContentURLPattern::parse): Use normalizeHostAndSetMatchSubdomains and return errors instead of bool.
(WebCore::UserContentURLPattern::originalHost const): Added.
(WebCore::UserContentURLPattern::matches const):
(WebCore::UserContentURLPattern::matchesScheme const):
(WebCore::UserContentURLPattern::matchesHost const):
(WebCore::MatchTester::test):
(WebCore::UserContentURLPattern::matchesPath const):
* Source/WebCore/page/UserContentURLPattern.h:
(WebCore::UserContentURLPattern::UserContentURLPattern):
(WebCore::UserContentURLPattern::isValid const):
(WebCore::UserContentURLPattern::error const):
(WebCore::UserContentURLPattern::matchesHost const):
(WebCore::UserContentURLPattern::matchesPath const):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(-[_WKWebExtensionMatchPattern scheme]): Return nil if the String is null.
(-[_WKWebExtensionMatchPattern host]): Ditto.
(-[_WKWebExtensionMatchPattern path]): Ditto.
(-[_WKWebExtensionMatchPattern matchesURL:options:]): Add assert for option that can&apos;t be used.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::registerCustomURLScheme):
(WebKit::WebExtensionMatchPattern::getOrCreate):
(WebKit::WebExtensionMatchPattern::WebExtensionMatchPattern):
(WebKit::WebExtensionMatchPattern::isSupported const):
(WebKit::WebExtensionMatchPattern::operator== const):
(WebKit::WebExtensionMatchPattern::scheme const): Added.
(WebKit::WebExtensionMatchPattern::host const): Added.
(WebKit::WebExtensionMatchPattern::path const): Added.
(WebKit::WebExtensionMatchPattern::stringWithScheme const):
(WebKit::WebExtensionMatchPattern::expandedStrings const):
(WebKit::WebExtensionMatchPattern::matchesAllHosts const):
(WebKit::WebExtensionMatchPattern::isValidScheme):
(WebKit::WebExtensionMatchPattern::matchesURL const):
(WebKit::WebExtensionMatchPattern::matchesPattern const):
(WebKit::WebExtensionMatchPattern::schemeMatches const):
(WebKit::WebExtensionMatchPattern::hostMatches const):
(WebKit::WebExtensionMatchPattern::pathMatches const):
(WebKit::WebExtensionMatchPattern::isValidHost): Deleted.
(WebKit::WebExtensionMatchPattern::isValidPath): Deleted.
(WebKit::WebExtensionMatchPattern::parse): Deleted.
(WebKit::WebExtensionMatchPattern::matchesURL): Deleted.
(WebKit::WebExtensionMatchPattern::matchesPattern): Deleted.
(WebKit::WebExtensionMatchPattern::schemeMatches): Deleted.
(WebKit::WebExtensionMatchPattern::hostMatches): Deleted.
(WebKit::WebExtensionMatchPattern::pathMatches): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm:
(TestWebKitAPI::TEST): Change some expectations to match new results for file URLs and URL percent encodings.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(navigationDelegateAllowingActiveActionsOnTestHost): Changed wildcard scheme in pattern to &apos;testscheme&apos; scheme expected by the test.
(TestWebKitAPI::TEST_F(WKContentRuleListStoreTest, NullPatternSet)): Ditto.
(TestWebKitAPI::TEST_F(WKContentRuleListStoreTest, ExtensionPath)): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
(TestWebKitAPI::TEST(URLSchemeHandler, DisableCORSCanvas)): Changed wildcard scheme in pattern to &apos;cors&apos; scheme expected by the test.

Canonical link: <a href="https://commits.webkit.org/259009@main">https://commits.webkit.org/259009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048e02d92be3ec8d627101d88e62446164949b2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12765 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112879 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3662 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109420 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6134 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8068 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3291 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->