### PR TITLE
Tighten webpushd sandbox on iOS

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
@@ -22,9 +22,7 @@
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
 (version 1)
-; FIXME: tighten sandbox after we get enough internal reports.
-; (deny default (with partial-symbolication))
-(allow (with report) default)
+(deny default (with partial-symbolication))
 (allow system-audit file-read-metadata)
 
 (import "util.sb")
@@ -186,7 +184,8 @@
 (allow mach-lookup
     (global-name "com.apple.coreservices.launchservicesd")
     (global-name "com.apple.coreservices.quarantine-resolver")
-    (global-name "com.apple.lsd.mapdb"))
+    (global-name "com.apple.lsd.mapdb")
+    (global-name "com.apple.lsd.open"))
 
 (allow user-preference-read
     (preference-domain


### PR DESCRIPTION
#### f8504aca74602bb8976581c31e3294abb2228b07
<pre>
Tighten webpushd sandbox on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=250728">https://bugs.webkit.org/show_bug.cgi?id=250728</a>
rdar://103494644

Reviewed by Brady Eidson and Per Arne Vollan.

This changes the default sandbox policy for webpushd from allow to deny. It also grants access to
the service &quot;com.apple.lsd.open&quot;, which is necessary to launch the app after clicking on a
notification.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in:

Canonical link: <a href="https://commits.webkit.org/259014@main">https://commits.webkit.org/259014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a6dac7822ca93b84ba810d7ac5fb38d8f6070b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112864 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3646 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95877 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109404 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38342 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25281 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6119 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6297 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46194 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6190 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8053 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->