### PR TITLE
<object> element shouldn't override FormListedElement::setCustomValidity()

### DIFF
--- a/LayoutTests/fast/forms/setCustomValidity-null-parameter.html
+++ b/LayoutTests/fast/forms/setCustomValidity-null-parameter.html
@@ -49,14 +49,9 @@ function testFormControlBarredFromValidation(control, name)
 
         control.setCustomValidity("error");
         assert_true(control.checkValidity(), "checkValidity() after setting custom validity message to 'error'");
-        // WebKit and Chrome 96 treat <object> differently here. Firefox 95 doesn't.
-        if (control.tagName == "OBJECT") {
-            assert_true(control.validity.valid, "ValidityState.valid after setting custom validity message to 'error'");
-            assert_false(control.validity.customError, "ValidityState.customError after setting custom validity message to 'error'");
-         } else {
-            assert_false(control.validity.valid, "ValidityState.valid after setting custom validity message to 'error'");
-            assert_true(control.validity.customError, "ValidityState.customError after setting custom validity message to 'error'");
-        }
+        // Chrome 110 treats <object> differently here. Firefox 95 doesn't.
+        assert_false(control.validity.valid, "ValidityState.valid after setting custom validity message to 'error'");
+        assert_true(control.validity.customError, "ValidityState.customError after setting custom validity message to 'error'");
         assert_equals(control.validationMessage, "", "validationMessage after setting custom validity message to 'error'");
 
         control.setCustomValidity("");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-setcustomvalidity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-setcustomvalidity-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL object setCustomValidity is correct assert_true: expected true got false
+PASS object setCustomValidity is correct
 

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -48,9 +48,6 @@ public:
     static bool checkValidity() { return true; }
     static bool reportValidity() { return true; }
 
-    void setCustomValidity(const String&) final { }
-    String validationMessage() const final { return String(); }
-
     using HTMLPlugInImageElement::ref;
     using HTMLPlugInImageElement::deref;
 


### PR DESCRIPTION
#### 189024a1815a58b3ee79bb3fe3d27dc4c6ccf82b
<pre>
&lt;object&gt; element shouldn&apos;t override FormListedElement::setCustomValidity()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250627">https://bugs.webkit.org/show_bug.cgi?id=250627</a>

Reviewed by Darin Adler.

Per spec [1], &lt;object&gt; element&apos;s constraint validation methods are the same as for other objects.

This change removes setCustomValidity() override, allowing &lt;object&gt; element&apos;s customError()
to be triggered, which aligns &lt;object&gt; with all the other elements: their validity states
are independent of willValidate().

Removal of validationMessage() override is non-observable: the message can&apos;t be retrieved for
an element that is not a candidate for constraint validation [2].

Aligns WebKit with the spec and Gecko.

[1] <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a>:the-constraint-validation-api
[2] <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage</a>

* LayoutTests/fast/forms/setCustomValidity-null-parameter.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-setcustomvalidity-expected.txt:
* Source/WebCore/html/HTMLObjectElement.h:

Canonical link: <a href="https://commits.webkit.org/258945@main">https://commits.webkit.org/258945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f66416814dc9da4d976a5548b89bbb50c7efe5a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112680 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172889 "Failed to checkout and rebase branch from PR 8662") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3467 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111867 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109217 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5952 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12110 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7884 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3270 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->