### PR TITLE
REGRESSION (252706@main): zillow.com shows a Recaptcha interstitial in private browsing mode

### DIFF
--- a/LayoutTests/http/tests/permissions/permission-state-for-notifications-in-ephemeral-session-expected.txt
+++ b/LayoutTests/http/tests/permissions/permission-state-for-notifications-in-ephemeral-session-expected.txt
@@ -1,0 +1,11 @@
+This test checks that Permissions::query() is consistent with Notification.permission in ephemeral sessions
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS notificationState is "default"
+PASS permissionsState is "prompt"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/permissions/permission-state-for-notifications-in-ephemeral-session.html
+++ b/LayoutTests/http/tests/permissions/permission-state-for-notifications-in-ephemeral-session.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("This test checks that Permissions::query() is consistent with Notification.permission in ephemeral sessions");
+
+jsTestIsAsync = true;
+
+(async () => {
+    notificationState = window?.Notification?.permission || "default";
+    permissionsState = (await navigator.permissions.query({ name: "notifications" })).state;
+    shouldBeEqualToString("notificationState", "default");
+    shouldBeEqualToString("permissionsState", "prompt");
+    finishJSTest();
+})();
+</script>
+<script src="/resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/push-api/permissions-ephemeral-expected.txt
+++ b/LayoutTests/http/tests/push-api/permissions-ephemeral-expected.txt
@@ -1,5 +1,5 @@
-PASS: service worker permissionState was denied
-PASS: document permissionState was denied
+PASS: service worker permissionState was prompt
+PASS: document permissionState was prompt
 PASS: service worker subscribe was error: NotAllowedError
 PASS: document subscribe without user gesture was error: NotAllowedError
 PASS: document subscribe with user gesture was error: NotAllowedError

--- a/LayoutTests/http/tests/push-api/permissions-ephemeral.html
+++ b/LayoutTests/http/tests/push-api/permissions-ephemeral.html
@@ -14,8 +14,8 @@ if (window.testRunner)
 navigator.serviceWorker.register("resources/subscribe-worker.js", { }).then(async (registration) => {
     try {
         await waitForState(registration.installing, "activated");
-        await testServiceWorkerPermissionState(registration, 'denied');
-        await testDocumentPermissionState(registration, 'denied');
+        await testServiceWorkerPermissionState(registration, 'prompt');
+        await testDocumentPermissionState(registration, 'prompt');
         await testServiceWorkerSubscribe(registration, 'NotAllowedError');
         await testDocumentSubscribeWithoutUserGesture(registration, 'NotAllowedError');
         await testDocumentSubscribeWithUserGesture(registration, 'NotAllowedError');

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9041,6 +9041,11 @@ void WebPageProxy::queryPermission(const ClientOrigin& clientOrigin, const Permi
         // this topOrigin has requested permission to use the Notifications API previously.
         if (m_notificationPermissionRequesters.contains(clientOrigin.topOrigin))
             shouldChangeDeniedToPrompt = false;
+
+        if (sessionID().isEphemeral()) {
+            completionHandler(shouldChangeDeniedToPrompt ? PermissionState::Prompt : PermissionState::Denied);
+            return;
+        }
 #endif
     } else if (descriptor.name == PermissionName::ScreenWakeLock) {
         name = "screen-wake-lock"_s;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
@@ -105,14 +105,16 @@ void WebNotificationClient::requestPermission(ScriptExecutionContext& context, P
 
 NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExecutionContext* context)
 {
-    if (!context
-        || (!context->isDocument() && !context->isServiceWorkerGlobalScope())
-        || WebProcess::singleton().sessionID().isEphemeral())
+    if (!context || (!context->isDocument() && !context->isServiceWorkerGlobalScope()))
         return NotificationClient::Permission::Denied;
 
     auto* origin = context->securityOrigin();
     if (!origin)
         return NotificationClient::Permission::Denied;
+
+    bool hasRequestedPermission = m_notificationPermissionRequesters.contains(origin->data());
+    if (WebProcess::singleton().sessionID().isEphemeral())
+        return hasRequestedPermission ? NotificationClient::Permission::Denied : NotificationClient::Permission::Default;
 
     NotificationClient::Permission resultPermission;
     callOnMainRunLoopAndWait([&resultPermission, origin = origin->data().toString().isolatedCopy()] {
@@ -121,7 +123,7 @@ NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExec
 
     // To reduce fingerprinting, if the origin has not requested permission to use the
     // Notifications API, and the permission state is "denied", return "default" instead.
-    if (resultPermission == NotificationClient::Permission::Denied && !m_notificationPermissionRequesters.contains(context->securityOrigin()->data()))
+    if (resultPermission == NotificationClient::Permission::Denied && !hasRequestedPermission)
         return NotificationClient::Permission::Default;
 
     return resultPermission;


### PR DESCRIPTION
#### 5e4c68005fe4b76b61be2e90bb7064226ce1f69d
<pre>
REGRESSION (252706@main): zillow.com shows a Recaptcha interstitial in private browsing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=250686">https://bugs.webkit.org/show_bug.cgi?id=250686</a>
rdar://103905006

Reviewed by Youenn Fablet and Ben Nham.

Currently, in private browsing mode (i.e. when using an ephemeral session) `Notification.permission`
unconditionally returns `&quot;denied&quot;` (with `Notification.requestPermission` also unconditionally
denying the request). However, the Permissions API (i.e. `navigator.permissions.query`) implements
inconsistent behavior, and instead returns `&quot;prompt&quot;` in this scenario. On zillow.com, this causes
a bot detection script to erroneously flag the UA as non-human in private browsing, and present
interstitial Recaptcha UI to the user.

Fix this by making the heuristics for &quot;notifications&quot; in `WebPageProxy::queryPermission` consistent
with the Notifications API, such that in an ephemeral session, we return &quot;default&quot; or &quot;prompt&quot;
unless the page has requested access (in which case we&apos;ll deny access, and then subsequently return
&quot;denied&quot;).

Test: http/tests/permissions/permission-state-for-notifications-in-ephemeral-session.html

* LayoutTests/http/tests/permissions/permission-state-for-notifications-in-ephemeral-session-expected.txt:
* LayoutTests/http/tests/permissions/permission-state-for-notifications-in-ephemeral-session.html:
* LayoutTests/http/tests/push-api/permissions-ephemeral-expected.txt:
* LayoutTests/http/tests/push-api/permissions-ephemeral.html:

Rebaseline an existing layout test.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::queryPermission):
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::checkPermission):

Canonical link: <a href="https://commits.webkit.org/259040@main">https://commits.webkit.org/259040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0122488012be22bca6d89dede9cefa2e099f27f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112801 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173007 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3580 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111973 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38297 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3151 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6212 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7993 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->