### PR TITLE
Add additional optional WebRTC media pipeline logging

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6733,6 +6733,20 @@ WebRTCH265CodecEnabled:
     WebCore:
       default: false
 
+WebRTCMediaPipelineAdditionalLoggingEnabled:
+  type: bool
+  status: internal
+  condition: USE(LIBWEBRTC)
+  humanReadableName: "WebRTC Media Pipeline Additional Logging"
+  humanReadableDescription: "Enable WebRTC Media Pipeline Additional Logging"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: true
+    WebCore:
+      default: false
+
 # FIXME: This is not relevant for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
 WebRTCPlatformCodecsInGPUProcessEnabled:
   type: bool

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -121,7 +121,10 @@ Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& doc
     }
     case cricket::MEDIA_TYPE_VIDEO: {
         rtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
-        return RealtimeIncomingVideoSource::create(WTFMove(videoTrack), fromStdString(rtcTrack->id()));
+        auto source = RealtimeIncomingVideoSource::create(WTFMove(videoTrack), fromStdString(rtcTrack->id()));
+        if (document.settings().webRTCMediaPipelineAdditionalLoggingEnabled())
+            source->enableFrameRatedMonitoring();
+        return source;
     }
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/FrameRateMonitor.cpp
+++ b/Source/WebCore/platform/FrameRateMonitor.cpp
@@ -42,7 +42,7 @@ void FrameRateMonitor::update()
     if (m_observedFrameRate) {
         auto maxDelay = MaxFrameDelayCount / m_observedFrameRate;
         if ((frameTime - lastFrameTime) > maxDelay)
-            m_lateFrameCallback({ MonotonicTime::fromRawSeconds(frameTime), MonotonicTime::fromRawSeconds(lastFrameTime) });
+            m_lateFrameCallback({ MonotonicTime::fromRawSeconds(frameTime), MonotonicTime::fromRawSeconds(lastFrameTime), m_observedFrameRate, m_frameCount });
     }
     m_observedFrameTimeStamps.append(frameTime);
     m_observedFrameTimeStamps.removeAllMatching([&](auto time) {

--- a/Source/WebCore/platform/FrameRateMonitor.h
+++ b/Source/WebCore/platform/FrameRateMonitor.h
@@ -32,15 +32,18 @@
 namespace WebCore {
 
 class FrameRateMonitor {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     struct LateFrameInfo {
         MonotonicTime frameTime;
         MonotonicTime lastFrameTime;
+        double observedFrameRate { 0 };
+        size_t frameCount { 0 };
     };
     using LateFrameCallback = Function<void(LateFrameInfo)>;
     explicit FrameRateMonitor(LateFrameCallback&&);
 
-    void update();
+    WEBCORE_EXPORT void update();
 
     double observedFrameRate() const { return m_observedFrameRate; }
     size_t frameCount() const { return m_frameCount; }
@@ -49,7 +52,7 @@ private:
     LateFrameCallback m_lateFrameCallback;
     Deque<double, 120> m_observedFrameTimeStamps;
     double m_observedFrameRate { 0 };
-    uint64_t m_frameCount { 0 };
+    size_t m_frameCount { 0 };
 };
 
 inline FrameRateMonitor::FrameRateMonitor(LateFrameCallback&& callback)

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -48,6 +48,7 @@ ALLOW_COMMA_END
 namespace WebCore {
 
 class CaptureDevice;
+class FrameRateMonitor;
 
 class RealtimeIncomingVideoSource
     : public RealtimeMediaSource
@@ -58,6 +59,8 @@ public:
     static Ref<RealtimeIncomingVideoSource> create(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
     ~RealtimeIncomingVideoSource();
 
+    void enableFrameRatedMonitoring();
+
 protected:
     RealtimeIncomingVideoSource(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
 
@@ -66,6 +69,8 @@ protected:
 #endif
 
     static VideoFrameTimeMetadata metadataFromVideoFrame(const webrtc::VideoFrame&);
+
+    void notifyNewFrame();
 
 private:
     // RealtimeMediaSource API
@@ -85,6 +90,7 @@ private:
     rtc::scoped_refptr<webrtc::VideoTrackInterface> m_videoTrack;
 
 #if !RELEASE_LOG_DISABLED
+    std::unique_ptr<FrameRateMonitor> m_frameRateMonitor;
     mutable RefPtr<const Logger> m_logger;
     const void* m_logIdentifier;
 #endif

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
@@ -170,6 +170,8 @@ void RealtimeIncomingVideoSourceCocoa::OnFrame(const webrtc::VideoFrame& webrtcV
     if (!videoFrame)
         return;
 
+    notifyNewFrame();
+
     setIntrinsicSize(IntSize(width, height));
     videoFrameAvailable(*videoFrame, metadataFromVideoFrame(webrtcVideoFrame));
 }

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -24,7 +24,7 @@
 #if USE(LIBWEBRTC) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 messages -> LibWebRTCCodecsProxy NotRefCounted {
-    CreateDecoder(WebKit::VideoDecoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, bool useRemoteFrames)
+    CreateDecoder(WebKit::VideoDecoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, bool useRemoteFrames, bool enableAdditionalLogging)
     ReleaseDecoder(WebKit::VideoDecoderIdentifier id)
     FlushDecoder(WebKit::VideoDecoderIdentifier id)
     SetDecoderFormatDescription(WebKit::VideoDecoderIdentifier id, IPC::DataReference description, uint16_t width, uint16_t height)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -68,6 +68,7 @@ public:
     ~LibWebRTCCodecs();
 
     static void setCallbacks(bool useGPUProcess, bool useRemoteFrames);
+    static void setWebRTCMediaPipelineAdditionalLoggingEnabled(bool);
     static void initializeIfNeeded();
 
     std::optional<VideoCodecType> videoCodecTypeFromWebCodec(const String&);
@@ -203,6 +204,7 @@ private:
     bool m_useGPUProcess { false };
     bool m_useRemoteFrames { false };
     bool m_hasVP9ExtensionSupport { false };
+    bool m_enableAdditionalLogging { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -89,6 +89,7 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 #endif
 #if USE(LIBWEBRTC)
     LibWebRTCCodecs::setCallbacks(m_page->settings().webRTCPlatformCodecsInGPUProcessEnabled(), m_page->settings().webRTCRemoteVideoFrameEnabled());
+    LibWebRTCCodecs::setWebRTCMediaPipelineAdditionalLoggingEnabled(m_page->settings().webRTCMediaPipelineAdditionalLoggingEnabled());
 #endif
 }
 


### PR DESCRIPTION
#### 9a5cf360c963fda62330b53cd08a83314fc5c876
<pre>
Add additional optional WebRTC media pipeline logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=250675">https://bugs.webkit.org/show_bug.cgi?id=250675</a>
rdar://problem/104296522

Reviewed by Eric Carlson.

We add three frame rate monitors just before decoder in GPUProcess, just after decoder in GPUProcess and just before rendering code path in WebProcess.
This can be enabled with the new internal runtime flag introduced in this patch.
This logging can allow to pinpoint areas where WebRTC video frame rate issues are introduced.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
(WebCore::LibWebRTCRtpReceiverBackend::createSource):
* Source/WebCore/platform/FrameRateMonitor.cpp:
(WebCore::FrameRateMonitor::update):
* Source/WebCore/platform/FrameRateMonitor.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp:
(WebCore::m_frameRateMonitor):
(WebCore::RealtimeIncomingVideoSource::notifyNewFrame):
(WebCore::RealtimeIncomingVideoSource::onIrregularFrameRateNotification):
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
(WebCore::RealtimeIncomingVideoSource::setShouldMonitorFrameRate):
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm:
(WebCore::RealtimeIncomingVideoSourceCocoa::OnFrame):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createDecoderCallback):
(WebKit::LibWebRTCCodecsProxy::createLocalDecoder):
(WebKit::LibWebRTCCodecsProxy::createDecoder):
(WebKit::LibWebRTCCodecsProxy::releaseDecoder):
(WebKit::LibWebRTCCodecsProxy::flushDecoder):
(WebKit::LibWebRTCCodecsProxy::setDecoderFormatDescription):
(WebKit::LibWebRTCCodecsProxy::doDecoderTask):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::createRemoteDecoder):
(WebKit::LibWebRTCCodecs::setWebRTCMediaPipelineAdditionalLoggingEnabled):
(WebKit::LibWebRTCCodecs::createDecoderInternal):
(WebKit::LibWebRTCCodecs::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):

Canonical link: <a href="https://commits.webkit.org/258980@main">https://commits.webkit.org/258980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be1b3310301b370872d3accb7292eb8b02fb8f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103550 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112786 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172992 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3565 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111958 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10543 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38283 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79924 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26607 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90114 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3794 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29797 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46117 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98717 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6169 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7978 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24865 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->