### PR TITLE
_WKHitTestResult NSURL properties shouldn't return URLs with empty strings

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -42,24 +42,29 @@
     [super dealloc];
 }
 
+static NSURL *URLFromString(const WTF::String& urlString)
+{
+    return urlString.isEmpty() ? nil : [NSURL URLWithString:urlString];
+}
+
 - (NSURL *)absoluteImageURL
 {
-    return [NSURL URLWithString:_hitTestResult->absoluteImageURL()];
+    return URLFromString(_hitTestResult->absoluteImageURL());
 }
 
 - (NSURL *)absolutePDFURL
 {
-    return [NSURL URLWithString:_hitTestResult->absolutePDFURL()];
+    return URLFromString(_hitTestResult->absolutePDFURL());
 }
 
 - (NSURL *)absoluteLinkURL
 {
-    return [NSURL URLWithString:_hitTestResult->absoluteLinkURL()];
+    return URLFromString(_hitTestResult->absoluteLinkURL());
 }
 
 - (NSURL *)absoluteMediaURL
 {
-    return [NSURL URLWithString:_hitTestResult->absoluteMediaURL()];
+    return URLFromString(_hitTestResult->absoluteMediaURL());
 }
 
 - (NSString *)linkLabel

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -38,6 +38,7 @@
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKContextMenuElementInfo.h>
+#import <WebKit/_WKHitTestResult.h>
 #import <wtf/BlockPtr.h>
 
 @interface PopoverNotificationListener : NSObject
@@ -254,6 +255,34 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsHitTestResult)
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
         EXPECT_NOT_NULL(elementInfo.hitTestResult);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
+
+TEST(ContextMenuTests, HitTestResultDoesNotContainEmptyURLs)
+{
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        _WKHitTestResult *hitTestResult = elementInfo.hitTestResult;
+        EXPECT_NOT_NULL(hitTestResult);
+
+        // simple.html does not contain any links, so every URL in _WKHitTestResult should be nil.
+        EXPECT_NULL(hitTestResult.absoluteImageURL);
+        EXPECT_NULL(hitTestResult.absolutePDFURL);
+        EXPECT_NULL(hitTestResult.absoluteLinkURL);
+        EXPECT_NULL(hitTestResult.absoluteMediaURL);
+
         completion(nil);
         gotProposedMenu = true;
     }];


### PR DESCRIPTION
#### c2a073072c5eb2746a567254f300998922ab7a1d
<pre>
_WKHitTestResult NSURL properties shouldn&apos;t return URLs with empty strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=250711">https://bugs.webkit.org/show_bug.cgi?id=250711</a>
&lt;rdar://103933402&gt;

Reviewed by Wenson Hsieh.

_WKHitTestResult&apos;s NSURL properties can currently return an NSURL created from an empty string.
Clients typically expect to get back nil in this case.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(URLFromString):
(-[_WKHitTestResult absoluteImageURL]):
(-[_WKHitTestResult absolutePDFURL]):
(-[_WKHitTestResult absoluteLinkURL]):
(-[_WKHitTestResult absoluteMediaURL]):
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):
Added a test that verifies the _WKHitTestResult properties above are nil in
_WKContextMenuElementInfo&apos;s hitTestResult when right-clicking on a page with no links.

Canonical link: <a href="https://commits.webkit.org/258993@main">https://commits.webkit.org/258993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/967617fab2717dc3867157b9139f197cac1bebe5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112811 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3590 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111982 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109348 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38299 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25228 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6070 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26629 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3160 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46140 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6176 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8003 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->