### PR TITLE
Rename RemoteLayerTreeTransaction::LayerProperties::keyPathsOfAnimationsToRemove

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -262,7 +262,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         PlatformCAFilters::setFiltersOnLayer(layer, properties.filters ? *properties.filters : FilterOperations());
 
     if (properties.changedProperties & RemoteLayerTreeTransaction::AnimationsChanged)
-        PlatformCAAnimationRemote::updateLayerAnimations(layer, layerTreeHost, properties.addedAnimations, properties.keyPathsOfAnimationsToRemove);
+        PlatformCAAnimationRemote::updateLayerAnimations(layer, layerTreeHost, properties.addedAnimations, properties.keysOfAnimationsToRemove);
 
     if (properties.changedProperties & RemoteLayerTreeTransaction::AntialiasesEdgesChanged)
         layer.edgeAntialiasingMask = properties.antialiasesEdges ? (kCALayerLeftEdge | kCALayerRightEdge | kCALayerBottomEdge | kCALayerTopEdge) : 0;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -157,7 +157,7 @@ public:
         Vector<WebCore::GraphicsLayer::PlatformLayerID> children;
 
         Vector<std::pair<String, PlatformCAAnimationRemote::Properties>> addedAnimations;
-        HashSet<String> keyPathsOfAnimationsToRemove;
+        HashSet<String> keysOfAnimationsToRemove;
 
         WebCore::FloatPoint3D position;
         WebCore::FloatPoint3D anchorPoint { 0.5, 0.5, 0 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -111,7 +111,7 @@ RemoteLayerTreeTransaction::LayerProperties::LayerProperties(const LayerProperti
     , name(other.name)
     , children(other.children)
     , addedAnimations(other.addedAnimations)
-    , keyPathsOfAnimationsToRemove(other.keyPathsOfAnimationsToRemove)
+    , keysOfAnimationsToRemove(other.keysOfAnimationsToRemove)
     , position(other.position)
     , anchorPoint(other.anchorPoint)
     , bounds(other.bounds)
@@ -178,7 +178,7 @@ void RemoteLayerTreeTransaction::LayerProperties::encode(IPC::Encoder& encoder) 
 
     if (changedProperties & AnimationsChanged) {
         encoder << addedAnimations;
-        encoder << keyPathsOfAnimationsToRemove;
+        encoder << keysOfAnimationsToRemove;
     }
 
     if (changedProperties & PositionChanged)
@@ -333,7 +333,7 @@ bool RemoteLayerTreeTransaction::LayerProperties::decode(IPC::Decoder& decoder, 
         if (!decoder.decode(result.addedAnimations))
             return false;
 
-        if (!decoder.decode(result.keyPathsOfAnimationsToRemove))
+        if (!decoder.decode(result.keysOfAnimationsToRemove))
             return false;
     }
 
@@ -957,7 +957,7 @@ static void dumpChangedLayers(TextStream& ts, const RemoteLayerTreeTransaction::
             for (const auto& keyAnimationPair : layerProperties.addedAnimations)
                 ts.dumpProperty("animation " +  keyAnimationPair.first, keyAnimationPair.second);
 
-            for (const auto& name : layerProperties.keyPathsOfAnimationsToRemove)
+            for (const auto& name : layerProperties.keysOfAnimationsToRemove)
                 ts.dumpProperty("removed animation", name);
         }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -213,7 +213,7 @@ void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& co
 void PlatformCALayerRemote::didCommit()
 {
     m_properties.addedAnimations.clear();
-    m_properties.keyPathsOfAnimationsToRemove.clear();
+    m_properties.keysOfAnimationsToRemove.clear();
     m_properties.resetChangedProperties();
 }
 
@@ -420,7 +420,7 @@ void PlatformCALayerRemote::removeAnimationForKey(const String& key)
             return pair.first == key;
         });
     }
-    m_properties.keyPathsOfAnimationsToRemove.add(key);
+    m_properties.keysOfAnimationsToRemove.add(key);
     m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::AnimationsChanged);
 }
 


### PR DESCRIPTION
#### 23ed9c160c93c7471d3f5176c30cfbc407055cb4
<pre>
Rename RemoteLayerTreeTransaction::LayerProperties::keyPathsOfAnimationsToRemove
<a href="https://bugs.webkit.org/show_bug.cgi?id=250642">https://bugs.webkit.org/show_bug.cgi?id=250642</a>

Reviewed by Simon Fraser.

These aren&apos;t key paths in the sense a key path is provided to an API such as
`-[CAKeyframeAnimation animationWithKeyPath:]` but rather keys as used in
`-[CALayer addAnimation:forKey:]`.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode):
(WebKit::dumpChangedLayers):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::didCommit):
(WebKit::PlatformCALayerRemote::removeAnimationForKey):

Canonical link: <a href="https://commits.webkit.org/258937@main">https://commits.webkit.org/258937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e63d28e13629ff2fc2d5afdae7dba0757104fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112627 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3415 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111540 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10402 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38035 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79766 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3003 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45981 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7833 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3267 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->