### PR TITLE
Stream IPC message send tests do not test with small connection buffer sizes

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -70,6 +70,7 @@ StreamServerConnection::~StreamServerConnection()
 
 void StreamServerConnection::open()
 {
+    ASSERT(!m_isOpen);
     static LazyNeverDestroyed<DedicatedConnectionClient> s_dedicatedConnectionClient;
     static std::once_flag s_onceFlag;
     std::call_once(s_onceFlag, [] {
@@ -78,11 +79,13 @@ void StreamServerConnection::open()
     // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
     m_connection->addMessageReceiveQueue(*this, { });
     m_connection->open(s_dedicatedConnectionClient.get());
+    m_isOpen = true;
 }
 
 void StreamServerConnection::invalidate()
 {
-    m_connection->removeMessageReceiveQueue({ });
+    if (m_isOpen)
+        m_connection->removeMessageReceiveQueue({ });
     m_connection->invalidate();
 }
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -136,6 +136,8 @@ private:
     ReceiversMap m_receivers WTF_GUARDED_BY_LOCK(m_receiversLock);
     uint64_t m_currentDestinationID { 0 };
 
+    bool m_isOpen { false };
+
     friend class StreamConnectionWorkQueue;
 };
 


### PR DESCRIPTION
#### 5d1eb8359a73e05a30dff4783ed765418e51e938
<pre>
Stream IPC message send tests do not test with small connection buffer sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250669">https://bugs.webkit.org/show_bug.cgi?id=250669</a>
rdar://104294217

Reviewed by Antti Koivisto.

Separate the message send tests to a new test fixture and
parametrize that with connection buffer size. Instantiate
with 128, 256, 512, 16k sizes. With the smallest buffers,
the buffer will wrap around so the tests exercise that
part of the implementation.

Fix a bug that affected the tests only, where unopened
StreamServerConnection would assert on invalidate().
Add a test for the case.

* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::open):
(IPC::StreamServerConnection::invalidate):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::StreamConnectionTestBase::setupBase):
(TestWebKitAPI::StreamConnectionTestBase::teardownBase):
(TestWebKitAPI::StreamConnectionTestBase::localReferenceBarrier):
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::StreamMessageTest::bufferSizeLog2 const):
(TestWebKitAPI::StreamMessageTest::defaultDestinationID):
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::StreamConnectionTest::localReferenceBarrier): Deleted.
(TestWebKitAPI::StreamConnectionTest::serverQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/258950@main">https://commits.webkit.org/258950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81b806c7fdfb4d0a3d3a98fbcec867007a2310f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112685 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172894 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3472 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111872 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10460 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38087 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25125 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26528 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6151 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7889 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->