### PR TITLE
Clip the start position when performing SVG text queries

### DIFF
--- a/LayoutTests/svg/text/text-getSubStringLength-expected.txt
+++ b/LayoutTests/svg/text/text-getSubStringLength-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL SVGTextContentElement.getSubStringLength, BiDi. assert_approx_equals: Sum of the parts equal the total. expected 37.7734375 +/- 0.01 but got 68.5293140411377
+FAIL SVGTextContentElement.getSubStringLength, multiple text-chunks. assert_approx_equals: Sum of the parts equal the total. expected 11.5546875 +/- 0.01 but got 22.2265625
+PASS SVGTextContentElement.getSubStringLength, 0-length
+W3C نشاط
+AB
+Text
+

--- a/LayoutTests/svg/text/text-getSubStringLength.html
+++ b/LayoutTests/svg/text/text-getSubStringLength.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>SVGTextContentElement.getSubStringLength</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id=log></div>
+<div>
+  <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <text x="10" y="20">W3C &#x0646;&#x0634;&#x0627;&#x0637;</text>
+    <text x="10 50" y="40">AB</text>
+    <text dx="-1 42 0 1">Text</text>
+  </svg>
+</div>
+<script>
+test(function() {
+    var text = document.querySelector('text');
+    assert_equals(text.getNumberOfChars(), 8);
+    var lenFirst4 = text.getSubStringLength(0, 4);
+    var lenLast4 = text.getSubStringLength(4, 4);
+    var lenAll = text.getSubStringLength(0, 8);
+    assert_approx_equals(lenFirst4 + lenLast4, lenAll, 0.01, 'Sum of the parts equal the total.');
+}, document.title+', BiDi.');
+test(function() {
+    var text = document.querySelector('text + text');
+    assert_equals(text.getNumberOfChars(), 2);
+    var lenFirst = text.getSubStringLength(0, 1);
+    var lenLast = text.getSubStringLength(1, 1);
+    var lenAll = text.getSubStringLength(0, 2);
+    assert_approx_equals(lenFirst + lenLast, lenAll, 0.01, 'Sum of the parts equal the total.');
+}, document.title+', multiple text-chunks.');
+
+test(() => {
+    let text = document.querySelectorAll('text')[2];
+    assert_equals(text.getSubStringLength(1, 0), 0.0);
+}, `${document.title}, 0-length`);
+</script>

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) Research In Motion Limited 2010-2012. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -144,6 +146,7 @@ bool SVGTextQuery::mapStartEndPositionsIntoFragmentCoordinates(Data* queryData, 
     startPosition -= queryData->processedCharacters;
     endPosition -= queryData->processedCharacters;
 
+    startPosition = std::max<unsigned>(0, startPosition);
     if (startPosition >= endPosition)
         return false;
 


### PR DESCRIPTION
<pre>
Clip the start position when performing SVG text queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=250631">https://bugs.webkit.org/show_bug.cgi?id=250631</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/55ceb3d896e75fbb5d3bb10e12b17b10d297bf27">https://chromium.googlesource.com/chromium/blink/+/55ceb3d896e75fbb5d3bb10e12b17b10d297bf27</a>

If a text query straddles multiple line boxes, only the first
would be considered, because 'startPosition' would end up being
negative. Instead clip the character range to [0] (the following
functions will clip against the end position) and only reject
ranges that are empty i.e. that appear before the current fragment
(logically).

* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(SVGTextQuery::mapStartEndPositionIntoFragmentCoordinates): Clamp 'startPosition' to '0'
* LayoutTests/svg/text/text-getSubStringLength.html: Add Test Case
* LayoutTests/svg/text/text-getSubStringLength-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69a90806e1de60ab7cd4e96edc3b65cde963c2aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112624 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172830 "Hash 69a90806 for PR 8664 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3412 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111532 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10401 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38032 "Found 1 new test failure: svg/text/text-getSubStringLength.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79762 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26470 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6072 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3000 "Found 1 new test failure: svg/text/text-getSubStringLength.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45979 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7830 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->