### PR TITLE
Sync SVGAnimationElement.idl with the specs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
@@ -320,7 +320,7 @@ PASS SVGFEDropShadowElement interface: attribute dx
 PASS SVGFEDropShadowElement interface: attribute dy
 PASS SVGFEDropShadowElement interface: attribute stdDeviationX
 PASS SVGFEDropShadowElement interface: attribute stdDeviationY
-FAIL SVGFEDropShadowElement interface: operation setStdDeviation(float, float) assert_equals: property has wrong .length expected 2 but got 0
+PASS SVGFEDropShadowElement interface: operation setStdDeviation(float, float)
 PASS SVGFEDropShadowElement interface: attribute x
 PASS SVGFEDropShadowElement interface: attribute y
 PASS SVGFEDropShadowElement interface: attribute width
@@ -355,7 +355,7 @@ PASS SVGFEGaussianBlurElement interface: attribute in1
 PASS SVGFEGaussianBlurElement interface: attribute stdDeviationX
 PASS SVGFEGaussianBlurElement interface: attribute stdDeviationY
 PASS SVGFEGaussianBlurElement interface: attribute edgeMode
-FAIL SVGFEGaussianBlurElement interface: operation setStdDeviation(float, float) assert_equals: property has wrong .length expected 2 but got 0
+PASS SVGFEGaussianBlurElement interface: operation setStdDeviation(float, float)
 PASS SVGFEGaussianBlurElement interface: attribute x
 PASS SVGFEGaussianBlurElement interface: attribute y
 PASS SVGFEGaussianBlurElement interface: attribute width

--- a/LayoutTests/platform/glib/svg/custom/elementTimeControl-nan-crash-expected.txt
+++ b/LayoutTests/platform/glib/svg/custom/elementTimeControl-nan-crash-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x238
   RenderBlock {HTML} at (0,0) size 800x238
     RenderBody {BODY} at (8,8) size 784x222
-      RenderText {#text} at (0,0) size 710x18
-        text run at (0,0) width 710: "Test for WK100322: ElementTimeControl should check for invalid values. This test passes if it does not crash."
+      RenderText {#text} at (0,0) size 696x17
+        text run at (0,0) width 696: "Test for WK100322: ElementTimeControl should check for invalid values. This test passes if it does not crash."
       RenderSVGRoot {svg} at (8,26) size 100x100
         RenderSVGRect {rect} at (8,26) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/svg/custom/elementTimeControl-nan-crash-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/elementTimeControl-nan-crash-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: TypeError: The provided value is non-finite
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x241
+  RenderBlock {HTML} at (0,0) size 800x241
+    RenderBody {BODY} at (8,8) size 784x225
+      RenderText {#text} at (0,0) size 710x19
+        text run at (0,0) width 710: "Test for WK100322: ElementTimeControl should check for invalid values. This test passes if it does not crash."
+      RenderSVGRoot {svg} at (8,28) size 100x100
+        RenderSVGRect {rect} at (8,28) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/svg/custom/elementTimeControl-nan-crash-expected.txt
+++ b/LayoutTests/platform/win/svg/custom/elementTimeControl-nan-crash-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x238
   RenderBlock {HTML} at (0,0) size 800x238
     RenderBody {BODY} at (8,8) size 784x222
-      RenderText {#text} at (0,0) size 710x18
-        text run at (0,0) width 710: "Test for WK100322: ElementTimeControl should check for invalid values. This test passes if it does not crash."
+      RenderText {#text} at (0,0) size 697x18
+        text run at (0,0) width 697: "Test for WK100322: ElementTimeControl should check for invalid values. This test passes if it does not crash."
       RenderSVGRoot {svg} at (8,26) size 100x100
         RenderSVGRect {rect} at (8,26) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/svg/dom/method-argument-aritychecks-expected.txt
+++ b/LayoutTests/svg/dom/method-argument-aritychecks-expected.txt
@@ -1,0 +1,34 @@
+Check that incorrect number of arguments throw TypeError.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+SVGAnimationElement
+
+beginElementAt(float offset)
+PASS animateElm.beginElementAt() threw exception TypeError: Not enough arguments.
+PASS animateElm.beginElementAt(0) did not throw exception.
+
+endElementAt(float offset)
+PASS animateElm.endElementAt() threw exception TypeError: Not enough arguments.
+PASS animateElm.endElementAt(0) did not throw exception.
+
+
+SVGFEDropShadowElement
+
+setStdDeviation(float stdDeviationX, float stdDeviationY)
+PASS dropShadow.setStdDeviation() threw exception TypeError: Not enough arguments.
+PASS dropShadow.setStdDeviation(0) threw exception TypeError: Not enough arguments.
+PASS dropShadow.setStdDeviation(0, 0) did not throw exception.
+
+
+SVGFEGaussianBlurElement
+
+setStdDeviation(float stdDeviationX, float stdDeviationY)
+PASS gaussian.setStdDeviation() threw exception TypeError: Not enough arguments.
+PASS gaussian.setStdDeviation(0) threw exception TypeError: Not enough arguments.
+PASS gaussian.setStdDeviation(0, 0) did not throw exception.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/dom/method-argument-aritychecks.html
+++ b/LayoutTests/svg/dom/method-argument-aritychecks.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<svg>
+  <feDropShadow id=dropshadow></feDropShadow>
+  <feGaussianBlur id=gaussian></feGaussianBlur>
+  <animate></animate>
+  <rect id="foo"></rect>
+  <use xlink:href="#foo"></use>
+</svg>
+<script>
+description('Check that incorrect number of arguments throw TypeError.');
+
+var dropShadow = document.getElementById('dropshadow');
+var gaussian = document.getElementById('gaussian');
+var rect = document.querySelector('rect');
+var animateElm = document.querySelector('animate');
+var useElm = document.querySelector('use');
+
+debug('SVGAnimationElement');
+
+debug('');
+debug('beginElementAt(float offset)');
+shouldThrow('animateElm.beginElementAt()');
+shouldNotThrow('animateElm.beginElementAt(0)');
+
+debug('');
+debug('endElementAt(float offset)');
+shouldThrow('animateElm.endElementAt()');
+shouldNotThrow('animateElm.endElementAt(0)');
+
+debug('');
+debug('');
+debug('SVGFEDropShadowElement');
+
+debug('');
+debug('setStdDeviation(float stdDeviationX, float stdDeviationY)');
+shouldThrow('dropShadow.setStdDeviation()');
+shouldThrow('dropShadow.setStdDeviation(0)');
+shouldNotThrow('dropShadow.setStdDeviation(0, 0)');
+
+debug('');
+debug('');
+debug('SVGFEGaussianBlurElement');
+
+debug('');
+debug('setStdDeviation(float stdDeviationX, float stdDeviationY)');
+shouldThrow('gaussian.setStdDeviation()');
+shouldThrow('gaussian.setStdDeviation(0)');
+shouldNotThrow('gaussian.setStdDeviation(0, 0)');
+
+</script>

--- a/LayoutTests/svg/dom/method-argument-typechecks-expected.txt
+++ b/LayoutTests/svg/dom/method-argument-typechecks-expected.txt
@@ -1,0 +1,40 @@
+Check that invalid values of arguments throw TypeError.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+SVGAnimationElement
+
+beginElementAt(float offset)
+PASS animateElm.beginElementAt(0) did not throw exception.
+PASS animateElm.beginElementAt(NaN) threw exception TypeError: The provided value is non-finite.
+PASS animateElm.beginElementAt(Infinity) threw exception TypeError: The provided value is non-finite.
+
+endElementAt(float offset)
+PASS animateElm.endElementAt(0) did not throw exception.
+PASS animateElm.endElementAt(NaN) threw exception TypeError: The provided value is non-finite.
+PASS animateElm.endElementAt(Infinity) threw exception TypeError: The provided value is non-finite.
+
+
+SVGFEDropShadowElement
+
+setStdDeviation(float stdDeviationX, float stdDeviationY)
+PASS dropShadow.setStdDeviation(0, 0) did not throw exception.
+PASS dropShadow.setStdDeviation(NaN, 1) threw exception TypeError: The provided value is non-finite.
+PASS dropShadow.setStdDeviation(Infinity, 1) threw exception TypeError: The provided value is non-finite.
+PASS dropShadow.setStdDeviation(1, NaN) threw exception TypeError: The provided value is non-finite.
+PASS dropShadow.setStdDeviation(1, Infinity) threw exception TypeError: The provided value is non-finite.
+
+
+SVGFEGaussianBlurElement
+
+setStdDeviation(float stdDeviationX, float stdDeviationY)
+PASS gaussian.setStdDeviation(0, 0) did not throw exception.
+PASS gaussian.setStdDeviation(NaN, 1) threw exception TypeError: The provided value is non-finite.
+PASS gaussian.setStdDeviation(Infinity, 1) threw exception TypeError: The provided value is non-finite.
+PASS gaussian.setStdDeviation(1, NaN) threw exception TypeError: The provided value is non-finite.
+PASS gaussian.setStdDeviation(1, Infinity) threw exception TypeError: The provided value is non-finite.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/dom/method-argument-typechecks.html
+++ b/LayoutTests/svg/dom/method-argument-typechecks.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<svg>
+  <feDropShadow id=dropshadow></feDropShadow>
+  <feGaussianBlur id=gaussian></feGaussianBlur>
+  <animate></animate>
+</svg>
+<script>
+description('Check that invalid values of arguments throw TypeError.');
+
+var dropShadow = document.getElementById('dropshadow');
+var gaussian = document.getElementById('gaussian');
+var animateElm = document.querySelector('animate');
+
+debug('SVGAnimationElement');
+
+debug('');
+debug('beginElementAt(float offset)');
+shouldNotThrow('animateElm.beginElementAt(0)');
+shouldThrow('animateElm.beginElementAt(NaN)');
+shouldThrow('animateElm.beginElementAt(Infinity)');
+
+debug('');
+debug('endElementAt(float offset)');
+shouldNotThrow('animateElm.endElementAt(0)');
+shouldThrow('animateElm.endElementAt(NaN)');
+shouldThrow('animateElm.endElementAt(Infinity)');
+
+debug('');
+debug('');
+debug('SVGFEDropShadowElement');
+
+debug('');
+debug('setStdDeviation(float stdDeviationX, float stdDeviationY)');
+shouldNotThrow('dropShadow.setStdDeviation(0, 0)');
+shouldThrow('dropShadow.setStdDeviation(NaN, 1)');
+shouldThrow('dropShadow.setStdDeviation(Infinity, 1)');
+shouldThrow('dropShadow.setStdDeviation(1, NaN)');
+shouldThrow('dropShadow.setStdDeviation(1, Infinity)');
+
+debug('');
+debug('');
+debug('SVGFEGaussianBlurElement');
+
+debug('');
+debug('setStdDeviation(float stdDeviationX, float stdDeviationY)');
+shouldNotThrow('gaussian.setStdDeviation(0, 0)');
+shouldThrow('gaussian.setStdDeviation(NaN, 1)');
+shouldThrow('gaussian.setStdDeviation(Infinity, 1)');
+shouldThrow('gaussian.setStdDeviation(1, NaN)');
+shouldThrow('gaussian.setStdDeviation(1, Infinity)');
+
+</script>

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -2,10 +2,11 @@
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -257,8 +258,6 @@ void SVGAnimationElement::beginElement()
 
 void SVGAnimationElement::beginElementAt(float offset)
 {
-    if (std::isnan(offset))
-        return;
     SMILTime elapsed = this->elapsed();
     addBeginTime(elapsed, elapsed + offset, SMILTimeWithOrigin::ScriptOrigin);
 }
@@ -270,8 +269,6 @@ void SVGAnimationElement::endElement()
 
 void SVGAnimationElement::endElementAt(float offset)
 {
-    if (std::isnan(offset))
-        return;
     SMILTime elapsed = this->elapsed();
     addEndTime(elapsed, elapsed + offset, SMILTimeWithOrigin::ScriptOrigin);
 }

--- a/Source/WebCore/svg/SVGAnimationElement.idl
+++ b/Source/WebCore/svg/SVGAnimationElement.idl
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,6 +25,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement
+
 [
     Exposed=Window
 ] interface SVGAnimationElement : SVGElement {
@@ -34,9 +37,9 @@
     unrestricted float getSimpleDuration();
 
     undefined beginElement();
-    undefined beginElementAt(optional unrestricted float offset = NaN);
+    undefined beginElementAt(float offset);
     undefined endElement();
-    undefined endElementAt(optional unrestricted float offset = NaN);
+    undefined endElementAt(float offset);
 };
 
 SVGAnimationElement includes SVGTests;


### PR DESCRIPTION
<pre>
Sync SVGAnimationElement.idl with the specs
<a href="https://bugs.webkit.org/show_bug.cgi?id=250575">https://bugs.webkit.org/show_bug.cgi?id=250575</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web-Specifications.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=rev&revision=171485">https://src.chromium.org/viewvc/blink?view=rev&revision=171485</a>

This patch aligns WebKit with web-specification by dropping unnecessary NaN (non-finite values) 
and remove 'optional unrestricted' from IDL files as needed across files.

This patch aligns WebKit with web-specification by dropping unnecessary
NaN (non-finite values) early return and remove 'optional unrestricted' from IDL files as needed across files.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(SVGAnimationElement::beginElementAt): Remove early return for 'nan' values
(SVGAnimationElement::endElementAt): Ditto
* Source/WebCore/svg/SVGAnimationElement.idl: Align with web-spec
* LayoutTests/svg/dom/method-argument-typechecks.html: Add Test Case
* LayoutTests/svg/dom/method-argument-typechecks-expected.txt: Add Test Case Expectation
* LayoutTests/svg/dom/method-argument-aritychecks.html: Add Test Case
* LayoutTests/svg/dom/method-argument-aritychecks-expected.txt: Add Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt: Rebaselined
* LayoutTests/svg/custom/elementTimeControl-nan-crash-expected.txt: Ditto
* LayoutTests/platform/glib/svg/custom/elementTimeControl-nan-crash-expected.txt: Add Platform Specific Expectation
* LayoutTests/platform/ios/svg/custom/elementTimeControl-nan-crash-expected.txt: Add Platform Specific Expectation
* LayoutTests/platform/win/svg/custom/elementTimeControl-nan-crash-expected.txt: Add Platform Specific Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e312fd9d71c024c5a0848ce8f305451723f5d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114906 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5968 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97945 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95287 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26927 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8037 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47827 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10086 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->