### PR TITLE
[WebGPU] GPUComputePassEncoder.dispatch renamed to .dispatchWorkgroups

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
@@ -48,12 +48,14 @@ void GPUComputePassEncoder::setPipeline(const GPUComputePipeline& computePipelin
     m_backing->setPipeline(computePipeline.backing());
 }
 
-void GPUComputePassEncoder::dispatch(GPUSize32 workgroupCountX, GPUSize32 workgroupCountY, GPUSize32 workgroupCountZ)
+void GPUComputePassEncoder::dispatchWorkgroups(GPUSize32 workgroupCountX, std::optional<GPUSize32> workgroupCountY, std::optional<GPUSize32> workgroupCountZ)
 {
-    m_backing->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219 we should be able to specify the
+    // default values via the idl file
+    m_backing->dispatch(workgroupCountX, workgroupCountY.value_or(1), workgroupCountZ.value_or(1));
 }
 
-void GPUComputePassEncoder::dispatchIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
+void GPUComputePassEncoder::dispatchWorkgroupsIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
     m_backing->dispatchIndirect(indirectBuffer.backing(), indirectOffset);
 }

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
@@ -52,8 +52,8 @@ public:
     void setLabel(String&&);
 
     void setPipeline(const GPUComputePipeline&);
-    void dispatch(GPUSize32 workgroupCountX, GPUSize32 workgroupCountY, GPUSize32 workgroupCountZ);
-    void dispatchIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset);
+    void dispatchWorkgroups(GPUSize32 workgroupCountX, std::optional<GPUSize32> workgroupCountY, std::optional<GPUSize32> workgroupCountZ);
+    void dispatchWorkgroupsIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset);
 
     void end();
 

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
@@ -36,8 +36,9 @@ typedef [EnforceRange] unsigned long long GPUSize64;
 ]
 interface GPUComputePassEncoder {
     undefined setPipeline(GPUComputePipeline pipeline);
-    undefined dispatch(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
-    undefined dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, last two parameters should have default value of 1
+    undefined dispatchWorkgroups(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY, optional GPUSize32 workgroupCountZ);
+    undefined dispatchWorkgroupsIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
     undefined end();
 };


### PR DESCRIPTION
#### 62754f80a4b7c312e27281f8f52eaa8bb16fdacb
<pre>
[WebGPU] GPUComputePassEncoder.dispatch renamed to .dispatchWorkgroups
<a href="https://bugs.webkit.org/show_bug.cgi?id=250737">https://bugs.webkit.org/show_bug.cgi?id=250737</a>
&lt;radar://104350711&gt;

Reviewed by Myles C. Maxfield.

Function was renamed in the specification.

Issued was discovered and tested via gpuweb.github.io/cts/standalone

* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp:
(WebCore::GPUComputePassEncoder::dispatchWorkgroups):
(WebCore::GPUComputePassEncoder::dispatchWorkgroupsIndirect):
Optional values with a default are not supported due to
<a href="https://bugs.webkit.org/show_bug.cgi?id=240219">https://bugs.webkit.org/show_bug.cgi?id=240219</a> so workaround
for now.

(WebCore::GPUComputePassEncoder::dispatch): Deleted.
(WebCore::GPUComputePassEncoder::dispatchIndirect): Deleted.
Rename member function.

* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h:
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl:

Canonical link: <a href="https://commits.webkit.org/259106@main">https://commits.webkit.org/259106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63964cd20052cbb189774896382b4993da5e2154

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112981 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173301 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3767 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96007 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112110 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38434 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80083 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6231 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26774 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3310 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46295 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6267 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8166 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->