### PR TITLE
[GPU Process] [FormControls] Add ControlPart for ImageControlsButton

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1759,6 +1759,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ControlFactory.h
     platform/graphics/controls/ControlPart.h
     platform/graphics/controls/ControlStyle.h
+    platform/graphics/controls/ImageControlsButtonPart.h
     platform/graphics/controls/InnerSpinButtonPart.h
     platform/graphics/controls/MenuListButtonPart.h
     platform/graphics/controls/MenuListPart.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -467,6 +467,7 @@ platform/graphics/mac/controls/ButtonControlMac.mm
 platform/graphics/mac/controls/ColorWellMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
+platform/graphics/mac/controls/ImageControlsButtonMac.mm
 platform/graphics/mac/controls/InnerSpinButtonMac.mm
 platform/graphics/mac/controls/MenuListButtonMac.mm
 platform/graphics/mac/controls/MenuListMac.mm

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class ButtonPart;
 class ColorWellPart;
+class ImageControlsButtonPart;
 class InnerSpinButtonPart;
 class MeterPart;
 class MenuListButtonPart;
@@ -54,6 +55,9 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) = 0;
 #if ENABLE(INPUT_TYPE_COLOR)
     virtual std::unique_ptr<PlatformControl> createPlatformColorWell(ColorWellPart&) = 0;
+#endif
+#if ENABLE(SERVICE_CONTROLS)
+    virtual std::unique_ptr<PlatformControl> createPlatformImageControlsButton(ImageControlsButtonPart&) = 0;
 #endif
     virtual std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/ImageControlsButtonPart.h
+++ b/Source/WebCore/platform/graphics/controls/ImageControlsButtonPart.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SERVICE_CONTROLS)
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class ImageControlsButtonPart final : public ControlPart {
+public:
+    static Ref<ImageControlsButtonPart> create()
+    {
+        return adoptRef(*new ImageControlsButtonPart());
+    }
+
+private:
+    ImageControlsButtonPart()
+        : ControlPart(StyleAppearance::ImageControlsButton)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformImageControlsButton(*this);
+    }
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(SERVICE_CONTROLS)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -30,18 +30,29 @@
 #import "ControlFactory.h"
 #import "WebControlView.h"
 
+OBJC_CLASS NSServicesRolloverButtonCell;
+
 namespace WebCore {
 
 class ControlFactoryMac final : public ControlFactory {
 public:
     using ControlFactory::ControlFactory;
 
+    static ControlFactoryMac& sharedControlFactory();
+
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
+
+#if ENABLE(SERVICE_CONTROLS)
+    NSServicesRolloverButtonCell *servicesRolloverButtonCell() const;
+#endif
 
 private:
     std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) final;
 #if ENABLE(INPUT_TYPE_COLOR)
     std::unique_ptr<PlatformControl> createPlatformColorWell(ColorWellPart&) final;
+#endif
+#if ENABLE(SERVICE_CONTROLS)
+    std::unique_ptr<PlatformControl> createPlatformImageControlsButton(ImageControlsButtonPart&) final;
 #endif
     std::unique_ptr<PlatformControl> createPlatformInnerSpinButton(InnerSpinButtonPart&) final;
     std::unique_ptr<PlatformControl> createPlatformMenuList(MenuListPart&) final;
@@ -74,6 +85,9 @@ private:
     mutable RetainPtr<NSButtonCell> m_radioCell;
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
     mutable RetainPtr<NSPopUpButtonCell> m_popUpButtonCell;
+#if ENABLE(SERVICE_CONTROLS)
+    mutable RetainPtr<NSServicesRolloverButtonCell> m_servicesRolloverButtonCell;
+#endif
     mutable RetainPtr<NSSearchFieldCell> m_searchFieldCell;
     mutable RetainPtr<NSSliderCell> m_sliderCell;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -30,6 +30,7 @@
 
 #import "ButtonMac.h"
 #import "ColorWellMac.h"
+#import "ImageControlsButtonMac.h"
 #import "InnerSpinButtonMac.h"
 #import "MenuListButtonMac.h"
 #import "MenuListMac.h"
@@ -44,6 +45,7 @@
 #import "ToggleButtonMac.h"
 #import "ToggleButtonPart.h"
 #import <pal/spi/mac/NSSearchFieldCellSPI.h>
+#import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 
@@ -52,6 +54,11 @@ namespace WebCore {
 std::unique_ptr<ControlFactory> ControlFactory::createControlFactory()
 {
     return makeUnique<ControlFactoryMac>();
+}
+
+ControlFactoryMac& ControlFactoryMac::sharedControlFactory()
+{
+    return static_cast<ControlFactoryMac&>(ControlFactory::sharedControlFactory());
 }
 
 NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle& style) const
@@ -155,6 +162,20 @@ NSPopUpButtonCell *ControlFactoryMac::popUpButtonCell() const
     return m_popUpButtonCell.get();
 }
 
+#if ENABLE(SERVICE_CONTROLS)
+NSServicesRolloverButtonCell *ControlFactoryMac::servicesRolloverButtonCell() const
+{
+    if (!m_servicesRolloverButtonCell) {
+        m_servicesRolloverButtonCell = [NSServicesRolloverButtonCell serviceRolloverButtonCellForStyle:NSSharingServicePickerStyleRollover];
+        [m_servicesRolloverButtonCell setBezelStyle:NSBezelStyleRoundedDisclosure];
+        [m_servicesRolloverButtonCell setButtonType:NSButtonTypePushOnPushOff];
+        [m_servicesRolloverButtonCell setImagePosition:NSImageOnly];
+        [m_servicesRolloverButtonCell setState:NO];
+    }
+    return m_servicesRolloverButtonCell.get();
+}
+#endif
+
 NSSearchFieldCell *ControlFactoryMac::searchFieldCell() const
 {
     if (!m_searchFieldCell) {
@@ -205,6 +226,13 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformButton(ButtonP
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformColorWell(ColorWellPart& part)
 {
     return makeUnique<ColorWellMac>(part, *this, buttonCell());
+}
+#endif
+
+#if ENABLE(SERVICE_CONTROLS)
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformImageControlsButton(ImageControlsButtonPart& part)
+{
+    return makeUnique<ImageControlsButtonMac>(part, *this, servicesRolloverButtonCell());
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC) && ENABLE(SERVICE_CONTROLS)
+
+#import "ControlMac.h"
+
+OBJC_CLASS NSServicesRolloverButtonCell;
+
+namespace WebCore {
+
+class ImageControlsButtonPart;
+
+class ImageControlsButtonMac : public ControlMac {
+public:
+    ImageControlsButtonMac(ImageControlsButtonPart&, ControlFactoryMac&, NSServicesRolloverButtonCell *);
+
+    static IntSize servicesRolloverButtonCellSize();
+
+private:
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+
+    RetainPtr<NSServicesRolloverButtonCell> m_servicesRolloverButtonCell;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC) && ENABLE(SERVICE_CONTROLS)

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ImageControlsButtonMac.h"
+
+#if PLATFORM(MAC) && ENABLE(SERVICE_CONTROLS)
+
+#import "GraphicsContext.h"
+#import "ImageControlsButtonPart.h"
+#import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
+
+namespace WebCore {
+
+ImageControlsButtonMac::ImageControlsButtonMac(ImageControlsButtonPart& owningPart, ControlFactoryMac& controlFactory, NSServicesRolloverButtonCell *servicesRolloverButtonCell)
+    : ControlMac(owningPart, controlFactory)
+    , m_servicesRolloverButtonCell(servicesRolloverButtonCell)
+{
+}
+
+IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
+{
+    auto& controlFactory = ControlFactoryMac::sharedControlFactory();
+    if (auto* servicesRolloverButtonCell = controlFactory.servicesRolloverButtonCell())
+        return IntSize { [servicesRolloverButtonCell cellSize] };
+    return { };
+}
+
+void ImageControlsButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    LocalCurrentGraphicsContext localContext(context);
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+    
+    drawCell(context, rect, deviceScaleFactor, style, m_servicesRolloverButtonCell.get(), view, true);
+    
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC) && ENABLE(SERVICE_CONTROLS)

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class InnerSpinButtonPart;
+
 class InnerSpinButtonMac : public ControlMac {
 public:
     InnerSpinButtonMac(InnerSpinButtonPart&, ControlFactoryMac&);

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class SliderThumbPart;
+
 class SliderThumbMac : public ControlMac {
 public:
     SliderThumbMac(SliderThumbPart&, ControlFactoryMac&, NSSliderCell *);

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "ControlFactoryMac.h"
 #import "GraphicsContext.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -45,6 +45,7 @@
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
 #include "HTMLTextAreaElement.h"
+#include "ImageControlsButtonPart.h"
 #include "InnerSpinButtonPart.h"
 #include "LocalizedStrings.h"
 #include "MenuListButtonPart.h"
@@ -596,12 +597,13 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 
 #if ENABLE(APPLE_PAY)
     case StyleAppearance::ApplePayButton:
+        break;
 #endif
 #if ENABLE(ATTACHMENT_ELEMENT)
     case StyleAppearance::Attachment:
     case StyleAppearance::BorderlessAttachment:
-#endif
         break;
+#endif
 
     case StyleAppearance::Listbox:
     case StyleAppearance::TextArea:
@@ -619,15 +621,17 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 #endif
 #if ENABLE(SERVICE_CONTROLS)
     case StyleAppearance::ImageControlsButton:
+        return ImageControlsButtonPart::create();
 #endif
-        break;
 
     case StyleAppearance::InnerSpinButton:
         return InnerSpinButtonPart::create();
 
 #if ENABLE(DATALIST_ELEMENT)
     case StyleAppearance::ListButton:
+        break;
 #endif
+
     case StyleAppearance::SearchFieldDecoration:
     case StyleAppearance::SearchFieldResultsDecoration:
     case StyleAppearance::SearchFieldResultsButton:

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -24,10 +24,6 @@
 
 #import "RenderThemeCocoa.h"
 
-#if ENABLE(SERVICE_CONTROLS)
-OBJC_CLASS NSServicesRolloverButtonCell;
-#endif
-
 OBJC_CLASS WebCoreRenderThemeNotificationObserver;
 
 namespace WebCore {
@@ -188,19 +184,13 @@ private:
     NSMenu *searchMenuTemplate() const;
 
 #if ENABLE(SERVICE_CONTROLS)
-    bool paintImageControlsButton(const RenderObject&, const PaintInfo&, const IntRect&) final;
     IntSize imageControlsButtonSize() const final;
     bool isImageControl(const Element&) const final;
-
-    NSServicesRolloverButtonCell *servicesRolloverButtonCell() const;
 #endif
 
     mutable RetainPtr<NSPopUpButtonCell> m_popupButton;
     mutable RetainPtr<NSSearchFieldCell> m_search;
     mutable RetainPtr<NSMenu> m_searchMenuTemplate;
-#if ENABLE(SERVICE_CONTROLS)
-    mutable RetainPtr<NSServicesRolloverButtonCell> m_servicesRolloverButton;
-#endif
 
     bool m_isSliderThumbHorizontalPressed { false };
     bool m_isSliderThumbVerticalPressed { false };

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -39,13 +39,12 @@
 #import "GraphicsContext.h"
 #import "HTMLAttachmentElement.h"
 #import "HTMLInputElement.h"
-#import "HTMLMediaElement.h"
 #import "HTMLMeterElement.h"
 #import "HTMLNames.h"
 #import "HTMLPlugInImageElement.h"
 #import "Icon.h"
 #import "Image.h"
-#import "ImageBuffer.h"
+#import "ImageControlsButtonMac.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "LocalizedStrings.h"
@@ -53,17 +52,14 @@
 #import "PaintInfo.h"
 #import "PathUtilities.h"
 #import "RenderAttachment.h"
-#import "RenderLayer.h"
 #import "RenderMedia.h"
 #import "RenderMeter.h"
 #import "RenderProgress.h"
 #import "RenderSlider.h"
 #import "RenderView.h"
-#import "SharedBuffer.h"
 #import "SliderThumbElement.h"
 #import "StringTruncator.h"
 #import "ThemeMac.h"
-#import "TimeRanges.h"
 #import "UTIUtilities.h"
 #import <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
@@ -76,13 +72,11 @@
 #import <pal/spi/mac/NSCellSPI.h>
 #import <pal/spi/mac/NSImageSPI.h>
 #import <pal/spi/mac/NSSearchFieldCellSPI.h>
-#import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
 #import <pal/spi/mac/NSSharingServicePickerSPI.h>
 #import <wtf/MathExtras.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
-#import <wtf/text/StringBuilder.h>
 
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
@@ -158,6 +152,9 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Style
     case StyleAppearance::ColorWell:
 #endif
     case StyleAppearance::DefaultButton:
+#if ENABLE(SERVICE_CONTROLS)
+    case StyleAppearance::ImageControlsButton:
+#endif
     case StyleAppearance::InnerSpinButton:
     case StyleAppearance::Listbox:
     case StyleAppearance::Menulist:
@@ -196,6 +193,9 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
         || type == StyleAppearance::ColorWell
 #endif
         || type == StyleAppearance::DefaultButton
+#if ENABLE(SERVICE_CONTROLS)
+        || type == StyleAppearance::ImageControlsButton
+#endif
         || type == StyleAppearance::InnerSpinButton
         || type == StyleAppearance::Menulist
         || type == StyleAppearance::Meter
@@ -1465,33 +1465,9 @@ String RenderThemeMac::fileListNameForWidth(const FileList* fileList, const Font
 }
 
 #if ENABLE(SERVICE_CONTROLS)
-NSServicesRolloverButtonCell* RenderThemeMac::servicesRolloverButtonCell() const
-{
-    if (!m_servicesRolloverButton) {
-        m_servicesRolloverButton = [NSServicesRolloverButtonCell serviceRolloverButtonCellForStyle:NSSharingServicePickerStyleRollover];
-        [m_servicesRolloverButton setBezelStyle:NSBezelStyleRoundedDisclosure];
-        [m_servicesRolloverButton setButtonType:NSButtonTypePushOnPushOff];
-        [m_servicesRolloverButton setImagePosition:NSImageOnly];
-        [m_servicesRolloverButton setState:NO];
-    }
-    return m_servicesRolloverButton.get();
-}
-
-bool RenderThemeMac::paintImageControlsButton(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
-{
-    NSServicesRolloverButtonCell *cell = servicesRolloverButtonCell();
-    LocalCurrentGraphicsContext localContext(paintInfo.context());
-    GraphicsContextStateSaver stateSaver(paintInfo.context());
-    paintInfo.context().translate(rect.location());
-    IntRect innerFrame(IntPoint(), rect.size());
-    [cell drawWithFrame:innerFrame inView:documentViewFor(renderer)];
-    [cell setControlView:nil];
-    return false;
-}
-
 IntSize RenderThemeMac::imageControlsButtonSize() const
 {
-    return IntSize(servicesRolloverButtonCell().cellSize);
+    return ImageControlsButtonMac::servicesRolloverButtonCellSize();
 }
 
 bool RenderThemeMac::isImageControl(const Element& elementPtr) const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -70,6 +70,7 @@
 #include <WebCore/IDBGetResult.h>
 #include <WebCore/IdentityTransformOperation.h>
 #include <WebCore/Image.h>
+#include <WebCore/ImageControlsButtonPart.h>
 #include <WebCore/InnerSpinButtonPart.h>
 #include <WebCore/JSDOMExceptionHandling.h>
 #include <WebCore/Length.h>
@@ -1604,21 +1605,25 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
         return WebCore::TextFieldPart::create();
 
     case WebCore::StyleAppearance::CapsLockIndicator:
+        break;
+
 #if ENABLE(INPUT_TYPE_COLOR)
     case WebCore::StyleAppearance::ColorWell:
         return WebCore::ColorWellPart::create();
 #endif
 #if ENABLE(SERVICE_CONTROLS)
     case WebCore::StyleAppearance::ImageControlsButton:
+        return WebCore::ImageControlsButtonPart::create();
 #endif
-        break;
 
     case WebCore::StyleAppearance::InnerSpinButton:
         return WebCore::InnerSpinButtonPart::create();
 
 #if ENABLE(DATALIST_ELEMENT)
     case WebCore::StyleAppearance::ListButton:
+        break;
 #endif
+
     case WebCore::StyleAppearance::SearchFieldDecoration:
     case WebCore::StyleAppearance::SearchFieldResultsDecoration:
     case WebCore::StyleAppearance::SearchFieldResultsButton:


### PR DESCRIPTION
#### 53cde7bfd6be60b50e8031edf9a150dbe74e30a3
<pre>
[GPU Process] [FormControls] Add ControlPart for ImageControlsButton
<a href="https://bugs.webkit.org/show_bug.cgi?id=250664">https://bugs.webkit.org/show_bug.cgi?id=250664</a>
rdar://104288189

Reviewed by Aditya Keerthi.

Drawing this control part will be moved to GraphicsContext so it can be recorded
in WebProcess and drawn in GPUProcess if DOM rendering is enabled for GPUProcess.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/ImageControlsButtonPart.h: Copied from Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::sharedControlFactory):
(WebCore::ControlFactoryMac::servicesRolloverButtonCell const):
(WebCore::ControlFactoryMac::createPlatformImageControlsButton):
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h: Copied from Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h.
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm: Copied from Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h.
(WebCore::ImageControlsButtonMac::ImageControlsButtonMac):
(WebCore::ImageControlsButtonMac::servicesRolloverButtonCellSize):
(WebCore::ImageControlsButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::imageControlsButtonSize const):
(WebCore::RenderThemeMac::servicesRolloverButtonCell const): Deleted.
(WebCore::RenderThemeMac::paintImageControlsButton): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/259061@main">https://commits.webkit.org/259061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ddf34f6b0b31cc0bf0f68b0ca4216b5cac7cdbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113013 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3799 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96037 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109559 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93806 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25414 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6262 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6431 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46324 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6230 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8198 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->