### PR TITLE
[WGSL] Update struct syntax

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -253,6 +253,10 @@ Expected<AST::StructDecl, Error> Parser<Lexer>::parseStructDecl(AST::Attribute::
     while (current().m_type != TokenType::BraceRight) {
         PARSE(member, StructMember);
         members.append(makeUniqueRef<AST::StructMember>(WTFMove(member)));
+        if (current().m_type == TokenType::Comma)
+            consume();
+        else
+            break;
     }
 
     CONSUME_TYPE(BraceRight);
@@ -269,7 +273,6 @@ Expected<AST::StructMember, Error> Parser<Lexer>::parseStructMember()
     CONSUME_TYPE_NAMED(name, Identifier);
     CONSUME_TYPE(Colon);
     PARSE(type, TypeDecl);
-    CONSUME_TYPE(Semicolon);
 
     RETURN_NODE(StructMember, name.m_ident, WTFMove(type), WTFMove(attributes));
 }

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -148,7 +148,7 @@ TEST(WGSLLexerTests, ComputeShader)
 {
     WGSL::Lexer<LChar> lexer(
         "@block struct B {\n"
-        "    a: i32;\n"
+        "    a: i32,\n"
         "}\n"
         "\n"
         "@group(0) @binding(0)\n"
@@ -172,7 +172,7 @@ TEST(WGSLLexerTests, ComputeShader)
     checkNextTokenIsIdentifier(lexer, "a"_s, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Colon, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::KeywordI32, lineNumber);
-    checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
 
     // }
     ++lineNumber;


### PR DESCRIPTION
#### 01831b153ff02d5f3735bf22f873898b65980532
<pre>
[WGSL] Update struct syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=250713">https://bugs.webkit.org/show_bug.cgi?id=250713</a>
&lt;rdar://problem/104338960&gt;

Reviewed by Myles C. Maxfield.

Struct fields are now comma separated instead of semicolon terminated

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStructDecl):
(WGSL::Parser&lt;Lexer&gt;::parseStructMember):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::testStruct):
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/259026@main">https://commits.webkit.org/259026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/844ca18dd28f16f7e63724afef2f7329bb19f99f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112926 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173246 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3711 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112071 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109472 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38386 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80036 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6178 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26729 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3255 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8112 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->