### PR TITLE
Restore/recreate corrupted SQLite file of local storage

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -160,12 +160,16 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
 
     m_database = makeUnique<WebCore::SQLiteDatabase>();
     FileSystem::makeAllDirectories(FileSystem::parentPath(m_path));
-    if (!m_database->open(m_path)) {
+    auto openResult  = m_database->open(m_path);
+    if (!openResult && handleDatabaseCorruptionIfNeeded(m_database->lastError()))
+        openResult = m_database->open(m_path);
+
+    if (!openResult) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::prepareDatabase failed to open database at '%s'", m_path.utf8().data());
         m_database = nullptr;
         return false;
     }
-        
+
     // Since a WorkQueue isn't bound to a specific thread, we need to disable threading check.
     // We will never access the database from different threads simultaneously.
     m_database->disableThreadingChecks();
@@ -243,11 +247,13 @@ Expected<String, StorageError> SQLiteStorageArea::getItemFromDatabase(const Stri
         return makeUnexpected(StorageError::Database);
     }
 
-    int result = statement->step();
+    const auto result = statement->step();
     if (result == SQLITE_ROW)
         return statement->columnBlobAsString(0);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::getItemFromDatabase failed on stepping statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        handleDatabaseCorruptionIfNeeded(result);
+
         return makeUnexpected(StorageError::Database);
     }
 
@@ -284,7 +290,7 @@ HashMap<String, String> SQLiteStorageArea::allItems()
     }
 
     m_cache = HashMap<String, String> { };
-    int result = statement->step();
+    auto result = statement->step();
     while (result == SQLITE_ROW) {
         String key = statement->columnText(0);
         String value = statement->columnBlobAsString(1);
@@ -296,8 +302,10 @@ HashMap<String, String> SQLiteStorageArea::allItems()
         result = statement->step();
     }
 
-    if (result != SQLITE_DONE)
+    if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::allItems failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        handleDatabaseCorruptionIfNeeded(result);
+    }
 
     return items;
 }
@@ -320,11 +328,13 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueI
         return makeUnexpected(StorageError::Database);
     }
 
-    int result = statement->step();
+    const auto result = statement->step();
     if (result == SQLITE_FULL)
         return makeUnexpected(StorageError::QuotaExceeded);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::setItem failed on stepping statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        handleDatabaseCorruptionIfNeeded(result);
+
         return makeUnexpected(StorageError::Database);
     }
 
@@ -353,8 +363,16 @@ Expected<void, StorageError> SQLiteStorageArea::removeItem(IPC::Connection::Uniq
         return makeUnexpected(StorageError::ItemNotFound);
 
     auto statement = cachedStatement(StatementType::DeleteItem);
-    if (!statement || statement->bindText(1, key) || statement->step() != SQLITE_DONE) {
+    if (!statement || statement->bindText(1, key)) {
+        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::removeItem failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        return makeUnexpected(StorageError::Database);
+    }
+
+    const auto result = statement->step();
+    if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::removeItem failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        handleDatabaseCorruptionIfNeeded(result);
+
         return makeUnexpected(StorageError::Database);
     }
 
@@ -383,8 +401,16 @@ Expected<void, StorageError> SQLiteStorageArea::clear(IPC::Connection::UniqueID 
 
     startTransactionIfNecessary();
     auto statement = cachedStatement(StatementType::DeleteAllItems);
-    if (!statement || statement->step() != SQLITE_DONE) {
+    if (!statement) {
+        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::clear failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        return makeUnexpected(StorageError::Database);
+    }
+
+    const auto result = statement->step();
+    if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::clear failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        handleDatabaseCorruptionIfNeeded(result);
+
         return makeUnexpected(StorageError::Database);
     }
 
@@ -410,5 +436,15 @@ void SQLiteStorageArea::handleLowMemoryWarning()
         m_database->releaseMemory();
 }
 
-} // namespace WebKit
+bool SQLiteStorageArea::handleDatabaseCorruptionIfNeeded(int databaseError)
+{
+    if (databaseError != SQLITE_CORRUPT && databaseError != SQLITE_NOTADB)
+        return false;
 
+    m_database = nullptr;
+    RELEASE_LOG(Storage, "SQLiteStorageArea::handleDatabaseCorruption deletes corrupted database file '%s'", m_path.utf8().data());
+    WebCore::SQLiteFileSystem::deleteDatabaseFile(m_path);
+    return true;
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -70,6 +70,8 @@ private:
     Expected<String, StorageError> getItem(const String& key);
     Expected<String, StorageError> getItemFromDatabase(const String& key);
 
+    bool handleDatabaseCorruptionIfNeeded(int databaseError);
+
     String m_path;
     Ref<WorkQueue> m_queue;
     std::unique_ptr<WebCore::SQLiteDatabase> m_database;


### PR DESCRIPTION
#### d5346d022b5cd2324b2540c581baaf194712e5eb
<pre>
Restore/recreate corrupted SQLite file of local storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=250470">https://bugs.webkit.org/show_bug.cgi?id=250470</a>

Reviewed by Sihui Liu.

The current implementation in case of corrupted database file of the
localstorage requires few restart to make it works again.
This fix solves it and if the database file of the localstorage is
currupted it deletes broken file.

* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::prepareDatabase):
(WebKit::SQLiteStorageArea::getItemFromDatabase):
(WebKit::SQLiteStorageArea::allItems):
(WebKit::SQLiteStorageArea::setItem):
(WebKit::SQLiteStorageArea::removeItem):
(WebKit::SQLiteStorageArea::clear):
(WebKit::SQLiteStorageArea::handleDatabaseCorruption):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:

Canonical link: <a href="https://commits.webkit.org/259573@main">https://commits.webkit.org/259573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49ec87807d9f336be7f02c78c94ab13bcfbdbb68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114321 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174518 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5059 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113334 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39313 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27796 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7569 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4380 "Found 1 new test failure: fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6595 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9358 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->