### PR TITLE
Expose member names of serializable types to the IPC testing API

### DIFF
--- a/LayoutTests/ipc/retrieve-serializable-member-type-and-name-expected.txt
+++ b/LayoutTests/ipc/retrieve-serializable-member-type-and-name-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Retrieving the type and name from a known member of a known serializable type
+

--- a/LayoutTests/ipc/retrieve-serializable-member-type-and-name.html
+++ b/LayoutTests/ipc/retrieve-serializable-member-type-and-name.html
@@ -1,0 +1,21 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Retrieve the type and name of a member from a serializable type</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+
+    assert_equals(IPC.serializedTypeInfo["WebCore::CharacterRange"][0].type, "uint64_t")
+    assert_equals(IPC.serializedTypeInfo["WebCore::CharacterRange"][0].name, "location")
+
+    assert_equals(IPC.serializedTypeInfo["WebCore::CharacterRange"][1].type, "uint64_t")
+    assert_equals(IPC.serializedTypeInfo["WebCore::CharacterRange"][1].name, "length")
+
+}, "Retrieving the type and name from a known member of a known serializable type");
+
+</script>
+</body>

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -604,7 +604,10 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers):
             continue
         result.append('        { "' + type.namespace_unless_wtf_and_name() + '"_s, {')
         for member in type.members:
+            result.append('            {')
             result.append('            "' + member.type + '"_s,')
+            result.append('            "' + member.name + '"_s')
+            result.append('            },')
         result.append('        } },')
     result.append('    };')
     result.append('}')

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -53,57 +53,57 @@ Vector<SerializedTypeInfo> allSerializedTypes()
 {
     return {
         { "Namespace::Subnamespace::StructName"_s, {
-            "FirstMemberType"_s,
-            "SecondMemberType"_s,
-            "RetainPtr<CFTypeRef>"_s,
+            { "FirstMemberType"_s, "a"_s },
+            { "SecondMemberType"_s, "b"_s },
+            { "RetainPtr<CFTypeRef>"_s, "c"_s }
         } },
         { "Namespace::OtherClass"_s, {
-            "bool"_s,
-            "int"_s,
-            "bool"_s,
-            "RetainPtr<NSArray>"_s,
+            { "bool"_s, "a"_s },
+            { "int"_s, "b"_s },
+            { "bool"_s, "c"_s },
+            { "RetainPtr<NSArray>"_s, "d"_s }
         } },
         { "Namespace::ReturnRefClass"_s, {
-            "double"_s,
-            "double"_s,
-            "std::unique_ptr<int>"_s,
+            { "double"_s, "a"_s },
+            { "double"_s, "b"_s },
+            { "std::unique_ptr<int>"_s, "c"_s }
         } },
         { "Namespace::EmptyConstructorStruct"_s, {
-            "int"_s,
-            "double"_s,
+            { "int"_s, "a"_s },
+            { "double"_s, "b"_s }
         } },
         { "Namespace::EmptyConstructorNullable"_s, {
-            "bool"_s,
-            "MemberType"_s,
-            "OtherMemberType"_s,
+            { "bool"_s, "a"_s },
+            { "MemberType"_s, "b"_s },
+            { "OtherMemberType"_s, "c"_s }
         } },
         { "WithoutNamespace"_s, {
-            "int"_s,
+            { "int"_s, "a"_s }
         } },
         { "WithoutNamespaceWithAttributes"_s, {
-            "int"_s,
+            { "int"_s, "a"_s }
         } },
         { "WebCore::InheritsFrom"_s, {
-            "float"_s,
+            { "float"_s, "a"_s }
         } },
         { "WebCore::InheritanceGrandchild"_s, {
-            "double"_s,
+            { "double"_s, "a"_s }
         } },
         { "Seconds"_s, {
-            "double"_s,
+            { "double"_s, "a"_s }
         } },
         { "CreateUsingClass"_s, {
-            "double"_s,
+            { "double"_s, "a"_s }
         } },
         { "WebCore::FloatBoxExtent"_s, {
-            "float"_s,
-            "float"_s,
-            "float"_s,
-            "float"_s,
+            { "float"_s, "a"_s },
+            { "float"_s, "b"_s },
+            { "float"_s, "c"_s },
+            { "float"_s, "d"_s }
         } },
         { "NullableSoftLinkedMember"_s, {
-            "RetainPtr<DDActionContext>"_s,
-            "RetainPtr<DDActionContext>"_s,
+            { "RetainPtr<DDActionContext>"_s, "a"_s },
+            { "RetainPtr<DDActionContext>"_s, "b"_s }
         } },
     };
 }

--- a/Source/WebKit/Shared/SerializedTypeInfo.h
+++ b/Source/WebKit/Shared/SerializedTypeInfo.h
@@ -32,9 +32,14 @@
 
 namespace WebKit {
 
+struct SerializedMember {
+    ASCIILiteral type;
+    ASCIILiteral name;
+};
+
 struct SerializedTypeInfo {
     ASCIILiteral name;
-    Vector<ASCIILiteral> members;
+    Vector<SerializedMember> members;
 };
 
 Vector<SerializedTypeInfo> allSerializedTypes();

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2549,7 +2549,16 @@ JSValueRef JSIPC::serializedTypeInfo(JSContextRef context, JSObjectRef thisObjec
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
         for (size_t i = 0; i < type.members.size(); i++) {
-            membersArray->putDirectIndex(globalObject, i, JSC::jsNontrivialString(vm, type.members[i]));
+            JSC::JSObject* entry = constructEmptyObject(globalObject, globalObject->objectPrototype());
+            RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+
+            entry->putDirect(vm, JSC::Identifier::fromString(vm, "type"_s), JSC::jsString(vm, String(type.members[i].type)));
+            RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+            
+            entry->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), JSC::jsString(vm, String(type.members[i].name)));
+            RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
+
+            membersArray->putDirectIndex(globalObject, i, entry);
             RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
         }
 


### PR DESCRIPTION
#### fee2513ebe872d50402d5d1cc9a6190865efe46a
<pre>
Expose member names of serializable types to the IPC testing API
<a href="https://bugs.webkit.org/show_bug.cgi?id=250678">https://bugs.webkit.org/show_bug.cgi?id=250678</a>
rdar://104297785

Reviewed by Alex Christensen.

Expose member names of individual types to the IPC testing API in order
to provide context to callers about the values of the fields to provide.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_serialized_type_info):
* Source/WebKit/Shared/SerializedTypeInfo.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::serializedTypeInfo):

Canonical link: <a href="https://commits.webkit.org/259112@main">https://commits.webkit.org/259112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81266f3f5348b82c2e55af92e924bcbb2b26494e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112836 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173174 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3617 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112002 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38322 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107099 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6094 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26655 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3182 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46166 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6274 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8027 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->