### PR TITLE
Remove unused PlatformCAAnimationWin::create(PlatformAnimationRef)

### DIFF
--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
@@ -148,11 +148,6 @@ Ref<PlatformCAAnimation> PlatformCAAnimationWin::create(AnimationType type, cons
     return adoptRef(*new PlatformCAAnimationWin(type, keyPath));
 }
 
-Ref<PlatformCAAnimation> PlatformCAAnimationWin::create(PlatformAnimationRef animation)
-{
-    return adoptRef(*new PlatformCAAnimationWin(animation));
-}
-
 PlatformCAAnimationWin::PlatformCAAnimationWin(AnimationType type, const String& keyPath)
     : PlatformCAAnimation(type)
 {
@@ -164,22 +159,6 @@ PlatformCAAnimationWin::PlatformCAAnimationWin(AnimationType type, const String&
         m_animation = adoptCF(CACFAnimationCreate(kCACFAnimationGroup));
     
     CACFAnimationSetKeyPath(m_animation.get(), keyPath.createCFString().get());
-}
-
-PlatformCAAnimationWin::PlatformCAAnimationWin(PlatformAnimationRef animation)
-{
-    if (CACFAnimationGetClass(animation) == kCACFBasicAnimation)
-        setType(Basic);
-    else if (CACFAnimationGetClass(animation) == kCACFKeyframeAnimation)
-        setType(Keyframe);
-    else if (CACFAnimationGetClass(animation) == kCACFAnimationGroup)
-        setType(Group);
-    else {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    
-    m_animation = animation;
 }
 
 Ref<PlatformCAAnimation> PlatformCAAnimationWin::copy() const

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h
@@ -38,7 +38,6 @@ namespace WebCore {
 class PlatformCAAnimationWin final : public PlatformCAAnimation {
 public:
     static Ref<PlatformCAAnimation> create(AnimationType, const String& keyPath);
-    static Ref<PlatformCAAnimation> create(PlatformAnimationRef);
 
     virtual ~PlatformCAAnimationWin();
 
@@ -118,7 +117,6 @@ public:
 
 private:
     PlatformCAAnimationWin(AnimationType, const String& keyPath);
-    PlatformCAAnimationWin(PlatformAnimationRef);
 
     RetainPtr<CACFAnimationRef> m_animation;
 };


### PR DESCRIPTION
#### 8562f1578759ff004e8705e7f8a0fa54fd342a89
<pre>
Remove unused PlatformCAAnimationWin::create(PlatformAnimationRef)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250641">https://bugs.webkit.org/show_bug.cgi?id=250641</a>

Reviewed by Simon Fraser.

* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp:
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.h:

Canonical link: <a href="https://commits.webkit.org/258936@main">https://commits.webkit.org/258936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97888e54a638ad22c950d22b38b52673ddc07260

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112626 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172837 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3414 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95607 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111531 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10403 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38038 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79769 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5900 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26475 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3002 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45984 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7832 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3266 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->