### PR TITLE
Web Inspector: WebKit-internal JSContexts should not be inspectable, even if internal policies would override `inspectable`

### DIFF
--- a/Source/JavaScriptCore/API/JSRemoteInspector.cpp
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 using namespace Inspector;
 
 static std::optional<bool> remoteInspectionEnabledByDefault = std::nullopt;
+static bool inspectionFollowsInternalPolicies = true;
 
 void JSRemoteInspectorDisableAutoStart(void)
 {
@@ -127,4 +128,14 @@ bool JSRemoteInspectorGetInspectionEnabledByDefault(void)
 void JSRemoteInspectorSetInspectionEnabledByDefault(bool enabledByDefault)
 {
     remoteInspectionEnabledByDefault = enabledByDefault;
+}
+
+bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void)
+{
+    return inspectionFollowsInternalPolicies;
+}
+
+void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool followsInternalPolicies)
+{
+    inspectionFollowsInternalPolicies = followsInternalPolicies;
 }

--- a/Source/JavaScriptCore/API/JSRemoteInspector.h
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ JS_EXPORT void JSRemoteInspectorSetLogToSystemConsole(bool) JSC_API_AVAILABLE(ma
 
 JS_EXPORT bool JSRemoteInspectorGetInspectionEnabledByDefault(void) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
 JS_EXPORT void JSRemoteInspectorSetInspectionEnabledByDefault(bool) JSC_API_DEPRECATED("Use JSGlobalContextSetInspectable on a single JSGlobalContextRef.", macos(10.11, JSC_MAC_TBA), ios(9.0, JSC_IOS_TBA));
+
+JS_EXPORT bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -211,7 +211,7 @@ bool JSGlobalObjectInspectorController::developerExtrasEnabled() const
     if (!RemoteInspector::singleton().enabled())
         return false;
 
-    if (!m_globalObject.inspectorDebuggable().inspectable())
+    if (!m_globalObject.inspectorDebuggable().allowsInspectionByPolicy())
         return false;
 #endif
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 
+#include "JSRemoteInspector.h"
 #include "RemoteControllableTarget.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
@@ -40,6 +41,8 @@ class JS_EXPORT_PRIVATE RemoteInspectionTarget : public RemoteControllableTarget
 public:
     bool inspectable() const;
     void setInspectable(bool);
+
+    bool allowsInspectionByPolicy() const;
 
 #if USE(CF)
     CFRunLoopRef targetRunLoop() const final { return m_runLoop.get(); }
@@ -60,7 +63,16 @@ public:
     bool remoteControlAllowed() const final;
 
 private:
-    bool m_inspectable { false };
+    enum class Inspectable : uint8_t {
+        Yes,
+        No,
+
+        // For WebKit internal proxies and wrappers, we want to always disable inspection even when internal policies
+        // would otherwise enable inspection.
+        NoIgnoringInternalPolicies,
+    };
+    Inspectable m_inspectable { JSRemoteInspectorGetInspectionFollowsInternalPolicies() ? Inspectable::No : Inspectable::NoIgnoringInternalPolicies };
+
 #if USE(CF)
     RetainPtr<CFRunLoopRef> m_runLoop;
 #endif

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -458,7 +458,7 @@ RetainPtr<NSDictionary> RemoteInspector::listingForInspectionTarget(const Remote
     // Must collect target information on the WebThread, Main, or Worker thread since RemoteTargets are
     // implemented by non-threadsafe JSC / WebCore classes such as JSGlobalObject or WebCore::Page.
 
-    if (!target.inspectable())
+    if (!target.allowsInspectionByPolicy())
         return nil;
 
     RetainPtr<NSMutableDictionary> listing = adoptNS([[NSMutableDictionary alloc] init]);

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -170,7 +170,7 @@ static const char* targetDebuggableType(RemoteInspectionTarget::Type type)
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
 {
-    if (!target.inspectable())
+    if (!target.allowsInspectionByPolicy())
         return nullptr;
 
     return g_variant_new("(tsssb)", static_cast<guint64>(target.targetIdentifier()),

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -117,7 +117,7 @@ void RemoteInspector::stopInternal(StopSource)
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
 {
-    if (!target.inspectable())
+    if (!target.allowsInspectionByPolicy())
         return nullptr;
 
     // FIXME: Support remote debugging of a ServiceWorker.

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -75,6 +75,10 @@
 #include <JavaScriptCore/WeakGCMapInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
+#if ENABLE(REMOTE_INSPECTOR)
+#include <JavaScriptCore/JSRemoteInspector.h>
+#endif
+
 namespace WebCore {
 using namespace JSC;
 
@@ -288,22 +292,40 @@ SUPPRESS_ASAN void JSDOMGlobalObject::addBuiltinGlobals(VM& vm)
 
 void JSDOMGlobalObject::finishCreation(VM& vm)
 {
+#if ENABLE(REMOTE_INSPECTOR)
+    bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+#endif
+
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
     addBuiltinGlobals(vm);
 
     RELEASE_ASSERT(classInfo());
+
+#if ENABLE(REMOTE_INSPECTOR)
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
+#endif
 }
 
 void JSDOMGlobalObject::finishCreation(VM& vm, JSObject* thisValue)
 {
+#if ENABLE(REMOTE_INSPECTOR)
+    bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+#endif
+
     Base::finishCreation(vm, thisValue);
     ASSERT(inherits(info()));
 
     addBuiltinGlobals(vm);
 
     RELEASE_ASSERT(classInfo());
+
+#if ENABLE(REMOTE_INSPECTOR)
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
+#endif
 }
 
 ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -49,6 +49,9 @@ public:
     {
         m_lastUseTime = MonotonicTime::now();
         if (!m_context) {
+            bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+            JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+
             // FIXME: rdar://100738357 Remote Web Inspector: Remove use of JSRemoteInspectorGetInspectionEnabledByDefault
             // and JSRemoteInspectorSetInspectionEnabledByDefault once the default state is always false.
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -57,6 +60,8 @@ public:
             m_context = adoptNS([[JSContext alloc] init]);
             JSRemoteInspectorSetInspectionEnabledByDefault(previous);
             ALLOW_DEPRECATED_DECLARATIONS_END
+
+            JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
 
             m_timer.startOneShot(sharedJSContextMaxIdleTime);
         }


### PR DESCRIPTION
#### 11aafb6ec00b2661ade8f516aacbcc0e805d727a
<pre>
Web Inspector: WebKit-internal JSContexts should not be inspectable, even if internal policies would override `inspectable`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250633">https://bugs.webkit.org/show_bug.cgi?id=250633</a>
rdar://103312497

Reviewed by Saam Barati.

On configurations where `inspectable` can be overriden, there are still some WebKit-internal contexts that should not be
inspectable. The first are JSDOMGlobalObjects, which are already inspectable via the WKWebView they exist for by using
the context picker in Web Inspector, making these JSContexts redundant and noisy. The second case is
APISerializedScriptValueCocoa which creates JSContexts to help serialize values to/from JS/Cocoa.

This problem did not exist before the introduction of the `inspectable` API because the default state of `inspectable`
was false, which would not be overriden because the decision by the platform as to whether an application was inspectable
occurred in a system daemon, which would not override the per-context `inspectable` setting. When unifying the decision
logic for what is inspectable into JSC/WebKit, this use case was initially overlooked as the only platform that implements
an internal policy for inspection doesn&apos;t have any symptoms of this that a user could observe due to the specific policy.
However, in use for those working on machines where this policy is applied, the noise of so many JSContexts is making it
difficult to sort through usefully inspectable contexts in Safari&apos;s Develop menu.

This patch also fixes a minor bug where `inspectable` would return `true` for JSContexts and WKWebViews, even if
inspection was disabled, when an internal policy is overriding inspection.

* Source/JavaScriptCore/API/JSRemoteInspector.cpp:
(JSRemoteInspectorGetInspectionFollowsInternalPolicies):
(JSRemoteInspectorSetInspectionFollowsInternalPolicies):
* Source/JavaScriptCore/API/JSRemoteInspector.h:
- Add methods to set and get the new &quot;followsInternalPolicies&quot; state to be applied to new contexts as well as those that
change their `inspectable` setting.

* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::developerExtrasEnabled const):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
- Use new `allowsInspectionByPolicy` which takes into account internal policies.

* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
(Inspector::RemoteInspectionTarget::remoteControlAllowed const):
(Inspector::RemoteInspectionTarget::allowsInspectionByPolicy const):
(Inspector::RemoteInspectionTarget::inspectable const):
(Inspector::RemoteInspectionTarget::setInspectable):
(Inspector::RemoteInspectionTarget::pauseWaitingForAutomaticInspection):
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
- Use the new `followsInternalPolicies` state to keep track of when a target should be exempt from internal policies for
contexts that never make sense to be inspectable.
- Introduce `allowsInspectionByPolicy` which takes into account internal policy when determining the inspectability of
a target. Previously this was baked into `inspectable`, but that inadvertently leaks the internal policy implementation
detail to clients of JSContext and WKWebView.

* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::finishCreation):
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
(API::SharedJSContext::ensureContext):
- Adopt new methods to mark the contexts created here as never inspectable since they do not expose any useful information.

Canonical link: <a href="https://commits.webkit.org/259000@main">https://commits.webkit.org/259000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c78b5ff96d9f390128cf1bc9151d590d92f7a8a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112665 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172874 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3452 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111859 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38069 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79800 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93568 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26507 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/89998 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3675 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3037 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29784 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46016 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98596 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6182 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7870 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24852 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->