### PR TITLE
REGRESSION (Safari 16): Service worker clientId is empty for web worker fetches

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -1,4 +1,5 @@
 
+PASS Verify a dedicated worker script request gets correct client Ids
 PASS Verify a dedicated worker script request issued from a uncontrolled document is intercepted by worker's own service worker.
 PASS Verify an out-of-scope dedicated worker script request issued from a controlled document should not be intercepted by document's service worker.
 PASS Verify a shared worker script request issued from a uncontrolled document is intercepted by worker's own service worker.

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html
@@ -14,7 +14,36 @@ async function setup_service_worker(t, service_worker_url, scope) {
       t, service_worker_url, scope);
   t.add_cleanup(() => service_worker_unregister(t, scope));
   await wait_for_state(t, r.installing, 'activated');
+  return r.active;
 }
+
+promise_test(async t => {
+  const worker_url = 'resources/sample-synthesized-worker.js?dedicated';
+  const service_worker_url = 'resources/sample-worker-interceptor.js';
+  const scope = worker_url;
+
+  const serviceWorker = await setup_service_worker(t, service_worker_url, scope);
+
+  const channels = new MessageChannel();
+  serviceWorker.postMessage({port: channels.port1}, [channels.port1]);
+
+  const clientId = await new Promise(resolve => channels.port2.onmessage = (e) => resolve(e.data.id));
+
+  const resultPromise =  new Promise(resolve => channels.port2.onmessage = (e) => resolve(e.data));
+
+  const w = new Worker(worker_url);
+  const data = await new Promise((resolve, reject) => {
+    w.onmessage = e => resolve(e.data);
+    w.onerror = e => reject(e.message);
+  });
+  assert_equals(data, 'worker loading intercepted by service worker');
+
+  const results = await resultPromise;
+  assert_equals(results.clientId, clientId);
+  assert_true(!!results.resultingClientId.length);
+
+  channels.port2.postMessage("done");
+}, `Verify a dedicated worker script request gets correct client Ids`);
 
 promise_test(async t => {
   const worker_url = 'resources/sample-synthesized-worker.js?dedicated';

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt
@@ -15,6 +15,7 @@ CONSOLE MESSAGE: Cannot load https://www1.web-platform.test:9443/service-workers
 CONSOLE MESSAGE: Response served by service worker is opaque
 CONSOLE MESSAGE: Cannot load https://www1.web-platform.test:9443/service-workers/service-worker/resources/postmessage-on-load-worker.js due to access control checks.
 
+PASS Verify a dedicated worker script request gets correct client Ids
 PASS Verify a dedicated worker script request issued from a uncontrolled document is intercepted by worker's own service worker.
 PASS Verify an out-of-scope dedicated worker script request issued from a controlled document should not be intercepted by document's service worker.
 PASS Verify a shared worker script request issued from a uncontrolled document is intercepted by worker's own service worker.

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2186,7 +2186,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
         m_resultingClientId = ScriptExecutionContextIdentifier::generate();
         ASSERT(!scriptExecutionContextIdentifierToLoaderMap().contains(m_resultingClientId));
         scriptExecutionContextIdentifierToLoaderMap().add(m_resultingClientId, this);
-        mainResourceLoadOptions.clientIdentifier = m_resultingClientId;
+        mainResourceLoadOptions.resultingClientIdentifier = m_resultingClientId;
     }
 #endif
 

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -49,9 +49,9 @@ struct FetchOptions {
     using Redirect = FetchOptionsRedirect;
 
     FetchOptions() = default;
-    FetchOptions(Destination, Mode, Credentials, Cache, Redirect, ReferrerPolicy, String&&, bool, std::optional<ScriptExecutionContextIdentifier>);
-    FetchOptions isolatedCopy() const & { return { destination, mode, credentials, cache, redirect, referrerPolicy, integrity.isolatedCopy(), keepAlive, clientIdentifier }; }
-    FetchOptions isolatedCopy() && { return { destination, mode, credentials, cache, redirect, referrerPolicy, WTFMove(integrity).isolatedCopy(), keepAlive, clientIdentifier }; }
+    FetchOptions(Destination, Mode, Credentials, Cache, Redirect, ReferrerPolicy, String&&, bool, std::optional<ScriptExecutionContextIdentifier>, std::optional<ScriptExecutionContextIdentifier>);
+    FetchOptions isolatedCopy() const & { return { destination, mode, credentials, cache, redirect, referrerPolicy, integrity.isolatedCopy(), keepAlive, clientIdentifier, resultingClientIdentifier }; }
+    FetchOptions isolatedCopy() && { return { destination, mode, credentials, cache, redirect, referrerPolicy, WTFMove(integrity).isolatedCopy(), keepAlive, clientIdentifier, resultingClientIdentifier }; }
 
     template<class Encoder> void encodePersistent(Encoder&) const;
     template<class Decoder> static WARN_UNUSED_RETURN bool decodePersistent(Decoder&, FetchOptions&);
@@ -64,10 +64,13 @@ struct FetchOptions {
     ReferrerPolicy referrerPolicy { ReferrerPolicy::EmptyString };
     String integrity;
     bool keepAlive { false };
+    // Identifier of https://fetch.spec.whatwg.org/#concept-request-client
     std::optional<ScriptExecutionContextIdentifier> clientIdentifier;
+    // Identifier of https://fetch.spec.whatwg.org/#concept-request-reserved-client
+    std::optional<ScriptExecutionContextIdentifier> resultingClientIdentifier;
 };
 
-inline FetchOptions::FetchOptions(Destination destination, Mode mode, Credentials credentials, Cache cache, Redirect redirect, ReferrerPolicy referrerPolicy, String&& integrity, bool keepAlive, std::optional<ScriptExecutionContextIdentifier> clientIdentifier)
+inline FetchOptions::FetchOptions(Destination destination, Mode mode, Credentials credentials, Cache cache, Redirect redirect, ReferrerPolicy referrerPolicy, String&& integrity, bool keepAlive, std::optional<ScriptExecutionContextIdentifier> clientIdentifier, std::optional<ScriptExecutionContextIdentifier> resultingClientIdentifier)
     : destination(destination)
     , mode(mode)
     , credentials(credentials)
@@ -77,6 +80,7 @@ inline FetchOptions::FetchOptions(Destination destination, Mode mode, Credential
     , integrity(WTFMove(integrity))
     , keepAlive(keepAlive)
     , clientIdentifier(clientIdentifier)
+    , resultingClientIdentifier(resultingClientIdentifier)
 {
 }
 

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -79,6 +79,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
     copy.integrity = this->integrity.isolatedCopy();
     copy.keepAlive = this->keepAlive;
     copy.clientIdentifier = this->clientIdentifier;
+    copy.resultingClientIdentifier = this->resultingClientIdentifier;
 
     // ResourceLoaderOptions
     copy.sendLoadCallbacks = this->sendLoadCallbacks;

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -161,7 +161,8 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     if (scriptExecutionContext.settingsValues().serviceWorkersEnabled && clientIdentifier) {
         ASSERT(m_destination == FetchOptions::Destination::Worker || m_destination == FetchOptions::Destination::Sharedworker);
         m_topOriginForServiceWorkerRegistration = SecurityOriginData { scriptExecutionContext.topOrigin().data() };
-        options.clientIdentifier = clientIdentifier;
+        options.clientIdentifier = scriptExecutionContext.identifier();
+        options.resultingClientIdentifier = clientIdentifier;
         m_serviceWorkerDataManager = ServiceWorkerDataManager::create(clientIdentifier);
         m_context = scriptExecutionContext;
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -591,6 +591,7 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
     m_parameters.webPageID = parameters.webPageID;
     m_parameters.webFrameID = parameters.webFrameID;
     m_parameters.options.clientIdentifier = parameters.options.clientIdentifier;
+    m_parameters.options.resultingClientIdentifier = parameters.options.resultingClientIdentifier;
 
 #if ENABLE(SERVICE_WORKER)
     ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -169,7 +169,7 @@ void ServiceWorkerFetchTask::startFetch()
     cleanHTTPRequestHeadersForAccessControl(request, m_loader.parameters().httpHeadersToKeep);
 
     String clientIdentifier;
-    if (m_loader.parameters().options.mode != FetchOptions::Mode::Navigate && m_loader.parameters().options.destination != FetchOptions::Destination::Worker) {
+    if (m_loader.parameters().options.mode != FetchOptions::Mode::Navigate) {
         if (auto identifier = m_loader.parameters().options.clientIdentifier)
             clientIdentifier = identifier->toString();
     }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -174,7 +174,7 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
     else
         clientType = ServiceWorkerClientType::Window;
 
-    auto clientIdentifier = *parameters.options.clientIdentifier;
+    auto clientIdentifier = *parameters.options.resultingClientIdentifier;
     // As per step 12 of https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm, the active service worker should be controlling the document.
     // We register the service worker client using the identifier provided by DocumentLoader and notify DocumentLoader about it.
     // If notification is successful, DocumentLoader is responsible to unregister the service worker client as needed.
@@ -211,7 +211,8 @@ std::unique_ptr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(N
 
         serviceWorkerRegistrationIdentifier = registration->identifier();
         controlClient(loader.parameters(), *registration, request);
-        loader.setResultingClientIdentifier(loader.parameters().options.clientIdentifier->toString());
+        if (auto resultingClientIdentifier = loader.parameters().options.resultingClientIdentifier)
+            loader.setResultingClientIdentifier(resultingClientIdentifier->toString());
         loader.setServiceWorkerRegistration(*registration);
     } else {
         if (!loader.parameters().serviceWorkerRegistrationIdentifier)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2330,6 +2330,7 @@ struct WebCore::FetchOptions {
     String integrity;
     bool keepAlive;
     std::optional<WebCore::ScriptExecutionContextIdentifier> clientIdentifier;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> resultingClientIdentifier;
 }
 
 enum class WebCore::FetchHeadersGuard : uint8_t {


### PR DESCRIPTION
#### 599d00ac6774a1c036faa6f6adf3f96fb95d337f
<pre>
REGRESSION (Safari 16): Service worker clientId is empty for web worker fetches
<a href="https://bugs.webkit.org/show_bug.cgi?id=245425">https://bugs.webkit.org/show_bug.cgi?id=245425</a>
rdar://problem/100368228

Reviewed by Chris Dumez.

After introducing correct matching of service worker registration for worker loads, we correctly filled resultingClientId to the worker context id.
As per <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a>, we need to set clientId to the context Id creating the worker.
To do so, we introduce resultingClientId as a FetchOptions so that we can set both clientId and resultingClientId when doing a load.
Set resultingClientId in DocumentLoader and set both clientId and resultingClientId for workers.
Update networking process code to pass clientId and resultingClientId when starting a fetch event.

Relanding after verifying through A/B testing that it is not regressing speedometer.

Covered by newly added test.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/sample-worker-interceptor.js:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/worker-interception.https-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/FetchOptions.h:
(WebCore::FetchOptions::isolatedCopy const):
(WebCore::FetchOptions::isolatedCopy):
(WebCore::FetchOptions::FetchOptions):
(WebCore::FetchOptions::decodePersistent):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::transferToNewWebProcess):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::startFetch):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::createFetchTask):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259031@main">https://commits.webkit.org/259031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feabd34e9b0799797ed99f577a189048f998064c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36645 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112922 "Reverted pull request changes (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173245 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3710 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112070 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109471 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38385 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25336 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80035 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26728 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3254 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46251 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6202 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8111 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->