### PR TITLE
Let MediaController.currentTime return the position previously set

### DIFF
--- a/LayoutTests/media/media-controller-playback-expected.txt
+++ b/LayoutTests/media/media-controller-playback-expected.txt
@@ -5,6 +5,7 @@ RUN(controller.play())
 EVENT(playing)
 EXPECTED (controller.paused == 'false') OK
 RUN(controller.currentTime = 5)
+EXPECTED (controller.currentTime == '5') OK
 EXPECTED (video.currentTime == '5') OK
 EXPECTED (video2.currentTime == '5') OK
 EVENT(ended)

--- a/LayoutTests/media/media-controller-playback.html
+++ b/LayoutTests/media/media-controller-playback.html
@@ -32,6 +32,7 @@
             testExpected('controller.paused', false);
             controller.addEventListener('ended', ended, true);
             run('controller.currentTime = 5');
+            testExpected('controller.currentTime', 5);
             testExpected('video.currentTime', 5);
             testExpected('video2.currentTime', 5);
         }

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -166,6 +167,7 @@ void MediaController::setCurrentTime(double time)
     time = std::min(time, duration());
     
     // Set the media controller position to the new playback position.
+    m_position = time;
     m_clock->setCurrentTime(time);
     
     // Seek each mediagroup element to the new playback position relative to the media element timeline.


### PR DESCRIPTION
#### 921f8243c150a68acf023bd56851540bb1cd8214
<pre>
Let MediaController.currentTime return the position previously set

Let MediaController.currentTime return the position previously set
<a href="https://bugs.webkit.org/show_bug.cgi?id=250594">https://bugs.webkit.org/show_bug.cgi?id=250594</a>

Reviewed by Eric Carlson.

This patch is to align WebKit with Web-Specification:

Web-Spec: <a href="https://html.spec.whatwg.org/multipage/media.html#seeking">https://html.spec.whatwg.org/multipage/media.html#seeking</a>

&quot;Set the current playback position to the new playback position.&quot;

This patch modifies &apos;setCurrenTime&apos; function to have &quot;m_position&quot; as &quot;time&quot; and return it according to web-specification.

Merge - <a href="http://src.chromium.org/viewvc/blink?view=rev&amp">http://src.chromium.org/viewvc/blink?view=rev&amp</a>;rev=170504

* Source/WebCore/html/MediaController.cpp:
(MediaController::setCurrentTime): Add &apos;m_position = time;&quot; for Step 11 of Web-Spec
* LayoutTests/media/media-controller-playback.html: Add new sub-test
* LayoutTests/media/media-controller-playback-expected.txt: Add new sub-test expectations

Canonical link: <a href="https://commits.webkit.org/259020@main">https://commits.webkit.org/259020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbb912dd41c2e2d3b340d8d9a61931051b496251

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112874 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173205 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3656 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112030 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38347 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79998 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26691 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3213 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46204 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8063 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->