### PR TITLE
SVGRenderStyle should repaint on resolved color change

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/svg-currentcolor-dynamic-inherit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/svg-currentcolor-dynamic-inherit-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<style>
+svg {
+   width: 10%;
+}
+</style>
+</head>
+<body>
+   <div>
+   <svg xmlns="http://www.w3.org/2000/svg" id="root" version="1.1" viewBox="0 0 16 16">
+       <circle fill="none" stroke="green" cx="8" cy="8" r="6"/>
+   </svg>
+   </div>
+</style>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/svg-currentcolor-dynamic-inherit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/svg-currentcolor-dynamic-inherit.html
@@ -1,0 +1,33 @@
+<html class="reftest-wait">
+<head>
+<style>
+.active {
+   color: green;
+}
+svg {
+   width: 10%;
+}
+</style>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+    addEventListener("load", async () => {
+      setTimeout(() => {
+        var svg = document.getElementById("root")
+        svg.classList.add("active")
+        requestAnimationFrame( () => {
+          document.documentElement.classList.remove("reftest-wait");
+        })
+      },10);
+    });
+</script>
+</head>
+<body>
+   <div style="color:red">
+   <svg xmlns="http://www.w3.org/2000/svg" id="root" version="1.1" viewBox="0 0 16 16">
+       <circle fill="none" stroke="currentColor" cx="8" cy="8" r="6"/>
+   </svg>
+   </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -890,6 +890,9 @@ static bool rareInheritedDataChangeRequiresLayout(const StyleRareInheritedData& 
 
 bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<StyleDifferenceContextSensitiveProperty>& changedContextSensitiveProperties) const
 {
+    if (m_svgStyle->changeRequiresLayout(other.m_svgStyle))
+        return true;
+
     if (m_boxData.ptr() != other.m_boxData.ptr()) {
         if (m_boxData->width() != other.m_boxData->width()
             || m_boxData->minWidth() != other.m_boxData->minWidth()
@@ -1197,6 +1200,11 @@ inline static bool changedCustomPaintWatchedProperty(const RenderStyle& a, const
 
 bool RenderStyle::changeRequiresRepaint(const RenderStyle& other, OptionSet<StyleDifferenceContextSensitiveProperty>& changedContextSensitiveProperties) const
 {
+    bool currentColorDiffers = m_inheritedData->color != other.m_inheritedData->color;
+
+    if (m_svgStyle->changeRequiresRepaint(other.m_svgStyle, currentColorDiffers))
+        return true;
+
     if (!requiresPainting(*this) && !requiresPainting(other))
         return false;
 
@@ -1207,7 +1215,6 @@ bool RenderStyle::changeRequiresRepaint(const RenderStyle& other, OptionSet<Styl
         return true;
 
 
-    bool currentColorDiffers = m_inheritedData->color != other.m_inheritedData->color;
     if (m_backgroundData.ptr() != other.m_backgroundData.ptr()) {
         if (!m_backgroundData->isEquivalentForPainting(*other.m_backgroundData, currentColorDiffers))
             return true;
@@ -1277,22 +1284,8 @@ StyleDifference RenderStyle::diff(const RenderStyle& other, OptionSet<StyleDiffe
 {
     changedContextSensitiveProperties = OptionSet<StyleDifferenceContextSensitiveProperty>();
 
-    StyleDifference svgChange = StyleDifference::Equal;
-    if (m_svgStyle != other.m_svgStyle) {
-        svgChange = m_svgStyle->diff(other.m_svgStyle.get());
-        if (svgChange == StyleDifference::Layout)
-            return svgChange;
-    }
-
     if (changeRequiresLayout(other, changedContextSensitiveProperties))
         return StyleDifference::Layout;
-
-    // SVGRenderStyle::diff() might have returned StyleDifference::Repaint, eg. if fill changes.
-    // If eg. the font-size changed at the same time, we're not allowed to return StyleDifference::Repaint,
-    // but have to return StyleDifference::Layout, that's why  this if branch comes after all branches
-    // that are relevant for SVG and might return StyleDifference::Layout.
-    if (svgChange != StyleDifference::Equal)
-        return svgChange;
 
     if (changeRequiresPositionedLayoutOnly(other, changedContextSensitiveProperties))
         return StyleDifference::LayoutPositionedMovementOnly;

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -135,17 +135,28 @@ void SVGRenderStyle::copyNonInheritedFrom(const SVGRenderStyle& other)
     m_layoutData = other.m_layoutData;
 }
 
-StyleDifference SVGRenderStyle::diff(const SVGRenderStyle& other) const
+static bool colorChangeRequiresRepaint(const StyleColor& a, const StyleColor& b, bool currentColorDiffers)
 {
-    // NOTE: All comparisions that may return StyleDifference::Layout have to go before those who return StyleDifference::Repaint
+    if (a != b)
+        return true;
 
+    if (a.isCurrentColor()) {
+        ASSERT(b.isCurrentColor());
+        return currentColorDiffers;
+    }
+
+    return false;
+}
+
+bool SVGRenderStyle::changeRequiresLayout(const SVGRenderStyle& other) const
+{
     // If kerning changes, we need a relayout, to force SVGCharacterData to be recalculated in the SVGRootInlineBox.
     if (m_textData != other.m_textData)
-        return StyleDifference::Layout;
+        return true;
 
     // If markers change, we need a relayout, as marker boundaries are cached in RenderSVGPath.
     if (m_inheritedResourceData != other.m_inheritedResourceData)
-        return StyleDifference::Layout;
+        return true;
 
     // All text related properties influence layout.
     if (m_inheritedFlags.textAnchor != other.m_inheritedFlags.textAnchor
@@ -154,56 +165,55 @@ StyleDifference SVGRenderStyle::diff(const SVGRenderStyle& other) const
         || m_nonInheritedFlags.flagBits.alignmentBaseline != other.m_nonInheritedFlags.flagBits.alignmentBaseline
         || m_nonInheritedFlags.flagBits.dominantBaseline != other.m_nonInheritedFlags.flagBits.dominantBaseline
         || m_nonInheritedFlags.flagBits.baselineShift != other.m_nonInheritedFlags.flagBits.baselineShift)
-        return StyleDifference::Layout;
+        return true;
 
     // Text related properties influence layout.
-    bool miscNotEqual = m_miscData != other.m_miscData;
-    if (miscNotEqual && m_miscData->baselineShiftValue != other.m_miscData->baselineShiftValue)
-        return StyleDifference::Layout;
+    if (m_miscData->baselineShiftValue != other.m_miscData->baselineShiftValue)
+        return true;
 
     // The x or y properties require relayout.
     if (m_layoutData != other.m_layoutData)
-        return StyleDifference::Layout; 
+        return true; 
 
     // Some stroke properties, requires relayouts, as the cached stroke boundaries need to be recalculated.
-    if (m_strokeData != other.m_strokeData) {
-        if (m_strokeData->paintType != other.m_strokeData->paintType
-            || m_strokeData->paintColor != other.m_strokeData->paintColor
-            || m_strokeData->paintUri != other.m_strokeData->paintUri
-            || m_strokeData->dashArray != other.m_strokeData->dashArray
-            || m_strokeData->dashOffset != other.m_strokeData->dashOffset
-            || m_strokeData->visitedLinkPaintColor != other.m_strokeData->visitedLinkPaintColor
-            || m_strokeData->visitedLinkPaintUri != other.m_strokeData->visitedLinkPaintUri
-            || m_strokeData->visitedLinkPaintType != other.m_strokeData->visitedLinkPaintType)
-            return StyleDifference::Layout;
-
-        // Only the stroke-opacity case remains, where we only need a repaint.
-        ASSERT(m_strokeData->opacity != other.m_strokeData->opacity);
-        return StyleDifference::Repaint;
-    }
+    if (m_strokeData->paintType != other.m_strokeData->paintType
+        || m_strokeData->paintUri != other.m_strokeData->paintUri
+        || m_strokeData->dashArray != other.m_strokeData->dashArray
+        || m_strokeData->dashOffset != other.m_strokeData->dashOffset
+        || m_strokeData->visitedLinkPaintUri != other.m_strokeData->visitedLinkPaintUri
+        || m_strokeData->visitedLinkPaintType != other.m_strokeData->visitedLinkPaintType)
+        return true;
 
     // vector-effect changes require a re-layout.
     if (m_nonInheritedFlags.flagBits.vectorEffect != other.m_nonInheritedFlags.flagBits.vectorEffect)
-        return StyleDifference::Layout;
+        return true;
 
-    // NOTE: All comparisions below may only return StyleDifference::Repaint
+    return false;
+}
+
+bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool currentColorDiffers) const
+{
+    if (m_strokeData->opacity != other.m_strokeData->opacity
+        || colorChangeRequiresRepaint(m_strokeData->paintColor, other.m_strokeData->paintColor, currentColorDiffers)
+        || colorChangeRequiresRepaint(m_strokeData->visitedLinkPaintColor, other.m_strokeData->visitedLinkPaintColor, currentColorDiffers))
+        return true;
 
     // Painting related properties only need repaints. 
-    if (miscNotEqual) {
-        if (m_miscData->floodColor != other.m_miscData->floodColor
-            || m_miscData->floodOpacity != other.m_miscData->floodOpacity
-            || m_miscData->lightingColor != other.m_miscData->lightingColor)
-            return StyleDifference::Repaint;
-    }
+    if (colorChangeRequiresRepaint(m_miscData->floodColor, other.m_miscData->floodColor, currentColorDiffers)
+        || m_miscData->floodOpacity != other.m_miscData->floodOpacity
+        || colorChangeRequiresRepaint(m_miscData->lightingColor, other.m_miscData->lightingColor, currentColorDiffers))
+        return true;
 
     // If fill data changes, we just need to repaint. Fill boundaries are not influenced by this, only by the Path, that RenderSVGPath contains.
-    if (m_fillData->paintType != other.m_fillData->paintType || m_fillData->paintColor != other.m_fillData->paintColor
-        || m_fillData->paintUri != other.m_fillData->paintUri || m_fillData->opacity != other.m_fillData->opacity)
-        return StyleDifference::Repaint;
+    if (m_fillData->paintType != other.m_fillData->paintType 
+        || colorChangeRequiresRepaint(m_fillData->paintColor, other.m_fillData->paintColor, currentColorDiffers)
+        || m_fillData->paintUri != other.m_fillData->paintUri 
+        || m_fillData->opacity != other.m_fillData->opacity)
+        return true;
 
     // If gradient stops change, we just need to repaint. Style updates are already handled through RenderSVGGradientSTop.
     if (m_stopData != other.m_stopData)
-        return StyleDifference::Repaint;
+        return true;
 
     // Changes of these flags only cause repaints.
     if (m_inheritedFlags.shapeRendering != other.m_inheritedFlags.shapeRendering
@@ -211,15 +221,15 @@ StyleDifference SVGRenderStyle::diff(const SVGRenderStyle& other) const
         || m_inheritedFlags.fillRule != other.m_inheritedFlags.fillRule
         || m_inheritedFlags.colorInterpolation != other.m_inheritedFlags.colorInterpolation
         || m_inheritedFlags.colorInterpolationFilters != other.m_inheritedFlags.colorInterpolationFilters)
-        return StyleDifference::Repaint;
+        return true;
 
     if (m_nonInheritedFlags.flagBits.bufferedRendering != other.m_nonInheritedFlags.flagBits.bufferedRendering)
-        return StyleDifference::Repaint;
+        return true;
 
     if (m_nonInheritedFlags.flagBits.maskType != other.m_nonInheritedFlags.flagBits.maskType)
-        return StyleDifference::Repaint;
+        return true;
 
-    return StyleDifference::Equal;
+    return false;
 }
 
 }

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -43,7 +43,8 @@ public:
     void inheritFrom(const SVGRenderStyle&);
     void copyNonInheritedFrom(const SVGRenderStyle&);
 
-    StyleDifference diff(const SVGRenderStyle&) const;
+    bool changeRequiresRepaint(const SVGRenderStyle& other, bool currentColorDiffers) const;
+    bool changeRequiresLayout(const SVGRenderStyle& other) const;
 
     bool operator==(const SVGRenderStyle&) const;
     bool operator!=(const SVGRenderStyle& other) const { return !(*this == other); }


### PR DESCRIPTION
#### f5b520fdec0edc2996ac754c2fa8f13fd2a7fb05
<pre>
SVGRenderStyle should repaint on resolved color change
<a href="https://bugs.webkit.org/show_bug.cgi?id=250718">https://bugs.webkit.org/show_bug.cgi?id=250718</a>
rdar://102904403

Reviewed by Antti Koivisto.

Before this patch, the diff algorithm would naively
compare the color properties value without taking into
account the dynamic nature of &quot;currentcolor&quot;.

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/svg-currentcolor-dynamic-inherit-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/svg-currentcolor-dynamic-inherit.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresLayout const):
(WebCore::RenderStyle::changeRequiresRepaint const):
(WebCore::RenderStyle::diff const):
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::colorChangeRequiresRepaint):
(WebCore::SVGRenderStyle::changeRequiresLayout const):
(WebCore::SVGRenderStyle::changeRequiresRepaint const):
(WebCore::SVGRenderStyle::diff const): Deleted.
* Source/WebCore/rendering/style/SVGRenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/259082@main">https://commits.webkit.org/259082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8089e5e40a8583b8ae52edd73e879f2d37f461e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113021 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173336 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3808 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96044 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112136 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80117 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6270 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26805 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3341 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6249 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8206 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->