### PR TITLE
A fixed header inside overflow scroll with a transformed ancestor stutters on scrolling (affects Libby app)

### DIFF
--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt
@@ -1,0 +1,39 @@
+Fixed inside scroller
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 5021)
+  (scrollable area parameters
+    (horizontal scroll elasticity 1)
+    (vertical scroll elasticity 1)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,4421))
+  (behavior for fixed 1)
+  (children 1
+    (Overflow scrolling node
+      (scroll position 0 50)
+      (scrollable area size 440 440)
+      (contents size 440 2040)
+      (requested scroll position 0 50)
+      (requested scroll position represents programmatic scroll 1)
+      (scrollable area parameters
+        (horizontal scroll elasticity 1)
+        (vertical scroll elasticity 1)
+        (horizontal scrollbar mode 0)
+        (vertical scrollbar mode 0)
+        (allows vertical scrolling 1))
+      (children 1
+        (Positioned node
+          (layout constraints
+            (layer-position-at-last-layout (10,160)))
+          (related overflow nodes 1)
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt
@@ -1,0 +1,40 @@
+Fixed inside scroller
+
+(Frame scrolling node
+  (scrollable area size 785 600)
+  (contents size 785 5021)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0)
+    (allows vertical scrolling 1))
+  (layout viewport at (0,0) size 785x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,4421))
+  (behavior for fixed 1)
+  (children 1
+    (Overflow scrolling node
+      (scroll position 0 50)
+      (scrollable area size 425 425)
+      (contents size 425 1965)
+      (requested scroll position 0 50)
+      (requested scroll position represents programmatic scroll 1)
+      (scrollable area parameters
+        (horizontal scroll elasticity 0)
+        (vertical scroll elasticity 0)
+        (horizontal scrollbar mode 0)
+        (vertical scrollbar mode 0)
+        (allows vertical scrolling 1))
+      (children 1
+        (Positioned node
+          (layout constraints
+            (layer-position-at-last-layout (10,160)))
+          (related overflow nodes 1)
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+
+        .container {
+            position: absolute;
+            margin: 20px;
+            transform: translateX(0);
+            padding: 10px;
+            border: 1px solid gray;
+        }
+        
+        .scroller {
+            position: relative;
+            z-index: 0;
+            margin: 20px;
+            width: 400px;
+            height: 400px;
+            overflow: scroll;
+            padding: 20px;
+            border: 10px solid gray;
+        }
+
+        .inner {
+            height: 500%;
+        }
+        
+        .inner-fixed {
+            position: fixed;
+            top: 150px;
+            left: 50px;
+            width: 400px;
+            height: 50px;
+            background-color: orange;
+        }
+
+        .box {
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', async () => {
+            const scroller = document.getElementsByClassName('scroller')[0];
+            scroller.scrollTo(0, 50);
+            await UIHelper.renderingUpdate();
+            if (window.internals)
+                document.getElementById('scrollingTree').innerText = window.internals.scrollingStateTreeAsText() + "\n";
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+<div class="container">
+    <div class="scroller">
+        <div class="inner"></div>
+        <div class="inner-fixed">
+            Fixed inside scroller
+        </div>
+    </div>
+</div>
+<pre id="scrollingTree"></pre>
+</body>
+</html>


### PR DESCRIPTION
#### 2f33fa54c40506def565e6af8f393614d02b2804
<pre>
A fixed header inside overflow scroll with a transformed ancestor stutters on scrolling (affects Libby app)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250652">https://bugs.webkit.org/show_bug.cgi?id=250652</a>
rdar://104095908

Reviewed by Alan Baradlay.

The Libby app has content which uses a stacking-context overflow:scroll with a position:fixed
descendant, and a CSS transform on an ancestor of the scroller. In this situation, we treat the
position:fixed as if it has position:absolute, but still need to use the correct containing block
for it (which is the enclosing transformed box).

Two fixes are required here. First, `RenderLayerCompositor::computeCoordinatedPositioningForLayer()`
needs to check if the position:fixed layer actually has fixed behavior (i.e. no transformed
ancestor) before the early return.

Second, the `traverseAncestorLayers()` helper only handled position:absolute containing block logic;
we need to fix it to also compute the correct containing block for position:fixed (which allows it
to find transformed ancestors of fixed).

Fixing `traverseAncestorLayers()` to have the correct containingBlock behavior for fixed layers
revealed a surprising behavior, which is that the deprecated CSS `clip` property on a
position:absolute element clips position:fixed descendants, which is odd because it&apos;s different from
how overflow works (<a href="https://github.com/w3c/csswg-drafts/issues/8336).">https://github.com/w3c/csswg-drafts/issues/8336).</a> So
RenderLayerCompositor::computeAncestorClippingStack() needs some special case code to detect this
case. This is tested by imported/blink/fast/css/fixed-overlaps-absolute-in-clip.html.

* LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::traverseAncestorLayers):
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):
(WebCore::RenderLayerCompositor::computeCoordinatedPositioningForLayer const):

Canonical link: <a href="https://commits.webkit.org/259175@main">https://commits.webkit.org/259175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/934ff9b0fbaab096982b783b16f36513ab07e24a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113421 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173712 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4215 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112479 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38735 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27108 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3657 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8582 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->