### PR TITLE
[@property] Initial value cleanups

### DIFF
--- a/Source/WebCore/css/CSSRegisteredCustomProperty.cpp
+++ b/Source/WebCore/css/CSSRegisteredCustomProperty.cpp
@@ -30,19 +30,6 @@
 
 namespace WebCore {
 
-CSSRegisteredCustomProperty::CSSRegisteredCustomProperty(const AtomString& name, const CSSCustomPropertySyntax& syntax, bool inherits, RefPtr<CSSCustomPropertyValue>&& initialValue)
-    : name(name)
-    , syntax(syntax)
-    , inherits(inherits)
-    , m_initialValue(WTFMove(initialValue))
-{
-}
-
-RefPtr<CSSCustomPropertyValue> CSSRegisteredCustomProperty::initialValueCopy() const
-{
-    if (m_initialValue)
-        return CSSCustomPropertyValue::create(*m_initialValue);
-    return nullptr;
-}
+CSSRegisteredCustomProperty::~CSSRegisteredCustomProperty() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRegisteredCustomProperty.h
+++ b/Source/WebCore/css/CSSRegisteredCustomProperty.h
@@ -35,17 +35,12 @@ class CSSCustomPropertyValue;
 struct CSSRegisteredCustomProperty {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    const AtomString name;
-    const CSSCustomPropertySyntax syntax;
-    const bool inherits;
+    AtomString name;
+    CSSCustomPropertySyntax syntax;
+    bool inherits;
+    RefPtr<const CSSCustomPropertyValue> initialValue;
 
-    CSSRegisteredCustomProperty(const AtomString& name, const CSSCustomPropertySyntax&, bool inherits, RefPtr<CSSCustomPropertyValue>&& initialValue);
-
-    const CSSCustomPropertyValue* initialValue() const { return m_initialValue.get(); }
-    RefPtr<CSSCustomPropertyValue> initialValueCopy() const;
-
-private:
-    const RefPtr<CSSCustomPropertyValue> m_initialValue;
+    ~CSSRegisteredCustomProperty();
 };
 
 }

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -121,12 +121,7 @@ bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange ran
         if (functionId == CSSValueEnv)
             return builderState.document().constantProperties().values().get(variableName);
 
-        auto* customProperty = builderState.style().getCustomProperty(variableName);
-        if (customProperty)
-            return customProperty;
-
-        auto* registered = builderState.document().customPropertyRegistry().get(variableName);
-        return registered && registered->initialValue() ? registered->initialValue() : nullptr;
+        return builderState.style().customPropertyValue(variableName, builderState.document().customPropertyRegistry());
     }();
 
     if (!property || property->isInvalid()) {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2703,17 +2703,9 @@ RefPtr<CSSValue> ComputedStyleExtractor::customPropertyValue(const AtomString& p
     if (!style)
         return nullptr;
 
-    auto* value = style->getCustomProperty(propertyName);
-    if (!value) {
-        auto registered = styledElement->document().customPropertyRegistry().get(propertyName);
-        return registered ? registered->initialValueCopy() : nullptr;
-    }
+    auto* value = style->customPropertyValue(propertyName, styledElement->document().customPropertyRegistry());
 
-    return WTF::switchOn(value->value(), [&](const Length& value) -> Ref<CSSValue> {
-        return zoomAdjustedPixelValueForLength(value, *style);
-    }, [&](auto&) -> Ref<CSSValue> {
-        return CSSCustomPropertyValue::create(*value);
-    });
+    return const_cast<CSSCustomPropertyValue*>(value);
 }
 
 String ComputedStyleExtractor::customPropertyText(const AtomString& propertyName)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -127,6 +127,10 @@ struct ScrollSnapType;
 
 struct TextEdge;
 
+namespace Style {
+class CustomPropertyRegistry;
+}
+
 using PseudoStyleCache = Vector<std::unique_ptr<RenderStyle>, 4>;
 
 template<typename T, typename U> inline bool compareEqual(const T& t, const U& u) { return t == static_cast<const T&>(u); }
@@ -192,10 +196,12 @@ public:
 
     const PseudoStyleCache* cachedPseudoStyles() const { return m_cachedPseudoStyles.get(); }
 
-    void deduplicateInheritedCustomProperties(const RenderStyle&);
     const CustomPropertyValueMap& inheritedCustomProperties() const { return m_rareInheritedData->customProperties->values; }
     const CustomPropertyValueMap& nonInheritedCustomProperties() const { return m_rareNonInheritedData->customProperties->values; }
-    const CSSCustomPropertyValue* getCustomProperty(const AtomString&) const;
+    const CSSCustomPropertyValue* customPropertyValue(const AtomString&, const Style::CustomPropertyRegistry&) const;
+    const CSSCustomPropertyValue* customPropertyValueWithoutResolvingInitial(const AtomString&) const;
+
+    void deduplicateInheritedCustomProperties(const RenderStyle&);
     void setInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
     void setNonInheritedCustomPropertyValue(const AtomString& name, Ref<CSSCustomPropertyValue>&&);
     bool customPropertiesEqual(const RenderStyle&) const;
@@ -2308,15 +2314,6 @@ inline BorderStyle collapsedBorderStyle(BorderStyle style)
     if (style == BorderStyle::Inset)
         return BorderStyle::Ridge;
     return style;
-}
-
-inline const CSSCustomPropertyValue* RenderStyle::getCustomProperty(const AtomString& name) const
-{
-    for (auto* map : { &nonInheritedCustomProperties(), &inheritedCustomProperties() }) {
-        if (auto* val = map->get(name))
-            return val;
-    }
-    return nullptr;
 }
 
 inline bool RenderStyle::hasBackground() const

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -42,6 +42,8 @@ CustomPropertyRegistry::CustomPropertyRegistry(Scope& scope)
 
 const CSSRegisteredCustomProperty* CustomPropertyRegistry::get(const AtomString& name) const
 {
+    ASSERT(isCustomPropertyName(name));
+
     // API wins.
     // https://drafts.css-houdini.org/css-properties-values-api/#determining-registration
     if (auto* property = m_propertiesFromAPI.get(name))
@@ -49,6 +51,13 @@ const CSSRegisteredCustomProperty* CustomPropertyRegistry::get(const AtomString&
 
     return m_propertiesFromStylesheet.get(name);
 }
+
+bool CustomPropertyRegistry::isInherited(const AtomString& name) const
+{
+    auto* registered = get(name);
+    return registered ? registered->inherits : true;
+}
+
 
 bool CustomPropertyRegistry::registerFromAPI(CSSRegisteredCustomProperty&& property)
 {

--- a/Source/WebCore/style/CustomPropertyRegistry.h
+++ b/Source/WebCore/style/CustomPropertyRegistry.h
@@ -39,6 +39,7 @@ public:
     CustomPropertyRegistry(Scope&);
 
     const CSSRegisteredCustomProperty* get(const AtomString&) const;
+    bool isInherited(const AtomString&) const;
 
     bool registerFromAPI(CSSRegisteredCustomProperty&&);
     void registerFromStylesheet(const StyleRuleProperty::Descriptor&);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -2148,9 +2148,8 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
 
 inline void BuilderCustom::applyInitialCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const AtomString& name)
 {
-    if (registered && registered->initialValue()) {
-        auto initialValue = registered->initialValueCopy();
-        applyValueCustomProperty(builderState, registered, *initialValue);
+    if (registered && registered->initialValue) {
+        applyValueCustomProperty(builderState, registered, const_cast<CSSCustomPropertyValue&>(*registered->initialValue));
         return;
     }
 


### PR DESCRIPTION
#### 0e9c19d6b9a6b5d1604dbe2f531b147eb0a5c9f9
<pre>
[@property] Initial value cleanups
<a href="https://bugs.webkit.org/show_bug.cgi?id=250707">https://bugs.webkit.org/show_bug.cgi?id=250707</a>
rdar://104330630

Reviewed by Antoine Quint.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendCustomProperty):
(WebCore::CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration):
(WebCore::CSSPropertyAnimation::propertiesEqual):
(WebCore::CSSPropertyAnimation::canPropertyBeInterpolated):
* Source/WebCore/css/CSSRegisteredCustomProperty.cpp:
(WebCore::CSSRegisteredCustomProperty::CSSRegisteredCustomProperty): Deleted.
(WebCore::CSSRegisteredCustomProperty::initialValueCopy const): Deleted.
* Source/WebCore/css/CSSRegisteredCustomProperty.h:
(WebCore::CSSRegisteredCustomProperty::initialValue const): Deleted.

Just make the field public.

* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::resolveVariableReference const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::customPropertyValue):

Remove the dead leftover code for resolving Length values.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::changedCustomPaintWatchedProperty):
(WebCore::RenderStyle::customPropertyValue const):

Handle resolving the initial value for a registered property here. Clients have to provide the registry.

(WebCore::RenderStyle::customPropertyValueWithoutResolvingInitial const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::getCustomProperty const): Deleted.
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::get const):
(WebCore::Style::CustomPropertyRegistry::isInherited const):
* Source/WebCore/style/CustomPropertyRegistry.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialCustomProperty):

Canonical link: <a href="https://commits.webkit.org/258991@main">https://commits.webkit.org/258991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60adfbe82969d892ecb502daac91f108d3abea68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112796 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173002 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3575 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111968 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10554 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38290 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79932 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6055 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26616 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6235 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6177 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7988 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->