### PR TITLE
Support https://wicg.github.io/webcrypto-secure-curves/#ed25519

### DIFF
--- a/LayoutTests/http/wpt/crypto/serialize-cryptokey-okp-expected.txt
+++ b/LayoutTests/http/wpt/crypto/serialize-cryptokey-okp-expected.txt
@@ -1,0 +1,3 @@
+
+PASS postMessage a CryptoKeyOKP should work
+

--- a/LayoutTests/http/wpt/crypto/serialize-cryptokey-okp.html
+++ b/LayoutTests/http/wpt/crypto/serialize-cryptokey-okp.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+<title>CryptoKey OKP serializationt</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    const channel = new MessageChannel();
+
+    const keyData1 = {
+        crv: "Ed25519",
+        x: "2OGJY9gJ1IfZVJrMrsZ0Ln7rok2KDTsUt-PK6gaJPcw",
+        kty: "OKP"
+    };
+    const keyData2 = {
+        crv: "Ed25519",
+        d: "88j0xI34eBRujNO_bfTlDjibpwdOFcI1Lc1dMI1MqB8",
+        x: "2OGJY9gJ1IfZVJrMrsZ0Ln7rok2KDTsUt-PK6gaJPcw",
+        kty: "OKP"
+    };
+    const key1 = await crypto.subtle.importKey("jwk", keyData1, "Ed25519", true, ["verify"]);
+    const key2 = await crypto.subtle.importKey("jwk", keyData2, "Ed25519", true, ["sign"]);
+
+    channel.port1.postMessage(key1);
+    const key3 = await new Promise(resolve => channel.port2.onmessage = (event) => resolve(event.data));
+
+    assert_equals(key3.extractable, key1.extractable, "key1 extractable");
+    assert_array_equals(key3.usages, key1.usages, "key1 usages");
+
+    const keyData3 = await crypto.subtle.exportKey("jwk", key3);
+    assert_equals(keyData3.crv, keyData1.crv, "keyData1.crv");
+    assert_equals(keyData3.x, keyData1.x, "keyData1.x");
+    assert_equals(keyData3.kty, keyData1.kty, "keyData1.kty");
+
+    channel.port1.postMessage(key2);
+    const key4 = await new Promise(resolve => channel.port2.onmessage = (event) => resolve(event.data));
+
+    assert_equals(key4.extractable, key2.extractable, "key2 extractable");
+    assert_array_equals(key4.usages, key2.usages, "key2 usages");
+
+    const keyData4 = await crypto.subtle.exportKey("jwk", key4);
+    assert_equals(keyData4.crv, keyData4.crv, "keyData1.crv");
+    assert_equals(keyData4.d, keyData4.d, "keyData4.d");
+    assert_equals(keyData4.kty, keyData4.kty, "keyData4.kty");
+}, "postMessage a CryptoKeyOKP should work");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any-expected.txt
@@ -323,30 +323,30 @@ PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, false, [decrypt, s
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, true, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, RED, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, 7, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
-FAIL Bad usages: generateKey({name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: Ed25519}, false, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: Ed25519}, true, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
+PASS Bad usages: generateKey({name: Ed25519}, true, [encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [deriveBits])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, deriveBits])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveBits])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveBits])
+PASS Empty usages: generateKey({name: Ed25519}, false, [])
+PASS Empty usages: generateKey({name: Ed25519}, true, [])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any.worker-expected.txt
@@ -323,30 +323,30 @@ PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, false, [decrypt, s
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, true, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, RED, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, 7, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
-FAIL Bad usages: generateKey({name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveBits]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: Ed25519}, false, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: Ed25519}, true, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
+PASS Bad usages: generateKey({name: Ed25519}, true, [encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, encrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, decrypt])
+PASS Bad usages: generateKey({name: Ed25519}, true, [wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, wrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, unwrapKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveKey])
+PASS Bad usages: generateKey({name: Ed25519}, true, [deriveBits])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, deriveBits])
+PASS Bad usages: generateKey({name: Ed25519}, true, [verify, sign, deriveBits])
+PASS Bad usages: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify, deriveBits])
+PASS Empty usages: generateKey({name: Ed25519}, false, [])
+PASS Empty usages: generateKey({name: Ed25519}, true, [])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any-expected.txt
@@ -1,20 +1,20 @@
 
-FAIL Success: generateKey({name: ED25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, false, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, true, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, false, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, true, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, false, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, true, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, false, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, true, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, false, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, true, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, false, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Success: generateKey({name: ED25519}, false, [sign])
+PASS Success: generateKey({name: ED25519}, true, [sign])
+PASS Success: generateKey({name: ED25519}, false, [verify, sign])
+PASS Success: generateKey({name: ED25519}, true, [verify, sign])
+PASS Success: generateKey({name: ED25519}, false, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: ED25519}, true, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: ed25519}, false, [sign])
+PASS Success: generateKey({name: ed25519}, true, [sign])
+PASS Success: generateKey({name: ed25519}, false, [verify, sign])
+PASS Success: generateKey({name: ed25519}, true, [verify, sign])
+PASS Success: generateKey({name: ed25519}, false, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: ed25519}, true, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: Ed25519}, false, [sign])
+PASS Success: generateKey({name: Ed25519}, true, [sign])
+PASS Success: generateKey({name: Ed25519}, false, [verify, sign])
+PASS Success: generateKey({name: Ed25519}, true, [verify, sign])
+PASS Success: generateKey({name: Ed25519}, false, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any.worker-expected.txt
@@ -1,20 +1,20 @@
 
-FAIL Success: generateKey({name: ED25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, false, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, true, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, false, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ED25519}, true, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, false, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, true, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, false, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: ed25519}, true, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, false, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, true, [verify, sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, false, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Success: generateKey({name: ED25519}, false, [sign])
+PASS Success: generateKey({name: ED25519}, true, [sign])
+PASS Success: generateKey({name: ED25519}, false, [verify, sign])
+PASS Success: generateKey({name: ED25519}, true, [verify, sign])
+PASS Success: generateKey({name: ED25519}, false, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: ED25519}, true, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: ed25519}, false, [sign])
+PASS Success: generateKey({name: ed25519}, true, [sign])
+PASS Success: generateKey({name: ed25519}, false, [verify, sign])
+PASS Success: generateKey({name: ed25519}, true, [verify, sign])
+PASS Success: generateKey({name: ed25519}, false, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: ed25519}, true, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: Ed25519}, false, [sign])
+PASS Success: generateKey({name: Ed25519}, true, [sign])
+PASS Success: generateKey({name: Ed25519}, false, [verify, sign])
+PASS Success: generateKey({name: Ed25519}, true, [verify, sign])
+PASS Success: generateKey({name: Ed25519}, false, [sign, verify, sign, sign, verify])
+PASS Success: generateKey({name: Ed25519}, true, [sign, verify, sign, sign, verify])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
+PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
+PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
+PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
+FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_true: Round trip works expected true got false
+PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [])
+PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [])
+PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, [])
+PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, false, [sign])
+PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, false, [sign])
 FAIL Good parameters: Ed448 bits (spki, buffer(69), {name: Ed448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (jwk, object(kty, crv, x), {name: Ed448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (raw, buffer(57), {name: Ed448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
+PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
+PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
+PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
+FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_true: Round trip works expected true got false
+PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [])
+PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [])
+PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, [])
+PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, false, [sign])
+PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, false, [sign])
 FAIL Good parameters: Ed448 bits (spki, buffer(69), {name: Ed448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (jwk, object(kty, crv, x), {name: Ed448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (raw, buffer(57), {name: Ed448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
@@ -1,200 +1,200 @@
 
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, true, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, false, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, true, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, false, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveBits])
+PASS Bad key length: importKey(spki, {name: Ed25519}, true, [verify])
+PASS Bad key length: importKey(spki, {name: Ed25519}, false, [verify])
+PASS Bad key length: importKey(spki, {name: Ed25519}, true, [verify, verify])
+PASS Bad key length: importKey(spki, {name: Ed25519}, false, [verify, verify])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign, sign])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign, sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign, sign])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
@@ -1,200 +1,200 @@
 
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, true, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, false, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, true, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: Ed25519}, false, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, encrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, decrypt])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, sign])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, wrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveKey])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, true, [verify, verify, deriveBits])
+PASS Bad usages: importKey(spki, {name: Ed25519}, false, [verify, verify, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, verify])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveKey])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, true, [sign, sign, deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: Ed25519}, false, [sign, sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, verify])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveKey])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, true, [sign, sign, deriveBits])
+PASS Bad usages: importKey(jwk(private), {name: Ed25519}, false, [sign, sign, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, sign])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify, deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify, deriveBits])
+PASS Bad key length: importKey(spki, {name: Ed25519}, true, [verify])
+PASS Bad key length: importKey(spki, {name: Ed25519}, false, [verify])
+PASS Bad key length: importKey(spki, {name: Ed25519}, true, [verify, verify])
+PASS Bad key length: importKey(spki, {name: Ed25519}, false, [verify, verify])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, true, [sign, sign])
+PASS Bad key length: importKey(pkcs8, {name: Ed25519}, false, [sign, sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
+PASS Bad key length: importKey(jwk(private), {name: Ed25519}, false, [sign, sign])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
+PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
 FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "TypeError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify]) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any-expected.txt
@@ -1,29 +1,29 @@
 
 PASS setup
-FAIL Sign and verify using generated Ed25519 keys. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Sign and verify using generated Ed25519 keys.
 FAIL Sign and verify using generated Ed448 keys. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL importVectorKeys step: EdDSA Ed25519 verification assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification
 FAIL importVectorKeys step: EdDSA Ed448 verification assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification with altered signature after call assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification with altered signature after call
 FAIL importVectorKeys step: EdDSA Ed448 verification with altered signature after call assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 with altered data after call assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 with altered data after call
 FAIL importVectorKeys step: EdDSA Ed448 with altered data after call assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 using privateKey to verify assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 using privateKey to verify
 FAIL importVectorKeys step: EdDSA Ed448 using privateKey to verify assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 using publicKey to sign assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 using publicKey to sign
 FAIL importVectorKeys step: EdDSA Ed448 using publicKey to sign assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 no verify usage assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 no verify usage
 FAIL importVectorKeys step: EdDSA Ed448 no verify usage assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 round trip assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 round trip
 FAIL importVectorKeys step: EdDSA Ed448 round trip assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification failure due to altered signature assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 signing with wrong algorithm name
+PASS EdDSA Ed25519 verifying with wrong algorithm name
+PASS EdDSA Ed25519 verification failure due to altered signature
 FAIL importVectorKeys step: EdDSA Ed448 verification failure due to altered signature assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification failure due to shortened signature assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification failure due to shortened signature
 FAIL importVectorKeys step: EdDSA Ed448 verification failure due to shortened signature assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification failure due to altered data assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification failure due to altered data
 FAIL importVectorKeys step: EdDSA Ed448 verification failure due to altered data assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 signing with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
 FAIL importVectorKeys step: EdDSA Ed448 signing with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verifying with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
 FAIL importVectorKeys step: EdDSA Ed448 verifying with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.worker-expected.txt
@@ -1,29 +1,29 @@
 
 PASS setup
-FAIL Sign and verify using generated Ed25519 keys. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Sign and verify using generated Ed25519 keys.
 FAIL Sign and verify using generated Ed448 keys. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL importVectorKeys step: EdDSA Ed25519 verification assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification
 FAIL importVectorKeys step: EdDSA Ed448 verification assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification with altered signature after call assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification with altered signature after call
 FAIL importVectorKeys step: EdDSA Ed448 verification with altered signature after call assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 with altered data after call assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 with altered data after call
 FAIL importVectorKeys step: EdDSA Ed448 with altered data after call assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 using privateKey to verify assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 using privateKey to verify
 FAIL importVectorKeys step: EdDSA Ed448 using privateKey to verify assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 using publicKey to sign assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 using publicKey to sign
 FAIL importVectorKeys step: EdDSA Ed448 using publicKey to sign assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 no verify usage assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 no verify usage
 FAIL importVectorKeys step: EdDSA Ed448 no verify usage assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 round trip assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 round trip
 FAIL importVectorKeys step: EdDSA Ed448 round trip assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification failure due to altered signature assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 signing with wrong algorithm name
+PASS EdDSA Ed25519 verifying with wrong algorithm name
+PASS EdDSA Ed25519 verification failure due to altered signature
 FAIL importVectorKeys step: EdDSA Ed448 verification failure due to altered signature assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification failure due to shortened signature assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification failure due to shortened signature
 FAIL importVectorKeys step: EdDSA Ed448 verification failure due to shortened signature assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verification failure due to altered data assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
+PASS EdDSA Ed25519 verification failure due to altered data
 FAIL importVectorKeys step: EdDSA Ed448 verification failure due to altered data assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 signing with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
 FAIL importVectorKeys step: EdDSA Ed448 signing with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
-FAIL importVectorKeys step: EdDSA Ed25519 verifying with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed25519. Message: ''The operation is not supported.'' Reached unreachable code
 FAIL importVectorKeys step: EdDSA Ed448 verifying with wrong algorithm name assert_unreached: importVectorKeys failed for EdDSA Ed448. Message: ''The operation is not supported.'' Reached unreachable code
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -90,6 +90,7 @@ crypto/workers/subtle/rsa-pss-import-key-sign.html [ Pass ]
 crypto/workers/subtle/rsa-pss-import-key-verify.html [ Pass ]
 http/wpt/crypto/rsa-pss-crash.any.html [ Pass ]
 http/wpt/crypto/rsa-pss-crash.any.worker.html [ Pass ]
+http/wpt/crypto/serialize-cryptokey-okp.html [ Failure ]
 
 fast/text/emoji-gender-3.html [ Pass ]
 fast/text/emoji-gender-4.html [ Pass ]
@@ -1687,6 +1688,10 @@ webkit.org/b/177226 imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapK
 webkit.org/b/213678 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html [ Failure Timeout ]
 webkit.org/b/213678 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html [ Failure Timeout ]
 # Needs rebasing.
+imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues-bigint.tentative.any.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues-bigint.tentative.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/historical.any.sharedworker.html [ Failure ]
@@ -1695,6 +1700,12 @@ imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.an
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.worker.html [ Failure ]
 
 # TODO: This failure exists in the general TestExpectations, I got in a GTK run.
 # I think marking the whole folder as 'Slow' makes the expected result for this test 'Pass'.

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6599,6 +6599,19 @@ WebCodecsEnabled:
       "USE(GSTREAMER)": true
       default: false
 
+WebCryptoSafeCurvesEnabled:
+  type: bool
+  status: preview
+  humanReadableName: "Web Crypto Safe Curves"
+  humanReadableDescription: "Enable Web Crypto Safe Curves"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 WebGL2Enabled:
   type: bool
   status: stable

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		31647FB0251759DD0010F8FB /* OpenGLSoftLinkCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 31647FAE251759DB0010F8FB /* OpenGLSoftLinkCocoa.mm */; };
 		3CBEEDE928A1861D00221FAE /* BarcodeSupportSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		416E995323DAE6BE00E871CB /* AudioToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */; };
+		4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */; };
 		41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995523DAEFF700E871CB /* VideoToolboxSoftLink.cpp */; };
 		41E9EE2328BB57A0006A2298 /* MediaExperienceAVSystemControllerSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E9EE2228BB57A0006A2298 /* MediaExperienceAVSystemControllerSPI.h */; };
 		41E9EE2628BCA19E006A2298 /* SBSStatusBarSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E9EE2528BCA19E006A2298 /* SBSStatusBarSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -907,6 +908,7 @@
 		416E995223DAE6BE00E871CB /* AudioToolboxSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioToolboxSoftLink.h; sourceTree = "<group>"; };
 		416E995523DAEFF700E871CB /* VideoToolboxSoftLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoToolboxSoftLink.cpp; sourceTree = "<group>"; };
 		416E995623DAEFF700E871CB /* VideoToolboxSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoToolboxSoftLink.h; sourceTree = "<group>"; };
+		4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreCryptoSPI.h; sourceTree = "<group>"; };
 		41B99E4525DD70150007829A /* AVStreamDataParserSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVStreamDataParserSPI.h; sourceTree = "<group>"; };
 		41E9EE2228BB57A0006A2298 /* MediaExperienceAVSystemControllerSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaExperienceAVSystemControllerSPI.h; sourceTree = "<group>"; };
 		41E9EE2528BCA19E006A2298 /* SBSStatusBarSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBSStatusBarSPI.h; sourceTree = "<group>"; };
@@ -1105,6 +1107,7 @@
 				29CDEB9E2548D055007C07B7 /* AXSpeechManagerSPI.h */,
 				0C2DA1231F3BEB4900DBC317 /* CFNSURLConnectionSPI.h */,
 				7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */,
+				4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */,
 				ABCA536724895DB900361BFF /* CoreMotionSPI.h */,
 				C138EA1A2436447200656DF1 /* CoreServicesSPI.h */,
 				DF83E208263734F1000825EF /* CryptoKitPrivateSPI.h */,
@@ -1783,6 +1786,7 @@
 				DD20DDE027BC90D70093D175 /* CommonCryptoSPI.h in Headers */,
 				DD20DE6527BC90F90093D175 /* config.h in Headers */,
 				DD20DDCE27BC90D70093D175 /* CoreAudioSPI.h in Headers */,
+				4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */,
 				7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */,
 				DD20DDD327BC90D70093D175 /* CoreGraphicsSPI.h in Headers */,
 				DD20DD1627BC90D60093D175 /* CoreMediaSoftLink.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+WTF_EXTERN_C_BEGIN
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <corecrypto/ccec25519.h>
+#include <corecrypto/ccec25519_priv.h>
+#include <corecrypto/ccsha2.h>
+#else
+
+#define CC_SPTR(_sn_, _n_) _n_
+
+#define CC_WIDE_NULL nullptr
+
+#define CCRNG_STATE_COMMON \
+int(*CC_SPTR(ccrng_state, generate))(struct ccrng_state *rng, size_t outlen, void *out);
+
+struct ccrng_state {
+    CCRNG_STATE_COMMON
+};
+struct ccrng_state *ccrng(int *error);
+
+#define ccrng_generate(rng, outlen, out) \
+((rng)->generate((struct ccrng_state *)(rng), (outlen), (out)))
+
+typedef uint8_t ccec25519key[32];
+typedef ccec25519key ccec25519secretkey;
+typedef ccec25519key ccec25519pubkey;
+typedef ccec25519key ccec25519base;
+
+typedef uint8_t ccec25519signature[64];
+
+const struct ccdigest_info *ccsha512_di(void);
+#define ccoid_sha512 ((unsigned char *)"\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03")
+#define ccoid_sha512_len 11
+/* SHA512 */
+#define CCSHA512_BLOCK_SIZE  128
+#define    CCSHA512_OUTPUT_SIZE  64
+#define    CCSHA512_STATE_SIZE   64
+extern const struct ccdigest_info ccsha512_ltc_di;
+
+void cccurve25519(ccec25519key out, const ccec25519secretkey sk, const ccec25519base);
+inline void cccurve25519_make_priv(struct ccrng_state *rng, ccec25519secretkey sk)
+{
+    ccrng_generate(rng, 32, sk);
+    sk[0] &= 248;
+    sk[31] &= 127;
+    sk[31] |= 64;
+}
+
+inline void cccurve25519_make_pub(ccec25519pubkey pk, const ccec25519secretkey sk)
+{
+    cccurve25519(pk, sk, CC_WIDE_NULL);
+}
+
+inline void cccurve25519_make_key_pair(struct ccrng_state *rng, ccec25519pubkey pk, ccec25519secretkey sk)
+{
+    cccurve25519_make_priv(rng, sk);
+    cccurve25519_make_pub(pk, sk);
+}
+
+int cced25519_make_pub(const struct ccdigest_info *, ccec25519pubkey pk, const ccec25519secretkey sk);
+
+void cced25519_make_key_pair(const struct ccdigest_info *, struct ccrng_state *, ccec25519pubkey pk, ccec25519secretkey sk);
+
+#if __has_feature(bounds_attributes)
+#define cc_sized_by(x) __attribute__((sized_by(x)))
+#else
+#define cc_sized_by(x)
+#endif // __has_feature(bounds_attributes)
+
+void cced25519_sign(const struct ccdigest_info *, ccec25519signature, size_t len, const void *cc_sized_by(len) msg, const ccec25519pubkey pk, const ccec25519secretkey sk);
+int cced25519_verify(const struct ccdigest_info *, size_t len, const void *cc_sized_by(len) msg, const ccec25519signature, const ccec25519pubkey pk);
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+WTF_EXTERN_C_END

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -710,6 +710,7 @@ crypto/algorithms/CryptoAlgorithmAES_GCM.cpp
 crypto/algorithms/CryptoAlgorithmAES_KW.cpp
 crypto/algorithms/CryptoAlgorithmECDH.cpp
 crypto/algorithms/CryptoAlgorithmECDSA.cpp
+crypto/algorithms/CryptoAlgorithmEd25519.cpp
 crypto/algorithms/CryptoAlgorithmHKDF.cpp
 crypto/algorithms/CryptoAlgorithmHMAC.cpp
 crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -725,6 +726,7 @@ crypto/algorithms/CryptoAlgorithmSHA512.cpp
 crypto/keys/CryptoKeyAES.cpp
 crypto/keys/CryptoKeyEC.cpp
 crypto/keys/CryptoKeyHMAC.cpp
+crypto/keys/CryptoKeyOKP.cpp
 crypto/keys/CryptoKeyRSA.cpp
 crypto/keys/CryptoKeyRSAComponents.cpp
 crypto/keys/CryptoKeyRaw.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -152,6 +152,7 @@ crypto/mac/CryptoAlgorithmAES_GCMMac.cpp
 crypto/mac/CryptoAlgorithmAES_KWMac.cpp
 crypto/mac/CryptoAlgorithmECDHMac.cpp
 crypto/mac/CryptoAlgorithmECDSAMac.cpp
+crypto/mac/CryptoAlgorithmEd25519Cocoa.cpp
 crypto/mac/CryptoAlgorithmHKDFMac.cpp
 crypto/mac/CryptoAlgorithmHMACMac.cpp
 crypto/mac/CryptoAlgorithmPBKDF2Mac.cpp
@@ -161,6 +162,7 @@ crypto/mac/CryptoAlgorithmRSA_OAEPMac.cpp
 crypto/mac/CryptoAlgorithmRSA_PSSMac.cpp
 crypto/mac/CryptoAlgorithmRegistryMac.cpp
 crypto/mac/CryptoKeyECMac.cpp
+crypto/mac/CryptoKeyOKPCocoa.cpp
 crypto/mac/CryptoKeyMac.cpp
 crypto/mac/CryptoKeyRSAMac.cpp
 crypto/mac/CryptoUtilitiesCocoa.cpp

--- a/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
@@ -48,7 +48,8 @@ enum class CryptoAlgorithmIdentifier {
     SHA_384,
     SHA_512,
     HKDF,
-    PBKDF2
+    PBKDF2,
+    Ed25519
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -51,6 +51,7 @@ enum class CryptoKeyClass {
     AES,
     EC,
     HMAC,
+    OKP,
     RSA,
     Raw,
 };

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoKeyOKP.h"
+#include "NotImplemented.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <wtf/CrossThreadCopier.h>
+
+namespace WebCore {
+
+#if !PLATFORM(COCOA)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&)
+{
+    ASSERT_NOT_REACHED();
+    notImplemented();
+    return Exception { NotSupportedError };
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&)
+{
+    ASSERT_NOT_REACHED();
+    notImplemented();
+    return Exception { NotSupportedError };
+}
+#endif // PLATFORM(COCOA)
+
+Ref<CryptoAlgorithm> CryptoAlgorithmEd25519::create()
+{
+    return adoptRef(*new CryptoAlgorithmEd25519);
+}
+
+void CryptoAlgorithmEd25519::generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
+{
+    if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey)) {
+        exceptionCallback(SyntaxError);
+        return;
+    }
+
+    auto result = CryptoKeyOKP::generatePair(CryptoAlgorithmIdentifier::Ed25519, CryptoKeyOKP::NamedCurve::Ed25519, extractable, usages);
+    if (result.hasException()) {
+        exceptionCallback(result.releaseException().code());
+        return;
+    }
+
+    auto pair = result.releaseReturnValue();
+    pair.publicKey->setUsagesBitmap(pair.publicKey->usagesBitmap() & CryptoKeyUsageVerify);
+    pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & CryptoKeyUsageSign);
+    callback(WTFMove(pair));
+}
+
+void CryptoAlgorithmEd25519::sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+{
+    if (key->type() != CryptoKeyType::Private) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
+        [key = WTFMove(key), data = WTFMove(data)] {
+            return platformSign(downcast<CryptoKeyOKP>(key.get()), data);
+    });
+}
+
+void CryptoAlgorithmEd25519::verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&& key, Vector<uint8_t>&& signature, Vector<uint8_t>&& data, BoolCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+{
+    if (key->type() != CryptoKeyType::Public) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
+        [key = WTFMove(key), signature = WTFMove(signature), data = WTFMove(data)] {
+            return platformVerify(downcast<CryptoKeyOKP>(key.get()), signature, data);
+        });
+}
+
+void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+{
+    RefPtr<CryptoKeyOKP> result;
+    switch (format) {
+    case CryptoKeyFormat::Jwk: {
+        JsonWebKey key = WTFMove(std::get<JsonWebKey>(data));
+        if (usages && ((!key.d.isNull() && (usages ^ CryptoKeyUsageSign)) || (key.d.isNull() && (usages ^ CryptoKeyUsageVerify)))) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        if (usages && !key.use.isNull() && key.use != "sig"_s) {
+            exceptionCallback(DataError);
+            return;
+        }
+        result = CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier::Ed25519, CryptoKeyOKP::NamedCurve::Ed25519, WTFMove(key), extractable, usages);
+        break;
+    }
+    case CryptoKeyFormat::Raw:
+        if (usages && (usages ^ CryptoKeyUsageVerify)) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyOKP::importRaw(CryptoAlgorithmIdentifier::Ed25519, CryptoKeyOKP::NamedCurve::Ed25519, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    case CryptoKeyFormat::Spki:
+        if (usages && (usages ^ CryptoKeyUsageVerify)) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier::Ed25519, CryptoKeyOKP::NamedCurve::Ed25519, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    case CryptoKeyFormat::Pkcs8:
+        if (usages && (usages ^ CryptoKeyUsageSign)) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier::Ed25519, CryptoKeyOKP::NamedCurve::Ed25519, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    }
+    if (!result) {
+        exceptionCallback(DataError);
+        return;
+    }
+    callback(*result);
+}
+
+void CryptoAlgorithmEd25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+{
+    const auto& okpKey = downcast<CryptoKeyOKP>(key.get());
+    if (!okpKey.keySizeInBits()) {
+        exceptionCallback(OperationError);
+        return;
+    }
+    KeyData result;
+    switch (format) {
+    case CryptoKeyFormat::Jwk: {
+        auto jwk = okpKey.exportJwk();
+        if (jwk.hasException()) {
+            exceptionCallback(jwk.releaseException().code());
+            return;
+        }
+        result = jwk.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Raw: {
+        auto raw = okpKey.exportRaw();
+        if (raw.hasException()) {
+            exceptionCallback(raw.releaseException().code());
+            return;
+        }
+        result = raw.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Spki: {
+        auto spki = okpKey.exportSpki();
+        if (spki.hasException()) {
+            exceptionCallback(spki.releaseException().code());
+            return;
+        }
+        result = spki.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Pkcs8: {
+        auto pkcs8 = okpKey.exportPkcs8();
+        if (pkcs8.hasException()) {
+            exceptionCallback(pkcs8.releaseException().code());
+            return;
+        }
+        result = pkcs8.releaseReturnValue();
+        break;
+    }
+    }
+    callback(format, WTFMove(result));
+}
+
+} // namespace WebCore
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "CryptoAlgorithm.h"
+
+#if ENABLE(WEB_CRYPTO)
+namespace WebCore {
+
+class CryptoKeyOKP;
+
+class CryptoAlgorithmEd25519 final : public CryptoAlgorithm {
+public:
+    static constexpr ASCIILiteral s_name = "Ed25519"_s;
+    static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::Ed25519;
+    static Ref<CryptoAlgorithm> create();
+
+private:
+    CryptoAlgorithmEd25519() = default;
+    CryptoAlgorithmIdentifier identifier() const final;
+
+    void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
+    void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&);
+    static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+};
+
+inline CryptoAlgorithmIdentifier CryptoAlgorithmEd25519::identifier() const
+{
+    return s_identifier;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoKeyOKP.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmRegistry.h"
+#include "JsonWebKey.h"
+#include <wtf/text/Base64.h>
+
+namespace WebCore {
+
+static const ASCIILiteral X25519 { "X25519"_s };
+static const ASCIILiteral Ed25519 { "Ed25519"_s };
+
+static constexpr size_t keySizeInBytesFromNamedCurve(CryptoKeyOKP::NamedCurve curve)
+{
+    switch (curve) {
+    case CryptoKeyOKP::NamedCurve::X25519:
+    case CryptoKeyOKP::NamedCurve::Ed25519:
+        return 32;
+    }
+    return 32;
+}
+
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::create(CryptoAlgorithmIdentifier identifier, NamedCurve curve, CryptoKeyType type, KeyMaterial&& platformKey, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    if (platformKey.size() != keySizeInBytesFromNamedCurve(curve))
+        return nullptr;
+    return adoptRef(*new CryptoKeyOKP(identifier, curve, type, WTFMove(platformKey), extractable, usages));
+}
+
+CryptoKeyOKP::CryptoKeyOKP(CryptoAlgorithmIdentifier identifier, NamedCurve curve, CryptoKeyType type, KeyMaterial&& data, bool extractable, CryptoKeyUsageBitmap usages)
+    : CryptoKey(identifier, type, extractable, usages)
+    , m_curve(curve)
+    , m_data(WTFMove(data))
+{
+}
+
+ExceptionOr<CryptoKeyPair> CryptoKeyOKP::generatePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    if (!isPlatformSupportedCurve(namedCurve))
+        return Exception { NotSupportedError };
+
+    auto result = platformGeneratePair(identifier, namedCurve, extractable, usages);
+    if (!result)
+        return Exception { OperationError };
+
+    return WTFMove(*result);
+}
+
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importRaw(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    if (!isPlatformSupportedCurve(namedCurve))
+        return nullptr;
+
+    return create(identifier, namedCurve, usages & CryptoKeyUsageSign ? CryptoKeyType::Private : CryptoKeyType::Public, WTFMove(keyData), extractable, usages);
+}
+
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    if (!isPlatformSupportedCurve(namedCurve))
+        return nullptr;
+
+    switch (namedCurve) {
+    case NamedCurve::Ed25519:
+        if (!keyData.d.isEmpty()) {
+            if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageVerify | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey))
+                return nullptr;
+        } else {
+            if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageSign | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey))
+                return nullptr;
+        }
+        if (keyData.kty != "OKP"_s)
+            return nullptr;
+       if (keyData.crv != "Ed25519"_s)
+            return nullptr;
+        if (!keyData.alg.isEmpty() && keyData.alg != "EdDSA"_s)
+            return nullptr;
+        if (usages && !keyData.use.isEmpty() && keyData.use != "sign"_s)
+            return nullptr;
+        if (keyData.key_ops && ((keyData.usages & usages) != usages))
+            return nullptr;
+        if (keyData.ext && !keyData.ext.value() && extractable)
+            return nullptr;
+        break;
+    case NamedCurve::X25519:
+        if (keyData.crv != "X25519"_s)
+            return nullptr;
+        // FIXME: Add further checks.
+        break;
+    }
+
+    if (!keyData.d.isNull()) {
+        // FIXME: Validate keyData.x is paired with keyData.d
+        auto d = base64URLDecode(keyData.d);
+        if (!d)
+            return nullptr;
+        return create(identifier, namedCurve, CryptoKeyType::Private, WTFMove(*d), extractable, usages);
+    }
+
+    if (keyData.x.isNull())
+        return nullptr;
+
+    auto x = base64URLDecode(keyData.x);
+    if (!x)
+        return nullptr;
+    return create(identifier, namedCurve, CryptoKeyType::Public, WTFMove(*x), extractable, usages);
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportRaw() const
+{
+    if (type() != CryptoKey::Type::Public)
+        return Exception { InvalidAccessError };
+
+    auto result = platformExportRaw();
+    if (result.isEmpty())
+        return Exception { OperationError };
+    return result;
+}
+
+ExceptionOr<JsonWebKey> CryptoKeyOKP::exportJwk() const
+{
+    JsonWebKey result;
+    result.kty = "OKP"_s;
+    switch (m_curve) {
+    case NamedCurve::X25519:
+        result.crv = X25519;
+        break;
+    case NamedCurve::Ed25519:
+        result.crv = Ed25519;
+        break;
+    }
+
+    result.key_ops = usages();
+    result.ext = extractable();
+
+    switch (type()) {
+    case CryptoKeyType::Private:
+        result.d = generateJwkD();
+        result.x = generateJwkX();
+        break;
+    case CryptoKeyType::Public:
+        result.x = generateJwkX();
+        break;
+    case CryptoKeyType::Secret:
+        return Exception { OperationError };
+    }
+
+    return result;
+}
+
+String CryptoKeyOKP::namedCurveString() const
+{
+    switch (m_curve) {
+    case NamedCurve::X25519:
+        return X25519;
+    case NamedCurve::Ed25519:
+        return Ed25519;
+    }
+
+    ASSERT_NOT_REACHED();
+    return emptyString();
+}
+
+bool CryptoKeyOKP::isValidOKPAlgorithm(CryptoAlgorithmIdentifier algorithm)
+{
+    return algorithm == CryptoAlgorithmIdentifier::Ed25519;
+}
+
+auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
+{
+    CryptoEcKeyAlgorithm result;
+    result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
+
+    switch (m_curve) {
+    case NamedCurve::X25519:
+        result.namedCurve = X25519;
+        break;
+    case NamedCurve::Ed25519:
+        result.namedCurve = Ed25519;
+        break;
+    }
+
+    return result;
+}
+
+#if !PLATFORM(COCOA)
+bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve)
+{
+    return false;
+}
+
+std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool, CryptoKeyUsageBitmap)
+{
+    return { };
+}
+
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&&, bool, CryptoKeyUsageBitmap)
+{
+    // FIXME: Implement it.
+    return nullptr;
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
+{
+    return Exception { NotSupportedError };
+}
+
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&&, bool, CryptoKeyUsageBitmap)
+{
+    // FIXME: Implement it.
+    return nullptr;
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportPkcs8() const
+{
+    return Exception { NotSupportedError };
+}
+
+String CryptoKeyOKP::generateJwkD() const
+{
+    return { };
+}
+
+String CryptoKeyOKP::generateJwkX() const
+{
+    return { };
+}
+
+Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const
+{
+    return { };
+}
+
+#endif
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoKey.h"
+#include "CryptoKeyPair.h"
+#include "ExceptionOr.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+namespace WebCore {
+
+struct JsonWebKey;
+
+class CryptoKeyOKP final : public CryptoKey {
+public:
+    using KeyMaterial = Vector<uint8_t>;
+
+    enum class NamedCurve {
+        X25519,
+        Ed25519,
+    };
+
+    static RefPtr<CryptoKeyOKP> create(CryptoAlgorithmIdentifier, NamedCurve, CryptoKeyType, KeyMaterial&&, bool extractable, CryptoKeyUsageBitmap);
+
+    WEBCORE_EXPORT static ExceptionOr<CryptoKeyPair> generatePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
+    WEBCORE_EXPORT static RefPtr<CryptoKeyOKP> importRaw(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyOKP> importJwk(CryptoAlgorithmIdentifier, NamedCurve, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyOKP> importSpki(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    static RefPtr<CryptoKeyOKP> importPkcs8(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+
+    WEBCORE_EXPORT ExceptionOr<Vector<uint8_t>> exportRaw() const;
+    ExceptionOr<JsonWebKey> exportJwk() const;
+    ExceptionOr<Vector<uint8_t>> exportSpki() const;
+    ExceptionOr<Vector<uint8_t>> exportPkcs8() const;
+
+    NamedCurve namedCurve() const { return m_curve; }
+    String namedCurveString() const;
+
+    static bool isValidOKPAlgorithm(CryptoAlgorithmIdentifier);
+
+    size_t keySizeInBits() const { return platformKey().size() * 8; }
+    size_t keySizeInBytes() const { return platformKey().size(); }
+    const KeyMaterial& platformKey() const { return m_data; }
+
+private:
+    CryptoKeyOKP(CryptoAlgorithmIdentifier, NamedCurve, CryptoKeyType, Vector<uint8_t>&&, bool extractable, CryptoKeyUsageBitmap);
+
+    CryptoKeyClass keyClass() const final { return CryptoKeyClass::OKP; }
+    KeyAlgorithm algorithm() const final;
+
+    String generateJwkD() const;
+    String generateJwkX() const;
+
+    static bool isPlatformSupportedCurve(NamedCurve);
+    static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
+    Vector<uint8_t> platformExportRaw() const;
+    Vector<uint8_t> platformExportSpki() const;
+    Vector<uint8_t> platformExportPkcs8() const;
+
+    NamedCurve m_curve;
+    KeyMaterial m_data;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CRYPTO_KEY(CryptoKeyOKP, CryptoKeyClass::OKP)
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Cocoa.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoKeyOKP.h"
+#include <pal/spi/cocoa/CoreCryptoSPI.h>
+
+namespace WebCore {
+
+static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, size_t, const Vector<uint8_t>& data)
+{
+    ccec25519pubkey pk;
+    const struct ccdigest_info* di = ccsha512_di();
+    cced25519_make_pub(di, pk, sk.data());
+    ccec25519signature newSignature;
+    cced25519_sign(di, newSignature, data.size(), data.data(), pk, sk.data());
+    return Vector<uint8_t>(newSignature, 64);
+}
+
+static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLengthInBytes, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
+{
+    if (signature.size() != keyLengthInBytes * 2)
+        return false;
+    const struct ccdigest_info* di = ccsha512_di();
+    return !cced25519_verify(di, data.size(), data.data(), signature.data(), key.data());
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)
+{
+    return signEd25519(key.platformKey(), key.keySizeInBytes(), data);
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    return verifyEd25519(key.platformKey(), key.keySizeInBytes(), signature, data);
+}
+
+}
+#endif

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_CRYPTO)
 
+#include "CommonCryptoUtilities.h"
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
 #include "CryptoUtilitiesCocoa.h"

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
@@ -35,6 +35,7 @@
 #include "CryptoAlgorithmAES_KW.h"
 #include "CryptoAlgorithmECDH.h"
 #include "CryptoAlgorithmECDSA.h"
+#include "CryptoAlgorithmEd25519.h"
 #include "CryptoAlgorithmHKDF.h"
 #include "CryptoAlgorithmHMAC.h"
 #include "CryptoAlgorithmPBKDF2.h"
@@ -59,6 +60,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmAES_KW>();
     registerAlgorithm<CryptoAlgorithmECDH>();
     registerAlgorithm<CryptoAlgorithmECDSA>();
+    registerAlgorithm<CryptoAlgorithmEd25519>();
     registerAlgorithm<CryptoAlgorithmHKDF>();
     registerAlgorithm<CryptoAlgorithmHMAC>();
     registerAlgorithm<CryptoAlgorithmPBKDF2>();

--- a/Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoKeyOKP.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CommonCryptoDERUtilities.h"
+#include "JsonWebKey.h"
+#include "Logging.h"
+#include <wtf/text/Base64.h>
+
+#include <pal/spi/cocoa/CoreCryptoSPI.h>
+
+namespace WebCore {
+
+bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve namedCurve)
+{
+    return namedCurve == NamedCurve::Ed25519;
+}
+
+std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    if (namedCurve != NamedCurve::Ed25519)
+        return { };
+
+    ccec25519pubkey ccPublicKey;
+    ccec25519secretkey ccPrivateKey;
+
+    if (identifier == CryptoAlgorithmIdentifier::Ed25519) {
+        int ccerror = 0;
+        const struct ccdigest_info* di = ccsha512_di();
+        cced25519_make_key_pair(di, ccrng(&ccerror),  ccPublicKey, ccPrivateKey);
+        if (ccerror) {
+            RELEASE_LOG_ERROR(Crypto, "Cannot generate Ed25519 key pair, error is %d", ccerror);
+            return { };
+        }
+    } else {
+        int ccerror = 0;
+        cccurve25519_make_key_pair(ccrng(&ccerror), ccPublicKey, ccPrivateKey);
+        if (ccerror) {
+            RELEASE_LOG_ERROR(Crypto, "Cannot generate curve 25519 key pair, error is %d", ccerror);
+            return { };
+        }
+    }
+    bool isPublicKeyExtractable = true;
+    auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, Vector<uint8_t>(ccPublicKey), isPublicKeyExtractable, usages);
+    ASSERT(publicKey);
+    auto privateKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Private, Vector<uint8_t>(ccPrivateKey), extractable, usages);
+    ASSERT(privateKey);
+    return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
+}
+
+// Per https://www.ietf.org/rfc/rfc5280.txt
+// SubjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
+// AlgorithmIdentifier  ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY DEFINED BY algorithm OPTIONAL }
+// Per https://www.rfc-editor.org/rfc/rfc8410
+// id-X25519    OBJECT IDENTIFIER ::= { 1 3 101 110 }
+// id-X448      OBJECT IDENTIFIER ::= { 1 3 101 111 }
+// id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
+// id-Ed448     OBJECT IDENTIFIER ::= { 1 3 101 113 }
+// For all of the OIDs, the parameters MUST be absent.
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    // FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.
+
+    // Read SEQUENCE
+    size_t index = 1;
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read length and SEQUENCE
+    // FIXME: Check length is 5 + 1 + 1 + 1 + keyByteSize.
+    index += bytesUsedToEncodedLength(keyData[index]) + 1;
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read length
+    // FIXME: Check length is 5.
+    index += bytesUsedToEncodedLength(keyData[index]);
+    if (keyData.size() < index + 5)
+        return nullptr;
+
+    // Read OID
+    // FIXME: spec says this is 1 3 101 11X but WPT tests expect 6 3 43 101 11X.
+    if (keyData[index++] != 6 || keyData[index++] != 3 || keyData[index++] != 43 || keyData[index++] != 101)
+        return nullptr;
+
+    switch (namedCurve) {
+        case NamedCurve::X25519:
+            if (keyData[index++] != 110)
+                return nullptr;
+            break;
+        case NamedCurve::Ed25519:
+            if (keyData[index++] != 112)
+                return nullptr;
+            break;
+    };
+
+    // Read BIT STRING
+    if (keyData.size() < index + 1)
+        return nullptr;
+    if (keyData[index++] != 3)
+        return nullptr;
+
+    // Read length
+    // FIXME: Check length is keyByteSize + 1.
+    index += bytesUsedToEncodedLength(keyData[index]);
+
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Initial octet
+    if (!!keyData[index])
+        return nullptr;
+    ++index;
+
+    return create(identifier, namedCurve, CryptoKeyType::Public, Span<const uint8_t> { keyData.data() + index, keyData.size() - index }, extractable, usages);
+}
+
+constexpr uint8_t OKPOIDFirstByte = 6;
+constexpr uint8_t OKPOIDSecondByte = 3;
+constexpr uint8_t OKPOIDThirdByte = 43;
+constexpr uint8_t OKPOIDFourthByte = 101;
+constexpr uint8_t OKPOIDX25519Byte = 110;
+constexpr uint8_t OKPOIDEd25519Byte = 112;
+
+static void writeOID(CryptoKeyOKP::NamedCurve namedCurve, Vector<uint8_t>& result)
+{
+    result.append(OKPOIDFirstByte);
+    result.append(OKPOIDSecondByte);
+    result.append(OKPOIDThirdByte);
+    result.append(OKPOIDFourthByte);
+
+    switch (namedCurve) {
+    case CryptoKeyOKP::NamedCurve::X25519:
+        result.append(OKPOIDX25519Byte);
+        break;
+    case CryptoKeyOKP::NamedCurve::Ed25519:
+        result.append(OKPOIDEd25519Byte);
+        break;
+    };
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
+{
+    if (type() != CryptoKeyType::Public)
+        return Exception { InvalidAccessError };
+
+    size_t keySize = keySizeInBytes();
+
+    // SEQUENCE, length, SEQUENCE, length, OID, Bit String (Initial octet prepended)
+    size_t totalSize = 1 + 1 + 1 + 1 + 5 + 1 + 1 + 1 + keySize;
+    Vector<uint8_t> result;
+    result.reserveInitialCapacity(totalSize);
+    result.append(SequenceMark);
+    addEncodedASN1Length(result, totalSize - 2);
+    result.append(SequenceMark);
+    addEncodedASN1Length(result, 5);
+
+    writeOID(namedCurve(), result);
+
+    result.append(BitStringMark);
+    addEncodedASN1Length(result, keySize + 1);
+    result.append(InitialOctet);
+    result.append(platformKey().data(), platformKey().size());
+
+    ASSERT(result.size() == totalSize);
+
+    return WTFMove(result);
+}
+
+// Per https://www.ietf.org/rfc/rfc5280.txt
+// PrivateKeyInfo ::= SEQUENCE { version INTEGER, privateKeyAlgorithm AlgorithmIdentifier, privateKey OCTET STRING }
+// AlgorithmIdentifier  ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY DEFINED BY algorithm OPTIONAL }
+// Per https://www.rfc-editor.org/rfc/rfc8410
+// id-X25519    OBJECT IDENTIFIER ::= { 1 3 101 110 }
+// id-X448      OBJECT IDENTIFIER ::= { 1 3 101 111 }
+// id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
+// id-Ed448     OBJECT IDENTIFIER ::= { 1 3 101 113 }
+// For all of the OIDs, the parameters MUST be absent.
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    // FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.
+
+    // Read SEQUENCE
+    size_t index = 1;
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read length
+    index += bytesUsedToEncodedLength(keyData[index]);
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read version
+    index += 3;
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read SEQUENCE
+    index += bytesUsedToEncodedLength(keyData[index]);
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read length
+    index += bytesUsedToEncodedLength(keyData[index]);
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read OID
+    if (keyData[index++] != OKPOIDFirstByte || keyData[index++] != OKPOIDSecondByte || keyData[index++] != OKPOIDThirdByte || keyData[index++] != OKPOIDFourthByte)
+        return nullptr;
+
+    switch (namedCurve) {
+        case NamedCurve::X25519:
+            if (keyData[index++] != OKPOIDX25519Byte)
+                return nullptr;
+            break;
+        case NamedCurve::Ed25519:
+            if (keyData[index++] != OKPOIDEd25519Byte)
+                return nullptr;
+            break;
+    };
+
+    // Read OCTET STRING
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    if (keyData[index++] != 4)
+        return nullptr;
+
+    index += bytesUsedToEncodedLength(keyData[index]);
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    // Read OCTET STRING
+    if (keyData[index++] != 4)
+        return nullptr;
+
+    index += bytesUsedToEncodedLength(keyData[index]);
+    if (keyData.size() < index + 1)
+        return nullptr;
+
+    return create(identifier, namedCurve, CryptoKeyType::Private, Span<const uint8_t> { keyData.data() + index, keyData.size() - index }, extractable, usages);
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportPkcs8() const
+{
+    if (type() != CryptoKeyType::Private)
+        return Exception { InvalidAccessError };
+
+    size_t keySize = keySizeInBytes();
+
+    // SEQUENCE, length, version SEQUENCE, length, OID, Octet String Octet String
+    size_t totalSize = 1 + 1 + 3 + 1 + 1 + 5 + 1 + 1 + 1 + 1 + keySize;
+    Vector<uint8_t> result;
+    result.reserveInitialCapacity(totalSize);
+    result.append(SequenceMark);
+    addEncodedASN1Length(result, totalSize - 2);
+
+    result.append(2);
+    result.append(1);
+    result.append(0);
+
+    result.append(SequenceMark);
+    addEncodedASN1Length(result, 5);
+
+    writeOID(namedCurve(), result);
+
+    result.append(OctetStringMark);
+    addEncodedASN1Length(result, keySize + 2);
+    result.append(OctetStringMark);
+    addEncodedASN1Length(result, keySize);
+    result.append(platformKey().data(), platformKey().size());
+
+    ASSERT(result.size() == totalSize);
+
+    return WTFMove(result);
+}
+
+String CryptoKeyOKP::generateJwkD() const
+{
+    ASSERT(type() == CryptoKeyType::Private);
+    return base64URLEncodeToString(m_data);
+}
+
+String CryptoKeyOKP::generateJwkX() const
+{
+    if (type() == CryptoKeyType::Public)
+        return base64URLEncodeToString(m_data);
+
+    ASSERT(type() == CryptoKeyType::Private);
+    ccec25519pubkey publicKey;
+    cccurve25519_make_pub(publicKey, m_data.data());
+    return base64URLEncodeToString(Span<const uint8_t> { publicKey, sizeof(publicKey) });
+}
+
+Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const
+{
+    return m_data;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -50,6 +50,7 @@ namespace WebCore {
     M(CompositingOverlap) \
     M(ContentFiltering) \
     M(ContentObservation) \
+    M(Crypto) \
     M(DatabaseTracker) \
     M(DisplayLink) \
     M(DisplayLists) \


### PR DESCRIPTION
#### 3abe0e45310ef3e846f8509e44b5514fb2099f76
<pre>
Support <a href="https://wicg.github.io/webcrypto-secure-curves/#ed25519">https://wicg.github.io/webcrypto-secure-curves/#ed25519</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=246145">https://bugs.webkit.org/show_bug.cgi?id=246145</a>
rdar://problem/100401588

Reviewed by Chris Dumez.

Introduce CryptoKeyOKP to support secure safe curves.
Add support for generating, importing and exporting Ed25519 keys.
Add a runtime flag to control exposing the support.

This patch reuses work done in <a href="https://github.com/WebKit/WebKit/pull/5026">https://github.com/WebKit/WebKit/pull/5026</a> by Angela Izquierdo Garcia.

* LayoutTests/http/wpt/crypto/serialize-cryptokey-okp-expected.txt: Added.
* LayoutTests/http/wpt/crypto/serialize-cryptokey-okp.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.worker-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h: Added.
(cccurve25519_make_priv):
(cccurve25519_make_pub):
(cccurve25519_make_key_pair):
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
(WebCore::CloneDeserializer::read):
(WebCore::CloneDeserializer::readOKPKey):
(WebCore::CloneDeserializer::readCryptoKey):
* Source/WebCore/crypto/CryptoAlgorithmIdentifier.h:
* Source/WebCore/crypto/CryptoKey.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::isSupportedExportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp: Added.
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
(WebCore::CryptoAlgorithmEd25519::create):
(WebCore::CryptoAlgorithmEd25519::identifier const):
(WebCore::CryptoAlgorithmEd25519::generateKey):
(WebCore::CryptoAlgorithmEd25519::sign):
(WebCore::CryptoAlgorithmEd25519::verify):
(WebCore::CryptoAlgorithmEd25519::importKey):
(WebCore::CryptoAlgorithmEd25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h: Added.
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp: Added.
(WebCore::keySizeInBytesFromNamedCurve):
(WebCore::CryptoKeyOKP::create):
(WebCore::CryptoKeyOKP::CryptoKeyOKP):
(WebCore::CryptoKeyOKP::generatePair):
(WebCore::CryptoKeyOKP::importRaw):
(WebCore::CryptoKeyOKP::importJwk):
(WebCore::CryptoKeyOKP::exportRaw const):
(WebCore::CryptoKeyOKP::exportJwk const):
(WebCore::CryptoKeyOKP::namedCurveString const):
(WebCore::CryptoKeyOKP::isValidOKPAlgorithm):
(WebCore::CryptoKeyOKP::algorithm const):
(WebCore::CryptoKeyOKP::platformSupportedCurve):
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::CryptoKeyOKP::exportSpki const):
(WebCore::CryptoKeyOKP::importPkcs8):
(WebCore::CryptoKeyOKP::exportPkcs8 const):
(WebCore::CryptoKeyOKP::computePublicKeyFromPrivateKey const):
* Source/WebCore/crypto/keys/CryptoKeyOKP.h: Added.
* Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Cocoa.cpp: Added.
(WebCore::signEd25519):
(WebCore::verifyEd25519):
(WebCore::CryptoAlgorithmEd25519::platformSign):
(WebCore::CryptoAlgorithmEd25519::platformVerify):
* Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp:
* Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp:
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms):
* Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp: Added.
(WebCore::CryptoKeyOKP::platformSupportedCurve):
(WebCore::CryptoKeyOKP::computePublicKeyFromPrivateKey const):
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::CryptoKeyOKP::exportSpki const):
(WebCore::CryptoKeyOKP::importPkcs8):
(WebCore::CryptoKeyOKP::exportPkcs8 const):
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/259277@main">https://commits.webkit.org/259277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791b854212f2d105fe150126c6498a73aa4149f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104512 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113786 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174010 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4513 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112748 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38915 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80585 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27351 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92403 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4730 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3911 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30025 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46911 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101089 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6396 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8860 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25088 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->