### PR TITLE
[ANGLE] Fix -Wsign-compare warnings on watchOS

### DIFF
--- a/Source/ThirdParty/ANGLE/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/ANGLE/Configurations/Base.xcconfig
@@ -59,7 +59,7 @@ PREBINDING = NO;
 WARNING_CFLAGS = $(WK_COMMON_WARNING_CFLAGS) $(WK_FIXME_WARNING_CFLAGS) -Wglobal-constructors -Wno-unknown-warning-option;
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
-WK_FIXME_WARNING_CFLAGS = -Wno-deprecated-declarations -Wno-inconsistent-missing-override -Wno-macro-redefined -Wno-sign-compare -Wno-undef -Wno-unused-parameter;
+WK_FIXME_WARNING_CFLAGS = -Wno-deprecated-declarations -Wno-inconsistent-missing-override -Wno-macro-redefined -Wno-undef -Wno-unused-parameter;
 
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator;
 SUPPORTS_MACCATALYST = YES;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -1667,8 +1667,10 @@ angle::Result FramebufferMtl::readPixelsToPBO(const gl::Context *context,
 
     ContextMtl *contextMtl = mtl::GetImpl(context);
 
-    ANGLE_MTL_CHECK(contextMtl, packPixelsParams.offset <= std::numeric_limits<uint32_t>::max(),
-                    GL_INVALID_OPERATION);
+    if constexpr (sizeof(packPixelsParams.offset) > sizeof(uint32_t)) {
+        ANGLE_MTL_CHECK(contextMtl, static_cast<std::make_unsigned_t<decltype(packPixelsParams.offset)>>(packPixelsParams.offset) <= std::numeric_limits<uint32_t>::max(),
+                        GL_INVALID_OPERATION);
+    }
     uint32_t offset = static_cast<uint32_t>(packPixelsParams.offset);
 
     BufferMtl *packBufferMtl = mtl::GetImpl(packPixelsParams.packBuffer);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -1092,16 +1092,21 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
     ANGLE_TRY(conversion->data.allocate(contextMtl, numVertices * targetStride, nullptr, &newBuffer,
                                         &newBufferOffset));
 
-    ANGLE_CHECK_GL_MATH(contextMtl, binding.getOffset() <= std::numeric_limits<uint32_t>::max());
+    GLintptr bindingOffset = binding.getOffset();
+
+    if constexpr (sizeof(bindingOffset) > sizeof(uint32_t))
+        ANGLE_CHECK_GL_MATH(contextMtl, static_cast<std::make_unsigned_t<decltype(bindingOffset)>>(bindingOffset) <= std::numeric_limits<uint32_t>::max());
     ANGLE_CHECK_GL_MATH(contextMtl, newBufferOffset <= std::numeric_limits<uint32_t>::max());
     ANGLE_CHECK_GL_MATH(contextMtl, numVertices <= std::numeric_limits<uint32_t>::max());
 
     mtl::VertexFormatConvertParams params;
     VertexConversionBufferMtl *vertexConversion =
         static_cast<VertexConversionBufferMtl *>(conversion);
+    if constexpr (sizeof(vertexConversion->offset) > sizeof(uint32_t))
+        ANGLE_CHECK_GL_MATH(contextMtl, vertexConversion->offset <= std::numeric_limits<uint32_t>::max());
     params.srcBuffer            = srcBuffer->getCurrentBuffer();
-    params.srcBufferStartOffset = static_cast<uint32_t>(
-        MIN(static_cast<GLintptr>(vertexConversion->offset), binding.getOffset()));
+    params.srcBufferStartOffset = std::min(
+        static_cast<uint32_t>(vertexConversion->offset), static_cast<uint32_t>(bindingOffset));
     params.srcStride           = binding.getStride();
     params.srcDefaultAlphaData = convertedFormat.defaultAlpha;
 


### PR DESCRIPTION
#### 076b5adb1937cf7b5f7ea2ac7b6629e0792a493b
<pre>
[ANGLE] Fix -Wsign-compare warnings on watchOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=250684">https://bugs.webkit.org/show_bug.cgi?id=250684</a>
&lt;rdar://104301662&gt;

Reviewed by Kimmo Kinnunen.

On watchOS, &apos;GLintptr&apos; and &apos;ptrdiff_t&apos; are defined as signed
types, so they must be converted to an unsigned value to compare
them to std::numeric_limits&lt;uint32_t&gt;::max().

In general, this code treats signed variables as containers for
unsigned values, so checking for negative values isn&apos;t important
in this context.  Instead overflow only needs to be checked
before casting if the signed type is larger than uint32_t.

* Source/ThirdParty/ANGLE/Configurations/Base.xcconfig:
(WK_FIXME_WARNING_CFLAGS): Remove -Wno-sign-compare.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm:
(rx::FramebufferMtl::readPixelsToPBO const):
- Only check for overflow if the size of
  `packPixelsParams.offset` (ptrdiff_t) is larger than the size
  of uint32_t.
- Use static_cast&lt;std::make_unsigned_t&lt;&gt;&gt;() when checking for
  overflow of `packPixelsParams.offset`.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::VertexArrayMtl::convertVertexBufferGPU):
- Extract `binding.getOffset()` into a local variable.
- Only check for overflow if the size of `bindingOffset`
  (GLintptr) is larger than the size of uint32_t.
- Use static_cast&lt;std::make_unsigned_t&lt;&gt;&gt;() when checking for
  overflow of `bindingOffset`.
- Add an overflow check for `vertexConversion-&gt;offset` since
  it&apos;s a size_t value, and switch to std::min() from MIN().

Canonical link: <a href="https://commits.webkit.org/259542@main">https://commits.webkit.org/259542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e58329e6cfbeff187aa25538789086483f1214f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113759 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173983 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4481 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112726 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38899 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80568 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27330 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3888 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46890 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6568 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8838 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->