### PR TITLE
Validate animation key paths sent over IPC

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -255,31 +255,6 @@ static PlatformCAAnimation::ValueFunctionType getValueFunctionNameForTransformOp
     }
 }
 
-static ASCIILiteral propertyIdToString(AnimatedProperty property)
-{
-    switch (property) {
-    case AnimatedProperty::Translate:
-    case AnimatedProperty::Scale:
-    case AnimatedProperty::Rotate:
-    case AnimatedProperty::Transform:
-        return "transform"_s;
-    case AnimatedProperty::Opacity:
-        return "opacity"_s;
-    case AnimatedProperty::BackgroundColor:
-        return "backgroundColor"_s;
-    case AnimatedProperty::Filter:
-        return "filters"_s;
-#if ENABLE(FILTERS_LEVEL_2)
-    case AnimatedProperty::WebkitBackdropFilter:
-        return "backdropFilters"_s;
-#endif
-    case AnimatedProperty::Invalid:
-        ASSERT_NOT_REACHED();
-    }
-    ASSERT_NOT_REACHED();
-    return { };
-}
-
 static bool animatedPropertyIsTransformOrRelated(AnimatedProperty property)
 {
     return property == AnimatedProperty::Transform || property == AnimatedProperty::Translate || property == AnimatedProperty::Scale || property == AnimatedProperty::Rotate;
@@ -3143,7 +3118,7 @@ void GraphicsLayerCA::updateAnimations()
         // A base value transform animation needs to last forever and use the same value for its from and to values,
         // unless we're just filling until an animation for this property starts, in which case it must last for duration
         // of the delay until that animation.
-        auto caAnimation = createPlatformCAAnimation(PlatformCAAnimation::Basic, propertyIdToString(property));
+        auto caAnimation = createPlatformCAAnimation(PlatformCAAnimation::Basic, PlatformCAAnimation::makeKeyPath(property));
         caAnimation->setDuration(delay ? delay.seconds() : infiniteDuration);
         caAnimation->setFromValue(matrix);
         caAnimation->setToValue(matrix);
@@ -3431,13 +3406,13 @@ bool GraphicsLayerCA::createAnimationFromKeyframes(const KeyframeValueList& valu
     RefPtr<PlatformCAAnimation> caAnimation;
 
     if (isKeyframe(valueList)) {
-        caAnimation = createKeyframeAnimation(animation, propertyIdToString(valueList.property()), additive, keyframesShouldUseAnimationWideTimingFunction);
+        caAnimation = createKeyframeAnimation(animation, PlatformCAAnimation::makeKeyPath(valueList.property()), additive, keyframesShouldUseAnimationWideTimingFunction);
         valuesOK = setAnimationKeyframes(valueList, animation, caAnimation.get(), keyframesShouldUseAnimationWideTimingFunction);
     } else {
         if (animation->timingFunction()->isSpringTimingFunction())
-            caAnimation = createSpringAnimation(animation, propertyIdToString(valueList.property()), additive, keyframesShouldUseAnimationWideTimingFunction);
+            caAnimation = createSpringAnimation(animation, PlatformCAAnimation::makeKeyPath(valueList.property()), additive, keyframesShouldUseAnimationWideTimingFunction);
         else
-            caAnimation = createBasicAnimation(animation, propertyIdToString(valueList.property()), additive, keyframesShouldUseAnimationWideTimingFunction);
+            caAnimation = createBasicAnimation(animation, PlatformCAAnimation::makeKeyPath(valueList.property()), additive, keyframesShouldUseAnimationWideTimingFunction);
         valuesOK = setAnimationEndpoints(valueList, animation, caAnimation.get());
     }
 
@@ -3454,13 +3429,13 @@ bool GraphicsLayerCA::appendToUncommittedAnimations(const KeyframeValueList& val
     RefPtr<PlatformCAAnimation> caAnimation;
     bool validMatrices = true;
     if (isKeyframe(valueList)) {
-        caAnimation = createKeyframeAnimation(animation, propertyIdToString(valueList.property()), false, keyframesShouldUseAnimationWideTimingFunction);
+        caAnimation = createKeyframeAnimation(animation, PlatformCAAnimation::makeKeyPath(valueList.property()), false, keyframesShouldUseAnimationWideTimingFunction);
         validMatrices = setTransformAnimationKeyframes(valueList, animation, caAnimation.get(), animationIndex, operationType, isMatrixAnimation, boxSize, keyframesShouldUseAnimationWideTimingFunction);
     } else {
         if (animation->timingFunction()->isSpringTimingFunction())
-            caAnimation = createSpringAnimation(animation, propertyIdToString(valueList.property()), false, keyframesShouldUseAnimationWideTimingFunction);
+            caAnimation = createSpringAnimation(animation, PlatformCAAnimation::makeKeyPath(valueList.property()), false, keyframesShouldUseAnimationWideTimingFunction);
         else
-            caAnimation = createBasicAnimation(animation, propertyIdToString(valueList.property()), false, keyframesShouldUseAnimationWideTimingFunction);
+            caAnimation = createBasicAnimation(animation, PlatformCAAnimation::makeKeyPath(valueList.property()), false, keyframesShouldUseAnimationWideTimingFunction);
         validMatrices = setTransformAnimationEndpoints(valueList, animation, caAnimation.get(), animationIndex, operationType, isMatrixAnimation, boxSize);
     }
     
@@ -3547,12 +3522,9 @@ bool GraphicsLayerCA::appendToUncommittedAnimations(const KeyframeValueList& val
     if (!PlatformCAFilters::isAnimatedFilterProperty(filterOp))
         return true;
 
-    // The keyPath is always of the form:
-    //
-    //      filter.filter_<animationIndex>.<filterPropertyName>
     bool valuesOK;
     RefPtr<PlatformCAAnimation> caAnimation;
-    auto keyPath = makeString("filters.filter_", animationIndex, '.', PlatformCAFilters::animatedFilterPropertyName(filterOp));
+    auto keyPath = PlatformCAAnimation::makeKeyPath(AnimatedProperty::Filter, filterOp, animationIndex);
 
     if (isKeyframe(valueList)) {
         caAnimation = createKeyframeAnimation(animation, keyPath, false, keyframesShouldUseAnimationWideTimingFunction);

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PlatformCAAnimation.h"
 
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -74,6 +75,77 @@ TextStream& operator<<(TextStream& ts, PlatformCAAnimation::ValueFunctionType va
 bool PlatformCAAnimation::isBasicAnimation() const
 {
     return animationType() == Basic || animationType() == Spring;
+}
+
+static constexpr auto transformKeyPath = "transform"_s;
+static constexpr auto opacityKeyPath = "opacity"_s;
+static constexpr auto backgroundColorKeyPath = "backgroundColor"_s;
+static constexpr auto filterKeyPathPrefix = "filters.filter_"_s;
+#if ENABLE(FILTERS_LEVEL_2)
+static constexpr auto backdropFiltersKeyPath = "backdropFilters"_s;
+#endif
+
+String PlatformCAAnimation::makeKeyPath(AnimatedProperty animatedProperty, FilterOperation::Type filterOperationType, int index)
+{
+    switch (animatedProperty) {
+    case AnimatedProperty::Translate:
+    case AnimatedProperty::Scale:
+    case AnimatedProperty::Rotate:
+    case AnimatedProperty::Transform:
+        return transformKeyPath;
+    case AnimatedProperty::Opacity:
+        return opacityKeyPath;
+    case AnimatedProperty::BackgroundColor:
+        return backgroundColorKeyPath;
+    case AnimatedProperty::Filter:
+        return makeString(filterKeyPathPrefix, index, ".", PlatformCAFilters::animatedFilterPropertyName(filterOperationType));
+#if ENABLE(FILTERS_LEVEL_2)
+    case AnimatedProperty::WebkitBackdropFilter:
+        return backdropFiltersKeyPath;
+#endif
+    case AnimatedProperty::Invalid:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+    ASSERT_NOT_REACHED();
+    return emptyString();
+}
+
+static bool isValidFilterKeyPath(const String& keyPath)
+{
+    if (!keyPath.startsWith(filterKeyPathPrefix))
+        return false;
+
+    size_t underscoreIndex = filterKeyPathPrefix.length();
+    auto dotIndex = keyPath.find('.', underscoreIndex);
+    if (dotIndex == notFound || dotIndex <= underscoreIndex)
+        return false;
+
+    auto indexString = keyPath.substring(underscoreIndex, dotIndex - underscoreIndex);
+    auto parsedIndex = parseInteger<unsigned>(indexString);
+    if (!parsedIndex)
+        return false;
+
+    auto filterOperationTypeString = keyPath.substring(dotIndex + 1);
+    return PlatformCAFilters::isValidAnimatedFilterPropertyName(filterOperationTypeString);
+}
+
+bool PlatformCAAnimation::isValidKeyPath(const String& keyPath)
+{
+    if (keyPath == transformKeyPath
+        || keyPath == opacityKeyPath
+        || keyPath == backgroundColorKeyPath)
+        return true;
+
+#if ENABLE(FILTERS_LEVEL_2)
+    if (keyPath == backdropFiltersKeyPath)
+        return true;
+#endif
+
+    if (isValidFilterKeyPath(keyPath))
+        return true;
+
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
@@ -28,6 +28,8 @@
 #include "Color.h"
 #include "FilterOperation.h"
 #include "FloatPoint3D.h"
+#include "GraphicsLayerClient.h"
+#include "PlatformCAFilters.h"
 #include "TransformationMatrix.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
@@ -130,6 +132,9 @@ public:
     }
 
     bool isBasicAnimation() const;
+
+    WEBCORE_EXPORT static String makeKeyPath(AnimatedProperty, FilterOperation::Type = FilterOperation::Type::None, int = 0);
+    WEBCORE_EXPORT static bool isValidKeyPath(const String&);
 
 protected:
     PlatformCAAnimation(AnimationType type = Basic)

--- a/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
@@ -41,7 +41,8 @@ public:
     WEBCORE_EXPORT static void setFiltersOnLayer(PlatformLayer*, const FilterOperations&);
     WEBCORE_EXPORT static void setBlendingFiltersOnLayer(PlatformLayer*, const BlendMode);
     static bool isAnimatedFilterProperty(FilterOperation::Type);
-    static const char* animatedFilterPropertyName(FilterOperation::Type);
+    static String animatedFilterPropertyName(FilterOperation::Type);
+    static bool isValidAnimatedFilterPropertyName(const String&);
 
     WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation*);
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -179,7 +179,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         double amount = 0;
         if (operation)
             amount = downcast<BasicColorMatrixFilterOperation>(*operation).amount();
-        
+
         value = @(amount);
         break;
     }
@@ -193,7 +193,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         double amount = 1;
         if (operation)
             amount = downcast<BasicColorMatrixFilterOperation>(*operation).amount();
-        
+
         value = @(amount);
         break;
     }
@@ -202,7 +202,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         double amount = 0;
         if (operation)
             amount = downcast<BasicColorMatrixFilterOperation>(*operation).amount();
-        
+
         amount = deg2rad(amount);
         value = @(amount);
         break;
@@ -220,7 +220,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
         break;
     }
-    
+
     case FilterOperation::Type::Brightness: {
         // Brightness CAFilter: inputColorMatrix
         value = PlatformCAFilters::colorMatrixValueForFilter(type, operation);
@@ -237,7 +237,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         double amount = 0;
         if (operation)
             amount = floatValueForLength(downcast<BlurFilterOperation>(*operation).stdDeviation(), 0);
-        
+
         value = @(amount);
         break;
     }
@@ -387,20 +387,38 @@ bool PlatformCAFilters::isAnimatedFilterProperty(FilterOperation::Type type)
     }
 }
 
-const char* PlatformCAFilters::animatedFilterPropertyName(FilterOperation::Type type)
+static constexpr auto inputAmountProperty = "inputAmount"_s;
+static constexpr auto inputColorMatrixProperty = "inputColorMatrix"_s;
+static constexpr auto inputAngleProperty = "inputAngle"_s;
+static constexpr auto inputRadiusProperty = "inputRadius"_s;
+
+String PlatformCAFilters::animatedFilterPropertyName(FilterOperation::Type type)
 {
     switch (type) {
-    case FilterOperation::Type::Grayscale: return "inputAmount";
-    case FilterOperation::Type::Sepia:return "inputColorMatrix";
-    case FilterOperation::Type::Saturate: return "inputAmount";
-    case FilterOperation::Type::HueRotate: return "inputAngle";
-    case FilterOperation::Type::Invert: return "inputColorMatrix";
-    case FilterOperation::Type::Opacity: return "inputColorMatrix";
-    case FilterOperation::Type::Brightness: return "inputColorMatrix";
-    case FilterOperation::Type::Contrast: return "inputColorMatrix";
-    case FilterOperation::Type::Blur: return "inputRadius";
-    default: return "";
+    case FilterOperation::Type::Grayscale:
+    case FilterOperation::Type::Saturate:
+        return inputAmountProperty;
+    case FilterOperation::Type::Sepia:
+    case FilterOperation::Type::Invert:
+    case FilterOperation::Type::Opacity:
+    case FilterOperation::Type::Brightness:
+    case FilterOperation::Type::Contrast:
+        return inputColorMatrixProperty;
+    case FilterOperation::Type::HueRotate:
+        return inputAngleProperty;
+    case FilterOperation::Type::Blur:
+        return inputRadiusProperty;
+    default:
+        return emptyString();
     }
+}
+
+bool PlatformCAFilters::isValidAnimatedFilterPropertyName(const String& animatedFilterPropertyName)
+{
+    return animatedFilterPropertyName == inputAmountProperty
+        || animatedFilterPropertyName == inputColorMatrixProperty
+        || animatedFilterPropertyName == inputAngleProperty
+        || animatedFilterPropertyName == inputRadiusProperty;
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -237,6 +237,7 @@ Ref<PlatformCAAnimation> PlatformCAAnimationRemote::copy() const
 PlatformCAAnimationRemote::PlatformCAAnimationRemote(AnimationType type, const String& keyPath)
     : PlatformCAAnimation(type)
 {
+    ASSERT(PlatformCAAnimation::isValidKeyPath(keyPath));
     m_properties.keyPath = keyPath;
     m_properties.animationType = type;
 }
@@ -697,6 +698,11 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
 
 static void addAnimationToLayer(CALayer *layer, RemoteLayerTreeHost* layerTreeHost, const String& key, const PlatformCAAnimationRemote::Properties& properties)
 {
+    if (!PlatformCAAnimation::isValidKeyPath(properties.keyPath)) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
     [layer addAnimation:createAnimation(layer, layerTreeHost, properties).get() forKey:key];
     [layer setInheritsTiming:NO];
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -329,8 +329,10 @@
 		51A587851D2739E3004BA9AF /* IndexedDBDatabaseProcessKill-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51A587821D272EB5004BA9AF /* IndexedDBDatabaseProcessKill-1.html */; };
 		51B1EE961C80FAEF0064FB98 /* IndexedDBPersistence-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE941C80FADD0064FB98 /* IndexedDBPersistence-1.html */; };
 		51B1EE971C80FAEF0064FB98 /* IndexedDBPersistence-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51B1EE951C80FADD0064FB98 /* IndexedDBPersistence-2.html */; };
+		51BB6B86296E931F0059B107 /* test-mse.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BB6B7E296E8FFD0059B107 /* test-mse.webm */; };
 		51BCEE4E1C84F53B0042C82E /* IndexedDBMultiProcess-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4C1C84F52C0042C82E /* IndexedDBMultiProcess-1.html */; };
 		51BCEE4F1C84F53B0042C82E /* IndexedDBMultiProcess-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BCEE4D1C84F52C0042C82E /* IndexedDBMultiProcess-2.html */; };
+		51C234CF2970E13500E35C4B /* test-mse-audio.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C234C72970E11400E35C4B /* test-mse-audio.webm */; };
 		51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */; };
 		51CD1C721B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51CD1C711B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html */; };
 		51DB16CE1F085137001FA4C5 /* WebViewIconLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */; };
@@ -521,6 +523,7 @@
 		6BF4A683239ED4CD00E2F45B /* LoggedInStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6BF4A682239ED4CD00E2F45B /* LoggedInStatus.cpp */; };
 		6BFD294C1D5E6C1D008EC968 /* HashCountedSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A38D7E51C752D5F004F157D /* HashCountedSet.cpp */; };
 		712E4BC125DDC52A0007201C /* AnimationFrameRate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */; };
+		7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */; };
 		71E88C4124B5299C00665160 /* ShareSheetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 71E88C4024B5299C00665160 /* ShareSheetTests.mm */; };
 		71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
 		725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
@@ -995,8 +998,6 @@
 		CD57779D211CE91F001B371E /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
 		CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53219E910AA00CF1835 /* file-with-mse.html */; };
 		CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
-		51C234CF2970E13500E35C4B /* test-mse-audio.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C234C72970E11400E35C4B /* test-mse-audio.webm */; };
-		51BB6B86296E931F0059B107 /* test-mse.webm in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51BB6B7E296E8FFD0059B107 /* test-mse.webm */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
 		CD758A6F20572EA00071834A /* video-with-paused-audio-and-playing-muted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */; };
 		CD78E11E1DB7EE2A0014A2DE /* FullscreenDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */; };
@@ -2411,10 +2412,12 @@
 		51B1EE951C80FADD0064FB98 /* IndexedDBPersistence-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBPersistence-2.html"; sourceTree = "<group>"; };
 		51B40D9D23AC960E00E05241 /* AsyncFunction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AsyncFunction.mm; sourceTree = "<group>"; };
 		51B454EB1B4E236B0085EAA6 /* WebViewCloseInsideDidFinishLoadForFrame.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebViewCloseInsideDidFinishLoadForFrame.mm; sourceTree = "<group>"; };
+		51BB6B7E296E8FFD0059B107 /* test-mse.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.webm"; sourceTree = "<group>"; };
 		51BCEE491C84F4AF0042C82E /* IndexedDBMultiProcess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IndexedDBMultiProcess.mm; sourceTree = "<group>"; };
 		51BCEE4C1C84F52C0042C82E /* IndexedDBMultiProcess-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBMultiProcess-1.html"; sourceTree = "<group>"; };
 		51BCEE4D1C84F52C0042C82E /* IndexedDBMultiProcess-2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBMultiProcess-2.html"; sourceTree = "<group>"; };
 		51BE9E652376089500B4E117 /* MediaType.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaType.mm; sourceTree = "<group>"; };
+		51C234C72970E11400E35C4B /* test-mse-audio.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse-audio.webm"; sourceTree = "<group>"; };
 		51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "WKURLSchemeHandler-1.mm"; sourceTree = "<group>"; };
 		51C8E1A41F26AC5400BF731B /* ResourceLoadStatistics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ResourceLoadStatistics.mm; sourceTree = "<group>"; };
 		51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = EmptyGrandfatheredResourceLoadStatistics.plist; sourceTree = "<group>"; };
@@ -2682,6 +2685,7 @@
 		6B9ABE112086952F00D75DE6 /* HTTPParsers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPParsers.cpp; sourceTree = "<group>"; };
 		6BF4A682239ED4CD00E2F45B /* LoggedInStatus.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LoggedInStatus.cpp; sourceTree = "<group>"; };
 		712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AnimationFrameRate.cpp; sourceTree = "<group>"; };
+		7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformCAAnimationKeyPath.cpp; sourceTree = "<group>"; };
 		71E88C4024B5299C00665160 /* ShareSheetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ShareSheetTests.mm; sourceTree = "<group>"; };
 		71E88C4324B533EC00665160 /* img-with-base64-url.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "img-with-base64-url.html"; sourceTree = "<group>"; };
 		725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = AdditionalSupportedImageTypes.html; sourceTree = "<group>"; };
@@ -3186,8 +3190,6 @@
 		CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "video-with-audio-and-web-audio.html"; sourceTree = "<group>"; };
 		CD59F53219E910AA00CF1835 /* file-with-mse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-mse.html"; sourceTree = "<group>"; };
 		CD59F53319E910BC00CF1835 /* test-mse.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.mp4"; sourceTree = "<group>"; };
-		51BB6B7E296E8FFD0059B107 /* test-mse.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.webm"; sourceTree = "<group>"; };
-		51C234C72970E11400E35C4B /* test-mse-audio.webm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse-audio.webm"; sourceTree = "<group>"; };
 		CD5FF4962162E27E004BD86F /* ISOBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBox.cpp; sourceTree = "<group>"; };
 		CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "video-with-paused-audio-and-playing-muted.html"; sourceTree = "<group>"; };
 		CD78E11A1DB7EA360014A2DE /* FullscreenDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenDelegate.mm; sourceTree = "<group>"; };
@@ -4233,6 +4235,7 @@
 				5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */,
 				CD225C071C45A69200140761 /* ParsedContentRange.cpp */,
 				AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */,
+				7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */,
 				6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */,
 				041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */,
 				EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */,
@@ -6390,6 +6393,7 @@
 				7CCE7F0A1A411AE600447C4C /* PasteboardNotifications.mm in Sources */,
 				7C83E0531D0A643A00FEBCF3 /* PendingAPIRequestURL.cpp in Sources */,
 				E325C90723E3870200BC7D3B /* PictureInPictureSupport.mm in Sources */,
+				7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */,
 				7CCE7EA61A411A0F00447C4C /* PlatformUtilitiesMac.mm in Sources */,
 				7CCE7EA71A411A1300447C4C /* PlatformWebViewMac.mm in Sources */,
 				F4010B8324DA267F00A876E2 /* PoseAsClass.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformCAAnimationKeyPath.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformCAAnimationKeyPath.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/PlatformCAAnimation.h>
+
+namespace TestWebKitAPI {
+
+TEST(PlatformCAAnimation, makeKeyPath)
+{
+    auto translate = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::Translate);
+    EXPECT_STREQ(translate.ascii().data(), "transform");
+
+    auto scale = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::Scale);
+    EXPECT_STREQ(scale.ascii().data(), "transform");
+
+    auto rotate = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::Rotate);
+    EXPECT_STREQ(rotate.ascii().data(), "transform");
+
+    auto transform = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::Transform);
+    EXPECT_STREQ(transform.ascii().data(), "transform");
+
+    auto opacity = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::Opacity);
+    EXPECT_STREQ(opacity.ascii().data(), "opacity");
+
+    auto backgroundColor = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::BackgroundColor);
+    EXPECT_STREQ(backgroundColor.ascii().data(), "backgroundColor");
+
+    auto filter = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Grayscale, 2);
+    EXPECT_STREQ(filter.ascii().data(), "filters.filter_2.inputAmount");
+
+#if ENABLE(FILTERS_LEVEL_2)
+    auto backdropFilter = WebCore::PlatformCAAnimation::makeKeyPath(WebCore::AnimatedProperty::WebkitBackdropFilter);
+    EXPECT_STREQ(backdropFilter.ascii().data(), "backdropFilters");
+#endif
+}
+
+static void validateGeneratedKeyPath(WebCore::AnimatedProperty animatedProperty, WebCore::FilterOperation::Type filterOperationType = WebCore::FilterOperation::Type::None, int index = 0)
+{
+    auto keyPath = WebCore::PlatformCAAnimation::makeKeyPath(animatedProperty, filterOperationType, index);
+    EXPECT_TRUE(WebCore::PlatformCAAnimation::isValidKeyPath(keyPath));
+}
+
+TEST(PlatformCAAnimation, isValidKeyPath)
+{
+    validateGeneratedKeyPath(WebCore::AnimatedProperty::Transform);
+    validateGeneratedKeyPath(WebCore::AnimatedProperty::Opacity);
+    validateGeneratedKeyPath(WebCore::AnimatedProperty::BackgroundColor);
+    validateGeneratedKeyPath(WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Grayscale, 2);
+    validateGeneratedKeyPath(WebCore::AnimatedProperty::Filter, WebCore::FilterOperation::Type::Sepia, 22);
+#if ENABLE(FILTERS_LEVEL_2)
+    validateGeneratedKeyPath(WebCore::AnimatedProperty::WebkitBackdropFilter);
+#endif
+
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("filters.filter_"_s));
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("filters.filter_0"_s));
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("filters.filter_10"_s));
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("filters.filter_0.inputAmount."_s));
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("filters.filter_0.inputAmounts"_s));
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("filters.filter_-10.inputAmount"_s));
+
+    EXPECT_FALSE(WebCore::PlatformCAAnimation::isValidKeyPath("dealloc"_s));
+}
+
+}


### PR DESCRIPTION
#### a4467affde12ae99f88dc7114e6bc9b2b95cd062
<pre>
Validate animation key paths sent over IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=250510">https://bugs.webkit.org/show_bug.cgi?id=250510</a>
rdar://102433824

Reviewed by Simon Fraser.

We use CAAnimation subclasses to perform certain type of animations that can be accelerated on Cocoa
ports. On iOS, we run those animations in the UIProcess where the target CALayer objects are hosted.
The `keyPath` for each of those animations is encoded and transmitted to the UIProcess as a string.
However, the way these key paths are handled by Core Animation, unexpected strings with certain symbols,
such as `dealloc`, could wreak havoc and compromise the UIProcess.

We add static methods to PlatformCAAnimation to create such key paths in GraphicsLayerCA. Then we assert
the key path is valid before it is sent over in the PlatformCAAnimationRemote constructor, which is run
in the WebProcess, and assert again in the static function addAnimationToLayer() before CAAnimation
objects are created in the UIProcess, returning early in case the key path turns out to be invalid.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateAnimations):
(WebCore::GraphicsLayerCA::createAnimationFromKeyframes):
(WebCore::GraphicsLayerCA::appendToUncommittedAnimations):
(WebCore::propertyIdToString): Deleted.
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.cpp:
(WebCore::PlatformCAAnimation::makeKeyPath):
(WebCore::isValidFilterKeyPath):
(WebCore::PlatformCAAnimation::isValidKeyPath):
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h:
* Source/WebCore/platform/graphics/ca/PlatformCAFilters.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::filterValueForOperation):
(WebCore::PlatformCAFilters::animatedFilterPropertyName):
(WebCore::PlatformCAFilters::isValidAnimatedFilterPropertyName):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::PlatformCAAnimationRemote):
(WebKit::addAnimationToLayer):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/PlatformCAAnimationKeyPath.cpp: Added.
(TestWebKitAPI::TEST):
(TestWebKitAPI::validateGeneratedKeyPath):

Canonical link: <a href="https://commits.webkit.org/258986@main">https://commits.webkit.org/258986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3be15da3895a0f2229631032f46fb45180a486c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12688 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3587 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/111980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109345 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3279 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->