### PR TITLE
[MQ4] Allow negative values in media queries

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4708,8 +4708,6 @@ webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/intrinsic-per
 webkit.org/b/214464 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-fixed.html [ ImageOnlyFailure ]
 webkit.org/b/214464 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-ink-skip-dilation.html [ ImageOnlyFailure ]
 
-webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-001.html [ ImageOnlyFailure ]
-webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-002.html [ ImageOnlyFailure ]
 webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/negation-001.html [ ImageOnlyFailure ]
 webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/negation-002.html [ ImageOnlyFailure ]
 webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-invalid-media-type-layer-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-1.html
+++ b/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-1.html
@@ -87,7 +87,7 @@
 <img srcset='../resources/green-1x1.png?e42 50w, ../resources/green-16x16.png?e42 51w' sizes='not (min-width:0) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e43 50w, ../resources/green-16x16.png?e43 51w' sizes='(min-width:unknown-mf-value) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e44 50w, ../resources/green-16x16.png?e44 51w' sizes='not (min-width:unknown-mf-value) 100vw, 1px'>
-<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 100vw, 1px'>
+<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 1px, 100vw'>
 <img srcset='../resources/green-1x1.png?e46 50w, ../resources/green-16x16.png?e46 51w' sizes='not (min-width:-1px) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e47 50w, ../resources/green-16x16.png?e47 51w' sizes='(unknown-mf-name) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e48 50w, ../resources/green-16x16.png?e48 51w' sizes='not (unknown-mf-name) 100vw, 1px'>

--- a/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-2.html
+++ b/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-2.html
@@ -88,7 +88,7 @@
 <img srcset='../resources/green-1x1.png?e42 50w, ../resources/green-16x16.png?e42 51w' sizes='not (min-width:0) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e43 50w, ../resources/green-16x16.png?e43 51w' sizes='(min-width:unknown-mf-value) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e44 50w, ../resources/green-16x16.png?e44 51w' sizes='not (min-width:unknown-mf-value) 100vw, 1px'>
-<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 100vw, 1px'>
+<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 1px, 100vw'>
 <img srcset='../resources/green-1x1.png?e46 50w, ../resources/green-16x16.png?e46 51w' sizes='not (min-width:-1px) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e47 50w, ../resources/green-16x16.png?e47 51w' sizes='(unknown-mf-name) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e48 50w, ../resources/green-16x16.png?e48 51w' sizes='not (unknown-mf-name) 100vw, 1px'>

--- a/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-3.html
+++ b/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-3.html
@@ -88,7 +88,7 @@
 <img srcset='../resources/green-1x1.png?e42 50w, ../resources/green-16x16.png?e42 51w' sizes='not (min-width:0) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e43 50w, ../resources/green-16x16.png?e43 51w' sizes='(min-width:unknown-mf-value) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e44 50w, ../resources/green-16x16.png?e44 51w' sizes='not (min-width:unknown-mf-value) 100vw, 1px'>
-<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 100vw, 1px'>
+<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 1px, 100vw'>
 <img srcset='../resources/green-1x1.png?e46 50w, ../resources/green-16x16.png?e46 51w' sizes='not (min-width:-1px) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e47 50w, ../resources/green-16x16.png?e47 51w' sizes='(unknown-mf-name) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e48 50w, ../resources/green-16x16.png?e48 51w' sizes='not (unknown-mf-name) 100vw, 1px'>

--- a/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-4.html
+++ b/LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-4.html
@@ -88,7 +88,7 @@
 <img srcset='../resources/green-1x1.png?e42 50w, ../resources/green-16x16.png?e42 51w' sizes='not (min-width:0) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e43 50w, ../resources/green-16x16.png?e43 51w' sizes='(min-width:unknown-mf-value) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e44 50w, ../resources/green-16x16.png?e44 51w' sizes='not (min-width:unknown-mf-value) 100vw, 1px'>
-<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 100vw, 1px'>
+<img srcset='../resources/green-1x1.png?e45 50w, ../resources/green-16x16.png?e45 51w' sizes='(min-width:-1px) 1px, 100vw'>
 <img srcset='../resources/green-1x1.png?e46 50w, ../resources/green-16x16.png?e46 51w' sizes='not (min-width:-1px) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e47 50w, ../resources/green-16x16.png?e47 51w' sizes='(unknown-mf-name) 100vw, 1px'>
 <img srcset='../resources/green-1x1.png?e48 50w, ../resources/green-16x16.png?e48 51w' sizes='not (unknown-mf-name) 100vw, 1px'>

--- a/LayoutTests/fast/media/mq-resolution-expected.txt
+++ b/LayoutTests/fast/media/mq-resolution-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS matchMedia('(resolution: 0dpi)').matches is false
-PASS matchMedia('(min-resolution: 0dpi)').matches is false
+PASS matchMedia('(min-resolution: 0dpi)').matches is true
 PASS matchMedia('(max-resolution: 0dpi)').matches is false
 PASS matchMedia('(resolution: 1.5dppx)').matches is true
 PASS resolutionFromStyle() is 1.5

--- a/LayoutTests/fast/media/mq-resolution.html
+++ b/LayoutTests/fast/media/mq-resolution.html
@@ -59,7 +59,7 @@
 
         (async function() {
             shouldBe("matchMedia('(resolution: 0dpi)').matches", "false");
-            shouldBe("matchMedia('(min-resolution: 0dpi)').matches", "false");
+            shouldBe("matchMedia('(min-resolution: 0dpi)').matches", "true");
             shouldBe("matchMedia('(max-resolution: 0dpi)').matches", "false");
 
             await setBackingScaleFactorPromise(1.5);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -33,11 +33,11 @@ PASS expression_should_be_known: width : 0.001mm
 PASS expression_should_be_known: width : 100000px
 PASS expression_should_be_known: min-width : -0
 PASS expression_should_be_known: max-width : -0
-FAIL expression_should_be_known: width : -1px assert_true: expected true got false
-FAIL expression_should_be_known: min-width : -1px assert_true: expected true got false
-FAIL expression_should_be_known: max-width : -1px assert_true: expected true got false
-FAIL expression_should_be_known: width : -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: width : -100000em assert_true: expected true got false
+PASS expression_should_be_known: width : -1px
+PASS expression_should_be_known: min-width : -1px
+PASS expression_should_be_known: max-width : -1px
+PASS expression_should_be_known: width : -0.00001mm
+PASS expression_should_be_known: width : -100000em
 PASS expression_should_be_parseable: 0px : width : 0px
 PASS expression_should_be_unknown: 0px : width : 0px
 PASS expression_should_be_parseable: 0px : width > 0px
@@ -63,13 +63,13 @@ PASS expression_should_be_unknown: min-width > -0
 PASS expression_should_be_parseable: max-width > -0
 PASS expression_should_be_unknown: max-width > -0
 PASS expression_should_be_known: 0px > width > 100000px
-FAIL expression_should_be_known: width > -1px assert_true: expected true got false
+PASS expression_should_be_known: width > -1px
 PASS expression_should_be_parseable: min-width > -1px
 PASS expression_should_be_unknown: min-width > -1px
 PASS expression_should_be_parseable: max-width > -1px
 PASS expression_should_be_unknown: max-width > -1px
-FAIL expression_should_be_known: width > -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: width > -100000em assert_true: expected true got false
+PASS expression_should_be_known: width > -0.00001mm
+PASS expression_should_be_known: width > -100000em
 PASS expression_should_be_parseable: 0px > width : 0px
 PASS expression_should_be_unknown: 0px > width : 0px
 PASS expression_should_be_known: 0px > width > 0px
@@ -95,13 +95,13 @@ PASS expression_should_be_unknown: max-width >= -0
 PASS expression_should_be_known: 0px >= width >= 100000px
 PASS expression_should_be_parseable: width > = 0px
 PASS expression_should_be_unknown: width > = 0px
-FAIL expression_should_be_known: width >= -1px assert_true: expected true got false
+PASS expression_should_be_known: width >= -1px
 PASS expression_should_be_parseable: min-width >= -1px
 PASS expression_should_be_unknown: min-width >= -1px
 PASS expression_should_be_parseable: max-width >= -1px
 PASS expression_should_be_unknown: max-width >= -1px
-FAIL expression_should_be_known: width >= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: width >= -100000em assert_true: expected true got false
+PASS expression_should_be_known: width >= -0.00001mm
+PASS expression_should_be_known: width >= -100000em
 PASS expression_should_be_parseable: 0px >= width : 0px
 PASS expression_should_be_unknown: 0px >= width : 0px
 PASS expression_should_be_known: 0px >= width > 0px
@@ -126,13 +126,13 @@ PASS expression_should_be_parseable: max-width = -0
 PASS expression_should_be_unknown: max-width = -0
 PASS expression_should_be_parseable: 0px = width = 100000px
 PASS expression_should_be_unknown: 0px = width = 100000px
-FAIL expression_should_be_known: width = -1px assert_true: expected true got false
+PASS expression_should_be_known: width = -1px
 PASS expression_should_be_parseable: min-width = -1px
 PASS expression_should_be_unknown: min-width = -1px
 PASS expression_should_be_parseable: max-width = -1px
 PASS expression_should_be_unknown: max-width = -1px
-FAIL expression_should_be_known: width = -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: width = -100000em assert_true: expected true got false
+PASS expression_should_be_known: width = -0.00001mm
+PASS expression_should_be_known: width = -100000em
 PASS expression_should_be_parseable: 0px = width : 0px
 PASS expression_should_be_unknown: 0px = width : 0px
 PASS expression_should_be_parseable: 0px = width > 0px
@@ -160,13 +160,13 @@ PASS expression_should_be_unknown: max-width <= -0
 PASS expression_should_be_known: 0px <= width <= 100000px
 PASS expression_should_be_parseable: width < = 0px
 PASS expression_should_be_unknown: width < = 0px
-FAIL expression_should_be_known: width <= -1px assert_true: expected true got false
+PASS expression_should_be_known: width <= -1px
 PASS expression_should_be_parseable: min-width <= -1px
 PASS expression_should_be_unknown: min-width <= -1px
 PASS expression_should_be_parseable: max-width <= -1px
 PASS expression_should_be_unknown: max-width <= -1px
-FAIL expression_should_be_known: width <= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: width <= -100000em assert_true: expected true got false
+PASS expression_should_be_known: width <= -0.00001mm
+PASS expression_should_be_known: width <= -100000em
 PASS expression_should_be_parseable: 0px <= width : 0px
 PASS expression_should_be_unknown: 0px <= width : 0px
 PASS expression_should_be_parseable: 0px <= width > 0px
@@ -190,13 +190,13 @@ PASS expression_should_be_unknown: min-width < -0
 PASS expression_should_be_parseable: max-width < -0
 PASS expression_should_be_unknown: max-width < -0
 PASS expression_should_be_known: 0px < width < 100000px
-FAIL expression_should_be_known: width < -1px assert_true: expected true got false
+PASS expression_should_be_known: width < -1px
 PASS expression_should_be_parseable: min-width < -1px
 PASS expression_should_be_unknown: min-width < -1px
 PASS expression_should_be_parseable: max-width < -1px
 PASS expression_should_be_unknown: max-width < -1px
-FAIL expression_should_be_known: width < -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: width < -100000em assert_true: expected true got false
+PASS expression_should_be_known: width < -0.00001mm
+PASS expression_should_be_known: width < -100000em
 PASS expression_should_be_parseable: 0px < width : 0px
 PASS expression_should_be_unknown: 0px < width : 0px
 PASS expression_should_be_parseable: 0px < width > 0px
@@ -222,11 +222,11 @@ PASS expression_should_be_known: height : 0.001mm
 PASS expression_should_be_known: height : 100000px
 PASS expression_should_be_known: min-height : -0
 PASS expression_should_be_known: max-height : -0
-FAIL expression_should_be_known: height : -1px assert_true: expected true got false
-FAIL expression_should_be_known: min-height : -1px assert_true: expected true got false
-FAIL expression_should_be_known: max-height : -1px assert_true: expected true got false
-FAIL expression_should_be_known: height : -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: height : -100000em assert_true: expected true got false
+PASS expression_should_be_known: height : -1px
+PASS expression_should_be_known: min-height : -1px
+PASS expression_should_be_known: max-height : -1px
+PASS expression_should_be_known: height : -0.00001mm
+PASS expression_should_be_known: height : -100000em
 PASS expression_should_be_parseable: 0px : height : 0px
 PASS expression_should_be_unknown: 0px : height : 0px
 PASS expression_should_be_parseable: 0px : height > 0px
@@ -252,13 +252,13 @@ PASS expression_should_be_unknown: min-height > -0
 PASS expression_should_be_parseable: max-height > -0
 PASS expression_should_be_unknown: max-height > -0
 PASS expression_should_be_known: 0px > height > 100000px
-FAIL expression_should_be_known: height > -1px assert_true: expected true got false
+PASS expression_should_be_known: height > -1px
 PASS expression_should_be_parseable: min-height > -1px
 PASS expression_should_be_unknown: min-height > -1px
 PASS expression_should_be_parseable: max-height > -1px
 PASS expression_should_be_unknown: max-height > -1px
-FAIL expression_should_be_known: height > -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: height > -100000em assert_true: expected true got false
+PASS expression_should_be_known: height > -0.00001mm
+PASS expression_should_be_known: height > -100000em
 PASS expression_should_be_parseable: 0px > height : 0px
 PASS expression_should_be_unknown: 0px > height : 0px
 PASS expression_should_be_known: 0px > height > 0px
@@ -284,13 +284,13 @@ PASS expression_should_be_unknown: max-height >= -0
 PASS expression_should_be_known: 0px >= height >= 100000px
 PASS expression_should_be_parseable: height > = 0px
 PASS expression_should_be_unknown: height > = 0px
-FAIL expression_should_be_known: height >= -1px assert_true: expected true got false
+PASS expression_should_be_known: height >= -1px
 PASS expression_should_be_parseable: min-height >= -1px
 PASS expression_should_be_unknown: min-height >= -1px
 PASS expression_should_be_parseable: max-height >= -1px
 PASS expression_should_be_unknown: max-height >= -1px
-FAIL expression_should_be_known: height >= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: height >= -100000em assert_true: expected true got false
+PASS expression_should_be_known: height >= -0.00001mm
+PASS expression_should_be_known: height >= -100000em
 PASS expression_should_be_parseable: 0px >= height : 0px
 PASS expression_should_be_unknown: 0px >= height : 0px
 PASS expression_should_be_known: 0px >= height > 0px
@@ -315,13 +315,13 @@ PASS expression_should_be_parseable: max-height = -0
 PASS expression_should_be_unknown: max-height = -0
 PASS expression_should_be_parseable: 0px = height = 100000px
 PASS expression_should_be_unknown: 0px = height = 100000px
-FAIL expression_should_be_known: height = -1px assert_true: expected true got false
+PASS expression_should_be_known: height = -1px
 PASS expression_should_be_parseable: min-height = -1px
 PASS expression_should_be_unknown: min-height = -1px
 PASS expression_should_be_parseable: max-height = -1px
 PASS expression_should_be_unknown: max-height = -1px
-FAIL expression_should_be_known: height = -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: height = -100000em assert_true: expected true got false
+PASS expression_should_be_known: height = -0.00001mm
+PASS expression_should_be_known: height = -100000em
 PASS expression_should_be_parseable: 0px = height : 0px
 PASS expression_should_be_unknown: 0px = height : 0px
 PASS expression_should_be_parseable: 0px = height > 0px
@@ -349,13 +349,13 @@ PASS expression_should_be_unknown: max-height <= -0
 PASS expression_should_be_known: 0px <= height <= 100000px
 PASS expression_should_be_parseable: height < = 0px
 PASS expression_should_be_unknown: height < = 0px
-FAIL expression_should_be_known: height <= -1px assert_true: expected true got false
+PASS expression_should_be_known: height <= -1px
 PASS expression_should_be_parseable: min-height <= -1px
 PASS expression_should_be_unknown: min-height <= -1px
 PASS expression_should_be_parseable: max-height <= -1px
 PASS expression_should_be_unknown: max-height <= -1px
-FAIL expression_should_be_known: height <= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: height <= -100000em assert_true: expected true got false
+PASS expression_should_be_known: height <= -0.00001mm
+PASS expression_should_be_known: height <= -100000em
 PASS expression_should_be_parseable: 0px <= height : 0px
 PASS expression_should_be_unknown: 0px <= height : 0px
 PASS expression_should_be_parseable: 0px <= height > 0px
@@ -379,13 +379,13 @@ PASS expression_should_be_unknown: min-height < -0
 PASS expression_should_be_parseable: max-height < -0
 PASS expression_should_be_unknown: max-height < -0
 PASS expression_should_be_known: 0px < height < 100000px
-FAIL expression_should_be_known: height < -1px assert_true: expected true got false
+PASS expression_should_be_known: height < -1px
 PASS expression_should_be_parseable: min-height < -1px
 PASS expression_should_be_unknown: min-height < -1px
 PASS expression_should_be_parseable: max-height < -1px
 PASS expression_should_be_unknown: max-height < -1px
-FAIL expression_should_be_known: height < -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: height < -100000em assert_true: expected true got false
+PASS expression_should_be_known: height < -0.00001mm
+PASS expression_should_be_known: height < -100000em
 PASS expression_should_be_parseable: 0px < height : 0px
 PASS expression_should_be_unknown: 0px < height : 0px
 PASS expression_should_be_parseable: 0px < height > 0px
@@ -411,11 +411,11 @@ PASS expression_should_be_known: device-width : 0.001mm
 PASS expression_should_be_known: device-width : 100000px
 PASS expression_should_be_known: min-device-width : -0
 PASS expression_should_be_known: max-device-width : -0
-FAIL expression_should_be_known: device-width : -1px assert_true: expected true got false
-FAIL expression_should_be_known: min-device-width : -1px assert_true: expected true got false
-FAIL expression_should_be_known: max-device-width : -1px assert_true: expected true got false
-FAIL expression_should_be_known: device-width : -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-width : -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-width : -1px
+PASS expression_should_be_known: min-device-width : -1px
+PASS expression_should_be_known: max-device-width : -1px
+PASS expression_should_be_known: device-width : -0.00001mm
+PASS expression_should_be_known: device-width : -100000em
 PASS expression_should_be_parseable: 0px : device-width : 0px
 PASS expression_should_be_unknown: 0px : device-width : 0px
 PASS expression_should_be_parseable: 0px : device-width > 0px
@@ -441,13 +441,13 @@ PASS expression_should_be_unknown: min-device-width > -0
 PASS expression_should_be_parseable: max-device-width > -0
 PASS expression_should_be_unknown: max-device-width > -0
 PASS expression_should_be_known: 0px > device-width > 100000px
-FAIL expression_should_be_known: device-width > -1px assert_true: expected true got false
+PASS expression_should_be_known: device-width > -1px
 PASS expression_should_be_parseable: min-device-width > -1px
 PASS expression_should_be_unknown: min-device-width > -1px
 PASS expression_should_be_parseable: max-device-width > -1px
 PASS expression_should_be_unknown: max-device-width > -1px
-FAIL expression_should_be_known: device-width > -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-width > -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-width > -0.00001mm
+PASS expression_should_be_known: device-width > -100000em
 PASS expression_should_be_parseable: 0px > device-width : 0px
 PASS expression_should_be_unknown: 0px > device-width : 0px
 PASS expression_should_be_known: 0px > device-width > 0px
@@ -473,13 +473,13 @@ PASS expression_should_be_unknown: max-device-width >= -0
 PASS expression_should_be_known: 0px >= device-width >= 100000px
 PASS expression_should_be_parseable: device-width > = 0px
 PASS expression_should_be_unknown: device-width > = 0px
-FAIL expression_should_be_known: device-width >= -1px assert_true: expected true got false
+PASS expression_should_be_known: device-width >= -1px
 PASS expression_should_be_parseable: min-device-width >= -1px
 PASS expression_should_be_unknown: min-device-width >= -1px
 PASS expression_should_be_parseable: max-device-width >= -1px
 PASS expression_should_be_unknown: max-device-width >= -1px
-FAIL expression_should_be_known: device-width >= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-width >= -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-width >= -0.00001mm
+PASS expression_should_be_known: device-width >= -100000em
 PASS expression_should_be_parseable: 0px >= device-width : 0px
 PASS expression_should_be_unknown: 0px >= device-width : 0px
 PASS expression_should_be_known: 0px >= device-width > 0px
@@ -504,13 +504,13 @@ PASS expression_should_be_parseable: max-device-width = -0
 PASS expression_should_be_unknown: max-device-width = -0
 PASS expression_should_be_parseable: 0px = device-width = 100000px
 PASS expression_should_be_unknown: 0px = device-width = 100000px
-FAIL expression_should_be_known: device-width = -1px assert_true: expected true got false
+PASS expression_should_be_known: device-width = -1px
 PASS expression_should_be_parseable: min-device-width = -1px
 PASS expression_should_be_unknown: min-device-width = -1px
 PASS expression_should_be_parseable: max-device-width = -1px
 PASS expression_should_be_unknown: max-device-width = -1px
-FAIL expression_should_be_known: device-width = -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-width = -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-width = -0.00001mm
+PASS expression_should_be_known: device-width = -100000em
 PASS expression_should_be_parseable: 0px = device-width : 0px
 PASS expression_should_be_unknown: 0px = device-width : 0px
 PASS expression_should_be_parseable: 0px = device-width > 0px
@@ -538,13 +538,13 @@ PASS expression_should_be_unknown: max-device-width <= -0
 PASS expression_should_be_known: 0px <= device-width <= 100000px
 PASS expression_should_be_parseable: device-width < = 0px
 PASS expression_should_be_unknown: device-width < = 0px
-FAIL expression_should_be_known: device-width <= -1px assert_true: expected true got false
+PASS expression_should_be_known: device-width <= -1px
 PASS expression_should_be_parseable: min-device-width <= -1px
 PASS expression_should_be_unknown: min-device-width <= -1px
 PASS expression_should_be_parseable: max-device-width <= -1px
 PASS expression_should_be_unknown: max-device-width <= -1px
-FAIL expression_should_be_known: device-width <= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-width <= -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-width <= -0.00001mm
+PASS expression_should_be_known: device-width <= -100000em
 PASS expression_should_be_parseable: 0px <= device-width : 0px
 PASS expression_should_be_unknown: 0px <= device-width : 0px
 PASS expression_should_be_parseable: 0px <= device-width > 0px
@@ -568,13 +568,13 @@ PASS expression_should_be_unknown: min-device-width < -0
 PASS expression_should_be_parseable: max-device-width < -0
 PASS expression_should_be_unknown: max-device-width < -0
 PASS expression_should_be_known: 0px < device-width < 100000px
-FAIL expression_should_be_known: device-width < -1px assert_true: expected true got false
+PASS expression_should_be_known: device-width < -1px
 PASS expression_should_be_parseable: min-device-width < -1px
 PASS expression_should_be_unknown: min-device-width < -1px
 PASS expression_should_be_parseable: max-device-width < -1px
 PASS expression_should_be_unknown: max-device-width < -1px
-FAIL expression_should_be_known: device-width < -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-width < -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-width < -0.00001mm
+PASS expression_should_be_known: device-width < -100000em
 PASS expression_should_be_parseable: 0px < device-width : 0px
 PASS expression_should_be_unknown: 0px < device-width : 0px
 PASS expression_should_be_parseable: 0px < device-width > 0px
@@ -600,11 +600,11 @@ PASS expression_should_be_known: device-height : 0.001mm
 PASS expression_should_be_known: device-height : 100000px
 PASS expression_should_be_known: min-device-height : -0
 PASS expression_should_be_known: max-device-height : -0
-FAIL expression_should_be_known: device-height : -1px assert_true: expected true got false
-FAIL expression_should_be_known: min-device-height : -1px assert_true: expected true got false
-FAIL expression_should_be_known: max-device-height : -1px assert_true: expected true got false
-FAIL expression_should_be_known: device-height : -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-height : -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-height : -1px
+PASS expression_should_be_known: min-device-height : -1px
+PASS expression_should_be_known: max-device-height : -1px
+PASS expression_should_be_known: device-height : -0.00001mm
+PASS expression_should_be_known: device-height : -100000em
 PASS expression_should_be_parseable: 0px : device-height : 0px
 PASS expression_should_be_unknown: 0px : device-height : 0px
 PASS expression_should_be_parseable: 0px : device-height > 0px
@@ -630,13 +630,13 @@ PASS expression_should_be_unknown: min-device-height > -0
 PASS expression_should_be_parseable: max-device-height > -0
 PASS expression_should_be_unknown: max-device-height > -0
 PASS expression_should_be_known: 0px > device-height > 100000px
-FAIL expression_should_be_known: device-height > -1px assert_true: expected true got false
+PASS expression_should_be_known: device-height > -1px
 PASS expression_should_be_parseable: min-device-height > -1px
 PASS expression_should_be_unknown: min-device-height > -1px
 PASS expression_should_be_parseable: max-device-height > -1px
 PASS expression_should_be_unknown: max-device-height > -1px
-FAIL expression_should_be_known: device-height > -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-height > -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-height > -0.00001mm
+PASS expression_should_be_known: device-height > -100000em
 PASS expression_should_be_parseable: 0px > device-height : 0px
 PASS expression_should_be_unknown: 0px > device-height : 0px
 PASS expression_should_be_known: 0px > device-height > 0px
@@ -662,13 +662,13 @@ PASS expression_should_be_unknown: max-device-height >= -0
 PASS expression_should_be_known: 0px >= device-height >= 100000px
 PASS expression_should_be_parseable: device-height > = 0px
 PASS expression_should_be_unknown: device-height > = 0px
-FAIL expression_should_be_known: device-height >= -1px assert_true: expected true got false
+PASS expression_should_be_known: device-height >= -1px
 PASS expression_should_be_parseable: min-device-height >= -1px
 PASS expression_should_be_unknown: min-device-height >= -1px
 PASS expression_should_be_parseable: max-device-height >= -1px
 PASS expression_should_be_unknown: max-device-height >= -1px
-FAIL expression_should_be_known: device-height >= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-height >= -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-height >= -0.00001mm
+PASS expression_should_be_known: device-height >= -100000em
 PASS expression_should_be_parseable: 0px >= device-height : 0px
 PASS expression_should_be_unknown: 0px >= device-height : 0px
 PASS expression_should_be_known: 0px >= device-height > 0px
@@ -693,13 +693,13 @@ PASS expression_should_be_parseable: max-device-height = -0
 PASS expression_should_be_unknown: max-device-height = -0
 PASS expression_should_be_parseable: 0px = device-height = 100000px
 PASS expression_should_be_unknown: 0px = device-height = 100000px
-FAIL expression_should_be_known: device-height = -1px assert_true: expected true got false
+PASS expression_should_be_known: device-height = -1px
 PASS expression_should_be_parseable: min-device-height = -1px
 PASS expression_should_be_unknown: min-device-height = -1px
 PASS expression_should_be_parseable: max-device-height = -1px
 PASS expression_should_be_unknown: max-device-height = -1px
-FAIL expression_should_be_known: device-height = -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-height = -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-height = -0.00001mm
+PASS expression_should_be_known: device-height = -100000em
 PASS expression_should_be_parseable: 0px = device-height : 0px
 PASS expression_should_be_unknown: 0px = device-height : 0px
 PASS expression_should_be_parseable: 0px = device-height > 0px
@@ -727,13 +727,13 @@ PASS expression_should_be_unknown: max-device-height <= -0
 PASS expression_should_be_known: 0px <= device-height <= 100000px
 PASS expression_should_be_parseable: device-height < = 0px
 PASS expression_should_be_unknown: device-height < = 0px
-FAIL expression_should_be_known: device-height <= -1px assert_true: expected true got false
+PASS expression_should_be_known: device-height <= -1px
 PASS expression_should_be_parseable: min-device-height <= -1px
 PASS expression_should_be_unknown: min-device-height <= -1px
 PASS expression_should_be_parseable: max-device-height <= -1px
 PASS expression_should_be_unknown: max-device-height <= -1px
-FAIL expression_should_be_known: device-height <= -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-height <= -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-height <= -0.00001mm
+PASS expression_should_be_known: device-height <= -100000em
 PASS expression_should_be_parseable: 0px <= device-height : 0px
 PASS expression_should_be_unknown: 0px <= device-height : 0px
 PASS expression_should_be_parseable: 0px <= device-height > 0px
@@ -757,13 +757,13 @@ PASS expression_should_be_unknown: min-device-height < -0
 PASS expression_should_be_parseable: max-device-height < -0
 PASS expression_should_be_unknown: max-device-height < -0
 PASS expression_should_be_known: 0px < device-height < 100000px
-FAIL expression_should_be_known: device-height < -1px assert_true: expected true got false
+PASS expression_should_be_known: device-height < -1px
 PASS expression_should_be_parseable: min-device-height < -1px
 PASS expression_should_be_unknown: min-device-height < -1px
 PASS expression_should_be_parseable: max-device-height < -1px
 PASS expression_should_be_unknown: max-device-height < -1px
-FAIL expression_should_be_known: device-height < -0.00001mm assert_true: expected true got false
-FAIL expression_should_be_known: device-height < -100000em assert_true: expected true got false
+PASS expression_should_be_known: device-height < -0.00001mm
+PASS expression_should_be_known: device-height < -100000em
 PASS expression_should_be_parseable: 0px < device-height : 0px
 PASS expression_should_be_unknown: 0px < device-height : 0px
 PASS expression_should_be_parseable: 0px < device-height > 0px
@@ -1107,7 +1107,7 @@ PASS expression_should_be_known: color: 327
 PASS expression_should_be_known: color: 0
 PASS expression_should_be_parseable: color: 1.0
 PASS expression_should_be_unknown: color: 1.0
-FAIL expression_should_be_known: color: -1 assert_true: expected true got false
+PASS expression_should_be_known: color: -1
 PASS expression_should_be_parseable: color: 1/1
 PASS expression_should_be_unknown: color: 1/1
 PASS expression_should_be_known: min-monochrome: 1
@@ -1115,7 +1115,7 @@ PASS expression_should_be_known: min-monochrome: 327
 PASS expression_should_be_known: min-monochrome: 0
 PASS expression_should_be_parseable: min-monochrome: 1.0
 PASS expression_should_be_unknown: min-monochrome: 1.0
-FAIL expression_should_be_known: min-monochrome: -1 assert_true: expected true got false
+PASS expression_should_be_known: min-monochrome: -1
 PASS expression_should_be_parseable: min-monochrome: 1/1
 PASS expression_should_be_unknown: min-monochrome: 1/1
 PASS expression_should_be_known: max-color-index: 1
@@ -1123,7 +1123,7 @@ PASS expression_should_be_known: max-color-index: 327
 PASS expression_should_be_known: max-color-index: 0
 PASS expression_should_be_parseable: max-color-index: 1.0
 PASS expression_should_be_unknown: max-color-index: 1.0
-FAIL expression_should_be_known: max-color-index: -1 assert_true: expected true got false
+PASS expression_should_be_known: max-color-index: -1
 PASS expression_should_be_parseable: max-color-index: 1/1
 PASS expression_should_be_unknown: max-color-index: 1/1
 PASS should_apply: (color-index: 0)
@@ -1143,10 +1143,10 @@ PASS expression_should_be_known: resolution: 1x
 PASS expression_should_be_known: resolution: 1.5dppx
 PASS expression_should_be_known: resolution: 1.5x
 PASS expression_should_be_known: resolution: 2.0dppx
-FAIL expression_should_be_known: resolution: 0dpi assert_true: expected true got false
-FAIL expression_should_be_known: resolution: -3dpi assert_true: expected true got false
-FAIL expression_should_be_known: resolution: 0dppx assert_true: expected true got false
-FAIL expression_should_be_known: resolution: 0x assert_true: expected true got false
+PASS expression_should_be_known: resolution: 0dpi
+PASS expression_should_be_known: resolution: -3dpi
+PASS expression_should_be_known: resolution: 0dppx
+PASS expression_should_be_known: resolution: 0x
 PASS expression_should_be_known: min-resolution: 3dpi
 PASS expression_should_be_known: min-resolution:3dpi
 PASS expression_should_be_known: min-resolution: 3.0dpi
@@ -1157,10 +1157,10 @@ PASS expression_should_be_known: min-resolution: 1x
 PASS expression_should_be_known: min-resolution: 1.5dppx
 PASS expression_should_be_known: min-resolution: 1.5x
 PASS expression_should_be_known: min-resolution: 2.0dppx
-FAIL expression_should_be_known: min-resolution: 0dpi assert_true: expected true got false
-FAIL expression_should_be_known: min-resolution: -3dpi assert_true: expected true got false
-FAIL expression_should_be_known: min-resolution: 0dppx assert_true: expected true got false
-FAIL expression_should_be_known: min-resolution: 0x assert_true: expected true got false
+PASS expression_should_be_known: min-resolution: 0dpi
+PASS expression_should_be_known: min-resolution: -3dpi
+PASS expression_should_be_known: min-resolution: 0dppx
+PASS expression_should_be_known: min-resolution: 0x
 PASS expression_should_be_known: max-resolution: 3dpi
 PASS expression_should_be_known: max-resolution:3dpi
 PASS expression_should_be_known: max-resolution: 3.0dpi
@@ -1171,10 +1171,10 @@ PASS expression_should_be_known: max-resolution: 1x
 PASS expression_should_be_known: max-resolution: 1.5dppx
 PASS expression_should_be_known: max-resolution: 1.5x
 PASS expression_should_be_known: max-resolution: 2.0dppx
-FAIL expression_should_be_known: max-resolution: 0dpi assert_true: expected true got false
-FAIL expression_should_be_known: max-resolution: -3dpi assert_true: expected true got false
-FAIL expression_should_be_known: max-resolution: 0dppx assert_true: expected true got false
-FAIL expression_should_be_known: max-resolution: 0x assert_true: expected true got false
+PASS expression_should_be_known: max-resolution: 0dpi
+PASS expression_should_be_known: max-resolution: -3dpi
+PASS expression_should_be_known: max-resolution: 0dppx
+PASS expression_should_be_known: max-resolution: 0x
 PASS find_resolution
 PASS resolution is exact: should_apply: (resolution: ${resolution}dpi)
 PASS resolution is exact: should_apply: (resolution: ${Math.floor(resolution/96)}dppx)

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -233,40 +233,24 @@ RefPtr<CSSValue> GenericMediaQueryParserBase::consumeValue(CSSParserTokenRange& 
 
 bool GenericMediaQueryParserBase::validateFeatureAgainstSchema(Feature& feature, const FeatureSchema& schema)
 {
-    auto isNegative = [&](auto& value) {
-        // Calc is supposed to clamp but let's just let the value through as we deal with negative values just fine.
-        if (value.isCalculated())
-            return false;
-        // FIXME: The spec allows negative values for some features but we use the legacy behavior for now.
-        return value.doubleValue() < 0;
-    };
-
     auto validateValue = [&](auto& value) {
         auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value.get());
         switch (schema.valueType) {
         case FeatureSchema::ValueType::Integer:
-            if (!primitiveValue || !primitiveValue->isInteger())
-                return false;
-            return !isNegative(*primitiveValue);
+            return primitiveValue && primitiveValue->isInteger();
 
         case FeatureSchema::ValueType::Number:
-            if (!primitiveValue || !primitiveValue->isNumberOrInteger())
-                return false;
-            return !isNegative(*primitiveValue);
+            return primitiveValue && primitiveValue->isNumberOrInteger();
 
         case FeatureSchema::ValueType::Length:
             if (!primitiveValue)
                 return false;
             if (primitiveValue->isInteger() && !primitiveValue->intValue())
                 return true;
-            if (!primitiveValue->isLength())
-                return false;
-            return !isNegative(*primitiveValue);
+            return primitiveValue->isLength();
 
         case FeatureSchema::ValueType::Resolution:
-            if (!primitiveValue || !primitiveValue->isResolution())
-                return false;
-            return primitiveValue->doubleValue() > 0;
+            return primitiveValue && primitiveValue->isResolution();
 
         case FeatureSchema::ValueType::Identifier:
             return primitiveValue && primitiveValue->isValueID() && schema.valueIdentifiers.contains(primitiveValue->valueID());


### PR DESCRIPTION
#### 19ed940b6949c1623a7eedb3ff2309c81f850ad8
<pre>
[MQ4] Allow negative values in media queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=250647">https://bugs.webkit.org/show_bug.cgi?id=250647</a>
rdar://104278059

Reviewed by Antoine Quint.

&quot;Some media features with a &apos;range&apos; type are said to be false in the negative range. This means that negative values are
valid and must be parsed, and that querying whether the media feature is equal to, less than, or less or equal than any
such negative value must evaluate to false. Querying whether the media feature is greater, or greater or equal, than
a negative value evaluates to true if the relationship is true.&quot;

- <a href="https://www.w3.org/TR/mediaqueries-4/#false-in-the-negative-range">https://www.w3.org/TR/mediaqueries-4/#false-in-the-negative-range</a>

In practice this applies to all range features for types other than &apos;ratio&apos;.

* LayoutTests/TestExpectations:
* LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-1.html:
* LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-2.html:
* LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-3.html:
* LayoutTests/fast/dom/HTMLImageElement/sizes/image-sizes-w3c-4.html:
* LayoutTests/fast/media/mq-resolution-expected.txt:
* LayoutTests/fast/media/mq-resolution.html:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::GenericMediaQueryParserBase::validateFeatureAgainstSchema):

Allow negative values during parsing. They already evaluate correctly.

Canonical link: <a href="https://commits.webkit.org/258938@main">https://commits.webkit.org/258938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c69cfddac8e5361979318b48869bc30ebd9ec68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112644 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172851 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3432 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111620 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10421 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38053 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79784 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5918 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26490 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3018 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45999 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6142 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7850 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->