### PR TITLE
Revert [258975@main] [ATSPI] Implement `AccessibilityUIElement::sortDirection()`

### DIFF
--- a/LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt
@@ -10,7 +10,7 @@ PASS accessibilityController.accessibleElementById("table-1").numberAttributeVal
 PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIARowCount") is 8
 PASS accessibilityController.accessibleElementById("row-header").role is "AXRole: AXRow"
 FAIL accessibilityController.accessibleElementById("header-1").role should be AXRole: AXCell. Was AXRole: AXColumnHeader.
-PASS accessibilityController.accessibleElementById("header-1").sortDirection is "AXAscendingSortDirection"
+FAIL accessibilityController.accessibleElementById("header-1").sortDirection should be AXAscendingSortDirection (of type string). Was null (of type object).
 PASS accessibilityController.accessibleElementById("row-1").role is "AXRole: AXRow"
 PASS accessibilityController.accessibleElementById("cell1").role is "AXRole: AXCell"
 PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIARowIndex") is 7

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -126,6 +126,7 @@ bool AccessibilityUIElement::isInDescriptionListDetail() const { return false; }
 bool AccessibilityUIElement::isInDescriptionListTerm() const { return false; }
 bool AccessibilityUIElement::isInCell() const { return false; }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const { return nullptr; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::lineRectsAndText() const { return { }; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -456,21 +456,6 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
     return OpaqueJSString::tryCreate(!value.isNull() ? value : "false"_s).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
-{
-    m_element->updateBackingStore();
-    auto sort = m_element->attributes().get("sort"_s);
-
-    if (sort == "ascending"_s)
-        return OpaqueJSString::tryCreate("AXAscendingSortDirection"_s).leakRef();
-    if (sort == "descending"_s)
-        return OpaqueJSString::tryCreate("AXDescendingSortDirection"_s).leakRef();
-    if (sort == "other"_s)
-        return OpaqueJSString::tryCreate("AXUnknownSortDirection"_s).leakRef();
-    
-    return nullptr;
-}
-
 JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
 {
     m_element->updateBackingStore();

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -196,12 +196,6 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
-{
-    notImplemented();
-    return nullptr;
-}
-
 JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeValue(JSStringRef)
 {
     notImplemented();


### PR DESCRIPTION
#### 3e06f2a9892cdb2573d79c5498b62435a41a6f1d
<pre>
Revert [258975@main] [ATSPI] Implement `AccessibilityUIElement::sortDirection()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250673.">https://bugs.webkit.org/show_bug.cgi?id=250673.</a>

Unreviewed revert.

* LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::sortDirection const):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElement::sortDirection const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
(WTR::AccessibilityUIElement::sortDirection const): Deleted.

Canonical link: <a href="https://commits.webkit.org/259012@main">https://commits.webkit.org/259012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd18ad4edca6bda3a0f21c8582e2fd83c1107b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103661 "Failed to checkout and rebase branch from PR 8746") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36609 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/112888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107612 "Failed to checkout and rebase branch from PR 8746") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/13799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3674 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/13799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/95899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/13799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/95899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3293 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->