### PR TITLE
[ews-build.webkit.org] Support PRs with many files changed

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019, 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2019-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -264,26 +264,37 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
 
     @defer.inlineCallbacks
     def _get_pr_files(self, repo, number):
-        # Copied from https://github.com/buildbot/buildbot/blob/v2.10.5/master/buildbot/www/hooks/github.py to include added/modified/deleted
-        headers = {"User-Agent": "Buildbot"}
+        # Heavy modification of https://github.com/buildbot/buildbot/blob/v2.10.5/master/buildbot/www/hooks/github.py
+        PER_PAGE_LIMIT = 100  # GitHub will list a maximum of 100 files in a single response
+        NUM_PAGE_LIMIT = 30  # GitHub stops returning files in a PR after 3000 files
+
+        headers = {}
         if self._token:
             headers["Authorization"] = "token " + self._token
 
-        url = "/repos/{}/pulls/{}/files".format(repo, number)
-        http = yield httpclientservice.HTTPClientService.getService(
-            self.master,
-            self.github_api_endpoint,
-            headers=headers,
-            debug=self.debug,
-            verify=self.verify,
-        )
-        res = yield http.get(url)
-        if 200 <= res.code < 300:
-            data = yield res.json()
-            return [self.file_with_status_sign(f) for f in data]
+        page = 1
+        files = []
+        while page < NUM_PAGE_LIMIT:
+            response = yield TwistedAdditions.request(
+                url="{}/repos/{}/pulls/{}/files".format(self.github_api_endpoint, repo, number),
+                type=b'GET',
+                params=dict(
+                    per_page=PER_PAGE_LIMIT,
+                    page=page,
+                ), headers=headers,
+                logger=log.msg,
+            )
+            if not response or response.status_code // 100 != 2:
+                break
+            data = response.json()
+            files += [self.file_with_status_sign(f) for f in data]
+            if len(data) < PER_PAGE_LIMIT:
+                break
+            page += 1
 
-        log.msg('Failed fetching PR files: response code {}'.format(res.code))
-        return []
+        if not files:
+            log.msg('Failed fetching files for PR #{}: response code {}'.format(number, response.code if response else '?'))
+        return defer.returnValue(files)
 
     def extractProperties(self, payload):
         result = super(GitHubEventHandlerNoEdits, self).extractProperties(payload)


### PR DESCRIPTION
#### 71af31493956aee8c303ef7443e8d3a74486730b
<pre>
[ews-build.webkit.org] Support PRs with many files changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=250714">https://bugs.webkit.org/show_bug.cgi?id=250714</a>
rdar://104339227

Reviewed by Aakash Jain.

GitHub&apos;s PR file changed API only provides a list of 30 files by default.
If we support pagination, we can get many more.

* Tools/CISupport/ews-build/events.py:
(GitHubEventHandlerNoEdits._get_pr_files): Paginate files changed.

Canonical link: <a href="https://commits.webkit.org/259213@main">https://commits.webkit.org/259213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/690d23c7d0b471c5685919e3e7528db2fe201dce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113592 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108299 "Failed to checkout and rebase branch from PR 8724") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4371 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96599 "Failed to checkout and rebase branch from PR 8724") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112632 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110142 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96599 "Failed to checkout and rebase branch from PR 8724") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96599 "Failed to checkout and rebase branch from PR 8724") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6816 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6946 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103219 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12971 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8739 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3355 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->