### PR TITLE
Make CSSPrimitiveValueMappings use the CSSValuePool

### DIFF
--- a/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,42 +26,36 @@
 #include "config.h"
 #include "CSSBackgroundRepeatValue.h"
 
-#include "CSSValuePool.h"
-#include "Rect.h"
-#include <wtf/text/WTFString.h>
-
 namespace WebCore {
 
-CSSBackgroundRepeatValue::CSSBackgroundRepeatValue(Ref<CSSPrimitiveValue>&& repeatXValue, Ref<CSSPrimitiveValue>&& repeatYValue)
+CSSBackgroundRepeatValue::CSSBackgroundRepeatValue(CSSValueID xValue, CSSValueID yValue)
     : CSSValue(BackgroundRepeatClass)
-    , m_xValue(WTFMove(repeatXValue))
-    , m_yValue(WTFMove(repeatYValue))
+    , m_xValue(xValue)
+    , m_yValue(yValue)
 {
 }
 
-CSSBackgroundRepeatValue::CSSBackgroundRepeatValue(CSSValueID repeatXValue, CSSValueID repeatYValue)
-    : CSSValue(BackgroundRepeatClass)
-    , m_xValue(CSSPrimitiveValue::create(repeatXValue))
-    , m_yValue(CSSPrimitiveValue::create(repeatYValue))
+Ref<CSSBackgroundRepeatValue> CSSBackgroundRepeatValue::create(CSSValueID repeatXValue, CSSValueID repeatYValue)
 {
+    return adoptRef(*new CSSBackgroundRepeatValue(repeatXValue, repeatYValue));
 }
 
 String CSSBackgroundRepeatValue::customCSSText() const
 {
     // background-repeat/mask-repeat behave a little like a shorthand, but `repeat no-repeat` is transformed to `repeat-x`.
-    if (!compareCSSValue(m_xValue, m_yValue)) {
-        if (m_xValue->valueID() == CSSValueRepeat && m_yValue->valueID() == CSSValueNoRepeat)
+    if (m_xValue != m_yValue) {
+        if (m_xValue == CSSValueRepeat && m_yValue == CSSValueNoRepeat)
             return nameString(CSSValueRepeatX);
-        if (m_xValue->valueID() == CSSValueNoRepeat && m_yValue->valueID() == CSSValueRepeat)
+        if (m_xValue == CSSValueNoRepeat && m_yValue == CSSValueRepeat)
             return nameString(CSSValueRepeatY);
-        return makeString(m_xValue->cssText(), ' ', m_yValue->cssText());
+        return makeString(nameLiteral(m_xValue), ' ', nameLiteral(m_yValue));
     }
-    return m_xValue->cssText();
+    return nameString(m_xValue);
 }
 
 bool CSSBackgroundRepeatValue::equals(const CSSBackgroundRepeatValue& other) const
 {
-    return compareCSSValue(m_xValue, other.m_xValue) && compareCSSValue(m_yValue, other.m_yValue);
+    return m_xValue == other.m_xValue && m_yValue == other.m_yValue;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.h
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,36 +25,27 @@
 
 #pragma once
 
-#include "CSSPrimitiveValue.h"
-#include <wtf/RefPtr.h>
+#include "CSSValue.h"
 
 namespace WebCore {
 
+enum CSSValueID : uint16_t;
+
 class CSSBackgroundRepeatValue final : public CSSValue {
 public:
-    static Ref<CSSBackgroundRepeatValue> create(Ref<CSSPrimitiveValue>&& repeatXValue, Ref<CSSPrimitiveValue>&& repeatYValue)
-    {
-        return adoptRef(*new CSSBackgroundRepeatValue(WTFMove(repeatXValue), WTFMove(repeatYValue)));
-    }
-
-    static Ref<CSSBackgroundRepeatValue> create(CSSValueID repeatXValue, CSSValueID repeatYValue)
-    {
-        return adoptRef(*new CSSBackgroundRepeatValue(repeatXValue, repeatYValue));
-    }
+    static Ref<CSSBackgroundRepeatValue> create(CSSValueID repeatXValue, CSSValueID repeatYValue);
 
     String customCSSText() const;
-
     bool equals(const CSSBackgroundRepeatValue&) const;
 
-    const CSSPrimitiveValue& xValue() const { return m_xValue.get(); }
-    const CSSPrimitiveValue& yValue() const { return m_yValue.get(); }
+    CSSValueID xValue() const { return m_xValue; }
+    CSSValueID yValue() const { return m_yValue; }
 
 private:
-    CSSBackgroundRepeatValue(Ref<CSSPrimitiveValue>&& repeatXValue, Ref<CSSPrimitiveValue>&& repeatYValue);
     CSSBackgroundRepeatValue(CSSValueID repeatXValue, CSSValueID repeatYValue);
 
-    Ref<CSSPrimitiveValue> m_xValue;
-    Ref<CSSPrimitiveValue> m_yValue;
+    CSSValueID m_xValue;
+    CSSValueID m_yValue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSContentDistributionValue.cpp
+++ b/Source/WebCore/css/CSSContentDistributionValue.cpp
@@ -36,25 +36,37 @@ CSSContentDistributionValue::CSSContentDistributionValue(CSSValueID distribution
 {
 }
 
-CSSContentDistributionValue::~CSSContentDistributionValue() = default;
+Ref<CSSContentDistributionValue> CSSContentDistributionValue::create(CSSValueID distribution, CSSValueID position, CSSValueID overflow)
+{
+    return adoptRef(*new CSSContentDistributionValue(distribution, position, overflow));
+}
 
 String CSSContentDistributionValue::customCSSText() const
 {
-    StringBuilder builder;
-    if (m_distribution != CSSValueInvalid)
-        builder.append(nameLiteral(m_distribution));
-    if (m_position != CSSValueInvalid) {
-        if (m_position == CSSValueFirstBaseline)
-            builder.append(builder.isEmpty() ? "" : " ", "first baseline");
-        else if (m_position == CSSValueLastBaseline)
-            builder.append(builder.isEmpty() ? "" : " ", "last baseline");
-        else {
-            if (m_overflow != CSSValueInvalid)
-                builder.append(builder.isEmpty() ? "" : " ", nameLiteral(m_overflow));
-            builder.append(builder.isEmpty() ? "" : " ", nameLiteral(m_position));
-        }
+    auto word1 = m_distribution;
+    CSSValueID word2;
+    CSSValueID word3;
+    switch (m_position) {
+    case CSSValueFirstBaseline:
+        word2 = CSSValueFirst;
+        word3 = CSSValueBaseline;
+        break;
+    case CSSValueLastBaseline:
+        word2 = CSSValueLast;
+        word3 = CSSValueBaseline;
+        break;
+    default:
+        word2 = m_overflow;
+        word3 = m_position;
+        break;
     }
-    return builder.toString();
+    return makeString(
+        word1 == CSSValueInvalid ? ""_s : nameLiteral(word1),
+        word1 != CSSValueInvalid && word2 != CSSValueInvalid ? " "_s : ""_s,
+        word2 == CSSValueInvalid ? ""_s : nameLiteral(word2),
+        word2 != CSSValueInvalid && word3 != CSSValueInvalid ? " "_s : ""_s,
+        word3 == CSSValueInvalid ? ""_s : nameLiteral(word3)
+    );
 }
 
 bool CSSContentDistributionValue::equals(const CSSContentDistributionValue& other) const

--- a/Source/WebCore/css/CSSContentDistributionValue.h
+++ b/Source/WebCore/css/CSSContentDistributionValue.h
@@ -26,25 +26,18 @@
 #pragma once
 
 #include "CSSValue.h"
-#include "CSSValuePool.h"
-#include <wtf/Ref.h>
 
 namespace WebCore {
 
 class CSSContentDistributionValue final : public CSSValue {
 public:
-    static Ref<CSSContentDistributionValue> create(CSSValueID distribution, CSSValueID position, CSSValueID overflow)
-    {
-        return adoptRef(*new CSSContentDistributionValue(distribution, position, overflow));
-    }
-    ~CSSContentDistributionValue();
+    static Ref<CSSContentDistributionValue> create(CSSValueID distribution, CSSValueID position, CSSValueID overflow);
 
-    Ref<CSSPrimitiveValue> distribution() const { return CSSPrimitiveValue::create(m_distribution); }
-    Ref<CSSPrimitiveValue> position() const { return CSSPrimitiveValue::create(m_position); }
-    Ref<CSSPrimitiveValue> overflow() const { return CSSPrimitiveValue::create(m_overflow); }
+    CSSValueID distribution() const { return m_distribution; }
+    CSSValueID position() const { return m_position; }
+    CSSValueID overflow() const { return m_overflow; }
 
     String customCSSText() const;
-
     bool equals(const CSSContentDistributionValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -178,8 +178,8 @@ void CSSToStyleMap::mapFillRepeat(CSSPropertyID propertyID, FillLayer& layer, co
         return;
 
     auto& backgroundRepeatValue = downcast<CSSBackgroundRepeatValue>(value);
-    FillRepeat repeatX = backgroundRepeatValue.xValue();
-    FillRepeat repeatY = backgroundRepeatValue.yValue();
+    auto repeatX = fromCSSValueID<FillRepeat>(backgroundRepeatValue.xValue());
+    auto repeatY = fromCSSValueID<FillRepeat>(backgroundRepeatValue.yValue());
     layer.setRepeat(FillRepeatXY { repeatX, repeatY });
 }
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -367,7 +367,10 @@ static RefPtr<CSSValue> valueForNinePieceImage(CSSPropertyID propertyID, const N
 
 static Ref<CSSPrimitiveValue> fontSizeAdjustFromStyle(const RenderStyle& style)
 {
-    return CSSPrimitiveValue::create(style.fontSizeAdjust());
+    auto adjust = style.fontSizeAdjust();
+    if (!adjust)
+        return CSSPrimitiveValue::create(CSSValueNone);
+    return CSSPrimitiveValue::create(*adjust, CSSUnitType::CSS_NUMBER);
 }
 
 static Ref<CSSPrimitiveValue> zoomAdjustedPixelValue(double value, const RenderStyle& style)
@@ -2895,10 +2898,10 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyMaskComposite: {
         auto& layers = style.maskLayers();
         if (!layers.next())
-            return CSSPrimitiveValue::create(layers.composite(), propertyID);
+            return CSSPrimitiveValue::create(toCSSValueID(layers.composite(), propertyID));
         auto list = CSSValueList::createCommaSeparated();
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
-            list->append(CSSPrimitiveValue::create(currLayer->composite(), propertyID));
+            list->append(CSSPrimitiveValue::create(toCSSValueID(currLayer->composite(), propertyID)));
         return list;
     }
     case CSSPropertyBackgroundAttachment: {
@@ -3131,9 +3134,9 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyFlexFlow:
         return getCSSPropertyValuesForShorthandProperties(flexFlowShorthand());
     case CSSPropertyFlexGrow:
-        return CSSPrimitiveValue::create(style.flexGrow());
+        return CSSPrimitiveValue::create(style.flexGrow(), CSSUnitType::CSS_NUMBER);
     case CSSPropertyFlexShrink:
-        return CSSPrimitiveValue::create(style.flexShrink());
+        return CSSPrimitiveValue::create(style.flexShrink(), CSSUnitType::CSS_NUMBER);
     case CSSPropertyFlexWrap:
         return CSSPrimitiveValue::create(style.flexWrap());
     case CSSPropertyJustifyContent:

--- a/Source/WebCore/css/DeprecatedCSSOMRGBColor.h
+++ b/Source/WebCore/css/DeprecatedCSSOMRGBColor.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "Color.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include <wtf/Ref.h>
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -195,7 +195,7 @@ public:
         if (!m_calcValue)
             return nullptr;
         m_sourceRange = m_range;
-        return CSSPrimitiveValue::create(WTFMove(m_calcValue));
+        return CSSPrimitiveValue::create(m_calcValue.releaseNonNull());
     }
 
     RefPtr<CSSPrimitiveValue> consumeValueIfCategory(CalculationCategory category)
@@ -208,7 +208,7 @@ public:
             return nullptr;
         }
         m_sourceRange = m_range;
-        return CSSPrimitiveValue::create(WTFMove(m_calcValue));
+        return CSSPrimitiveValue::create(m_calcValue.releaseNonNull());
     }
 
 private:
@@ -7292,15 +7292,15 @@ RefPtr<CSSValue> consumeRepeatStyle(CSSParserTokenRange& range, const CSSParserC
     if (consumeIdent<CSSValueRepeatY>(range))
         return CSSBackgroundRepeatValue::create(CSSValueNoRepeat, CSSValueRepeat);
 
-    auto value1 = consumeIdent<CSSValueRepeat, CSSValueNoRepeat, CSSValueRound, CSSValueSpace>(range);
+    auto value1 = consumeIdentRaw<CSSValueRepeat, CSSValueNoRepeat, CSSValueRound, CSSValueSpace>(range);
     if (!value1)
         return nullptr;
 
-    auto value2 = consumeIdent<CSSValueRepeat, CSSValueNoRepeat, CSSValueRound, CSSValueSpace>(range);
+    auto value2 = consumeIdentRaw<CSSValueRepeat, CSSValueNoRepeat, CSSValueRound, CSSValueSpace>(range);
     if (!value2)
         value2 = value1;
 
-    return CSSBackgroundRepeatValue::create(value1.releaseNonNull(), value2.releaseNonNull());
+    return CSSBackgroundRepeatValue::create(*value1, *value2);
 }
 
 RefPtr<CSSValue> consumeSingleBackgroundSize(CSSParserTokenRange& range, const CSSParserContext& context)

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -264,7 +264,10 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         auto sumNode = CSSCalcOperationNode::createSum(Vector { node.releaseNonNull() });
         if (!sumNode)
             return nullptr;
-        return CSSPrimitiveValue::create(CSSCalcValue::create(sumNode.releaseNonNull()));
+        auto value = CSSCalcValue::create(sumNode.releaseNonNull());
+        if (!value)
+            return nullptr;
+        return CSSPrimitiveValue::create(value.releaseNonNull());
     }
     return toCSSValue();
 }

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.h
@@ -69,7 +69,10 @@ public:
         auto node = toCalcExpressionNode();
         if (!node)
             return nullptr;
-        return CSSPrimitiveValue::create(CSSCalcValue::create(node.releaseNonNull()));
+        auto value = CSSCalcValue::create(node.releaseNonNull());
+        if (!value)
+            return nullptr;
+        return CSSPrimitiveValue::create(value.releaseNonNull());
     }
 };
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "ColorTypes.h"
 #include "HTMLNames.h"
 #include "InputMode.h"
 #include "StyledElement.h"
@@ -37,6 +38,7 @@ class FormListedElement;
 class FormAssociatedElement;
 class HTMLFormElement;
 class VisibleSelection;
+
 struct SimpleRange;
 struct TextRecognitionResult;
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -955,7 +955,6 @@ TextStream& operator<<(TextStream& ts, ScrollSnapStop stop)
 TextStream& operator<<(TextStream& ts, SpeakAs speakAs)
 {
     switch (speakAs) {
-    case SpeakAs::Normal: ts << "normal"; break;
     case SpeakAs::SpellOut: ts << "spell-out"; break;
     case SpeakAs::Digits: ts << "digits"; break;
     case SpeakAs::LiteralPunctuation: ts << "literal-punctuation"; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -995,7 +995,6 @@ enum class Hyphens : uint8_t {
 };
 
 enum class SpeakAs : uint8_t {
-    Normal             = 0,
     SpellOut           = 1 << 0,
     Digits             = 1 << 1,
     LiteralPunctuation = 1 << 2,

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1666,12 +1666,12 @@ inline StyleContentAlignmentData BuilderConverter::convertContentAlignmentData(B
     if (!is<CSSContentDistributionValue>(value))
         return alignmentData;
     auto& contentValue = downcast<CSSContentDistributionValue>(value);
-    if (contentValue.distribution()->valueID() != CSSValueInvalid)
-        alignmentData.setDistribution(contentValue.distribution().get());
-    if (contentValue.position()->valueID() != CSSValueInvalid)
-        alignmentData.setPosition(contentValue.position().get());
-    if (contentValue.overflow()->valueID() != CSSValueInvalid)
-        alignmentData.setOverflow(contentValue.overflow().get());
+    if (contentValue.distribution() != CSSValueInvalid)
+        alignmentData.setDistribution(fromCSSValueID<ContentDistribution>(contentValue.distribution()));
+    if (contentValue.position() != CSSValueInvalid)
+        alignmentData.setPosition(fromCSSValueID<ContentPosition>(contentValue.position()));
+    if (contentValue.overflow() != CSSValueInvalid)
+        alignmentData.setOverflow(fromCSSValueID<OverflowAlignment>(contentValue.overflow()));
     return alignmentData;
 }
 


### PR DESCRIPTION
#### ef049694b61c0c82f351d1a33f736c4b5f0f3532
<pre>
Make CSSPrimitiveValueMappings use the CSSValuePool
<a href="https://bugs.webkit.org/show_bug.cgi?id=250648">https://bugs.webkit.org/show_bug.cgi?id=250648</a>
rdar://problem/104278110

Reviewed by Tim Nguyen.

CSSPrimitiveValueMappings.h is a file full of constructor template specializations and conversion
operator template instances for CSSPrimitiveValue, along with an assortment of other things.

The main purpose of this change is to get rid of all those constructor template specializations,
since we would like to allocate the values out of the StaticCSSValuePool, and so we need to use
create functions, not direct construction.

We do this by specializing a create function template rather than a constructor template. But
making the observation that almost all of these involve mapping to and from CSSValueID to
enumerations, in most cases we do not specialize the create function template or the conversion
operator template. Instead we overload a function named toCSSValueID and specialize a function
name fromCSSValueID in all but the most exotic cases. And further, for the simplest mappings, we
use a macro, so both toCSSValueID and fromCSSValueID are generated by the macro.

In addition, we simplified call sites that are unnecessarily using CSSPrimitiveValue in
cases where instead a CSSValueID suffices.

Part of this is taking the knowledge about these mappings and moving it out into functions
that are not specific to CSSPrimitiveValue. In future i&apos;s not clear we should have a single
CSSPrimitiveValue. Instead we could have a separate CSSValue class for each of the types in
the union. Having two levels of polymorphism isn&apos;t all that helpful. The way that CSSUnitType
mixes structure types and different types of numeric value is pretty messy and also seems like
something we do not need to keep around in its current form.

* Source/WebCore/css/CSSBackgroundRepeatValue.cpp:
(WebCore::CSSBackgroundRepeatValue::CSSBackgroundRepeatValue): Use CSSValueID instead of
CSSPrimitiveValue.
(WebCore::CSSBackgroundRepeatValue::create): Moved this out of the header for better inlining.
(WebCore::CSSBackgroundRepeatValue::customCSSText const): Use CSSValueID.
(WebCore::CSSBackgroundRepeatValue::equals const): Ditto.
* Source/WebCore/css/CSSBackgroundRepeatValue.h: Ditto.

* Source/WebCore/css/CSSContentDistributionValue.cpp:
(WebCore::CSSContentDistributionValue::~CSSContentDistributionValue): Removed this since it can
be generated in the header without explicitly defining it at all and since this class adds no
data members with destructors it will be trivial.
(WebCore::CSSContentDistributionValue::create): Moved this out of the header for better inlining.
(WebCore::CSSContentDistributionValue::customCSSText const): Build this all at once with
makeString rather than using StringBuilder.
* Source/WebCore/css/CSSContentDistributionValue.h: Removed unneeded includes and destructor.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::CSSPrimitiveValue): Got rid of most constructors. The only ones
we kept are the ones for the actual primitive types that this class stores. Changed the
CSSCalcValue one to take a Ref like the others instead of a RefPtr. Changed the Color
constructor to store the color as an integer rather than on the heap. Our Color object
basically works as a union of integer and smart pointer and for our use here we just need
to know how to copy and destroy it. We copy it using a placement new operator and destroy
it using an explicit call to the destructor.
(WebCore::CSSPrimitiveValue::init): Deleted. We don&apos;t need these functions any more because
they can be constructors now. The reason they needed to exist before was that we wanted to
share code iwth the code in CSSPrimitiveValueMappings.h and also this was long ago before
one constructor could call through to another.
(WebCore::CSSPrimitiveValue::cleanup): Updated the CSS_CALC case since it can&apos;t be nullptr
any more. Updated the CSS_RGBCOLOR case since we are now storing the Color directly rather
than allocating each Color on the heap.
(WebCore::CSSPrimitiveValue::create): Put most create functions here, where they can inline
the constructors. Also, some of the create functions simply call the other create functions.
This works well with the CSS value pool.

* Source/WebCore/css/CSSPrimitiveValue.h: Removed unneded include of Color.h since we can
just use a forward declaration. Added explicit overloads of create for all the basic types.
Also, create functions that call constructors that are not in the header are now moved to
the CSSPrimitiveValue.cpp file to give us better inlining of the constructors. Continue to
use a create function template for the automatic mapping, but now we specialize this instead
of having a default version that calls through to a constructor template. In the future, we
could consider giving the create function template a different name since it&apos;s not clear we
need call sites that mix the overloaded functions and function template, but for now this is
more like how the class worked before. Moved the conversion operators for integer types here,
and have them be separate functions, not template specializations. Add more constructors, one
for each of the value types the union knows how to store. Get rid of all the template
constructors. Replaced the color pointer with the colorAsInteger, which makes all the values
containing a Color more efficient. Added a function template named fromCSSValueID and a
conversion function template definition that calls it so we can specialize that instead of
specializing the conversion operator in almost all cases.

* Source/WebCore/css/CSSPrimitiveValueMappings.h: Removed all the specializations for
numeric types. Added the macros that we can use to define the toCSSValueID and fromCSSValueID
function for trivial cases. Used specializations of create and the conversion operator
in a few special cases, but in most cases, just overload toCSSValueID and specialize
fromCSSValueID.

* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapFillRepeat): Use fromCSSValueID since CSSBackgroundRepeatValue
now returns CSSValueID rather than a CSSPrimitiveValue.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle): Handle the std::optional&lt;float&gt; here explicitly
rather than using a CSSPrimitiveValue feature specific to std::optional&lt;float&gt;.
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle): Call toCSSValueID explicitly
in the case where we have to pass the property ID in, getting rid of the need to overload
CSSPrimitiveValue::create for this cases. Update a couple places that were relying on the
conversion operator to make a CSS_NUMBER to instead do that directly.

* Source/WebCore/css/DeprecatedCSSOMRGBColor.h: Added Color.h include since
CSSPrimitiveValue.h does not pull it in any more.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::CalcParser::consumeValue): Use releaseNonNull since
we have already checked for null and create now takes a Ref rather than RefPtr.
(WebCore::CSSPropertyParserHelpers::CalcParser::consumeValueIfCategory): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeRepeatStyle): Use consumeIdentRaw because
CSSBackgroundRepeatValue::create now takes CSSValueID, not CSSPrimitiveValue.

* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toCSSValueWithProperty const): Add an explicit check for
nodes we can&apos;t parse that cause CSSCalcValue::create to return null, and handle them
by returning nullptr rather than a CSSPrimitiveValue with a nullptr for its CSSCalcValue.
* Source/WebCore/css/typedom/numeric/CSSMathValue.h: Ditto.

* Source/WebCore/html/HTMLElement.h: Added ColorTypes.h include since CSSPrimitiveValue.h
does not pull in Color.h any more.

* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;): Removed code to handle SpeakAs::Normal.

* Source/WebCore/rendering/style/RenderStyleConstants.h: Removed the Normal value from
SpeakAs, since we use OptionSet&lt;SpeakAs&gt; so we don&apos;t need a named empty value.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertContentAlignmentData): Updated since
CSSContentDistributionValue returns CSSValueID, not CSSPrimitiveValue. We can use the
fromCSSValueID functions to do the conversion. The only thing less elegant is that we
now need to specify the type name. We could do this with implicit type conversion, we
would need to make a class to put the CSSValueID in that could do the conversion. That&apos;s
because enumerations themselves can&apos;t implement custom conversion functions.

Canonical link: <a href="https://commits.webkit.org/259025@main">https://commits.webkit.org/259025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8926a496140736627bcc215f63c72c81dd76ab5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112866 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173197 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3648 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112022 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93677 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38343 "Found 2 new test failures: http/wpt/service-workers/controlled-sharedworker.https.html, imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-destroy-script-execution.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79995 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26681 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3207 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46192 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6203 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8055 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->