### PR TITLE
Resync libwebrtc up to final M106

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/screen_capture_portal_interface.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/screen_capture_portal_interface.cc
@@ -8,6 +8,7 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 #include "modules/desktop_capture/linux/wayland/screen_capture_portal_interface.h"
+#include "modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.h"
 
 #include <string>
 
@@ -67,18 +68,26 @@ void ScreenCapturePortalInterface::RegisterSessionClosedSignalHandler(
     GDBusConnection* connection,
     std::string& session_handle,
     guint& session_closed_signal_id) {
-  uint32_t portal_response;
+  uint32_t portal_response = 2;
   Scoped<GVariant> response_data;
   g_variant_get(parameters, /*format_string=*/"(u@a{sv})", &portal_response,
                 response_data.receive());
+
+  if (RequestResponseFromPortalResponse(portal_response) !=
+      RequestResponse::kSuccess) {
+    RTC_LOG(LS_ERROR) << "Failed to request the session subscription.";
+    OnPortalDone(RequestResponse::kError);
+    return;
+  }
+
   Scoped<GVariant> g_session_handle(
       g_variant_lookup_value(response_data.get(), /*key=*/"session_handle",
                              /*expected_type=*/nullptr));
-  session_handle = g_variant_dup_string(
+  session_handle = g_variant_get_string(
       /*value=*/g_session_handle.get(), /*length=*/nullptr);
 
-  if (session_handle.empty() || portal_response) {
-    RTC_LOG(LS_ERROR) << "Failed to request the session subscription.";
+  if (session_handle.empty()) {
+    RTC_LOG(LS_ERROR) << "Could not get session handle despite valid response";
     OnPortalDone(RequestResponse::kError);
     return;
   }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/screencast_portal.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/screencast_portal.cc
@@ -29,21 +29,7 @@ using xdg_portal::SetupRequestResponseSignal;
 using xdg_portal::SetupSessionRequestHandlers;
 using xdg_portal::StartSessionRequest;
 using xdg_portal::TearDownSession;
-
-RequestResponse ToRequestResponseFromSignal(uint32_t signal_response) {
-  // See:
-  //  https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-signal-org-freedesktop-portal-Request.Response
-  switch (signal_response) {
-    case 0:
-      return RequestResponse::kSuccess;
-    case 1:
-      return RequestResponse::kUserCancelled;
-    case 2:
-      return RequestResponse::kError;
-    default:
-      return RequestResponse::kUnknown;
-  }
-}
+using xdg_portal::RequestResponseFromPortalResponse;
 
 }  // namespace
 
@@ -176,7 +162,13 @@ void ScreenCastPortal::OnSessionRequestResponseSignal(
   that->RegisterSessionClosedSignalHandler(
       OnSessionClosedSignal, parameters, that->connection_,
       that->session_handle_, that->session_closed_signal_id_);
-  that->SourcesRequest();
+
+  // Do not continue if we don't get session_handle back. The call above will
+  // already notify the capturer there is a failure, but we would still continue
+  // to make following request and crash on that.
+  if (!that->session_handle_.empty()) {
+    that->SourcesRequest();
+  }
 }
 
 // static
@@ -357,7 +349,7 @@ void ScreenCastPortal::OnStartRequestResponseSignal(GDBusConnection* connection,
                 response_data.receive());
   if (portal_response || !response_data) {
     RTC_LOG(LS_ERROR) << "Failed to start the screen cast session.";
-    that->OnPortalDone(ToRequestResponseFromSignal(portal_response));
+    that->OnPortalDone(RequestResponseFromPortalResponse(portal_response));
     return;
   }
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.cc
@@ -33,6 +33,21 @@ std::string RequestResponseToString(RequestResponse request) {
   }
 }
 
+RequestResponse RequestResponseFromPortalResponse(uint32_t portal_response) {
+  // See:
+  //  https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-signal-org-freedesktop-portal-Request.Response
+  switch (portal_response) {
+    case 0:
+      return RequestResponse::kSuccess;
+    case 1:
+      return RequestResponse::kUserCancelled;
+    case 2:
+      return RequestResponse::kError;
+    default:
+      return RequestResponse::kUnknown;
+  }
+}
+
 std::string PrepareSignalHandle(absl::string_view token,
                                 GDBusConnection* connection) {
   Scoped<char> sender(

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.h
@@ -57,6 +57,8 @@ using SessionStartRequestedHandler = void (*)(GDBusProxy*,
 
 std::string RequestResponseToString(RequestResponse request);
 
+RequestResponse RequestResponseFromPortalResponse(uint32_t portal_response);
+
 // Returns a string path for signal handle based on the provided connection and
 // token.
 std::string PrepareSignalHandle(absl::string_view token,

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/BUILD.gn
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/BUILD.gn
@@ -598,6 +598,10 @@ webrtc_fuzzer_test("rtp_dependency_descriptor_fuzzer") {
     "../../modules/rtp_rtcp:rtp_rtcp_format",
     "../../rtc_base:checks",
   ]
+
+  # video_layers_allocation is an rtp header extension and thus can't be longer
+  # than 255 bytes on the wire.
+  libfuzzer_options = [ "max_len=255" ]
 }
 
 webrtc_fuzzer_test("rtp_frame_reference_finder_fuzzer") {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_video_layers_allocation_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_video_layers_allocation_fuzzer.cc
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include "api/array_view.h"
 #include "api/video/video_layers_allocation.h"
@@ -19,6 +20,14 @@
 namespace webrtc {
 
 void FuzzOneInput(const uint8_t* data, size_t size) {
+  // Video layers allocation is an rtp header extension.
+  // Per https://datatracker.ietf.org/doc/html/rfc8285#section-4.3
+  // rtp header extension uses up to one byte to store the size, i.e.
+  // maximum size of any rtp header extension is 255 bytes.
+  constexpr int kMaxSize = std::numeric_limits<uint8_t>::max();
+  if (size > kMaxSize) {
+    return;
+  }
   auto raw = rtc::MakeArrayView(data, size);
 
   VideoLayersAllocation allocation1;
@@ -32,10 +41,8 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
   // Check `writer` use minimal number of bytes to pack the extension by
   // checking it doesn't use more than reader consumed.
   RTC_CHECK_LE(value_size, raw.size());
-  uint8_t some_memory[256];
-  // An extension may not be larger than 255 bytes since the extension lenght
-  // field is only one byte.
-  RTC_CHECK_LT(value_size, 256);
+  uint8_t some_memory[kMaxSize];
+  RTC_CHECK_LE(value_size, kMaxSize);
   rtc::ArrayView<uint8_t> write_buffer(some_memory, value_size);
   RTC_CHECK(
       RtpVideoLayersAllocationExtension::Write(write_buffer, allocation1));

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/frame_cadence_adapter.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/frame_cadence_adapter.h
@@ -47,7 +47,7 @@ class FrameCadenceAdapterInterface
 
   struct ZeroHertzModeParams {
     // The number of simulcast layers used in this configuration.
-    int num_simulcast_layers = 0;
+    size_t num_simulcast_layers = 0;
   };
 
   // Callback interface used to inform instance owners.
@@ -106,11 +106,11 @@ class FrameCadenceAdapterInterface
   // Updates quality convergence status for an enabled spatial layer.
   // Convergence means QP has dropped to a low-enough level to warrant ceasing
   // to send identical frames at high frequency.
-  virtual void UpdateLayerQualityConvergence(int spatial_index,
+  virtual void UpdateLayerQualityConvergence(size_t spatial_index,
                                              bool converged) = 0;
 
   // Updates spatial layer enabled status.
-  virtual void UpdateLayerStatus(int spatial_index, bool enabled) = 0;
+  virtual void UpdateLayerStatus(size_t spatial_index, bool enabled) = 0;
 
   // Conditionally requests a refresh frame via
   // Callback::RequestRefreshFrame.

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/task_queue_frame_decode_scheduler.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/task_queue_frame_decode_scheduler.cc
@@ -44,7 +44,7 @@ void TaskQueueFrameDecodeScheduler::ScheduleFrame(
 
   TimeDelta wait = std::max(
       TimeDelta::Zero(), schedule.latest_decode_time - clock_->CurrentTime());
-  bookkeeping_queue_->PostDelayedTask(
+  bookkeeping_queue_->PostDelayedHighPrecisionTask(
       SafeTask(task_safety_.flag(),
                [this, rtp, schedule, cb = std::move(cb)] {
                  RTC_DCHECK_RUN_ON(bookkeeping_queue_);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder.h
@@ -450,12 +450,15 @@ class VideoStreamEncoder : public VideoStreamEncoderInterface,
 
   const absl::optional<int> vp9_low_tier_core_threshold_;
 
+  // Used to cancel any potentially pending tasks to the worker thread.
+  // Refrenced by tasks running on `encoder_queue_` so need to be destroyed
+  // after stopping that queue. Must be created and destroyed on
+  // `worker_queue_`.
+  ScopedTaskSafety task_safety_;
+
   // Public methods are proxied to the task queues. The queues must be destroyed
   // first to make sure no tasks run that use other members.
   rtc::TaskQueue encoder_queue_;
-
-  // Used to cancel any potentially pending tasks to the worker thread.
-  ScopedTaskSafety task_safety_;
 };
 
 }  // namespace webrtc

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder_unittest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder_unittest.cc
@@ -776,11 +776,11 @@ class MockFrameCadenceAdapter : public FrameCadenceAdapterInterface {
   MOCK_METHOD(void, UpdateFrameRate, (), (override));
   MOCK_METHOD(void,
               UpdateLayerQualityConvergence,
-              (int spatial_index, bool converged),
+              (size_t spatial_index, bool converged),
               (override));
   MOCK_METHOD(void,
               UpdateLayerStatus,
-              (int spatial_index, bool enabled),
+              (size_t spatial_index, bool enabled),
               (override));
   MOCK_METHOD(void, ProcessKeyFrameRequest, (), (override));
 };
@@ -9170,7 +9170,7 @@ TEST(VideoStreamEncoderFrameCadenceTest, ActivatesFrameCadenceOnContentType) {
   EXPECT_CALL(*adapter_ptr, SetZeroHertzModeEnabled(Optional(Field(
                                 &FrameCadenceAdapterInterface::
                                     ZeroHertzModeParams::num_simulcast_layers,
-                                Eq(0)))));
+                                Eq(0u)))));
   VideoEncoderConfig config;
   test::FillEncoderConfiguration(kVideoCodecVP8, 1, &config);
   config.content_type = VideoEncoderConfig::ContentType::kScreen;
@@ -9182,7 +9182,7 @@ TEST(VideoStreamEncoderFrameCadenceTest, ActivatesFrameCadenceOnContentType) {
   EXPECT_CALL(*adapter_ptr, SetZeroHertzModeEnabled(Optional(Field(
                                 &FrameCadenceAdapterInterface::
                                     ZeroHertzModeParams::num_simulcast_layers,
-                                Gt(0)))));
+                                Gt(0u)))));
   PassAFrame(encoder_queue, video_stream_encoder_callback, /*ntp_time_ms=*/1);
   factory.DepleteTaskQueues();
   Mock::VerifyAndClearExpectations(adapter_ptr);


### PR DESCRIPTION
#### cdd4a6b971e667c079f18b92a3ef327afa94a898
<pre>
Resync libwebrtc up to final M106
<a href="https://bugs.webkit.org/show_bug.cgi?id=250679">https://bugs.webkit.org/show_bug.cgi?id=250679</a>
rdar://problem/104298234

Reviewed by Eric Carlson.

M106 shipped and contains a few additional fixes compared to the M106 version we resynced.
This patch cherry-picks those changes to fully align with shipping M106.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/screen_capture_portal_interface.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/screencast_portal.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/BUILD.gn:
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_video_layers_allocation_fuzzer.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/frame_cadence_adapter.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/frame_cadence_adapter.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/frame_cadence_adapter_unittest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/task_queue_frame_decode_scheduler.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder_unittest.cc:

Canonical link: <a href="https://commits.webkit.org/258979@main">https://commits.webkit.org/258979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/906a89b3b26232da37864014e36625ac87852bd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112784 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172990 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3563 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111956 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10539 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38275 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79916 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3132 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6168 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7976 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->