### PR TITLE
Consider overflowX/Y in applyCachedClipAndScrollPosition()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/v2/position-absolute-overflow-visible-and-not-visible-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/v2/position-absolute-overflow-visible-and-not-visible-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ParentWithOverflowVisibleAndNotVisible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/v2/position-absolute-overflow-visible-and-not-visible.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/v2/position-absolute-overflow-visible-and-not-visible.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/intersection-observer-test-utils.js"></script>
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: 200px;
+    width: 100%;
+  }
+  #parent {
+    position: relative;
+    height: 200px;
+    width: 200px;
+    background-color: rgb(250, 221, 221);
+    overflow-y: clip;
+    overflow-x: visible;
+  }
+  #child {
+    background-color: rgb(208, 250, 208);
+    position: absolute;
+    left: 100%;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+</head>
+<body>
+<div id="parent">
+  <div id="child"></div>
+</div>
+</body>
+<script>
+const test = async_test("ParentWithOverflowVisibleAndNotVisible");
+const child = document.getElementById("child");
+const observer = new IntersectionObserver((entries) => {
+  test.step(() => {
+    assert_true(entries[0].isIntersecting);
+    assert_equals(entries[0].intersectionRatio, 1.0);
+    assert_equals(entries[0].intersectionRect.height, 200);
+    assert_equals(entries[0].intersectionRect.width, 200);
+  });
+  test.done();
+});
+observer.observe(child);
+</script>
+</html>

--- a/Source/WebCore/platform/graphics/LayoutRect.cpp
+++ b/Source/WebCore/platform/graphics/LayoutRect.cpp
@@ -164,6 +164,20 @@ void LayoutRect::scale(float xScale, float yScale)
     m_size.scale(xScale, yScale);
 }
 
+void LayoutRect::expandToInfiniteY()
+{
+    LayoutRect infRect = LayoutRect::infiniteRect();
+    setY(infRect.y());
+    setHeight(infRect.height());
+}
+
+void LayoutRect::expandToInfiniteX()
+{
+    LayoutRect infRect = LayoutRect::infiniteRect();
+    setX(infRect.x());
+    setWidth(infRect.width());
+}
+
 LayoutRect unionRect(const Vector<LayoutRect>& rects)
 {
     LayoutRect result;

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -93,6 +93,8 @@ public:
         m_location.move(-box.left(), -box.top());
         m_size.expand(box.left() + box.right(), box.top() + box.bottom());
     }
+    void expandToInfiniteY();
+    void expandToInfiniteX();
     template<typename T, typename U> void expand(T dw, U dh) { m_size.expand(dw, dh); }
     void contract(const LayoutSize& size) { m_size -= size; }
     void contract(const LayoutBoxExtent& box)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1165,6 +1165,10 @@ bool RenderBox::applyCachedClipAndScrollPosition(LayoutRect& rect, const RenderL
     // layer's size instead. Even if the layer's size is wrong, the layer itself will repaint
     // anyway if its size does change.
     LayoutRect clipRect(LayoutPoint(), cachedSizeForOverflowClip());
+    if (effectiveOverflowX() == Overflow::Visible)
+        clipRect.expandToInfiniteX();
+    if (effectiveOverflowY() == Overflow::Visible)
+        clipRect.expandToInfiniteY();
     bool intersects;
     if (context.options.contains(VisibleRectContextOption::UseEdgeInclusiveIntersection))
         intersects = rect.edgeInclusiveIntersect(clipRect);
@@ -2109,15 +2113,10 @@ LayoutRect RenderBox::overflowClipRect(const LayoutPoint& location, RenderFragme
     LayoutRect clipRect = borderBoxRectInFragment(fragment);
     clipRect.setLocation(location + clipRect.location() + LayoutSize(borderLeft(), borderTop()));
     clipRect.setSize(clipRect.size() - LayoutSize(borderLeft() + borderRight(), borderTop() + borderBottom()));
-    if (style().overflowX() == Overflow::Clip && style().overflowY() == Overflow::Visible) {
-        LayoutRect infRect = LayoutRect::infiniteRect();
-        clipRect.setY(infRect.y());
-        clipRect.setHeight(infRect.height());
-    } else if (style().overflowY() == Overflow::Clip && style().overflowX() == Overflow::Visible) {
-        LayoutRect infRect = LayoutRect::infiniteRect();
-        clipRect.setX(infRect.x());
-        clipRect.setWidth(infRect.width());
-    }
+    if (style().overflowX() == Overflow::Clip && style().overflowY() == Overflow::Visible)
+        clipRect.expandToInfiniteY();
+    else if (style().overflowY() == Overflow::Clip && style().overflowX() == Overflow::Visible)
+        clipRect.expandToInfiniteX();
 
     // Subtract out scrollbars if we have them.
     if (auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -251,6 +251,10 @@ bool RenderSVGModelObject::applyCachedClipAndScrollPosition(LayoutRect& rect, co
         return true;
 
     LayoutRect clipRect(LayoutPoint(), cachedSizeForOverflowClip());
+    if (effectiveOverflowX() == Overflow::Visible)
+        clipRect.expandToInfiniteX();
+    if (effectiveOverflowY() == Overflow::Visible)
+        clipRect.expandToInfiniteY();
     bool intersects;
     if (context.options.contains(VisibleRectContextOption::UseEdgeInclusiveIntersection))
         intersects = rect.edgeInclusiveIntersect(clipRect);


### PR DESCRIPTION
#### ba441a1628f18c0e81953ff64d14e4546c3f8617
<pre>
Consider overflowX/Y in applyCachedClipAndScrollPosition()
<a href="https://bugs.webkit.org/show_bug.cgi?id=249693">https://bugs.webkit.org/show_bug.cgi?id=249693</a>
rdar://103734614

Reviewed by Simon Fraser.

Up to now, applyCachedClipAndScrollPosition() doesn&apos;t take
in consideration that the overflow for an axis can be visible
when computing the interection with the given target.

Now, if overflow is visible in one of the axis, we expand the
target within this axis.

Imagine a case where a children box with absolute position is placed
below its parent. Before, this children box would not be considered
visible even if it would have overflow-y : visible, because there would
not be intersection between parent and children. For this case, we
would now expand the parent into the Y axis when calculating intersection,
resulting in the intersecion rect to be the children box itself.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/v2/position-absolute-overflow-visible-and-not-visible-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/v2/position-absolute-overflow-visible-and-not-visible.html: Added.

* Source/WebCore/platform/graphics/LayoutRect.cpp:
(WebCore::LayoutRect::expandToInfiniteY):
(WebCore::LayoutRect::expandToInfiniteX):
* Source/WebCore/platform/graphics/LayoutRect.h:
Functions for expanding the Rect to infinite in each axis.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::applyCachedClipAndScrollPosition const):
(WebCore::RenderBox::overflowClipRect const):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::applyCachedClipAndScrollPosition const):

Canonical link: <a href="https://commits.webkit.org/259007@main">https://commits.webkit.org/259007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/836ed9a8a6ace5c92ddeaa9b5d3f88d3d5c13ec5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112823 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3602 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111989 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109361 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38320 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25244 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6081 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26645 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3171 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6189 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8014 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->