### PR TITLE
Make sure to reload subresources loaded during the load of a hard reloaded document

### DIFF
--- a/LayoutTests/http/tests/inspector/network/har/har-page-aggressive-gc-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/har/har-page-aggressive-gc-expected.txt
@@ -157,6 +157,49 @@ HAR Page Test.
         "time": "<filtered>",
         "request": {
           "method": "GET",
+          "url": "http://127.0.0.1:8000/cookies/resources/cookie-utilities.js",
+          "httpVersion": "<filtered>",
+          "cookies": [],
+          "headers": "<filtered>",
+          "queryString": [],
+          "headersSize": "<filtered>",
+          "bodySize": "<filtered>"
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "<filtered>",
+          "cookies": [],
+          "headers": "<filtered>",
+          "content": {
+            "size": "<filtered>",
+            "compression": 0,
+            "mimeType": "application/x-javascript",
+            "text": "<filtered>"
+          },
+          "redirectURL": "",
+          "headersSize": "<filtered>",
+          "bodySize": "<filtered>"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": "<filtered>",
+          "dns": "<filtered>",
+          "connect": "<filtered>",
+          "ssl": -1,
+          "send": "<filtered>",
+          "wait": "<filtered>",
+          "receive": "<filtered>"
+        },
+        "_serverPort": 8000,
+        "_priority": "high"
+      },
+      {
+        "pageref": "page_0",
+        "startedDateTime": "<filtered>",
+        "time": "<filtered>",
+        "request": {
+          "method": "GET",
           "url": "http://127.0.0.1:8000/cookies/resources/setCookies.cgi",
           "httpVersion": "<filtered>",
           "cookies": [],

--- a/LayoutTests/http/tests/inspector/network/har/har-page-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/har/har-page-expected.txt
@@ -157,6 +157,49 @@ HAR Page Test.
         "time": "<filtered>",
         "request": {
           "method": "GET",
+          "url": "http://127.0.0.1:8000/cookies/resources/cookie-utilities.js",
+          "httpVersion": "<filtered>",
+          "cookies": [],
+          "headers": "<filtered>",
+          "queryString": [],
+          "headersSize": "<filtered>",
+          "bodySize": "<filtered>"
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "<filtered>",
+          "cookies": [],
+          "headers": "<filtered>",
+          "content": {
+            "size": "<filtered>",
+            "compression": 0,
+            "mimeType": "application/x-javascript",
+            "text": "<filtered>"
+          },
+          "redirectURL": "",
+          "headersSize": "<filtered>",
+          "bodySize": "<filtered>"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": "<filtered>",
+          "dns": "<filtered>",
+          "connect": "<filtered>",
+          "ssl": -1,
+          "send": "<filtered>",
+          "wait": "<filtered>",
+          "receive": "<filtered>"
+        },
+        "_serverPort": 8000,
+        "_priority": "high"
+      },
+      {
+        "pageref": "page_0",
+        "startedDateTime": "<filtered>",
+        "time": "<filtered>",
+        "request": {
+          "method": "GET",
           "url": "http://127.0.0.1:8000/cookies/resources/setCookies.cgi",
           "httpVersion": "<filtered>",
           "cookies": [],

--- a/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker-expected.txt
@@ -1,0 +1,6 @@
+
+PASS : {"url":"http://localhost:8800/WebKit/service-workers/cache-mode-hard-reload-serviceworker.html","cache":"reload"}
+PASS : {"url":"http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?first-script-static","cache":"reload"}
+PASS : {"url":"http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?second-script-dynamic","cache":"reload"}
+PASS : {"url":"http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?third-script-async","cache":"reload"}
+

--- a/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
+++ b/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
@@ -1,0 +1,118 @@
+<html>
+<head>
+</head>
+<body>
+<br>
+<div id="logElement">
+<button onclick="clearLog()">clear</button>
+</div>
+<div id="testElement"></div>
+<script>
+var scope = "/WebKit/service-workers/cache-mode-hard-reload-serviceworker.html";
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(msg) {
+    logElement.innerHTML += msg + "<br>";
+}
+
+function clearLog() {
+    logElement.innerHTML = "";
+}
+
+let activeWorker;
+async function registerServiceWorkerIfNeeded()
+{
+    var registration = await navigator.serviceWorker.getRegistration(scope);
+    if (registration && registration.scope === scope) {
+        if (window.location.search === "?register") {
+            hasServiceWorker = true;
+            if (registration.active)
+                setInterval(() => registration.active.postMessage("ping"), 50);
+            return;
+        }
+        await registration.unregister();
+    }
+
+    var registration = await navigator.serviceWorker.register("cache-mode-hard-reload-serviceworker.js", { scope : scope });
+    hasServiceWorker = true;
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+    activeWorker = registration.installing;
+    await new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+};
+
+registerServiceWorkerIfNeeded();
+</script>
+<script src="resources/cache-mode-hard-reload-serviceworker.py?first-script-static"></script>
+<script>
+function addScript(url)
+{
+    const script = document.createElement("script");
+    script.setAttribute("src", url);
+    testElement.appendChild(script);
+}
+addScript("resources/cache-mode-hard-reload-serviceworker.py?second-script-dynamic");
+setTimeout(() => addScript("resources/cache-mode-hard-reload-serviceworker.py?third-script-async"), 100);
+setTimeout(() => addScript("resources/cache-mode-hard-reload-serviceworker.py?sixth-script-async"), 1000);
+onload = () => {
+    addScript("resources/cache-mode-hard-reload-serviceworker.py?fourth-script-during-onload");
+    setTimeout(() => {
+        addScript("resources/cache-mode-hard-reload-serviceworker.py?fifth-script-just-after-onload");
+        setTimeout(async () => {
+            activeWorker.postMessage("getState");
+            const state = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => resolve(e.data));
+            if (state === "startTest") {
+                activeWorker.postMessage("endTest");
+                const results = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => resolve(e.data));
+                validateResults(results);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+                return;
+            }
+            activeWorker.postMessage("startTest");
+            if (window.testRunner)
+                testRunner.reloadFromOrigin();
+        }, 1000);
+    }, 0);
+}
+
+function validateResult(result)
+{
+    if (result.url === "http://localhost:8800/WebKit/service-workers/cache-mode-hard-reload-serviceworker.html")
+        return result.cache === "reload";
+    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?first-script-static")
+        return result.cache === "reload";
+    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?second-script-dynamic")
+        return result.cache === "reload";
+    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?third-script-async")
+        return result.cache === "reload";
+
+    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fourth-script-during-onload")
+        return result.cache === "reload";
+    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fifth-script-just-after-onload")
+        return result.cache === "reload";
+    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?sixth-script-async")
+        return result.cache === "reload";
+
+}
+
+function validateResults(results)
+{
+    clearLog();
+    for (let result of results)
+        log((validateResult(result) ? "PASS" : "FAIL") + " : " + JSON.stringify(result));
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.js
+++ b/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.js
@@ -1,0 +1,36 @@
+async function doClaim()
+{
+    await clients.claim();
+    setTimeout(doClaim, 50);
+}
+
+onactivate = (e) => {
+    e.waitUntil(doClaim());
+};
+
+let state;
+let loads = [];
+onfetch = async (e) => {
+    loads.push({url: e.request.url, cache: e.request.cache});
+}
+
+onmessage = (event) => {
+    if (event.data === "getState") {
+        event.source.postMessage(state);
+        return;
+    }
+
+    if (event.data === "startTest") {
+        state = "startTest";
+        loads = [];
+        return;
+    }
+
+    if (event.data === "endTest") {
+        state = "endTest";
+        event.source.postMessage(loads);
+        return;
+    }
+
+    doClaim();
+}

--- a/LayoutTests/http/wpt/service-workers/resources/cache-mode-hard-reload-serviceworker.py
+++ b/LayoutTests/http/wpt/service-workers/resources/cache-mode-hard-reload-serviceworker.py
@@ -1,0 +1,11 @@
+import random
+import time
+
+
+def main(request, response):
+    headers = [
+        (b"Content-type", b"text/javascript"),
+        (b"Cache-Control", b"max-age=360000")
+    ]
+    time.sleep(0.5)
+    return headers, "log('" + str(random.random()) + "');"

--- a/LayoutTests/platform/mac-wk1/http/tests/inspector/network/har/har-page-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/inspector/network/har/har-page-expected.txt
@@ -151,6 +151,47 @@ HAR Page Test.
         "time": "<filtered>",
         "request": {
           "method": "GET",
+          "url": "http://127.0.0.1:8000/cookies/resources/cookie-utilities.js",
+          "httpVersion": "<filtered>",
+          "cookies": [],
+          "headers": "<filtered>",
+          "queryString": [],
+          "headersSize": "<filtered>",
+          "bodySize": "<filtered>"
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "<filtered>",
+          "cookies": [],
+          "headers": "<filtered>",
+          "content": {
+            "size": "<filtered>",
+            "compression": 0,
+            "mimeType": "application/x-javascript",
+            "text": "<filtered>"
+          },
+          "redirectURL": "",
+          "headersSize": "<filtered>",
+          "bodySize": "<filtered>"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": "<filtered>",
+          "dns": "<filtered>",
+          "connect": "<filtered>",
+          "ssl": -1,
+          "send": "<filtered>",
+          "wait": "<filtered>",
+          "receive": "<filtered>"
+        }
+      },
+      {
+        "pageref": "page_0",
+        "startedDateTime": "<filtered>",
+        "time": "<filtered>",
+        "request": {
+          "method": "GET",
           "url": "http://127.0.0.1:8000/cookies/resources/setCookies.cgi",
           "httpVersion": "<filtered>",
           "cookies": [],

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -891,6 +891,8 @@ void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, Ca
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)
     request.updateUserAgentHeader(frameLoader);
 
+    if (frameLoader.frame().loader().loadType() == FrameLoadType::ReloadFromOrigin)
+        request.updateCacheModeIfNeeded(cachePolicy(type, request.resourceRequest().url()));
     request.updateAccordingCacheMode();
     request.updateAcceptEncodingHeader();
 }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CachedResourceRequest.h"
 
+#include "CachePolicy.h"
 #include "CachedResourceLoader.h"
 #include "ContentExtensionsBackend.h"
 #include "CrossOriginAccessControl.h"
@@ -222,6 +223,12 @@ void CachedResourceRequest::updateAccordingCacheMode()
         m_resourceRequest.setCachePolicy(ResourceRequestCachePolicy::ReturnCacheDataDontLoad);
         break;
     }
+}
+
+void CachedResourceRequest::updateCacheModeIfNeeded(CachePolicy cachePolicy)
+{
+    if (cachePolicy == CachePolicy::Reload && m_options.cache == FetchOptions::Cache::Default && m_options.cachingPolicy == CachingPolicy::AllowCaching)
+        m_options.cache = FetchOptions::Cache::Reload;
 }
 
 void CachedResourceRequest::updateAcceptEncodingHeader()

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -42,6 +42,7 @@ class Document;
 class FrameLoader;
 class Page;
 struct ServiceWorkerRegistrationData;
+enum class CachePolicy : uint8_t;
 enum class ReferrerPolicy : uint8_t;
 
 bool isRequestCrossOrigin(SecurityOrigin*, const URL& requestURL, const ResourceLoaderOptions&);
@@ -85,6 +86,7 @@ public:
     void setAcceptHeaderIfNone(CachedResource::Type);
     void updateAccordingCacheMode();
     void updateAcceptEncodingHeader();
+    void updateCacheModeIfNeeded(CachePolicy);
 
     void disableCachingIfNeeded();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -351,6 +351,8 @@ interface TestRunner {
     undefined statisticsSetThirdPartyCNAMEDomain(DOMString cnameURLString, object callback);
     undefined loadedSubresourceDomains(object callback);
 
+    undefined reloadFromOrigin();
+
     // Injected bundle form client.
     undefined installTextDidChangeInTextFieldCallback(object callback);
     undefined installTextFieldDidBeginEditingCallback(object callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -604,6 +604,12 @@ void InjectedBundle::clearResourceLoadStatistics()
     WKBundleClearResourceLoadStatistics(m_bundle.get());
 }
 
+void InjectedBundle::reloadFromOrigin()
+{
+    m_useWorkQueue = true;
+    postPageMessage("ReloadFromOrigin");
+}
+
 void InjectedBundle::dumpBackForwardListsForAllPages(StringBuilder& stringBuilder)
 {
     size_t size = m_pages.size();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -154,6 +154,7 @@ public:
     size_t userScriptInjectedCount() const { return m_userScriptInjectedCount; }
 
     void clearResourceLoadStatistics();
+    void reloadFromOrigin();
 
 private:
     InjectedBundle() = default;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1798,6 +1798,11 @@ void TestRunner::loadedSubresourceDomains(JSValueRef callback)
     postMessage("LoadedSubresourceDomains");
 }
 
+void TestRunner::reloadFromOrigin()
+{
+    InjectedBundle::singleton().reloadFromOrigin();
+}
+
 void TestRunner::callDidReceiveLoadedSubresourceDomainsCallback(Vector<String>&& domains)
 {
     auto result = makeDomainsValue(domains);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -326,6 +326,7 @@ public:
     void queueLoad(JSStringRef url, JSStringRef target, bool shouldOpenExternalURLs);
     void queueLoadHTMLString(JSStringRef content, JSStringRef baseURL, JSStringRef unreachableURL);
     void queueReload();
+    void reloadFromOrigin();
     void queueLoadingScript(JSStringRef script);
     void queueNonLoadingScript(JSStringRef script);
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3189,6 +3189,11 @@ void TestController::clearLoadedSubresourceDomains()
 
 #endif // !PLATFORM(COCOA)
 
+void TestController::reloadFromOrigin()
+{
+    WKPageReloadFromOrigin(m_mainWebView->page());
+}
+
 struct GenericVoidContext {
     explicit GenericVoidContext(TestController& controller)
         : testController(controller)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -279,6 +279,8 @@ public:
     bool didLoadAppInitiatedRequest();
     bool didLoadNonAppInitiatedRequest();
 
+    void reloadFromOrigin();
+
     void updateBundleIdentifierInNetworkProcess(const std::string& bundleIdentifier);
     void clearBundleIdentifierInNetworkProcess();
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -673,6 +673,11 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "ReloadFromOrigin")) {
+        TestController::singleton().reloadFromOrigin();
+        return;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "SetStatisticsDebugMode")) {
         TestController::singleton().setStatisticsDebugMode(booleanValue(messageBody));
         return;


### PR DESCRIPTION
#### 3612aa5748ea37b492f8b45541eaaae130877779
<pre>
Make sure to reload subresources loaded during the load of a hard reloaded document
<a href="https://bugs.webkit.org/show_bug.cgi?id=250705">https://bugs.webkit.org/show_bug.cgi?id=250705</a>
rdar://36246099

Reviewed by Alex Christensen.

When doing a page reload from origin, we should ensure to reload from origin the subresources loaded during the initial load.
This is on par with Chrome and Firefox.
To do so, we set the fetch cache to reload in case page is being reloaded from origin.

Add a test that checks through service worker that we set the cache mode of a request accordingly.
Update inspector tests that make use of reload from origin.

* LayoutTests/http/tests/inspector/network/har/har-page-aggressive-gc-expected.txt:
* LayoutTests/http/tests/inspector/network/har/har-page-expected.txt:
* LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html: Added.
* LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.js: Added.
(async doClaim):
(onactivate):
(onfetch.async e):
(onmessage):
* LayoutTests/http/wpt/service-workers/cache-test-serviceworker.html: Added.
* LayoutTests/http/wpt/service-workers/cache-test-serviceworker.js: Added.
(async doClaim):
(onactivate):
(onfetch.async e):
* LayoutTests/http/wpt/service-workers/resources/cache-mode-hard-reload-serviceworker.py: Added.
(main):
* LayoutTests/http/wpt/service-workers/resources/test.py: Added.
(main):
* LayoutTests/platform/mac-wk1/http/tests/inspector/network/har/har-page-expected.txt:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::updateCacheModeIfNeeded):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::reloadFromOrigin):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::reloadFromOrigin):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::reloadFromOrigin):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/259019@main">https://commits.webkit.org/259019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/913092abe28c12ba66f8b6b0d8e5ea260f9ed88b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112787 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172993 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3566 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111959 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38279 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26611 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3138 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6194 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7979 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->