### PR TITLE
RenderLayer::setHasVisibleContent shouldn't call dirtyZOrderLists()

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
  * Copyright (c) 2020, 2021, 2022 Igalia S.L.
  *
@@ -1519,16 +1520,6 @@ void RenderLayer::setHasVisibleContent()
     m_visibleContentStatusDirty = false; 
     m_hasVisibleContent = true;
     computeRepaintRects(renderer().containerForRepaint().renderer);
-    if (!isNormalFlowOnly()) {
-        // We don't collect invisible layers in z-order lists if we are not in compositing mode.
-        // As we became visible, we need to dirty our stacking containers ancestors to be properly
-        // collected. FIXME: When compositing, we could skip this dirtying phase.
-        for (auto* sc = stackingContext(); sc; sc = sc->stackingContext()) {
-            sc->dirtyZOrderLists();
-            if (sc->hasVisibleContent())
-                break;
-        }
-    }
 
     if (parent())
         parent()->setAncestorChainHasVisibleDescendant();


### PR DESCRIPTION
<pre>
RenderLayer::setHasVisibleContent shouldn't call dirtyZOrderLists()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250283">https://bugs.webkit.org/show_bug.cgi?id=250283</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=rev&revision=175708">https://src.chromium.org/viewvc/blink?view=rev&revision=175708</a>

This patch remove FIXME and also dead code since there is no connection
between being visible and z-order lists.
There is no reason to mark the z-order list as dirty when changing visibility status.

* Source/WebCore/rendering/RenderLayer.cpp:
(RenderLayer::setHasVisibleContent): Remove 'dirtyZOrderList'
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2633ede58a2fd02fabbaab8e291e8d8ecb1f48db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112699 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172908 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3486 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111885 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38212 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79851 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26540 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3070 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46049 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7903 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->