### PR TITLE
[Stress Test EWS] failing to find modified layout tests for pull requests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1097,7 +1097,7 @@ class AnalyzeChange(buildstep.BuildStep, AddToLogMixin):
     def _get_patch(self):
         sourcestamp = self.build.getSourceStamp(self.getProperty('codebase', ''))
         if sourcestamp and sourcestamp.changes:
-            return '\n'.join(sourcestamp.changes[0].files)
+            return '\n'.join(sourcestamp.changes[0].files).encode('utf-8')
         if sourcestamp and sourcestamp.patch:
             return sourcestamp.patch[1]
         return None
@@ -5326,7 +5326,7 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
             for line in sourcestamp.patch[1].splitlines():
                 match = re.search(self.RE_CHANGELOG, line)
                 if match:
-                    files.append(match.group(1))
+                    files.append(match.group(1).decode('utf-8'))
             return files
         return []
 


### PR DESCRIPTION
#### 692cd4308e630a0955c468c5a5983f2b058a11a1
<pre>
[Stress Test EWS] failing to find modified layout tests for pull requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=246323">https://bugs.webkit.org/show_bug.cgi?id=246323</a>
rdar://101034678

Reviewed by Aakash Jain.

buildbot always expects patches to be bytes, not strings.

* Tools/CISupport/ews-build/steps.py:
(AnalyzeChange._get_patch): Construct patch as bytes instead of a string.
(ValidateCommitMessage._files): Decode bytes lines into strings.

Canonical link: <a href="https://commits.webkit.org/259088@main">https://commits.webkit.org/259088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83a3c474fbcea4351690d8b3dffacfb01e492b51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113138 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3919 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96158 "Failed to checkout and rebase branch from PR 8744") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112238 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109679 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93900 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96158 "Failed to checkout and rebase branch from PR 8744") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25510 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96158 "Failed to checkout and rebase branch from PR 8744") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6382 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6544 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/102777 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46421 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8315 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3319 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->