### PR TITLE
IPC stream buffer cannot be tested without the connection

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -30,8 +30,7 @@
 #include "Decoder.h"
 #include "IPCSemaphore.h"
 #include "MessageNames.h"
-#include "StreamConnectionBuffer.h"
-#include "StreamConnectionEncoder.h"
+#include "StreamClientConnectionBuffer.h"
 #include "StreamServerConnection.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/Threading.h>
@@ -68,14 +67,9 @@ public:
 
     ~StreamClientConnection();
 
-    StreamConnectionBuffer& streamBuffer() { return m_buffer; }
     void setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait);
-    bool hasSemaphores() const { return m_semaphores.has_value(); }
-    void setMaxBatchSize(unsigned size)
-    {
-        m_maxBatchSize = size;
-        wakeUpServer(WakeUpServer::Yes);
-    }
+    bool hasSemaphores() const;
+    void setMaxBatchSize(unsigned);
 
     void open(Connection::Client&, SerialFunctionDispatcher& = RunLoop::current());
     void invalidate();
@@ -93,49 +87,21 @@ public:
     template<typename T, typename U>
     bool waitForAndDispatchImmediately(ObjectIdentifier<U> destinationID, Timeout, OptionSet<WaitForOption> = { });
 
-
-    StreamConnectionBuffer& bufferForTesting();
+    StreamClientConnectionBuffer& bufferForTesting();
     Connection& connectionForTesting();
 
 private:
     StreamClientConnection(Ref<Connection>, unsigned bufferSizeLog2);
 
-    struct Span {
-        uint8_t* data;
-        size_t size;
-    };
-    static constexpr size_t minimumMessageSize = StreamConnectionEncoder::minimumMessageSize;
-    static constexpr size_t messageAlignment = StreamConnectionEncoder::messageAlignment;
     template<typename T, typename... AdditionalData>
-    bool trySendStream(Span&, T& message, AdditionalData&&...);
+    bool trySendStream(Span<uint8_t>&, T& message, AdditionalData&&...);
     template<typename T>
-    std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, Span&);
+    std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, Span<uint8_t>&);
     bool trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
-    void sendProcessOutOfStreamMessage(Span&&);
-
-    std::optional<Span> tryAcquire(Timeout);
-    std::optional<Span> tryAcquireAll(Timeout);
-
-    enum class WakeUpServer : bool {
-        No,
-        Yes
-    };
-    WakeUpServer release(size_t writeSize);
+    void sendProcessOutOfStreamMessage(Span<uint8_t>&&);
+    using WakeUpServer = StreamClientConnectionBuffer::WakeUpServer;
     void wakeUpServerBatched(WakeUpServer);
     void wakeUpServer(WakeUpServer);
-
-    Span alignedSpan(size_t offset, size_t limit);
-    size_t size(size_t offset, size_t limit);
-
-    size_t wrapOffset(size_t offset) const { return m_buffer.wrapOffset(offset); }
-    size_t alignOffset(size_t offset) const { return m_buffer.alignOffset<messageAlignment>(offset, minimumMessageSize); }
-    using ClientOffset = StreamConnectionBuffer::ClientOffset;
-    Atomic<ClientOffset>& sharedClientOffset() { return m_buffer.clientOffset(); }
-    using ClientLimit = StreamConnectionBuffer::ServerOffset;
-    Atomic<ClientLimit>& sharedClientLimit() { return m_buffer.serverOffset(); }
-    size_t toLimit(ClientLimit) const;
-    uint8_t* data() const { return m_buffer.data(); }
-    size_t dataSize() const { return m_buffer.dataSize(); }
 
     Ref<Connection> m_connection;
     class DedicatedConnectionClient final : public Connection::Client {
@@ -152,13 +118,7 @@ private:
     };
     std::optional<DedicatedConnectionClient> m_dedicatedConnectionClient;
     uint64_t m_currentDestinationID { 0 };
-    size_t m_clientOffset { 0 };
-    StreamConnectionBuffer m_buffer;
-    struct Semaphores {
-        Semaphore wakeUp;
-        Semaphore clientWait;
-    };
-    std::optional<Semaphores> m_semaphores;
+    StreamClientConnectionBuffer m_buffer;
     unsigned m_maxBatchSize { 20 }; // Number of messages marked as StreamBatched to accumulate before notifying the server.
     unsigned m_batchSize { 0 };
 
@@ -171,7 +131,7 @@ bool StreamClientConnection::send(T&& message, ObjectIdentifier<U> destinationID
     static_assert(!T::isSync, "Message is sync!");
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
         return false;
-    auto span = tryAcquire(timeout);
+    auto span = m_buffer.tryAcquire(timeout);
     if (!span)
         return false;
     if constexpr(T::isStreamEncodable) {
@@ -191,7 +151,7 @@ StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
         return { };
 
-    auto span = tryAcquire(timeout);
+    auto span = m_buffer.tryAcquire(timeout);
     if (!span)
         return { };
     auto handler = Connection::makeAsyncReplyHandler<T>(WTFMove(completionHandler));
@@ -219,11 +179,11 @@ StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(
 }
 
 template<typename T, typename... AdditionalData>
-bool StreamClientConnection::trySendStream(Span& span, T& message, AdditionalData&&... args)
+bool StreamClientConnection::trySendStream(Span<uint8_t>& span, T& message, AdditionalData&&... args)
 {
-    StreamConnectionEncoder messageEncoder { T::name(), span.data, span.size };
+    StreamConnectionEncoder messageEncoder { T::name(), span.data(), span.size() };
     if (((messageEncoder << message.arguments()) << ... << std::forward<decltype(args)>(args))) {
-        auto wakeUpResult = release(messageEncoder.size());
+        auto wakeUpResult = m_buffer.release(messageEncoder.size());
         if constexpr(T::isStreamBatched)
             wakeUpServerBatched(wakeUpResult);
         else
@@ -239,7 +199,7 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
     static_assert(T::isSync, "Message is not sync!");
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
         return { };
-    auto span = tryAcquire(timeout);
+    auto span = m_buffer.tryAcquire(timeout);
     if (!span)
         return { };
     if constexpr(T::isStreamEncodable) {
@@ -258,7 +218,7 @@ bool StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifier<U> d
 }
 
 template<typename T>
-std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection::trySendSyncStream(T& message, Timeout timeout, Span& span)
+std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection::trySendSyncStream(T& message, Timeout timeout, Span<uint8_t>& span)
 {
     // In this function, SendSyncResult<T> { } means error happened and caller should stop processing.
     // std::nullopt means we couldn't send through the stream, so try sending out of stream.
@@ -267,22 +227,23 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
         return SendSyncResult<T> { };
 
     auto decoderResult = [&]() -> std::optional<std::unique_ptr<Decoder>> {
-        StreamConnectionEncoder messageEncoder { T::name(), span.data, span.size };
+        StreamConnectionEncoder messageEncoder { T::name(), span.data(), span.size() };
         if (!(messageEncoder << syncRequestID << message.arguments()))
             return std::nullopt;
-        auto wakeUpResult = release(messageEncoder.size());
+        auto wakeUpResult = m_buffer.release(messageEncoder.size());
         wakeUpServer(wakeUpResult);
         if constexpr(T::isReplyStreamEncodable) {
-            auto replySpan = tryAcquireAll(timeout);
+            auto replySpan = m_buffer.tryAcquireAll(timeout);
             if (!replySpan)
                 return std::unique_ptr<Decoder> { };
-            auto decoder = std::unique_ptr<Decoder> { new Decoder(replySpan->data, replySpan->size, m_currentDestinationID) };
+            auto decoder = std::unique_ptr<Decoder> { new Decoder(replySpan->data(), replySpan->size(), m_currentDestinationID) };
             if (decoder->messageName() != MessageName::ProcessOutOfStreamMessage) {
                 ASSERT(decoder->messageName() == MessageName::SyncMessageReply);
                 return decoder;
             }
         } else
-            m_clientOffset = 0;
+            m_buffer.resetClientOffset();
+
         return m_connection->waitForSyncReply(syncRequestID, T::name(), timeout, { });
     }();
     m_connection->popPendingSyncRequestID(syncRequestID);
@@ -304,132 +265,27 @@ inline bool StreamClientConnection::trySendDestinationIDIfNeeded(uint64_t destin
 {
     if (destinationID == m_currentDestinationID)
         return true;
-    auto span = tryAcquire(timeout);
+    auto span = m_buffer.tryAcquire(timeout);
     if (!span)
         return false;
-    StreamConnectionEncoder encoder { MessageName::SetStreamDestinationID, span->data, span->size };
+    StreamConnectionEncoder encoder { MessageName::SetStreamDestinationID, span->data(), span->size() };
     if (!(encoder << destinationID)) {
         ASSERT_NOT_REACHED(); // Size of the minimum allocation is incorrect. Likely an alignment issue.
         return false;
     }
-    auto wakeUpResult = release(encoder.size());
+    auto wakeUpResult = m_buffer.release(encoder.size());
     wakeUpServer(wakeUpResult);
     m_currentDestinationID = destinationID;
     return true;
 }
 
-inline void StreamClientConnection::sendProcessOutOfStreamMessage(Span&& span)
+inline void StreamClientConnection::sendProcessOutOfStreamMessage(Span<uint8_t>&& span)
 {
-    StreamConnectionEncoder encoder { MessageName::ProcessOutOfStreamMessage, span.data, span.size };
+    StreamConnectionEncoder encoder { MessageName::ProcessOutOfStreamMessage, span.data(), span.size() };
     // Not notifying on wake up since the out-of-stream message will do that.
-    auto result = release(encoder.size());
+    auto result = m_buffer.release(encoder.size());
     UNUSED_VARIABLE(result);
     m_batchSize = 0;
-}
-
-inline std::optional<StreamClientConnection::Span> StreamClientConnection::tryAcquire(Timeout timeout)
-{
-    ClientLimit clientLimit = sharedClientLimit().load(std::memory_order_acquire);
-    // This would mean we try to send messages after a timeout. It is a programming error.
-    // Since the value is trusted, we only assert.
-    ASSERT(clientLimit != ClientLimit::clientIsWaitingTag);
-
-    for (;;) {
-        if (clientLimit != ClientLimit::clientIsWaitingTag) {
-            auto result = alignedSpan(m_clientOffset, toLimit(clientLimit));
-            if (result.size >= minimumMessageSize)
-                return result;
-        }
-        if (timeout.didTimeOut())
-            break;
-        ClientLimit oldClientLimit = sharedClientLimit().compareExchangeStrong(clientLimit, ClientLimit::clientIsWaitingTag, std::memory_order_acq_rel, std::memory_order_acq_rel);
-        if (clientLimit == oldClientLimit) {
-            if (!m_semaphores || !m_semaphores->clientWait.waitFor(timeout))
-                return std::nullopt;
-            clientLimit = sharedClientLimit().load(std::memory_order_acquire);
-        } else
-            clientLimit = oldClientLimit;
-        // The alignedSpan uses the minimumMessageSize to calculate the next beginning position in the buffer,
-        // and not the size. The size might be more or less what is needed, depending on where the reader is.
-        // If there is no capacity for minimum message size, wait until more is available.
-        // In the case where clientOffset < clientLimit we can arrive to a situation where
-        // 0 < result.size < minimumMessageSize.
-    }
-    return std::nullopt;
-}
-
-inline std::optional<StreamClientConnection::Span> StreamClientConnection::tryAcquireAll(Timeout timeout)
-{
-    // This would mean we try to send messages after a timeout. It is a programming error.
-    // Since the value is trusted, we only assert.
-    ASSERT(sharedClientLimit().load(std::memory_order_acquire) != ClientLimit::clientIsWaitingTag);
-
-    // The server acknowledges that sync message has been processed by setting clientOffset == clientLimit == 0.
-    // Wait for this condition, or then the condition where server says that it started to sleep after setting that condition.
-    // The wait sequence involves two variables, so form a transaction by setting clientLimit == clientIsWaitingTag.
-    // The transaction is cancelled if the server has already set clientOffset == clientLimit == 0, otherwise it commits.
-    // If the transaction commits, server is guaranteed to signal.
-
-    for (;;) {
-        ClientLimit clientLimit = sharedClientLimit().exchange(ClientLimit::clientIsWaitingTag, std::memory_order_acq_rel);
-        ClientOffset clientOffset = sharedClientOffset().load(std::memory_order_acquire);
-        if (!clientLimit && (clientOffset == ClientOffset::serverIsSleepingTag || !clientOffset))
-            break;
-
-        if (!m_semaphores || !m_semaphores->clientWait.waitFor(timeout))
-            return std::nullopt;
-        if (timeout.didTimeOut())
-            return std::nullopt;
-    }
-    // In case the transaction was cancelled, undo the transaction marker.
-    sharedClientLimit().store(static_cast<ClientLimit>(0), std::memory_order_release);
-    m_clientOffset = 0;
-    return alignedSpan(m_clientOffset, 0);
-}
-
-inline StreamClientConnection::WakeUpServer StreamClientConnection::release(size_t size)
-{
-    size = std::max(size, minimumMessageSize);
-    m_clientOffset = wrapOffset(alignOffset(m_clientOffset) + size);
-    ASSERT(m_clientOffset < dataSize());
-    // If the server wrote over the clientOffset with serverIsSleepingTag, we know it is sleeping.
-    ClientOffset oldClientOffset = sharedClientOffset().exchange(static_cast<ClientOffset>(m_clientOffset), std::memory_order_acq_rel);
-    if (oldClientOffset == ClientOffset::serverIsSleepingTag)
-        return WakeUpServer::Yes;
-    ASSERT(!(oldClientOffset & ClientOffset::serverIsSleepingTag));
-    return WakeUpServer::No;
-}
-
-inline StreamClientConnection::Span StreamClientConnection::alignedSpan(size_t offset, size_t limit)
-{
-    ASSERT(offset < dataSize());
-    ASSERT(limit < dataSize());
-    size_t aligned = alignOffset(offset);
-    size_t resultSize = 0;
-    if (offset < limit) {
-        if (aligned >= offset && aligned < limit)
-            resultSize = size(aligned, limit);
-    } else {
-        if (aligned >= offset || aligned < limit)
-            resultSize = size(aligned, limit);
-    }
-    return { data() + aligned, resultSize };
-}
-
-inline size_t StreamClientConnection::size(size_t offset, size_t limit)
-{
-    if (!limit)
-        return dataSize() - 1 - offset;
-    if (limit <= offset)
-        return dataSize() - offset;
-    return limit - offset - 1;
-}
-
-inline size_t StreamClientConnection::toLimit(ClientLimit clientLimit) const
-{
-    ASSERT(!(clientLimit & ClientLimit::clientIsWaitingTag));
-    ASSERT(static_cast<size_t>(clientLimit) <= dataSize() - 1);
-    return static_cast<size_t>(clientLimit);
 }
 
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IPCSemaphore.h"
+#include "StreamConnectionBuffer.h"
+#include "StreamConnectionEncoder.h"
+
+namespace IPC {
+
+class StreamClientConnectionBuffer : public StreamConnectionBuffer {
+public:
+    explicit StreamClientConnectionBuffer(unsigned dataSizeLog2);
+
+    std::optional<Span<uint8_t>> tryAcquire(Timeout);
+    std::optional<Span<uint8_t>> tryAcquireAll(Timeout);
+
+    enum class WakeUpServer : bool {
+        No,
+        Yes
+    };
+    WakeUpServer release(size_t writeSize);
+    void resetClientOffset();
+    Span<uint8_t> alignedSpan(size_t offset, size_t limit);
+    void setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait);
+    bool hasSemaphores() const { return m_semaphores.has_value(); }
+    void wakeUpServer();
+
+private:
+    static constexpr size_t minimumMessageSize = StreamConnectionEncoder::minimumMessageSize;
+    static constexpr size_t messageAlignment = StreamConnectionEncoder::messageAlignment;
+    static Ref<WebKit::SharedMemory> createMemory(unsigned dataSizeLog2);
+    size_t size(size_t offset, size_t limit);
+    size_t alignOffset(size_t offset) const { return StreamConnectionBuffer::alignOffset<messageAlignment>(offset, minimumMessageSize); }
+    Atomic<ClientOffset>& sharedClientOffset() { return clientOffset(); }
+    using ClientLimit = ServerOffset;
+    Atomic<ClientLimit>& sharedClientLimit() { return serverOffset(); }
+    size_t toLimit(ClientLimit) const;
+
+    size_t m_clientOffset { 0 };
+    struct Semaphores {
+        Semaphore wakeUp;
+        Semaphore clientWait;
+    };
+    std::optional<Semaphores> m_semaphores;
+};
+
+inline Ref<WebKit::SharedMemory> StreamClientConnectionBuffer::createMemory(unsigned dataSizeLog2)
+{
+    auto size = (static_cast<size_t>(1) << dataSizeLog2) + headerSize();
+    auto memory = WebKit::SharedMemory::allocate(size);
+    if (!memory)
+        CRASH();
+    return memory.releaseNonNull();
+}
+
+inline StreamClientConnectionBuffer::StreamClientConnectionBuffer(unsigned dataSizeLog2)
+    : StreamConnectionBuffer(createMemory(dataSizeLog2))
+{
+    ASSERT(dataSizeLog2 < 31u); // Currently expected to be not that big, and offset to fit in size_t with the tag bits.
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(sharedMemorySizeIsValid(m_sharedMemory->size()));
+
+    // Read starts from 0 with limit of 0 and reader sleeping.
+    sharedClientOffset().store(ClientOffset::serverIsSleepingTag, std::memory_order_relaxed);
+    // Write starts from 0 with a limit of the whole buffer.
+    sharedClientLimit().store(static_cast<ClientLimit>(0), std::memory_order_relaxed);
+}
+
+inline std::optional<Span<uint8_t>> StreamClientConnectionBuffer::tryAcquire(Timeout timeout)
+{
+    ClientLimit clientLimit = sharedClientLimit().load(std::memory_order_acquire);
+    // This would mean we try to send messages after a timeout. It is a programming error.
+    // Since the value is trusted, we only assert.
+    ASSERT(clientLimit != ClientLimit::clientIsWaitingTag);
+
+    for (;;) {
+        if (clientLimit != ClientLimit::clientIsWaitingTag) {
+            auto result = alignedSpan(m_clientOffset, toLimit(clientLimit));
+            if (result.size() >= minimumMessageSize)
+                return result;
+        }
+        if (timeout.didTimeOut())
+            break;
+        ClientLimit oldClientLimit = sharedClientLimit().compareExchangeStrong(clientLimit, ClientLimit::clientIsWaitingTag, std::memory_order_acq_rel, std::memory_order_acq_rel);
+        if (clientLimit == oldClientLimit) {
+            if (!m_semaphores || !m_semaphores->clientWait.waitFor(timeout))
+                return std::nullopt;
+            clientLimit = sharedClientLimit().load(std::memory_order_acquire);
+        } else
+            clientLimit = oldClientLimit;
+        // The alignedSpan uses the minimumMessageSize to calculate the next beginning position in the buffer,
+        // and not the size. The size might be more or less what is needed, depending on where the reader is.
+        // If there is no capacity for minimum message size, wait until more is available.
+        // In the case where clientOffset < clientLimit we can arrive to a situation where
+        // 0 < result.size() < minimumMessageSize.
+    }
+    return std::nullopt;
+}
+
+inline std::optional<Span<uint8_t>> StreamClientConnectionBuffer::tryAcquireAll(Timeout timeout)
+{
+    // This would mean we try to send messages after a timeout. It is a programming error.
+    // Since the value is trusted, we only assert.
+    ASSERT(sharedClientLimit().load(std::memory_order_acquire) != ClientLimit::clientIsWaitingTag);
+
+    // The server acknowledges that sync message has been processed by setting clientOffset == clientLimit == 0.
+    // Wait for this condition, or then the condition where server says that it started to sleep after setting that condition.
+    // The wait sequence involves two variables, so form a transaction by setting clientLimit == clientIsWaitingTag.
+    // The transaction is cancelled if the server has already set clientOffset == clientLimit == 0, otherwise it commits.
+    // If the transaction commits, server is guaranteed to signal.
+
+    for (;;) {
+        ClientLimit clientLimit = sharedClientLimit().exchange(ClientLimit::clientIsWaitingTag, std::memory_order_acq_rel);
+        ClientOffset clientOffset = sharedClientOffset().load(std::memory_order_acquire);
+        if (!clientLimit && (clientOffset == ClientOffset::serverIsSleepingTag || !clientOffset))
+            break;
+
+        if (!m_semaphores || !m_semaphores->clientWait.waitFor(timeout))
+            return std::nullopt;
+        if (timeout.didTimeOut())
+            return std::nullopt;
+    }
+    // In case the transaction was cancelled, undo the transaction marker.
+    sharedClientLimit().store(static_cast<ClientLimit>(0), std::memory_order_release);
+    m_clientOffset = 0;
+    return alignedSpan(m_clientOffset, 0);
+}
+
+inline StreamClientConnectionBuffer::WakeUpServer StreamClientConnectionBuffer::release(size_t size)
+{
+    size = std::max(size, minimumMessageSize);
+    m_clientOffset = wrapOffset(alignOffset(m_clientOffset) + size);
+    ASSERT(m_clientOffset < dataSize());
+    // If the server wrote over the clientOffset with serverIsSleepingTag, we know it is sleeping.
+    ClientOffset oldClientOffset = sharedClientOffset().exchange(static_cast<ClientOffset>(m_clientOffset), std::memory_order_acq_rel);
+    if (oldClientOffset == ClientOffset::serverIsSleepingTag)
+        return WakeUpServer::Yes;
+    ASSERT(!(oldClientOffset & ClientOffset::serverIsSleepingTag));
+    return WakeUpServer::No;
+}
+
+inline void StreamClientConnectionBuffer::resetClientOffset()
+{
+    // For synchronous send protocols with replies out-of-band.
+    m_clientOffset = 0;
+}
+
+inline Span<uint8_t> StreamClientConnectionBuffer::alignedSpan(size_t offset, size_t limit)
+{
+    ASSERT(offset < dataSize());
+    ASSERT(limit < dataSize());
+    size_t aligned = alignOffset(offset);
+    size_t resultSize = 0;
+    if (offset < limit) {
+        if (aligned >= offset && aligned < limit)
+            resultSize = size(aligned, limit);
+    } else {
+        if (aligned >= offset || aligned < limit)
+            resultSize = size(aligned, limit);
+    }
+    return { data() + aligned, resultSize };
+}
+
+inline size_t StreamClientConnectionBuffer::size(size_t offset, size_t limit)
+{
+    if (!limit)
+        return dataSize() - 1 - offset;
+    if (limit <= offset)
+        return dataSize() - offset;
+    return limit - offset - 1;
+}
+
+inline size_t StreamClientConnectionBuffer::toLimit(ClientLimit clientLimit) const
+{
+    ASSERT(!(clientLimit & ClientLimit::clientIsWaitingTag));
+    ASSERT(static_cast<size_t>(clientLimit) <= dataSize() - 1);
+    return static_cast<size_t>(clientLimit);
+}
+
+inline void StreamClientConnectionBuffer::setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait)
+{
+    m_semaphores = { WTFMove(wakeUp), WTFMove(clientWait) };
+    m_semaphores->wakeUp.signal();
+}
+
+inline void StreamClientConnectionBuffer::wakeUpServer()
+{
+    if (!m_semaphores)
+        return;
+    m_semaphores->wakeUp.signal();
+}
+
+}

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -71,8 +71,6 @@ class Encoder;
 class StreamConnectionBuffer {
     WTF_MAKE_NONCOPYABLE(StreamConnectionBuffer);
 public:
-    explicit StreamConnectionBuffer(unsigned dataSizeLog2);
-    StreamConnectionBuffer(StreamConnectionBuffer&&);
     ~StreamConnectionBuffer();
 
     struct Handle {
@@ -80,7 +78,6 @@ public:
         void encode(Encoder&) const;
         static std::optional<Handle> decode(Decoder&);
     };
-    static std::optional<StreamConnectionBuffer> map(Handle&&);
     Handle createHandle();
 
     size_t wrapOffset(size_t offset) const
@@ -124,8 +121,10 @@ public:
     Span<uint8_t> headerForTesting();
     Span<uint8_t> dataForTesting();
 
-private:
+protected:
     StreamConnectionBuffer(Ref<WebKit::SharedMemory>&&);
+    StreamConnectionBuffer(StreamConnectionBuffer&&) = default;
+    StreamConnectionBuffer& operator=(StreamConnectionBuffer&&) = default;
 
     struct Header {
         Atomic<ServerOffset> serverOffset;

--- a/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IPCSemaphore.h"
+#include "StreamConnectionBuffer.h"
+#include "StreamConnectionEncoder.h"
+
+namespace IPC {
+
+class StreamServerConnectionBuffer : public StreamConnectionBuffer {
+public:
+    static std::optional<StreamServerConnectionBuffer> map(Handle&&);
+    StreamServerConnectionBuffer(StreamServerConnectionBuffer&&) = default;
+    StreamServerConnectionBuffer& operator=(StreamServerConnectionBuffer&&) = default;
+    std::optional<Span<uint8_t>> tryAcquire();
+    Span<uint8_t> acquireAll();
+    enum class WakeUpClient : bool {
+        No,
+        Yes
+    };
+    WakeUpClient release(size_t readSize);
+    WakeUpClient releaseAll();
+
+private:
+    using StreamConnectionBuffer::StreamConnectionBuffer;
+    static constexpr size_t minimumMessageSize = StreamConnectionEncoder::minimumMessageSize;
+    static constexpr size_t messageAlignment = StreamConnectionEncoder::messageAlignment;
+    Span<uint8_t> alignedSpan(size_t offset, size_t limit);
+    size_t size(size_t offset, size_t limit);
+    size_t alignOffset(size_t offset) const { return StreamConnectionBuffer::alignOffset<messageAlignment>(offset, minimumMessageSize); }
+    using ServerLimit = ClientOffset;
+    Atomic<ServerLimit>& sharedServerLimit() { return clientOffset(); }
+    Atomic<ServerOffset>& sharedServerOffset() { return serverOffset(); }
+    size_t clampedLimit(ServerLimit) const;
+
+    size_t m_serverOffset { 0 };
+};
+
+inline std::optional<StreamServerConnectionBuffer> StreamServerConnectionBuffer::map(Handle&& handle)
+{
+    auto sharedMemory = WebKit::SharedMemory::map(handle.memory, WebKit::SharedMemory::Protection::ReadWrite);
+    if (UNLIKELY(!sharedMemory))
+        return std::nullopt;
+    return StreamServerConnectionBuffer { sharedMemory.releaseNonNull() };
+}
+
+inline std::optional<Span<uint8_t>> StreamServerConnectionBuffer::tryAcquire()
+{
+    ServerLimit serverLimit = sharedServerLimit().load(std::memory_order_acquire);
+    if (serverLimit == ServerLimit::serverIsSleepingTag)
+        return std::nullopt;
+
+    auto result = alignedSpan(m_serverOffset, clampedLimit(serverLimit));
+    if (result.size() < minimumMessageSize) {
+        serverLimit = sharedServerLimit().compareExchangeStrong(serverLimit, ServerLimit::serverIsSleepingTag, std::memory_order_acq_rel, std::memory_order_acq_rel);
+        result = alignedSpan(m_serverOffset, clampedLimit(serverLimit));
+    }
+
+    if (result.size() < minimumMessageSize)
+        return std::nullopt;
+
+    return result;
+}
+
+inline Span<uint8_t> StreamServerConnectionBuffer::acquireAll()
+{
+    return alignedSpan(0, dataSize() - 1);
+}
+
+inline StreamServerConnectionBuffer::WakeUpClient StreamServerConnectionBuffer::release(size_t readSize)
+{
+    ASSERT(readSize);
+    readSize = std::max(readSize, minimumMessageSize);
+    ServerOffset serverOffset = static_cast<ServerOffset>(wrapOffset(alignOffset(m_serverOffset) + readSize));
+
+    ServerOffset oldServerOffset = sharedServerOffset().exchange(serverOffset, std::memory_order_acq_rel);
+    WakeUpClient wakeUpClient = WakeUpClient::No;
+    // If the client wrote over serverOffset, it means the client is waiting.
+    if (oldServerOffset == ServerOffset::clientIsWaitingTag)
+        wakeUpClient = WakeUpClient::Yes;
+    else
+        ASSERT(!(oldServerOffset & ServerOffset::clientIsWaitingTag));
+
+    m_serverOffset = serverOffset;
+    return wakeUpClient;
+}
+
+inline StreamServerConnectionBuffer::WakeUpClient StreamServerConnectionBuffer::releaseAll()
+{
+    sharedServerLimit().store(static_cast<ServerLimit>(0), std::memory_order_release);
+    ServerOffset oldServerOffset = sharedServerOffset().exchange(static_cast<ServerOffset>(0), std::memory_order_acq_rel);
+    WakeUpClient wakeUpClient = WakeUpClient::No;
+    // If the client wrote over serverOffset, it means the client is waiting.
+    if (oldServerOffset == ServerOffset::clientIsWaitingTag)
+        wakeUpClient = WakeUpClient::Yes;
+    else
+        ASSERT(!(oldServerOffset & ServerOffset::clientIsWaitingTag));
+    m_serverOffset = 0;
+    return wakeUpClient;
+}
+
+inline Span<uint8_t> StreamServerConnectionBuffer::alignedSpan(size_t offset, size_t limit)
+{
+    ASSERT(offset < dataSize());
+    ASSERT(limit < dataSize());
+    size_t aligned = alignOffset(offset);
+    size_t resultSize = 0;
+    if (offset < limit) {
+        if (offset <= aligned && aligned < limit)
+            resultSize = size(aligned, limit);
+    } else if (offset > limit) {
+        if (aligned >= offset || aligned < limit)
+            resultSize = size(aligned, limit);
+    }
+    return { data() + aligned, resultSize };
+}
+
+inline size_t StreamServerConnectionBuffer::size(size_t offset, size_t limit)
+{
+    if (offset <= limit)
+        return limit - offset;
+    return dataSize() - offset;
+}
+
+inline size_t StreamServerConnectionBuffer::clampedLimit(ServerLimit serverLimit) const
+{
+    ASSERT(!(serverLimit & ServerLimit::serverIsSleepingTag));
+    size_t limit = static_cast<size_t>(serverLimit);
+    ASSERT(limit <= dataSize() - 1);
+    return std::min(limit, dataSize() - 1);
+}
+
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1433,6 +1433,8 @@
 		7BDD9DDC28D205C6004CDF48 /* MessageObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */; };
 		7BDD9DDD28D205C6004CDF48 /* WorkQueueMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */; };
 		7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE37F9227C7C518007A6CD3 /* IPCStreamTesterIdentifier.h */; };
+		7BE5134B29768F0E00814F18 /* StreamClientConnectionBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE5134929768F0D00814F18 /* StreamClientConnectionBuffer.h */; };
+		7BE5134C29768F0E00814F18 /* StreamServerConnectionBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE5134A29768F0E00814F18 /* StreamServerConnectionBuffer.h */; };
 		7BE9326327F5C75A00D5FEFB /* ReceiverMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE9326227F5C75A00D5FEFB /* ReceiverMatcher.h */; };
 		7BEDA69E28B396BB00B41C7C /* WebCore.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1AA1C79A100E7FC50078DEBC /* WebCore.framework */; };
 		7C065F2C1C8CD95F00C2D950 /* WebUserContentControllerDataTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C065F2A1C8CD95F00C2D950 /* WebUserContentControllerDataTypes.h */; };
@@ -5904,6 +5906,8 @@
 		7BE37F9227C7C518007A6CD3 /* IPCStreamTesterIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTesterIdentifier.h; sourceTree = "<group>"; };
 		7BE37F9427C7CD51007A6CD3 /* IPCStreamTester.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTester.h; sourceTree = "<group>"; };
 		7BE37F9527C7CD90007A6CD3 /* IPCStreamTester.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCStreamTester.cpp; sourceTree = "<group>"; };
+		7BE5134929768F0D00814F18 /* StreamClientConnectionBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamClientConnectionBuffer.h; sourceTree = "<group>"; };
+		7BE5134A29768F0E00814F18 /* StreamServerConnectionBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamServerConnectionBuffer.h; sourceTree = "<group>"; };
 		7BE726572574F67200E85D98 /* RemoteGraphicsContextGLProxyFunctionsGenerated.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxyFunctionsGenerated.cpp; sourceTree = "<group>"; };
 		7BE72668257680EF00E85D98 /* RemoteGraphicsContextGLCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLCocoa.cpp; sourceTree = "<group>"; };
 		7BE9326227F5C75A00D5FEFB /* ReceiverMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReceiverMatcher.h; sourceTree = "<group>"; };
@@ -8851,6 +8855,7 @@
 				93122C852710CCDE001D819F /* SharedFileHandle.h */,
 				7B73123625CC8524003B2796 /* StreamClientConnection.cpp */,
 				7B73123325CC8523003B2796 /* StreamClientConnection.h */,
+				7BE5134929768F0D00814F18 /* StreamClientConnectionBuffer.h */,
 				7B73123425CC8524003B2796 /* StreamConnectionBuffer.cpp */,
 				7B73123125CC8523003B2796 /* StreamConnectionBuffer.h */,
 				7B73123925CC8525003B2796 /* StreamConnectionEncoder.h */,
@@ -8859,6 +8864,7 @@
 				F4299506270E234C0032298B /* StreamMessageReceiver.h */,
 				7B73123725CC8524003B2796 /* StreamServerConnection.cpp */,
 				7B73123825CC8524003B2796 /* StreamServerConnection.h */,
+				7BE5134A29768F0E00814F18 /* StreamServerConnectionBuffer.h */,
 				F48570A22644BEC400C05F71 /* Timeout.h */,
 				7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */,
 			);
@@ -15431,11 +15437,13 @@
 				465F4E06230B2E95003CEDB7 /* StorageNamespaceIdentifier.h in Headers */,
 				935BF80A2936CB8500B41326 /* StorageUtilities.h in Headers */,
 				7B73123C25CC8525003B2796 /* StreamClientConnection.h in Headers */,
+				7BE5134B29768F0E00814F18 /* StreamClientConnectionBuffer.h in Headers */,
 				7B73123A25CC8525003B2796 /* StreamConnectionBuffer.h in Headers */,
 				7B73124225CC8525003B2796 /* StreamConnectionEncoder.h in Headers */,
 				7B73123E25CC8525003B2796 /* StreamConnectionWorkQueue.h in Headers */,
 				F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */,
 				7B73124125CC8525003B2796 /* StreamServerConnection.h in Headers */,
+				7BE5134C29768F0E00814F18 /* StreamServerConnectionBuffer.h in Headers */,
 				296BD85D15019BC30071F424 /* StringUtilities.h in Headers */,
 				57FD318622B3516C008D0E8B /* SubFrameSOAuthorizationSession.h in Headers */,
 				448AC24E267135A700B28921 /* SynapseSPI.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -268,7 +268,7 @@ public:
     JSObjectRef createJSWrapper(JSContextRef);
     static JSIPCStreamConnectionBuffer* toWrapped(JSContextRef, JSValueRef);
 
-    void encode(IPC::Encoder& encoder) const { m_streamConnection->connection().streamBuffer().createHandle().encode(encoder); }
+    void encode(IPC::Encoder& encoder) const { m_streamConnection->connection().bufferForTesting().createHandle().encode(encoder); }
 
 private:
     JSIPCStreamConnectionBuffer(JSIPCStreamClientConnection& streamConnection)
@@ -1031,7 +1031,7 @@ bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(JSContextRef c
     if (!streamConnection.trySendDestinationIDIfNeeded(destinationID, timeout))
         return false;
 
-    auto span = streamConnection.tryAcquire(timeout);
+    auto span = streamConnection.bufferForTesting().tryAcquire(timeout);
     if (!span)
         return false;
 


### PR DESCRIPTION
#### 47dfb60d326b5d2004e4642fcc2b49f138df2b9c
<pre>
IPC stream buffer cannot be tested without the connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=250704">https://bugs.webkit.org/show_bug.cgi?id=250704</a>
rdar://104325129

Reviewed by Antti Koivisto.

The logic to manipulate IPC stream buffer was partly inline
in Stream{Client,Server}Connection. This made both the
connection code harder to understand and the buffer code
harder to understand and modify.

Move the buffer code to Stream{Client,Server}ConnectionBuffer
classes which are subclasses of StreamConnectionBuffer.
The goal is to be able to test the buffer implementation in
isolation. Also, in the future some of the duplicated functionality
should be moved to the base class.

Removes custom Stream{Client,Server}Connection::Span and uses normal
WTF::Span&lt;uint8_t&gt;.

No intended change in functionality.

* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
(IPC::StreamClientConnection::StreamClientConnection):
(IPC::StreamClientConnection::setSemaphores):
(IPC::StreamClientConnection::hasSemaphores const):
(IPC::StreamClientConnection::setMaxBatchSize):
(IPC::StreamClientConnection::wakeUpServer):
(IPC::StreamClientConnection::bufferForTesting):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::trySendSyncStream):
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
(IPC::StreamClientConnection::sendProcessOutOfStreamMessage):
(IPC::StreamClientConnection::tryAcquire): Deleted.
(IPC::StreamClientConnection::tryAcquireAll): Deleted.
(IPC::StreamClientConnection::release): Deleted.
(IPC::StreamClientConnection::alignedSpan): Deleted.
(IPC::StreamClientConnection::size): Deleted.
(IPC::StreamClientConnection::toLimit const): Deleted.
* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h: Added.
(IPC::StreamClientConnectionBuffer::hasSemaphores const):
(IPC::StreamClientConnectionBuffer::alignOffset const):
(IPC::StreamClientConnectionBuffer::sharedClientOffset):
(IPC::StreamClientConnectionBuffer::sharedClientLimit):
(IPC::StreamClientConnectionBuffer::createMemory):
(IPC::StreamClientConnectionBuffer::StreamClientConnectionBuffer):
(IPC::StreamClientConnectionBuffer::tryAcquire):
(IPC::StreamClientConnectionBuffer::tryAcquireAll):
(IPC::StreamClientConnectionBuffer::release):
(IPC::StreamClientConnectionBuffer::resetClientOffset):
(IPC::StreamClientConnectionBuffer::alignedSpan):
(IPC::StreamClientConnectionBuffer::size):
(IPC::StreamClientConnectionBuffer::toLimit const):
(IPC::StreamClientConnectionBuffer::setSemaphores):
(IPC::StreamClientConnectionBuffer::wakeUpServer):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::createMemory): Deleted.
(IPC::StreamConnectionBuffer::map): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::create):
(IPC::StreamServerConnection::StreamServerConnection):
(IPC::StreamServerConnection::dispatchStreamMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::dispatchOutOfStreamMessage):
(IPC::StreamServerConnection::tryAcquire): Deleted.
(IPC::StreamServerConnection::acquireAll): Deleted.
(IPC::StreamServerConnection::release): Deleted.
(IPC::StreamServerConnection::releaseAll): Deleted.
(IPC::StreamServerConnection::alignedSpan): Deleted.
(IPC::StreamServerConnection::size): Deleted.
(IPC::StreamServerConnection::clampedLimit const): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendSyncReply):
* Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h: Added.
(IPC::StreamServerConnectionBuffer::clientWaitSemaphore):
(IPC::StreamServerConnectionBuffer::alignOffset const):
(IPC::StreamServerConnectionBuffer::sharedServerLimit):
(IPC::StreamServerConnectionBuffer::sharedServerOffset):
(IPC::StreamServerConnectionBuffer::map):
(IPC::StreamServerConnectionBuffer::tryAcquire):
(IPC::StreamServerConnectionBuffer::acquireAll):
(IPC::StreamServerConnectionBuffer::release):
(IPC::StreamServerConnectionBuffer::releaseAll):
(IPC::StreamServerConnectionBuffer::alignedSpan):
(IPC::StreamServerConnectionBuffer::size):
(IPC::StreamServerConnectionBuffer::clampedLimit const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::encode const):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp:
(TestWebKitAPI::TEST):
(TestWebKitAPI::StreamConnectionBufferTest::bufferSizeLog2 const):
(TestWebKitAPI::StreamConnectionBufferTest::client):
(TestWebKitAPI::StreamConnectionBufferTest::server):
(TestWebKitAPI::StreamConnectionBufferTest::isValid const):
(TestWebKitAPI::fill):
(TestWebKitAPI::expectFilled):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/258977@main">https://commits.webkit.org/258977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6085c177948bf2adfc3743bd3f7d0233eeb642ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112782 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172988 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3561 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111954 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10540 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38274 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26604 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3133 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46114 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6165 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7974 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->