### PR TITLE
`text-combine-upright: all` & `text-transform` don't work together

### DIFF
--- a/LayoutTests/fast/text/text-combine-upright-text-transform-expected.html
+++ b/LayoutTests/fast/text/text-combine-upright-text-transform-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<body style="writing-mode: vertical-rl">
+Test text-combine-upright: all + text-transform<br><br>
+text-transform: capitalize<br>
+The following "a" should be upright and captalize: <span style="text-combine-upright: all;">A</span><br><br>
+text-transform: lowercase<br>
+The following "A" should be upright and lowercase: <span style="text-combine-upright: all;">a</span><br><br>
+text-transform: uppercase<br>
+The following "a" should be upright and uppercase: <span style="text-combine-upright: all;">A</span><br><br>
+</body>

--- a/LayoutTests/fast/text/text-combine-upright-text-transform.html
+++ b/LayoutTests/fast/text/text-combine-upright-text-transform.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<body style="writing-mode: vertical-rl">
+Test text-combine-upright: all + text-transform<br><br>
+text-transform: capitalize<br>
+The following "a" should be upright and captalize: <span style="text-combine-upright: all; text-transform: capitalize;">a</span><br><br>
+text-transform: lowercase<br>
+The following "A" should be upright and lowercase: <span style="text-combine-upright: all; text-transform: lowercase;">A</span><br><br>
+text-transform: uppercase<br>
+The following "a" should be upright and uppercase: <span style="text-combine-upright: all; text-transform: uppercase;">a</span><br><br>
+</body>

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -99,7 +100,7 @@ void RenderCombineText::combineTextIfNeeded()
 
     // An ancestor element may trigger us to lay out again, even when we're already combined.
     if (m_isCombined)
-        RenderText::setRenderedText(originalText());
+        RenderText::setRenderedText(m_renderedText);
 
     m_isCombined = false;
     m_needsFontUpdate = false;
@@ -185,6 +186,7 @@ void RenderCombineText::combineTextIfNeeded()
 
     if (m_isCombined) {
         static NeverDestroyed<String> objectReplacementCharacterString(&objectReplacementCharacter, 1);
+        m_renderedText = text();
         RenderText::setRenderedText(objectReplacementCharacterString.get());
         m_combinedTextWidth = combinedTextWidth;
         m_combinedTextAscent = glyphOverflow.top;

--- a/Source/WebCore/rendering/RenderCombineText.h
+++ b/Source/WebCore/rendering/RenderCombineText.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -53,6 +54,7 @@ private:
     float m_combinedTextWidth { 0 };
     float m_combinedTextAscent { 0 };
     float m_combinedTextDescent { 0 };
+    String m_renderedText;
     bool m_isCombined : 1;
     bool m_needsFontUpdate : 1;
 };


### PR DESCRIPTION
<pre>
`text-combine-upright: all` & `text-transform` don't work together
<a href="https://bugs.webkit.org/show_bug.cgi?id=250657">https://bugs.webkit.org/show_bug.cgi?id=250657</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=rev&revision=167624">https://src.chromium.org/viewvc/blink?view=rev&revision=167624</a>

When we transform text, we set transformed text to
RenderText::m_text. RenderCombineText overwrites the text at
combineText() and use originalText() at combineTextIfNeeded() in
painting. Therefore, text combine paints original text instead of
transformed text.

* Source/WebCore/rendering/RenderCombineText.h: Add "m_renderedText" as String definition
* Source/WebCore/rendering/RenderCombineText.cpp:
(RenderCombineText::combineTextIfNeeded): Change 'originalText' to "m_renderedText" and call it also while object replacement
* LayoutTests/fast/text/text-combine-upright-text-transform.html: Add Test Case
* LayoutTests/fast/text/text-combine-upright-text-transform-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2537d1faca3cc23e6a227a703d41a7c4b2aa7786

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112739 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172948 "Found 1 new test failure: fast/text/text-combine-upright-text-transform.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3524 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111918 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109277 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10506 "Found 1 new test failure: fast/text/text-combine-upright-text-transform.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93582 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38242 "Found 1 new test failure: fast/text/text-combine-upright-text-transform.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92327 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25169 "Found 1 new test failure: fast/text/text-combine-upright-text-transform.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79886 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6007 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26572 "Found 2 new test failures: fast/text/text-combine-upright-text-transform.html, media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6184 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3100 "Found 1 new test failure: fast/text/text-combine-upright-text-transform.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46081 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7939 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->