### PR TITLE
Revert [259000@main] Web Inspector: WebKit-internal JSContexts should not be inspectable, even if internal policies would override `inspectable`

### DIFF
--- a/Source/JavaScriptCore/API/JSRemoteInspector.cpp
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,7 +41,6 @@
 using namespace Inspector;
 
 static std::optional<bool> remoteInspectionEnabledByDefault = std::nullopt;
-static bool inspectionFollowsInternalPolicies = true;
 
 void JSRemoteInspectorDisableAutoStart(void)
 {
@@ -128,14 +127,4 @@ bool JSRemoteInspectorGetInspectionEnabledByDefault(void)
 void JSRemoteInspectorSetInspectionEnabledByDefault(bool enabledByDefault)
 {
     remoteInspectionEnabledByDefault = enabledByDefault;
-}
-
-bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void)
-{
-    return inspectionFollowsInternalPolicies;
-}
-
-void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool followsInternalPolicies)
-{
-    inspectionFollowsInternalPolicies = followsInternalPolicies;
 }

--- a/Source/JavaScriptCore/API/JSRemoteInspector.h
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,9 +49,6 @@ JS_EXPORT void JSRemoteInspectorSetLogToSystemConsole(bool) JSC_API_AVAILABLE(ma
 
 JS_EXPORT bool JSRemoteInspectorGetInspectionEnabledByDefault(void) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
 JS_EXPORT void JSRemoteInspectorSetInspectionEnabledByDefault(bool) JSC_API_DEPRECATED("Use JSGlobalContextSetInspectable on a single JSGlobalContextRef.", macos(10.11, JSC_MAC_TBA), ios(9.0, JSC_IOS_TBA));
-
-JS_EXPORT bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
-JS_EXPORT void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -211,7 +211,7 @@ bool JSGlobalObjectInspectorController::developerExtrasEnabled() const
     if (!RemoteInspector::singleton().enabled())
         return false;
 
-    if (!m_globalObject.inspectorDebuggable().allowsInspectionByPolicy())
+    if (!m_globalObject.inspectorDebuggable().inspectable())
         return false;
 #endif
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2013, 2015 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,55 +40,24 @@ namespace Inspector {
 
 bool RemoteInspectionTarget::remoteControlAllowed() const
 {
-    return allowsInspectionByPolicy() || hasLocalDebugger();
-}
-
-bool RemoteInspectionTarget::allowsInspectionByPolicy() const
-{
-    switch (m_inspectable) {
-    case Inspectable::Yes:
-        return true;
-    case Inspectable::No:
-#if PLATFORM(COCOA)
-        static bool allowInternalSecurityPolicies = os_variant_allows_internal_security_policies("com.apple.WebInspector");
-        if (allowInternalSecurityPolicies && !RemoteInspector::singleton().isSimulatingCustomerInstall())
-            return true;
-        FALLTHROUGH;
-#endif
-    case Inspectable::NoIgnoringInternalPolicies:
-        return false;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
+    return inspectable() || hasLocalDebugger();
 }
 
 bool RemoteInspectionTarget::inspectable() const
 {
-    switch (m_inspectable) {
-    case Inspectable::Yes:
+#if PLATFORM(COCOA)
+    static bool allowInternalSecurityPolicies = os_variant_allows_internal_security_policies("com.apple.WebInspector");
+    if (allowInternalSecurityPolicies && !RemoteInspector::singleton().isSimulatingCustomerInstall())
         return true;
-    case Inspectable::No:
-    case Inspectable::NoIgnoringInternalPolicies:
-        return false;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
+#endif
+    return m_inspectable;
 }
 
 void RemoteInspectionTarget::setInspectable(bool inspectable)
 {
-    if (inspectable)
-        m_inspectable = Inspectable::Yes;
-    else {
-        if (!JSRemoteInspectorGetInspectionFollowsInternalPolicies())
-            m_inspectable = Inspectable::NoIgnoringInternalPolicies;
-        else
-            m_inspectable = Inspectable::No;
-    }
+    m_inspectable = inspectable;
 
-    if (allowsInspectionByPolicy() && automaticInspectionAllowed())
+    if (RemoteInspectionTarget::inspectable() && automaticInspectionAllowed())
         RemoteInspector::singleton().updateAutomaticInspectionCandidate(this);
     else
         RemoteInspector::singleton().updateTarget(this);
@@ -97,7 +66,7 @@ void RemoteInspectionTarget::setInspectable(bool inspectable)
 void RemoteInspectionTarget::pauseWaitingForAutomaticInspection()
 {
     ASSERT(targetIdentifier());
-    ASSERT(allowsInspectionByPolicy());
+    ASSERT(inspectable());
     ASSERT(automaticInspectionAllowed());
 
     while (RemoteInspector::singleton().waitingForAutomaticInspection(targetIdentifier())) {

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2013, 2015 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,6 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 
-#include "JSRemoteInspector.h"
 #include "RemoteControllableTarget.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
@@ -41,8 +40,6 @@ class JS_EXPORT_PRIVATE RemoteInspectionTarget : public RemoteControllableTarget
 public:
     bool inspectable() const;
     void setInspectable(bool);
-
-    bool allowsInspectionByPolicy() const;
 
 #if USE(CF)
     CFRunLoopRef targetRunLoop() const final { return m_runLoop.get(); }
@@ -63,16 +60,7 @@ public:
     bool remoteControlAllowed() const final;
 
 private:
-    enum class Inspectable : uint8_t {
-        Yes,
-        No,
-
-        // For WebKit internal proxies and wrappers, we want to always disable inspection even when internal policies
-        // would otherwise enable inspection.
-        NoIgnoringInternalPolicies,
-    };
-    Inspectable m_inspectable { JSRemoteInspectorGetInspectionFollowsInternalPolicies() ? Inspectable::No : Inspectable::NoIgnoringInternalPolicies };
-
+    bool m_inspectable { false };
 #if USE(CF)
     RetainPtr<CFRunLoopRef> m_runLoop;
 #endif

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -458,7 +458,7 @@ RetainPtr<NSDictionary> RemoteInspector::listingForInspectionTarget(const Remote
     // Must collect target information on the WebThread, Main, or Worker thread since RemoteTargets are
     // implemented by non-threadsafe JSC / WebCore classes such as JSGlobalObject or WebCore::Page.
 
-    if (!target.allowsInspectionByPolicy())
+    if (!target.inspectable())
         return nil;
 
     RetainPtr<NSMutableDictionary> listing = adoptNS([[NSMutableDictionary alloc] init]);

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -170,7 +170,7 @@ static const char* targetDebuggableType(RemoteInspectionTarget::Type type)
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
 {
-    if (!target.allowsInspectionByPolicy())
+    if (!target.inspectable())
         return nullptr;
 
     return g_variant_new("(tsssb)", static_cast<guint64>(target.targetIdentifier()),

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -117,7 +117,7 @@ void RemoteInspector::stopInternal(StopSource)
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
 {
-    if (!target.allowsInspectionByPolicy())
+    if (!target.inspectable())
         return nullptr;
 
     // FIXME: Support remote debugging of a ServiceWorker.

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -75,10 +75,6 @@
 #include <JavaScriptCore/WeakGCMapInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
-#if ENABLE(REMOTE_INSPECTOR)
-#include <JavaScriptCore/JSRemoteInspector.h>
-#endif
-
 namespace WebCore {
 using namespace JSC;
 
@@ -292,40 +288,22 @@ SUPPRESS_ASAN void JSDOMGlobalObject::addBuiltinGlobals(VM& vm)
 
 void JSDOMGlobalObject::finishCreation(VM& vm)
 {
-#if ENABLE(REMOTE_INSPECTOR)
-    bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
-    JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
-#endif
-
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
     addBuiltinGlobals(vm);
 
     RELEASE_ASSERT(classInfo());
-
-#if ENABLE(REMOTE_INSPECTOR)
-    JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
-#endif
 }
 
 void JSDOMGlobalObject::finishCreation(VM& vm, JSObject* thisValue)
 {
-#if ENABLE(REMOTE_INSPECTOR)
-    bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
-    JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
-#endif
-
     Base::finishCreation(vm, thisValue);
     ASSERT(inherits(info()));
 
     addBuiltinGlobals(vm);
 
     RELEASE_ASSERT(classInfo());
-
-#if ENABLE(REMOTE_INSPECTOR)
-    JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
-#endif
 }
 
 ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -49,9 +49,6 @@ public:
     {
         m_lastUseTime = MonotonicTime::now();
         if (!m_context) {
-            bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
-            JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
-
             // FIXME: rdar://100738357 Remote Web Inspector: Remove use of JSRemoteInspectorGetInspectionEnabledByDefault
             // and JSRemoteInspectorSetInspectionEnabledByDefault once the default state is always false.
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -60,8 +57,6 @@ public:
             m_context = adoptNS([[JSContext alloc] init]);
             JSRemoteInspectorSetInspectionEnabledByDefault(previous);
             ALLOW_DEPRECATED_DECLARATIONS_END
-
-            JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
 
             m_timer.startOneShot(sharedJSContextMaxIdleTime);
         }


### PR DESCRIPTION
#### c9e1cf59eeca6fd69f84616b29ac850316f1c61e
<pre>
Revert [259000@main] Web Inspector: WebKit-internal JSContexts should not be inspectable, even if internal policies would override `inspectable`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250633">https://bugs.webkit.org/show_bug.cgi?id=250633</a>
rdar://103312497

Unreviewed revert.

* Source/JavaScriptCore/API/JSRemoteInspector.cpp:
(JSRemoteInspectorSetInspectionEnabledByDefault):
(JSRemoteInspectorGetInspectionFollowsInternalPolicies): Deleted.
(JSRemoteInspectorSetInspectionFollowsInternalPolicies): Deleted.
* Source/JavaScriptCore/API/JSRemoteInspector.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::developerExtrasEnabled const):
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
(Inspector::RemoteInspectionTarget::remoteControlAllowed const):
(Inspector::RemoteInspectionTarget::inspectable const):
(Inspector::RemoteInspectionTarget::setInspectable):
(Inspector::RemoteInspectionTarget::pauseWaitingForAutomaticInspection):
(Inspector::RemoteInspectionTarget::allowsInspectionByPolicy const): Deleted.
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::finishCreation):
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
(API::SharedJSContext::ensureContext):

Canonical link: <a href="https://commits.webkit.org/259004@main">https://commits.webkit.org/259004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9684b084200407b7fb1ecf3781dbe682e94382e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12733 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112850 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3631 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109390 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/93759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90183 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/3864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98788 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8040 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/24870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3289 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->