### PR TITLE
Non-unified build fixes, mid-January 2023 edition

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(GAMEPAD)
 
+#include <wtf/Seconds.h>
+
 namespace WebCore {
 
 struct GamepadEffectParameters {

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -27,6 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "RenderStyleConstants.h"
+#include "WebAnimationTypes.h"
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
 #include <wtf/Seconds.h>

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -29,6 +29,7 @@
 #include "CustomElementRegistry.h"
 #include "DOMWindow.h"
 #include "Document.h"
+#include "FormAssociatedElement.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLFormElement.h"
 #include "JSCustomElementInterface.h"

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -27,6 +27,7 @@
 
 #include "CSSCounterStyleDescriptors.h"
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -26,7 +26,10 @@
 #include "config.h"
 #include "CSSCounterStyleDescriptors.h"
 
-#include "StyleProperties.h"
+#include "CSSCounterStyleRule.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSValueList.h"
+#include "Pair.h"
 
 #include <utility>
 

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -28,7 +28,7 @@
 #include "CSSCounterStyle.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
-#include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/color/CSSUnresolvedColorMix.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColorMix.h
@@ -27,6 +27,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "ColorInterpolationMethod.h"
+#include "StyleColor.h"
 #include <variant>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -29,6 +29,7 @@
 
 #include "CSSFilter.h"
 #include "CSSFilterImageValue.h"
+#include "CSSValuePool.h"
 #include "CachedImage.h"
 #include "CachedResourceLoader.h"
 #include "ComputedStyleExtractor.h"

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSPropertyParser.h"
 #include "CSSRegisteredCustomProperty.h"
+#include "Document.h"
 #include "StyleBuilder.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -35,6 +35,7 @@
 #include "CSSSelectorList.h"
 #include "CommonAtomStrings.h"
 #include "HTMLNames.h"
+#include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "SelectorChecker.h"
 #include "SelectorFilter.h"

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -38,6 +38,7 @@
 #include "MediaQueryEvaluator.h"
 #include "RuleSetBuilder.h"
 #include "SVGElement.h"
+#include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "SelectorChecker.h"
 #include "SelectorFilter.h"

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -35,6 +35,7 @@
 #include "CSSKeyframesRule.h"
 #include "CSSSelectorParser.h"
 #include "CustomPropertyRegistry.h"
+#include "Document.h"
 #include "MediaQueryEvaluator.h"
 #include "StyleResolver.h"
 #include "StyleRuleImport.h"

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -48,6 +48,7 @@
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "StyleAdjuster.h"
+#include "StyleBuilder.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
@@ -28,6 +28,7 @@
 #if ENABLE(SERVICE_WORKER)
 
 #include "FetchIdentifier.h"
+#include "ResourceResponse.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -40,7 +41,6 @@ class FormData;
 class NetworkLoadMetrics;
 class ResourceError;
 class ResourceRequest;
-class ResourceResponse;
 class ServiceWorkerGlobalScope;
 class ServiceWorkerGlobalScope;
 class SharedBuffer;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -40,6 +40,7 @@
 #include "UnifiedOriginStorageLevel.h"
 #include "WebsiteDataType.h"
 #include <WebCore/SQLiteFileSystem.h>
+#include <WebCore/StorageEstimate.h>
 #include <wtf/FileSystem.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -351,6 +351,8 @@ static unsigned maximumWebProcessRelaunchAttempts = 1;
 static const Seconds audibleActivityClearDelay = 10_s;
 static const Seconds tryCloseTimeoutDelay = 50_ms;
 
+using namespace WebCore;
+
 namespace WebKit {
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, webPageProxyCounter, ("WebPageProxy"));


### PR DESCRIPTION
#### e1c35f7fdd555c8aad8335b909095445ab6e0bd1
<pre>
Non-unified build fixes, mid-January 2023 edition

Unreviewed non-unified build fixes.

* Source/WebCore/Modules/gamepad/GamepadEffectParameters.h: Add missing
  wtf/Seconds.h header.
* Source/WebCore/animation/WebAnimationUtilities.h: Add missing
  WebAnimationTypes.h header.
* Source/WebCore/bindings/js/JSHTMLElementCustom.cpp: Add missing
  FormAssociatedElement.h header.
* Source/WebCore/css/CSSCounterStyle.h: Add missing wtf/WeakPtr.h
  header.
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp: Add missing headers
  CSSCounterStyleRule.h, CSSPrimitiveValue.h, CSSValueList.h, and Pair.h
  headers; remove now unneeded StyleProperties.h header.
* Source/WebCore/css/CSSCounterStyleRegistry.h: Replace inclusion of
  wtf/text/AtomString.h with wtf/text/AtomStringHash.h to bring in
  missing definitions.
* Source/WebCore/css/color/CSSUnresolvedColorMix.h: Add missing
  StyleColor.h header.
* Source/WebCore/rendering/style/StyleFilterImage.cpp: Add missing
  CSSValuePool.h header.
* Source/WebCore/style/CustomPropertyRegistry.cpp: Add missing
  Document.h header.
* Source/WebCore/style/RuleData.cpp: Add missing
  ScriptExecutionContext.h header.
* Source/WebCore/style/RuleSet.cpp: Ditto.
* Source/WebCore/style/RuleSetBuilder.cpp: Add missing Document.h
  header.
* Source/WebCore/style/StyleTreeResolver.cpp: Add missing StyleBuilder.h
  header.
* Source/WebCore/workers/service/context/ServiceWorkerFetch.h: Replace
  forward declaration of ResourceResponse with the inclusion of
  ResourceResponse.h in order to bring in the declaration for nested
  types which cannot be forward-declared.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp: Add
  missing WebCore/StorageEstimate.h header.
* Source/WebKit/UIProcess/WebPageProxy.cpp: Add missing WebCore
  namespace import.

Canonical link: <a href="https://commits.webkit.org/258978@main">https://commits.webkit.org/258978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4fcb7faeab65dcb3cc2ab60bdb7930753598b19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112791 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172997 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3570 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111963 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10549 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92370 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79925 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6050 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3141 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12212 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6167 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7983 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->