### PR TITLE
Compute the keyTimes index correctly for discrete (values) animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-14-t-drt-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-14-t-drt-expected.txt
@@ -7,5 +7,5 @@ Time (s):
 6
 $Revision: 1.6 $
 
-FAIL A copy of the corresponding W3C-SVG-1.1 test, which dumps the animation at certain times assert_approx_equals: expected 30 +/- 1 but got 180
+PASS A copy of the corresponding W3C-SVG-1.1 test, which dumps the animation at certain times
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-18-t-drt-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-18-t-drt-expected.txt
@@ -7,5 +7,5 @@ Time (s):
 8
 $Revision: 1.1 $
 
-FAIL A copy of the corresponding W3C-SVG-1.1 test, which dumps the animation at certain times assert_approx_equals: expected 30 +/- 1 but got 180
+PASS A copy of the corresponding W3C-SVG-1.1 test, which dumps the animation at certain times
 

--- a/LayoutTests/svg/animations/animate-elem-14-t-drt-expected.txt
+++ b/LayoutTests/svg/animations/animate-elem-14-t-drt-expected.txt
@@ -18,15 +18,15 @@ PASS rect.width.animVal.value is 180
 PASS rect.width.baseVal.value is 300
 PASS rect.width.animVal.value is 180
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
 PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300

--- a/LayoutTests/svg/animations/animate-elem-18-t-drt-expected.txt
+++ b/LayoutTests/svg/animations/animate-elem-18-t-drt-expected.txt
@@ -18,9 +18,9 @@ PASS rect.width.animVal.value is 180
 PASS rect.width.baseVal.value is 300
 PASS rect.width.animVal.value is 180
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
-FAIL rect.width.animVal.value should be close to 30. Was 180.
+PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300
 PASS rect.width.animVal.value is 30
 PASS rect.width.baseVal.value is 300

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -2,10 +2,11 @@
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -403,10 +404,12 @@ unsigned SVGAnimationElement::calculateKeyTimesIndex(float percent) const
     const auto& keyTimes = this->keyTimes();
     unsigned index;
     unsigned keyTimesCount = keyTimes.size();
-    // Compare index + 1 to keyTimesCount because the last keyTimes entry is
-    // required to be 1, and percent can never exceed 1; i.e., the second last
-    // keyTimes entry defines the beginning of the final interval
-    for (index = 1; index + 1 < keyTimesCount; ++index) {
+    // For linear and spline animations, the last value must be '1'. In those
+    // cases we don't need to consider the last value, since |percent| is never
+    // greater than one.
+    if (keyTimesCount && calcMode() != CalcMode::Discrete)
+        --keyTimesCount;
+    for (index = 1; index < keyTimesCount; ++index) {
         if (keyTimes[index] > percent)
             break;
     }
@@ -437,14 +440,15 @@ float SVGAnimationElement::calculatePercentFromKeyPoints(float percent) const
         return m_keyPoints[m_keyPoints.size() - 1];
 
     unsigned index = calculateKeyTimesIndex(percent);
-    float fromPercent = keyTimes[index];
-    float toPercent = keyTimes[index + 1];
     float fromKeyPoint = m_keyPoints[index];
-    float toKeyPoint = m_keyPoints[index + 1];
     
     if (calcMode() == CalcMode::Discrete)
         return fromKeyPoint;
     
+    ASSERT(index + 1 < keyTimes.size());
+    float fromPercent = keyTimes[index];
+    float toPercent = keyTimes[index + 1];
+    float toKeyPoint = m_keyPoints[index + 1];
     float keyPointPercent = (percent - fromPercent) / (toPercent - fromPercent);
     
     if (calcMode() == CalcMode::Spline) {


### PR DESCRIPTION
#### 580e9612e2c69282a564a14213dff82250b4bda8
<pre>
Compute the keyTimes index correctly for discrete (values) animations

Compute the keyTimes index correctly for discrete (values) animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250643">https://bugs.webkit.org/show_bug.cgi?id=250643</a>

Reviewed by Simon Fraser.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/be50d8baacafe25f3a96d22be3e9a96ab882df4a">https://chromium.googlesource.com/chromium/blink/+/be50d8baacafe25f3a96d22be3e9a96ab882df4a</a>

This patch is to modify to ensure that the last value is allowed to be non-one
for discrete mode animations (but not for linear and spline mode animations).

* Source/WebCore/svg/SVGAnimationElement.cpp:
(SVGAnimationElement::calaculateKeyTimesIndex): Update function to exclude &apos;discrete&apos; mode
(SVGAnimationElement::calculatePercentFromKeyPoints): Add ASSERT and move functions after Disrete mode
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-18-t-drt-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-elem-14-t-drt-expected.txt: Ditto
* LayoutTests/svg/animations/animate-elem-14-t-drt-expected.txt: Ditto
* LayoutTests/svg/animations/animate-elem-18-t-drt-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/258939@main">https://commits.webkit.org/258939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2b7be70eb66140452d851d80cdbb27b4dc89c37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12538 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36382 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112654 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172861 "An unexpected error occured. Recent messages:Running check-change-relevance; Failed to print configuration; Running set-build-summary") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3442 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111807 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10435 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38063 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/106925 "Build is in progress. Recent messages:Pull request doesn't have relevant changes") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79794 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5928 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6102 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/102302 "Build is in progress. Recent messages:Running worker_preparation; configuring build; Pull request doesn't have relevant changes") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12085 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/36382 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98586 "Build is in progress. Recent messages:Running configure-build; Pull request doesn't have relevant changes") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6143 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7860 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/98586 "Build is in progress. Recent messages:Running configure-build; Pull request doesn't have relevant changes") | 
| | | | | 
<!--EWS-Status-Bubble-End-->