### PR TITLE
REGRESSION(254254@main): [ macOS ] http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html is a constant failure

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/eme2016.js
+++ b/LayoutTests/http/tests/media/fairplay/eme2016.js
@@ -56,10 +56,10 @@ async function startEME(options) {
     return keys;
 }
 
-async function fetchAndAppend(sourceBuffer, url) {
+async function fetchAndAppend(sourceBuffer, url, silent) {
     let buffer = await fetchBuffer(url);
     sourceBuffer.appendBuffer(buffer);
-    await waitFor(sourceBuffer, 'updateend');
+    await waitFor(sourceBuffer, 'updateend', silent);
 }
 
 async function runAndWaitForLicenseRequest(session, callback) {
@@ -79,7 +79,7 @@ async function fetchAndWaitForLicenseRequest(session, sourceBuffer, url) {
 }
 
 async function fetchAppendAndWaitForEncrypted(video, sourceBuffer, url) {
-    let updateEndPromise = fetchAndAppend(sourceBuffer, url);
+    let updateEndPromise = fetchAndAppend(sourceBuffer, url, true);
     let encryptedEvent = await waitFor(video, 'encrypted');
 
     let session = video.mediaKeys.createSession();
@@ -89,7 +89,8 @@ async function fetchAppendAndWaitForEncrypted(video, sourceBuffer, url) {
     await session.update(response);
     consoleWrite('PROMISE: session.update() resolved');
     await updateEndPromise;
-    return session
+    consoleWrite(`EVENT(updateend)`);
+    return session;
 }
 
 async function createBufferAndAppend(mediaSource, type, url) {

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2368,8 +2368,6 @@ imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allow
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ DumpJSConsoleLogInStdErr Failure Pass ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ DumpJSConsoleLogInStdErr Failure Pass ]
 
-webkit.org/b/244928 http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html [ Pass Failure ]
-
 webkit.org/b/245092 webaudio/offlineaudiocontext-gc.html [ Pass Failure ]
 
 webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-streams/construct-byob-request.any.worker.html [ Pass Failure ]


### PR DESCRIPTION
#### 2ec3e23f7d3507e520fdeafc50a06e8373d79c68
<pre>
REGRESSION(254254@main): [ macOS ] http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244928">https://bugs.webkit.org/show_bug.cgi?id=244928</a>
rdar://99693593

Reviewed by Jer Noble.

In the EME event summary (<a href="https://www.w3.org/TR/encrypted-media/#dom-evt-encrypted)">https://www.w3.org/TR/encrypted-media/#dom-evt-encrypted)</a> we read as pre-conditions that the encrypted event is to be fired once readyState is greater than HAVE_METADATA

In Initialisation Data encountered algorithm (<a href="https://www.w3.org/TR/encrypted-media/#initdata-encountered)">https://www.w3.org/TR/encrypted-media/#initdata-encountered)</a>
 The Initialization Data Encountered algorithm queues an encrypted event for Initialization Data encounterd in the media data. Requests to run this algorithm include a target HTMLMediaElement object.

The following steps are run:

    Let the media element be the specified HTMLMediaElement object.

    Let initDataType be the empty string.

    Let initData be null.

    If the media data is CORS-same-origin and not mixed content, run the following steps:

        Let initDataType be the string representing the Initialization Data Type of the Initialization Data.

        Let initData be the Initialization Data.
    Note

    While the media element may allow loading of &quot;Optionally-blockable Content&quot; [MIXED-CONTENT], the user agent MUST NOT expose Initialization Data from such media data to the application.

    Queue a task to create an event named encrypted that does not bubble and is not cancellable using the MediaEncryptedEvent interface with its type attribute set to encrypted and its isTrusted attribute initialized to true, and dispatch it at the media element.

    The event interface MediaEncryptedEvent has:
        initDataType = initDataType

        initData = initData

There doesn’t seem to be any explicit requirements that the MediaSource updateend event is to be fired before the encrypted event, test should be modified to cater for this scenario

Adjust the test so that the updateend can be fired at anytime.

* LayoutTests/http/tests/media/fairplay/eme2016.js:
(async fetchAndAppend):
(async fetchAppendAndWaitForEncrypted):
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259010@main">https://commits.webkit.org/259010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2a26bf30845a8709e4db4659a28b8e0b94b384b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112747 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172956 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3531 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111925 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38255 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79898 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6192 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3109 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46091 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6191 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7946 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->