### PR TITLE
[@property] Handle dependency cycles involving root style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt
@@ -5,19 +5,19 @@ PASS Lengths with ex units may not be referenced from font-size
 PASS Lengths with ch units may not be referenced from font-size
 PASS Lengths with lh units may not be referenced from font-size
 PASS Lengths with rem units may be referenced from font-size on non-root element
-FAIL Lengths with rem units may not be referenced from font-size on root element assert_equals: expected "16px" but got "32px"
+PASS Lengths with rem units may not be referenced from font-size on root element
 PASS Lengths with lh units may not be referenced from line-height
 PASS Fallback may not use font-relative units
 PASS Fallback may not use line-height-relative units
 PASS Fallback not triggered while inside em unit cycle
 PASS Fallback not triggered while inside ex unit cycle
 PASS Fallback not triggered while inside ch unit cycle
-FAIL Fallback not triggered while inside rem unit cycle on root element assert_equals: expected "16px" but got "32px"
+PASS Fallback not triggered while inside rem unit cycle on root element
 PASS Fallback not triggered while inside lh unit cycle
 PASS Lengths with em units are detected via var references
 PASS Lengths with ex units are detected via var references
 PASS Lengths with ch units are detected via var references
-FAIL Lengths with rem units are detected via var references assert_equals: expected "16px" but got "160px"
+PASS Lengths with rem units are detected via var references
 PASS Lengths with lh units are detected via var references
 PASS Inherited lengths with em units may be used
 PASS Inherited lengths with ex units may be used

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1674,40 +1674,29 @@ Ref<DeprecatedCSSOMPrimitiveValue> CSSPrimitiveValue::createDeprecatedCSSOMPrimi
 }
 
 // https://drafts.css-houdini.org/css-properties-values-api/#dependency-cycles
-void CSSPrimitiveValue::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
+void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     switch (primitiveUnitType()) {
+    case CSSUnitType::CSS_REMS:
+        dependencies.rootProperties.appendIfNotContains(CSSPropertyFontSize);
+        break;
+    case CSSUnitType::CSS_RLHS:
+        dependencies.rootProperties.appendIfNotContains(CSSPropertyFontSize);
+        dependencies.rootProperties.appendIfNotContains(CSSPropertyLineHeight);
+        break;
     case CSSUnitType::CSS_EMS:
     case CSSUnitType::CSS_QUIRKY_EMS:
     case CSSUnitType::CSS_EXS:
     case CSSUnitType::CSS_CHS:
     case CSSUnitType::CSS_IC:
-        values.add(CSSPropertyFontSize);
+        dependencies.properties.appendIfNotContains(CSSPropertyFontSize);
         break;
     case CSSUnitType::CSS_LHS:
-        values.add(CSSPropertyFontSize);
-        values.add(CSSPropertyLineHeight);
+        dependencies.properties.appendIfNotContains(CSSPropertyFontSize);
+        dependencies.properties.appendIfNotContains(CSSPropertyLineHeight);
         break;
     case CSSUnitType::CSS_CALC:
-        m_value.calc->collectDirectComputationalDependencies(values);
-        break;
-    default:
-        break;
-    }
-}
-
-void CSSPrimitiveValue::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& values) const
-{
-    switch (primitiveUnitType()) {
-    case CSSUnitType::CSS_REMS:
-        values.add(CSSPropertyFontSize);
-        break;
-    case CSSUnitType::CSS_RLHS:
-        values.add(CSSPropertyFontSize);
-        values.add(CSSPropertyLineHeight);
-        break;
-    case CSSUnitType::CSS_CALC:
-        m_value.calc->collectDirectRootComputationalDependencies(values);
+        m_value.calc->collectComputedStyleDependencies(dependencies);
         break;
     default:
         break;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -202,8 +202,7 @@ public:
 
     Ref<DeprecatedCSSOMPrimitiveValue> createDeprecatedCSSOMPrimitiveWrapper(CSSStyleDeclaration&) const;
 
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const;
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const;
+    void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
 private:
     friend class CSSValuePool;

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -222,28 +222,23 @@ bool CSSValue::traverseSubresources(const Function<bool(const CachedResource&)>&
     });
 }
 
-void CSSValue::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
+ComputedStyleDependencies CSSValue::computedStyleDependencies() const
 {
-    if (auto* asList = dynamicDowncast<CSSValueList>(*this)) {
-        for (auto& listValue : *asList)
-            listValue->collectDirectComputationalDependencies(values);
-        return;
-    }
-
-    if (is<CSSPrimitiveValue>(*this))
-        downcast<CSSPrimitiveValue>(*this).collectDirectComputationalDependencies(values);
+    ComputedStyleDependencies dependencies;
+    collectComputedStyleDependencies(dependencies);
+    return dependencies;
 }
 
-void CSSValue::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& values) const
+void CSSValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     if (auto* asList = dynamicDowncast<CSSValueList>(*this)) {
         for (auto& listValue : *asList)
-            listValue->collectDirectRootComputationalDependencies(values);
+            listValue->collectComputedStyleDependencies(dependencies);
         return;
     }
 
     if (is<CSSPrimitiveValue>(*this))
-        downcast<CSSPrimitiveValue>(*this).collectDirectRootComputationalDependencies(values);
+        downcast<CSSPrimitiveValue>(*this).collectComputedStyleDependencies(dependencies);
 }
 
 bool CSSValue::equals(const CSSValue& other) const

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -23,6 +23,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
+#include <wtf/Vector.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
@@ -32,6 +33,13 @@ class CachedResource;
 class DeprecatedCSSOMValue;
 
 enum CSSPropertyID : uint16_t;
+
+struct ComputedStyleDependencies {
+    Vector<CSSPropertyID> properties;
+    Vector<CSSPropertyID> rootProperties;
+
+    bool isEmpty() const { return properties.isEmpty() && rootProperties.isEmpty(); }
+};
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);
 class CSSValue {
@@ -122,9 +130,8 @@ public:
     bool traverseSubresources(const Function<bool(const CachedResource&)>&) const;
 
     // What properties does this value rely on (eg, font-size for em units)
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const;
-    // What properties in the root element does this value rely on (eg. font-size for rem units)
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const;
+    ComputedStyleDependencies computedStyleDependencies() const;
+    void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
     bool equals(const CSSValue&) const;
     bool operator==(const CSSValue& other) const { return equals(other); }

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -58,8 +58,7 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
     if (!descriptor.initialValue.isNull()) {
         CSSTokenizer tokenizer(descriptor.initialValue);
 
-        HashSet<CSSPropertyID> dependencies;
-        CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, true /* isInitial */, dependencies, tokenizer.tokenRange(), strictCSSParserContext());
+        auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, tokenizer.tokenRange(), strictCSSParserContext());
 
         if (!dependencies.isEmpty())
             return Exception { SyntaxError, "The given initial value must be computationally independent."_s };

--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class CSSToLengthConversionData;
+struct ComputedStyleDependencies;
 
 enum CSSPropertyID : uint16_t;
 
@@ -57,8 +58,7 @@ public:
     virtual Type type() const = 0;
     virtual CSSUnitType primitiveType() const = 0;
 
-    virtual void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const = 0;
-    virtual void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const = 0;
+    virtual void collectComputedStyleDependencies(ComputedStyleDependencies&) const = 0;
     virtual bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const = 0;
 
     CalculationCategory category() const { return m_category; }

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.h
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.h
@@ -56,8 +56,7 @@ private:
     Type type() const final { return Type::CssCalcInvert; }
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }
 
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>& properties) const final { m_child->collectDirectComputationalDependencies(properties); }
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& properties) const final { m_child->collectDirectRootComputationalDependencies(properties); }
+    void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const final { m_child->collectComputedStyleDependencies(dependencies); }
     bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final { return m_child->convertingToLengthRequiresNonNullStyle(lengthConversion); }
 
     void dump(TextStream&) const final;

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.h
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.h
@@ -56,8 +56,7 @@ private:
     Type type() const final { return Type::CssCalcNegate; }
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }
 
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>& properties) const final { m_child->collectDirectComputationalDependencies(properties); }
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& properties) const final { m_child->collectDirectRootComputationalDependencies(properties); }
+    void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const final { m_child->collectComputedStyleDependencies(dependencies); }
     bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final { return m_child->convertingToLengthRequiresNonNullStyle(lengthConversion); }
 
     void dump(TextStream&) const final;

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1072,16 +1072,10 @@ double CSSCalcOperationNode::computeLengthPx(const CSSToLengthConversionData& co
     }));
 }
 
-void CSSCalcOperationNode::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
+void CSSCalcOperationNode::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     for (auto& child : m_children)
-        child->collectDirectComputationalDependencies(values);
-}
-
-void CSSCalcOperationNode::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& values) const
-{
-    for (auto& child : m_children)
-        child->collectDirectRootComputationalDependencies(values);
+        child->collectComputedStyleDependencies(dependencies);
 }
 
 bool CSSCalcOperationNode::convertingToLengthRequiresNonNullStyle(int lengthConversion) const

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -115,8 +115,7 @@ private:
     double doubleValue(CSSUnitType) const final;
     double computeLengthPx(const CSSToLengthConversionData&) const final;
 
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const final;
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const final;
+    void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
     bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final;
 
     void dump(TextStream&) const final;

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -201,14 +201,9 @@ double CSSCalcPrimitiveValueNode::computeLengthPx(const CSSToLengthConversionDat
     return 0;
 }
 
-void CSSCalcPrimitiveValueNode::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
+void CSSCalcPrimitiveValueNode::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
-    m_value->collectDirectComputationalDependencies(values);
-}
-
-void CSSCalcPrimitiveValueNode::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& values) const
-{
-    m_value->collectDirectRootComputationalDependencies(values);
+    m_value->collectComputedStyleDependencies(dependencies);
 }
 
 bool CSSCalcPrimitiveValueNode::convertingToLengthRequiresNonNullStyle(int lengthConversion) const

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -72,8 +72,7 @@ private:
     std::unique_ptr<CalcExpressionNode> createCalcExpression(const CSSToLengthConversionData&) const final;
 
     double computeLengthPx(const CSSToLengthConversionData&) const final;
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const final;
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const final;
+    void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
     bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final;
 
     void dump(TextStream&) const final;

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -301,14 +301,9 @@ void CSSCalcValue::setPermittedValueRange(ValueRange range)
     m_shouldClampToNonNegative = range != ValueRange::All;
 }
 
-void CSSCalcValue::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
+void CSSCalcValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
-    m_expression->collectDirectComputationalDependencies(values);
-}
-
-void CSSCalcValue::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& values) const
-{
-    m_expression->collectDirectRootComputationalDependencies(values);
+    m_expression->collectComputedStyleDependencies(dependencies);
 }
 
 String CSSCalcValue::customCSSText() const

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -66,8 +66,7 @@ public:
     Ref<CalculationValue> createCalculationValue(const CSSToLengthConversionData&) const;
     void setPermittedValueRange(ValueRange);
 
-    void collectDirectComputationalDependencies(HashSet<CSSPropertyID>&) const;
-    void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const;
+    void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
     String customCSSText() const;
     bool equals(const CSSCalcValue&) const;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -273,10 +273,10 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyInitia
     return value;
 }
 
-void CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax& syntax, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange& tokens, const CSSParserContext& context)
+ComputedStyleDependencies CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax& syntax, const CSSParserTokenRange& tokens, const CSSParserContext& context)
 {
     CSSPropertyParser parser(tokens, context, nullptr);
-    parser.collectParsedCustomPropertyValueDependencies(syntax, isRoot, dependencies);
+    return parser.collectParsedCustomPropertyValueDependencies(syntax);
 }
 
 bool CSSPropertyParser::isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax& syntax, CSSParserTokenRange tokens, const CSSParserContext& context)
@@ -424,20 +424,18 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
     return { nullptr, CSSCustomPropertySyntax::Type::Unknown };
 }
 
-void CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax& syntax, bool isInitial, HashSet<CSSPropertyID>& dependencies)
+ComputedStyleDependencies CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax& syntax)
 {
     if (syntax.isUniversal())
-        return;
+        return { };
 
     m_range.consumeWhitespace();
 
     auto [value, syntaxType] = consumeCustomPropertyValueWithSyntax(syntax);
     if (!value)
-        return;
+        return { };
 
-    value->collectDirectComputationalDependencies(dependencies);
-    if (isInitial)
-        value->collectDirectRootComputationalDependencies(dependencies);
+    return value->computedStyleDependencies();
 }
 
 RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax& syntax, Style::BuilderState& builderState)

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -52,7 +52,7 @@ public:
 
     static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyInitialValue(const AtomString&, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&);
     static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, const CSSParserTokenRange&, Style::BuilderState&, const CSSParserContext&);
-    static void collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
+    static ComputedStyleDependencies collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, const CSSParserTokenRange&, const CSSParserContext&);
     static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
 
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
@@ -67,7 +67,7 @@ private:
     
     std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(const CSSCustomPropertySyntax&);
     RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, Style::BuilderState&);
-    void collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, bool isInitial, HashSet<CSSPropertyID>& dependencies);
+    ComputedStyleDependencies collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&);
 
     bool inQuirksMode() const { return m_context.mode == HTMLQuirksMode; }
 

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -93,8 +93,7 @@ void CustomPropertyRegistry::registerFromStylesheet(const StyleRuleProperty::Des
         auto tokenRange = descriptor.initialValue->tokenRange();
 
         // FIXME: This parses twice.
-        HashSet<CSSPropertyID> dependencies;
-        CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, true /* isInitial */, dependencies, tokenRange, strictCSSParserContext());
+        auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, tokenRange, strictCSSParserContext());
         if (!dependencies.isEmpty())
             return nullptr;
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -272,11 +272,10 @@ bool PropertyCascade::shouldApplyAfterAnimation(const StyleProperties::PropertyR
 
     // Check for 'em' units and similar property dependencies.
     if (m_animationLayer->hasFontSize || m_animationLayer->hasLineHeight) {
-        HashSet<CSSPropertyID> dependencies;
-        property.value()->collectDirectComputationalDependencies(dependencies);
-        if (m_animationLayer->hasFontSize && dependencies.contains(CSSPropertyFontSize))
+        auto dependencies = property.value()->computedStyleDependencies();
+        if (m_animationLayer->hasFontSize && dependencies.properties.contains(CSSPropertyFontSize))
             return true;
-        if (m_animationLayer->hasLineHeight && dependencies.contains(CSSPropertyLineHeight))
+        if (m_animationLayer->hasLineHeight && dependencies.properties.contains(CSSPropertyLineHeight))
             return true;
     }
 


### PR DESCRIPTION
#### c3229c227bf84f8e8577ec0e6ded842ddc36e527
<pre>
[@property] Handle dependency cycles involving root style
<a href="https://bugs.webkit.org/show_bug.cgi?id=250703">https://bugs.webkit.org/show_bug.cgi?id=250703</a>
rdar://104324136

Reviewed by Alan Baradlay.

&apos;rem&apos; unit and others can create dependency cycles that apply to the document element style only.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const):

Use Vector instead of a HashMap since there are never very many of these properties.

(WebCore::CSSPrimitiveValue::collectDirectComputationalDependencies const): Deleted.
(WebCore::CSSPrimitiveValue::collectDirectRootComputationalDependencies const): Deleted.

Factor these to a single function that collect both root and normal dependencies.

* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::computedStyleDependencies const):
(WebCore::CSSValue::collectComputedStyleDependencies const):
(WebCore::CSSValue::collectDirectComputationalDependencies const): Deleted.
(WebCore::CSSValue::collectDirectRootComputationalDependencies const): Deleted.
* Source/WebCore/css/CSSValue.h:
(WebCore::ComputedStyleDependencies::isEmpty const):
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):
* Source/WebCore/css/calc/CSSCalcExpressionNode.h:
* Source/WebCore/css/calc/CSSCalcInvertNode.h:
* Source/WebCore/css/calc/CSSCalcNegateNode.h:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::collectComputedStyleDependencies const):
(WebCore::CSSCalcOperationNode::collectDirectComputationalDependencies const): Deleted.
(WebCore::CSSCalcOperationNode::collectDirectRootComputationalDependencies const): Deleted.
* Source/WebCore/css/calc/CSSCalcOperationNode.h:
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
(WebCore::CSSCalcPrimitiveValueNode::collectComputedStyleDependencies const):
(WebCore::CSSCalcPrimitiveValueNode::collectDirectComputationalDependencies const): Deleted.
(WebCore::CSSCalcPrimitiveValueNode::collectDirectRootComputationalDependencies const): Deleted.
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::collectComputedStyleDependencies const):
(WebCore::CSSCalcValue::collectDirectComputationalDependencies const): Deleted.
(WebCore::CSSCalcValue::collectDirectRootComputationalDependencies const): Deleted.
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseCustomPropertyValueWithVariableReferences):

Check for root style dependencies if needed.
Always mark all cycles. This could have impact in some sort of multi-property cycle case.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::collectParsedCustomPropertyValueDependencies):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):

Canonical link: <a href="https://commits.webkit.org/258985@main">https://commits.webkit.org/258985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98880270818244f6be1c83383682b035b906f7c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112797 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3576 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111969 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10553 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25216 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6056 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6236 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46128 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6170 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7989 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->