### PR TITLE
Revert [258946@main] Improve StringTypeAdapter templates and handling

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -95,7 +95,7 @@ Ref<JSON::Value> InjectedScriptBase::makeCall(Deprecated::ScriptFunctionCall& fu
 
     auto resultJSONValue = toInspectorValue(globalObject, value);
     if (!resultJSONValue)
-        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", unsigned(JSON::Value::maxDepth), ')'));
+        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')'));
 
     return resultJSONValue.releaseNonNull();
 }
@@ -125,7 +125,7 @@ void InjectedScriptBase::makeAsyncCall(Deprecated::ScriptFunctionCall& function,
             else if (auto resultJSONValue = toInspectorValue(globalObject, callFrame->argument(0)))
                 checkAsyncCallResult(resultJSONValue, callback);
             else
-                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", unsigned(JSON::Value::maxDepth), ')')), callback);
+                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')')), callback);
             return JSC::JSValue::encode(JSC::jsUndefined());
         });
     }

--- a/Source/WTF/wtf/text/StringOperators.h
+++ b/Source/WTF/wtf/text/StringOperators.h
@@ -46,14 +46,14 @@ public:
         return AtomString(operator String());
     }
 
-    bool is8Bit() const
+    bool is8Bit()
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
         return adapter1.is8Bit() && adapter2.is8Bit();
     }
 
-    void writeTo(LChar* destination) const
+    void writeTo(LChar* destination)
     {
         ASSERT(is8Bit());
         StringTypeAdapter<StringType1> adapter1(m_string1);
@@ -62,7 +62,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    void writeTo(UChar* destination) const
+    void writeTo(UChar* destination)
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -70,7 +70,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    unsigned length() const
+    unsigned length()
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -85,7 +85,7 @@ private:
 template<typename StringType1, typename StringType2>
 class StringTypeAdapter<StringAppend<StringType1, StringType2>> {
 public:
-    StringTypeAdapter(const StringAppend<StringType1, StringType2>& buffer)
+    StringTypeAdapter(StringAppend<StringType1, StringType2>& buffer)
         : m_buffer { buffer }
     {
     }
@@ -95,7 +95,7 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { m_buffer.writeTo(destination); }
 
 private:
-    const StringAppend<StringType1, StringType2>& m_buffer;
+    StringAppend<StringType1, StringType2>& m_buffer;
 };
 
 inline StringAppend<const char*, String> operator+(const char* string1, const String& string2)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -67,21 +67,11 @@ public:
     StringView(const LChar*, unsigned length);
     StringView(const UChar*, unsigned length);
     StringView(const char*, unsigned length);
-    StringView(const ASCIILiteral&);
-    ALWAYS_INLINE StringView(const Span<const LChar>& characters) : StringView(characters.data(), characters.size()) { }
-    ALWAYS_INLINE StringView(const Span<const UChar>& characters) : StringView(characters.data(), characters.size()) { }
+    StringView(ASCIILiteral);
+    ALWAYS_INLINE StringView(Span<const LChar> characters) : StringView(characters.data(), characters.size()) { }
+    ALWAYS_INLINE StringView(Span<const UChar> characters) : StringView(characters.data(), characters.size()) { }
 
-    template<typename CharType, size_t N>
-    StringView(const CharType(&characters)[N])
-        : StringView { characters, N - 1 }
-    {
-        ASSERT(!characters[N - 1]);
-    }
-
-    ALWAYS_INLINE static StringView fromLatin1(const char* characters)
-    {
-        return { characters, static_cast<unsigned>(characters ? strlen(characters) : 0) };
-    }
+    ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
 
     static StringView empty();
 
@@ -206,6 +196,9 @@ public:
     struct UnderlyingString;
 
 private:
+    // Clients should use StringView(ASCIILiteral) or StringView::fromLatin1() instead.
+    explicit StringView(const char*);
+
     friend bool equal(StringView, StringView);
     friend bool equal(StringView, StringView, unsigned length);
     friend WTF_EXPORT_PRIVATE bool equalRespectingNullity(StringView, StringView);
@@ -379,12 +372,17 @@ inline StringView::StringView(const UChar* characters, unsigned length)
     initialize(characters, length);
 }
 
+inline StringView::StringView(const char* characters)
+{
+    initialize(reinterpret_cast<const LChar*>(characters), characters ? strlen(characters) : 0);
+}
+
 inline StringView::StringView(const char* characters, unsigned length)
 {
     initialize(reinterpret_cast<const LChar*>(characters), length);
 }
 
-inline StringView::StringView(const ASCIILiteral& string)
+inline StringView::StringView(ASCIILiteral string)
 {
     initialize(string.characters8(), string.length());
 }
@@ -675,6 +673,21 @@ inline void StringView::invalidate(const StringImpl&)
 }
 
 #endif
+
+template<> class StringTypeAdapter<StringView, void> {
+public:
+    StringTypeAdapter(StringView string)
+        : m_string { string }
+    {
+    }
+
+    unsigned length() { return m_string.length(); }
+    bool is8Bit() { return m_string.is8Bit(); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) { m_string.getCharacters(destination); }
+
+private:
+    StringView m_string;
+};
 
 template<typename CharacterType, size_t inlineCapacity> void append(Vector<CharacterType, inlineCapacity>& buffer, StringView string)
 {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -387,7 +387,7 @@ void AXIsolatedTree::updatePropertiesForSelfAndDescendants(AXCoreObject& axObjec
 void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const Vector<AXPropertyName>& properties)
 {
     AXTRACE("AXIsolatedTree::updateNodeProperties"_s);
-    AXLOG(makeString("Updating properties ", Span { reinterpret_cast<const UChar*>(properties.data()), properties.size() }, " for objectID ", axObject.objectID().loggingString()));
+    AXLOG(makeString("Updating properties ", properties, " for objectID ", axObject.objectID().loggingString()));
     ASSERT(isMainThread());
 
     AXPropertyMap propertyMap;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -108,7 +108,7 @@ public:
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
     // FIXME: When this is incremented, remove LegacyCertificateInfoType.
-    static constexpr unsigned version = 16;
+    static const unsigned version = 16;
 
     String basePathIsolatedCopy() const;
     String versionPath() const;


### PR DESCRIPTION
#### d087dce13acac618807110847add6fa1ffb6de2a
<pre>
Revert [258946@main] Improve StringTypeAdapter templates and handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=250017">https://bugs.webkit.org/show_bug.cgi?id=250017</a>

Unreviewed.

String literals are great, in theory, with the size of the string specified
right there in the type. But that size isn&apos;t a given, i.e. the literal can have
an escaped null character positioned inside the string, not necessarily at the
end. One way this is exhibited is by fixed-length arrays that serve as buffers
for character data, which is what&apos;s causing misconstruction of the user agent
string on Unix, in UserAgentGLib.cpp.

This could be somewhat softly validated in the relevant StringView constructor,
asserting that the result of strlen() (or an equivalent) equals the size value
integrated in the type.

The patch that&apos;s being reverted here will be updated to have these fixed-data
arrays treated as pointers of character type, effectively returning back to
enforcing strlen()-like computation of the string length.

* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::makeCall):
(Inspector::InjectedScriptBase::makeAsyncCall):
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::are8Bit):
(WTF::stringTypeAdapterAccumulator):
(WTF::tryMakeStringImplFromAdaptersInternal):
(WTF::handleWithAdapters):
(WTF::tryMakeStringFromAdapters):
(WTF::tryMakeString):
(WTF::makeString):
(WTF::tryMakeAtomStringFromAdapters):
(WTF::tryMakeAtomString):
(WTF::makeAtomString):
* Source/WTF/wtf/text/StringOperators.h:
(WTF::StringAppend::is8Bit):
(WTF::StringAppend::writeTo):
(WTF::StringAppend::length):
(WTF::StringAppend::is8Bit const): Deleted.
(WTF::StringAppend::writeTo const): Deleted.
(WTF::StringAppend::length const): Deleted.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:

Canonical link: <a href="https://commits.webkit.org/258958@main">https://commits.webkit.org/258958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd9e5ffba8594f8f7a2bd24fa661cd19b12c5985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112708 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172917 "Failed to checkout and rebase branch from PR 8698") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3494 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/111894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109245 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5979 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90040 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3717 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6155 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12138 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98639 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7911 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/24861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3274 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->