### PR TITLE
Don't crash WebContent process when passing invalid URL for cache

### DIFF
--- a/LayoutTests/http/tests/cache-storage/cache-match-invalid-url-expected.txt
+++ b/LayoutTests/http/tests/cache-storage/cache-match-invalid-url-expected.txt
@@ -1,0 +1,1 @@
+PASS Throwing exception on invalid url.

--- a/LayoutTests/http/tests/cache-storage/cache-match-invalid-url.html
+++ b/LayoutTests/http/tests/cache-storage/cache-match-invalid-url.html
@@ -1,0 +1,28 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function testFunc() {
+  (async () => {
+    let cache = await caches.open("a");
+    try {
+      let ret = await cache.match("/\\X\u0600");
+      assert_unreached("Should never reach here, expected exception.")
+    } catch (err) {
+      assert_true(err instanceof TypeError);
+      assert_equals(err.message, "URL is not valid or contains user credentials.");
+      if (window.testRunner)
+        testRunner.notifyDone();
+    }
+  })();
+}
+</script>
+<body onload="testFunc()">
+<p>
+PASS Throwing exception on invalid url.
+</p>
+</body>

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -99,9 +99,13 @@ void DOMCache::doMatch(RequestInfo&& info, CacheQueryOptions&& options, MatchCal
     if (UNLIKELY(!scriptExecutionContext()))
         return;
 
-    auto requestOrException = requestFromInfo(WTFMove(info), options.ignoreMethod);
+    bool requestValidationFailed = false;
+    auto requestOrException = requestFromInfo(WTFMove(info), options.ignoreMethod, &requestValidationFailed);
     if (requestOrException.hasException()) {
-        callback(nullptr);
+        if (requestValidationFailed)
+            callback(nullptr);
+        else
+            callback(requestOrException.releaseException());
         return;
     }
 
@@ -135,9 +139,13 @@ void DOMCache::matchAll(std::optional<RequestInfo>&& info, CacheQueryOptions&& o
 
     ResourceRequest resourceRequest;
     if (info) {
-        auto requestOrException = requestFromInfo(WTFMove(info.value()), options.ignoreMethod);
+        bool requestValidationFailed = false;
+        auto requestOrException = requestFromInfo(WTFMove(info.value()), options.ignoreMethod, &requestValidationFailed);
         if (requestOrException.hasException()) {
-            promise.resolve({ });
+            if (requestValidationFailed)
+                promise.resolve({ });
+            else
+                promise.reject(requestOrException.releaseException());
             return;
         }
         resourceRequest = requestOrException.releaseReturnValue()->resourceRequest();
@@ -218,18 +226,28 @@ private:
     CompletionHandler<void(ExceptionOr<Vector<Record>>&&)> m_callback;
 };
 
-ExceptionOr<Ref<FetchRequest>> DOMCache::requestFromInfo(RequestInfo&& info, bool ignoreMethod)
+ExceptionOr<Ref<FetchRequest>> DOMCache::requestFromInfo(RequestInfo&& info, bool ignoreMethod, bool* requestValidationFailed)
 {
     RefPtr<FetchRequest> request;
     if (std::holds_alternative<RefPtr<FetchRequest>>(info)) {
         request = std::get<RefPtr<FetchRequest>>(info).releaseNonNull();
-        if (request->method() != "GET"_s && !ignoreMethod)
+        if (request->method() != "GET"_s && !ignoreMethod) {
+            if (requestValidationFailed)
+                *requestValidationFailed = true;
             return Exception { TypeError, "Request method is not GET"_s };
-    } else
-        request = FetchRequest::create(*scriptExecutionContext(), WTFMove(info), { }).releaseReturnValue();
+        }
+    } else {
+        auto result = FetchRequest::create(*scriptExecutionContext(), WTFMove(info), { });
+        if (result.hasException())
+            return result.releaseException();
+        request = result.releaseReturnValue();
+    }
 
-    if (!request->url().protocolIsInHTTPFamily())
+    if (!request->url().protocolIsInHTTPFamily()) {
+        if (requestValidationFailed)
+            *requestValidationFailed = true;
         return Exception { TypeError, "Request url is not HTTP/HTTPS"_s };
+    }
 
     return request.releaseNonNull();
 }

--- a/Source/WebCore/Modules/cache/DOMCache.h
+++ b/Source/WebCore/Modules/cache/DOMCache.h
@@ -66,7 +66,7 @@ public:
 private:
     DOMCache(ScriptExecutionContext&, String&& name, DOMCacheIdentifier, Ref<CacheStorageConnection>&&);
 
-    ExceptionOr<Ref<FetchRequest>> requestFromInfo(RequestInfo&&, bool ignoreMethod);
+    ExceptionOr<Ref<FetchRequest>> requestFromInfo(RequestInfo&&, bool ignoreMethod, bool* requestValidationFailed = nullptr);
 
     // ActiveDOMObject
     void stop() final;


### PR DESCRIPTION
#### 99afca995277e6c9ac1e2e68ccfc133b4d99fc3d
<pre>
Don&apos;t crash WebContent process when passing invalid URL for cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=250727">https://bugs.webkit.org/show_bug.cgi?id=250727</a>
rdar://104294986

Reviewed by Chris Dumez and Sihui Liu.

Before this change, if FetchRequest::create() returned an exception, we
never used to check for that and call releaseReturnValue() on that which
would cause a crash. This change fixes that, so that we can correctly
return the &quot;URL is not valid or contains user credentials.&quot; exception.
This change also fixes a bug where correct exception wasn&apos;t returned.

* LayoutTests/http/tests/cache-storage/cache-match-invalid-url-expected.txt: Added.
* LayoutTests/http/tests/cache-storage/cache-match-invalid-url.html: Added.
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::doMatch):
(WebCore::DOMCache::matchAll):
(WebCore::DOMCache::requestFromInfo):
* Source/WebCore/Modules/cache/DOMCache.h:

Canonical link: <a href="https://commits.webkit.org/259091@main">https://commits.webkit.org/259091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ad07ea4e2c754d070800991ac985f3ce4c4f53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113036 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173347 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3822 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96058 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112148 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38471 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26816 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3355 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46339 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6257 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8220 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->