### PR TITLE
Improve StringTypeAdapter templates and handling

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -95,7 +95,7 @@ Ref<JSON::Value> InjectedScriptBase::makeCall(Deprecated::ScriptFunctionCall& fu
 
     auto resultJSONValue = toInspectorValue(globalObject, value);
     if (!resultJSONValue)
-        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')'));
+        return JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", unsigned(JSON::Value::maxDepth), ')'));
 
     return resultJSONValue.releaseNonNull();
 }
@@ -125,7 +125,7 @@ void InjectedScriptBase::makeAsyncCall(Deprecated::ScriptFunctionCall& function,
             else if (auto resultJSONValue = toInspectorValue(globalObject, callFrame->argument(0)))
                 checkAsyncCallResult(resultJSONValue, callback);
             else
-                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", JSON::Value::maxDepth, ')')), callback);
+                checkAsyncCallResult(JSON::Value::create(makeString("Object has too long reference chain (must not be longer than ", unsigned(JSON::Value::maxDepth), ')')), callback);
             return JSC::JSValue::encode(JSC::jsUndefined());
         });
     }

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -44,6 +44,21 @@ WTF_EXPORT_PRIVATE extern std::atomic<int> wtfStringCopyCount;
 
 namespace WTF {
 
+template<> class StringTypeAdapter<StringView, void> {
+public:
+    StringTypeAdapter(const StringView& string)
+        : m_string { string }
+    {
+    }
+
+    unsigned length() const { return m_string.length(); }
+    bool is8Bit() const { return m_string.is8Bit(); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { m_string.getCharacters(destination); }
+
+private:
+    StringView m_string;
+};
+
 template<> class StringTypeAdapter<char, void> {
 public:
     StringTypeAdapter(char character)
@@ -51,8 +66,8 @@ public:
     {
     }
 
-    unsigned length() { return 1; }
-    bool is8Bit() { return true; }
+    unsigned length() const { return 1; }
+    bool is8Bit() const { return true; }
     template<typename CharacterType> void writeTo(CharacterType* destination) const { *destination = m_character; }
 
 private:
@@ -148,104 +163,20 @@ public:
     }
 };
 
-template<> class StringTypeAdapter<ASCIILiteral, void> : public StringTypeAdapter<const char*, void> {
+template<typename CharacterType, size_t N>
+class StringTypeAdapter<CharacterType[N], void> : public StringTypeAdapter<const CharacterType*, void> {
 public:
-    StringTypeAdapter(ASCIILiteral characters)
-        : StringTypeAdapter<const char*, void> { characters }
+    StringTypeAdapter(const CharacterType(&characters)[N])
+        : StringTypeAdapter<const CharacterType*, void> { characters }
     {
     }
 };
 
-template<typename CharType, size_t N>
-class StringTypeAdapter<Vector<CharType, N>, void> {
+template<typename T>
+class StringTypeAdapter<T, std::enable_if_t<std::is_constructible_v<StringView, const T&>>> : public StringTypeAdapter<StringView, void> {
 public:
-    using CharTypeForString = std::conditional_t<sizeof(CharType) == sizeof(LChar), LChar, UChar>;
-    static_assert(sizeof(CharTypeForString) == sizeof(CharType));
-
-    StringTypeAdapter(const Vector<CharType, N>& vector)
-        : m_vector { vector }
-    {
-    }
-
-    size_t length() const { return m_vector.size(); }
-    bool is8Bit() const { return sizeof(CharType) == 1; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, characters(), length()); }
-
-private:
-    const CharTypeForString* characters() const
-    {
-        return reinterpret_cast<const CharTypeForString*>(m_vector.data());
-    }
-
-    const Vector<CharType, N>& m_vector;
-};
-
-template<> class StringTypeAdapter<StringImpl*, void> {
-public:
-    StringTypeAdapter(StringImpl* string)
-        : m_string { string }
-    {
-    }
-
-    unsigned length() const { return m_string ? m_string->length() : 0; }
-    bool is8Bit() const { return !m_string || m_string->is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
-    {
-        StringView { m_string }.getCharacters(destination);
-        WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING();
-    }
-
-private:
-    StringImpl* const m_string;
-};
-
-template<> class StringTypeAdapter<AtomStringImpl*, void> : public StringTypeAdapter<StringImpl*, void> {
-public:
-    StringTypeAdapter(AtomStringImpl* string)
-        : StringTypeAdapter<StringImpl*, void> { static_cast<StringImpl*>(string) }
-    {
-    }
-};
-
-template<> class StringTypeAdapter<String, void> : public StringTypeAdapter<StringImpl*, void> {
-public:
-    StringTypeAdapter(const String& string)
-        : StringTypeAdapter<StringImpl*, void> { string.impl() }
-    {
-    }
-};
-
-template<> class StringTypeAdapter<AtomString, void> : public StringTypeAdapter<String, void> {
-public:
-    StringTypeAdapter(const AtomString& string)
-        : StringTypeAdapter<String, void> { string.string() }
-    {
-    }
-};
-
-template<> class StringTypeAdapter<StringImpl&, void> {
-public:
-    StringTypeAdapter(StringImpl& string)
-        : m_string { string }
-    {
-    }
-
-    unsigned length() const { return m_string.length(); }
-    bool is8Bit() const { return m_string.is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
-    {
-        StringView { m_string }.getCharacters(destination);
-        WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING();
-    }
-
-private:
-    StringImpl& m_string;
-};
-
-template<> class StringTypeAdapter<AtomStringImpl&, void> : public StringTypeAdapter<StringImpl&, void> {
-public:
-    StringTypeAdapter(StringImpl& string)
-        : StringTypeAdapter<StringImpl&, void> { string }
+    StringTypeAdapter(const T& string)
+        : StringTypeAdapter<StringView, void> { StringView { string } }
     {
     }
 };
@@ -358,17 +289,17 @@ public:
     {
     }
 
-    unsigned length()
+    unsigned length() const
     {
         return m_indentation.value * N;
     }
 
-    bool is8Bit()
+    bool is8Bit() const
     {
         return true;
     }
 
-    template<typename CharacterType> void writeTo(CharacterType* destination)
+    template<typename CharacterType> void writeTo(CharacterType* destination) const
     {
         std::fill_n(destination, m_indentation.value * N, ' ');
     }
@@ -410,33 +341,24 @@ private:
     const ASCIICaseConverter& m_converter;
 };
 
-template<typename Adapter>
-inline bool are8Bit(Adapter adapter)
+template<typename... Adapters>
+inline bool are8Bit(const Adapters&... adapters)
 {
-    return adapter.is8Bit();
+    return (... && adapters.is8Bit());
 }
 
-template<typename Adapter, typename... Adapters>
-inline bool are8Bit(Adapter adapter, Adapters ...adapters)
+template<typename ResultType, typename... Adapters>
+inline void stringTypeAdapterAccumulator(ResultType* result, const Adapters&... adapters)
 {
-    return adapter.is8Bit() && are8Bit(adapters...);
+    unsigned offset = 0;
+    (..., [&] {
+        adapters.writeTo(result + offset);
+        offset += adapters.length();
+    }());
 }
 
-template<typename ResultType, typename Adapter>
-inline void stringTypeAdapterAccumulator(ResultType* result, Adapter adapter)
-{
-    adapter.writeTo(result);
-}
-
-template<typename ResultType, typename Adapter, typename... Adapters>
-inline void stringTypeAdapterAccumulator(ResultType* result, Adapter adapter, Adapters ...adapters)
-{
-    adapter.writeTo(result);
-    stringTypeAdapterAccumulator(result + adapter.length(), adapters...);
-}
-
-template<typename StringTypeAdapter, typename... StringTypeAdapters>
-RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool areAllAdapters8Bit, StringTypeAdapter adapter, StringTypeAdapters ...adapters)
+template<typename... StringTypeAdapters>
+RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool areAllAdapters8Bit, const StringTypeAdapters&... adapters)
 {
     ASSERT(length <= String::MaxLength);
     if (areAllAdapters8Bit) {
@@ -446,7 +368,7 @@ RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool a
             return nullptr;
 
         if (buffer)
-            stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+            stringTypeAdapterAccumulator(buffer, adapters...);
 
         return resultImpl;
     }
@@ -457,37 +379,37 @@ RefPtr<StringImpl> tryMakeStringImplFromAdaptersInternal(unsigned length, bool a
         return nullptr;
 
     if (buffer)
-        stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+        stringTypeAdapterAccumulator(buffer, adapters...);
 
     return resultImpl;
 }
 
 template<typename Func, typename... StringTypes>
-auto handleWithAdapters(Func&& func, StringTypes&& ...strings) -> decltype(auto)
+auto handleWithAdapters(Func&& func, const StringTypes&... strings) -> decltype(auto)
 {
-    return func(StringTypeAdapter<StringTypes>(std::forward<StringTypes>(strings))...);
+    return func(StringTypeAdapter<StringTypes>(strings)...);
 }
 
-template<typename StringTypeAdapter, typename... StringTypeAdapters>
-String tryMakeStringFromAdapters(StringTypeAdapter adapter, StringTypeAdapters ...adapters)
+template<typename... StringTypeAdapters>
+String tryMakeStringFromAdapters(const StringTypeAdapters&... adapters)
 {
     static_assert(String::MaxLength == std::numeric_limits<int32_t>::max());
-    auto sum = checkedSum<int32_t>(adapter.length(), adapters.length()...);
+    auto sum = checkedSum<int32_t>(adapters.length()...);
     if (sum.hasOverflowed())
         return String();
 
-    bool areAllAdapters8Bit = are8Bit(adapter, adapters...);
-    return tryMakeStringImplFromAdaptersInternal(sum, areAllAdapters8Bit, adapter, adapters...);
+    bool areAllAdapters8Bit = are8Bit(adapters...);
+    return tryMakeStringImplFromAdaptersInternal(sum, areAllAdapters8Bit, adapters...);
 }
 
 template<typename... StringTypes>
-String tryMakeString(StringTypes ...strings)
+String tryMakeString(const StringTypes&... strings)
 {
     return tryMakeStringFromAdapters(StringTypeAdapter<StringTypes>(strings)...);
 }
 
 template<typename... StringTypes>
-String makeString(StringTypes... strings)
+String makeString(const StringTypes&... strings)
 {
     String result = tryMakeString(strings...);
     if (!result)
@@ -495,40 +417,40 @@ String makeString(StringTypes... strings)
     return result;
 }
 
-template<typename StringTypeAdapter, typename... StringTypeAdapters>
-AtomString tryMakeAtomStringFromAdapters(StringTypeAdapter adapter, StringTypeAdapters ...adapters)
+template<typename... StringTypeAdapters>
+AtomString tryMakeAtomStringFromAdapters(const StringTypeAdapters&... adapters)
 {
     static_assert(String::MaxLength == std::numeric_limits<int32_t>::max());
-    auto sum = checkedSum<int32_t>(adapter.length(), adapters.length()...);
+    auto sum = checkedSum<int32_t>(adapters.length()...);
     if (sum.hasOverflowed())
         return AtomString();
 
     unsigned length = sum;
     ASSERT(length <= String::MaxLength);
 
-    bool areAllAdapters8Bit = are8Bit(adapter, adapters...);
+    bool areAllAdapters8Bit = are8Bit(adapters...);
     constexpr size_t maxLengthToUseStackVariable = 64;
     if (length < maxLengthToUseStackVariable) {
         if (areAllAdapters8Bit) {
             LChar buffer[maxLengthToUseStackVariable];
-            stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+            stringTypeAdapterAccumulator(buffer, adapters...);
             return AtomString { buffer, length };
         }
         UChar buffer[maxLengthToUseStackVariable];
-        stringTypeAdapterAccumulator(buffer, adapter, adapters...);
+        stringTypeAdapterAccumulator(buffer, adapters...);
         return AtomString { buffer, length };
     }
-    return tryMakeStringImplFromAdaptersInternal(length, areAllAdapters8Bit, adapter, adapters...).get();
+    return tryMakeStringImplFromAdaptersInternal(length, areAllAdapters8Bit, adapters...).get();
 }
 
 template<typename... StringTypes>
-AtomString tryMakeAtomString(StringTypes ...strings)
+AtomString tryMakeAtomString(const StringTypes&... strings)
 {
     return tryMakeAtomStringFromAdapters(StringTypeAdapter<StringTypes>(strings)...);
 }
 
 template<typename... StringTypes>
-AtomString makeAtomString(StringTypes... strings)
+AtomString makeAtomString(const StringTypes&... strings)
 {
     AtomString result = tryMakeAtomString(strings...);
     if (result.isNull())

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -397,8 +397,8 @@ public:
         //       StringImpl::hash() only sets a new hash iff !hasHash().
         //       Additionally, StringImpl::setHash() asserts hasHash() and !isStatic().
 
-        template<unsigned characterCount> constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
-        template<unsigned characterCount> constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
+        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
+        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
         operator StringImpl&();
     };
 

--- a/Source/WTF/wtf/text/StringOperators.h
+++ b/Source/WTF/wtf/text/StringOperators.h
@@ -46,14 +46,14 @@ public:
         return AtomString(operator String());
     }
 
-    bool is8Bit()
+    bool is8Bit() const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
         return adapter1.is8Bit() && adapter2.is8Bit();
     }
 
-    void writeTo(LChar* destination)
+    void writeTo(LChar* destination) const
     {
         ASSERT(is8Bit());
         StringTypeAdapter<StringType1> adapter1(m_string1);
@@ -62,7 +62,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    void writeTo(UChar* destination)
+    void writeTo(UChar* destination) const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -70,7 +70,7 @@ public:
         adapter2.writeTo(destination + adapter1.length());
     }
 
-    unsigned length()
+    unsigned length() const
     {
         StringTypeAdapter<StringType1> adapter1(m_string1);
         StringTypeAdapter<StringType2> adapter2(m_string2);
@@ -85,7 +85,7 @@ private:
 template<typename StringType1, typename StringType2>
 class StringTypeAdapter<StringAppend<StringType1, StringType2>> {
 public:
-    StringTypeAdapter(StringAppend<StringType1, StringType2>& buffer)
+    StringTypeAdapter(const StringAppend<StringType1, StringType2>& buffer)
         : m_buffer { buffer }
     {
     }
@@ -95,7 +95,7 @@ public:
     template<typename CharacterType> void writeTo(CharacterType* destination) const { m_buffer.writeTo(destination); }
 
 private:
-    StringAppend<StringType1, StringType2>& m_buffer;
+    const StringAppend<StringType1, StringType2>& m_buffer;
 };
 
 inline StringAppend<const char*, String> operator+(const char* string1, const String& string2)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -81,6 +81,13 @@ public:
     // Construct a string from a constant string literal.
     String(ASCIILiteral);
 
+    // Explicitly deleting these constructors prevents construction of String objects with
+    // native string literals by using implicit converting constructors of StaticStringImpl and Span types.
+    template<typename CharacterType, size_t N>
+    String(CharacterType(&)[N]) = delete;
+    template<typename CharacterType, size_t N>
+    String(const CharacterType(&)[N]) = delete;
+
     String(const String&) = default;
     String(String&&) = default;
     String& operator=(const String&) = default;

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -224,7 +224,7 @@ static String generateTemporaryPath(const Function<bool(const String&)>& action)
 
         ASSERT(wcslen(tempFile) == std::size(tempFile) - 1);
 
-        proposedPath = pathByAppendingComponent(String(tempPath), String(tempFile));
+        proposedPath = pathByAppendingComponent(String(std::data(tempPath)), String(std::data(tempFile)));
         if (proposedPath.isEmpty())
             break;
     } while (!action(proposedPath));

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -386,7 +386,7 @@ void AXIsolatedTree::updatePropertiesForSelfAndDescendants(AccessibilityObject& 
 void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const Vector<AXPropertyName>& properties)
 {
     AXTRACE("AXIsolatedTree::updateNodeProperties"_s);
-    AXLOG(makeString("Updating properties ", properties, " for objectID ", axObject.objectID().loggingString()));
+    AXLOG(makeString("Updating properties ", Span { reinterpret_cast<const UChar*>(properties.data()), properties.size() }, " for objectID ", axObject.objectID().loggingString()));
     ASSERT(isMainThread());
 
     AXPropertyMap propertyMap;

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -968,7 +968,7 @@ sub printTagNameCppFile
     print F "static constexpr StringImpl::StaticStringImpl unadjustedTagNames[] = {\n";
     for my $elementKey (sort byElementNameOrder keys %allElements) {
         next if $allElements{$elementKey}{unadjustedTagEnumValue} eq "";
-        print F "    \"$allElements{$elementKey}{parsedTagName}\",\n";
+        print F "    StringImpl::StaticStringImpl { \"$allElements{$elementKey}{parsedTagName}\" },\n";
     }
     print F "};\n";
     print F "\n";

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -108,7 +108,7 @@ public:
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
     // FIXME: When this is incremented, remove LegacyCertificateInfoType.
-    static const unsigned version = 16;
+    static constexpr unsigned version = 16;
 
     String basePathIsolatedCopy() const;
     String versionPath() const;

--- a/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
@@ -216,4 +216,24 @@ TEST(WTF, StringConcatenate_Tuple)
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42), ' ', "world")).utf8().data());
 }
 
+TEST(WTF, StringConcatenate_StringLiteral)
+{
+    EXPECT_STREQ("hello 42 world", makeString("hello", ' ', 42, " ", "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString("hello"_s, ' ', 42, " "_s, "world"_s).utf8().data());
+
+    EXPECT_STREQ("hello 42 world", makeString("hello 42\0ignored", ' ', "world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString("hello 42\0ignored"_s, ' ', "world").utf8().data());
+
+    const char helloChars[] = { 'h', 'e', 'l', 'l', 'o', '\0' };
+    char helloData[64];
+    memcpy(helloData, helloChars, sizeof(helloChars));
+
+    auto hello = makeString(helloData);
+    EXPECT_STREQ("hello", hello.utf8().data());
+    EXPECT_EQ(5u, hello.length());
+
+    EXPECT_STREQ("hello 42 world", makeString(helloData, " 42 world").utf8().data());
+    EXPECT_STREQ("hello 42 world", makeString(hello, " 42 world").utf8().data());
+}
+
 }


### PR DESCRIPTION
#### 4b89b603e1e19e17fed1c93f72872821b4a2b984
<pre>
Improve StringTypeAdapter templates and handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=250017">https://bugs.webkit.org/show_bug.cgi?id=250017</a>

Reviewed by NOBODY (OOPS!).

StringConcatenate&apos;s makeString() and makeAtomString() are adjusted to accept
arguments as const lvalue references, propagating them down to each
StringTypeAdapter object without unnecessary copies. Similarly, the adapter
objects too are handled through const lvalue references once constructed and
passed on.

Newly-imposed constness requires additional const qualifiers on common methods
across different StringTypeAdapter specializations.

The are8Bit() and stringTypeAdapterAccumulator() helper functions are simplified
through using parameter packs and fold expressions to perform the necessary
operations across a range of adapter objects.

StringTypeAdapter specialization for StringView is moved from the StringView
header into the StringConcatenate header. A new partial specialization for the
StringTypeAdapter template is added, conditionally enabled if a const reference
of the specified type can be used to construct a StringView object. This
specialization inherits from the StringView specialization, hence a StringView
is constructed for such objects.

An exception for this partial specialization are character string literals whose
type is reduced to a fixed-length C array. These for the moment require a
separate specialization in order to avoid implicitly creating a String object
that&apos;s then used for the StringView. The fixed-length array data is instead
passed to the partial specializations handling string pointers, in order to
pass the data through string-length computation and getting the correct length.
This avoids potential problems with fixed-length arrays with inflated size that
are used as buffers for string data that&apos;s otherwise null-terminated at some
previous position. Unit tests are provided to cover this detail.

Related to this, additional constructors on the String and StringView classes
accepting fixed-length C array values are deleted. This should prevent
constructing String and StringView objects from string literals or fixed-length
C arrays by using implicit conversion through StaticStringImpl or Span objects.

This enables removing a bunch of other StringTypeAdapter specializations.
Different WTF string and impl types can be used to construct the StringView,
as well as ASCIILiteral. For Vectors of character values, a corresponding Span
can be implicitly constructed and is then used for StringView construction.

In StringView, constructors taking in ASCIILiteral or Span are adjusted to
handle const lvalue references of those objects.

Different static integer values can now end up generating undesired symbols when
handled through references in calls to makeString() and makeAtomString(). This
can be avoided by explicitly copying the passed-in value.

* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::makeCall):
(Inspector::InjectedScriptBase::makeAsyncCall):
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::are8Bit):
(WTF::stringTypeAdapterAccumulator):
(WTF::tryMakeStringImplFromAdaptersInternal):
(WTF::handleWithAdapters):
(WTF::tryMakeStringFromAdapters):
(WTF::tryMakeString):
(WTF::makeString):
(WTF::tryMakeAtomStringFromAdapters):
(WTF::tryMakeAtomString):
(WTF::makeAtomString):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringOperators.h:
(WTF::StringAppend::is8Bit const):
(WTF::StringAppend::writeTo const):
(WTF::StringAppend::length const):
(WTF::StringAppend::is8Bit): Deleted.
(WTF::StringAppend::writeTo): Deleted.
(WTF::StringAppend::length): Deleted.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::generateTemporaryPath):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/dom/make_names.pl:
(printTagNameCppFile):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b89b603e1e19e17fed1c93f72872821b4a2b984

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114455 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174635 "Hash 4b89b603 for PR 8712 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5196 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97510 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114397 "Hash 4b89b603 for PR 8712 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39422 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26549 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81088 "Found 3 new API test failures: /TestWTF:WTF_ParkingLot.UnparkOneOneFast, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27908 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93078 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5340 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4481 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30320 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47463 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101780 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9493 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25398 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->