### PR TITLE
Clean up WebKitAdditions logic in postprocess-header-rule

### DIFF
--- a/Source/JavaScriptCore/API/JSRemoteInspector.cpp
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 using namespace Inspector;
 
 static std::optional<bool> remoteInspectionEnabledByDefault = std::nullopt;
+static bool inspectionFollowsInternalPolicies = true;
 
 void JSRemoteInspectorDisableAutoStart(void)
 {
@@ -127,4 +128,14 @@ bool JSRemoteInspectorGetInspectionEnabledByDefault(void)
 void JSRemoteInspectorSetInspectionEnabledByDefault(bool enabledByDefault)
 {
     remoteInspectionEnabledByDefault = enabledByDefault;
+}
+
+bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void)
+{
+    return inspectionFollowsInternalPolicies;
+}
+
+void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool followsInternalPolicies)
+{
+    inspectionFollowsInternalPolicies = followsInternalPolicies;
 }

--- a/Source/JavaScriptCore/API/JSRemoteInspector.h
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ JS_EXPORT void JSRemoteInspectorSetLogToSystemConsole(bool) JSC_API_AVAILABLE(ma
 
 JS_EXPORT bool JSRemoteInspectorGetInspectionEnabledByDefault(void) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
 JS_EXPORT void JSRemoteInspectorSetInspectionEnabledByDefault(bool) JSC_API_DEPRECATED("Use JSGlobalContextSetInspectable on a single JSGlobalContextRef.", macos(10.11, JSC_MAC_TBA), ios(9.0, JSC_IOS_TBA));
+
+JS_EXPORT bool JSRemoteInspectorGetInspectionFollowsInternalPolicies(void) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JS_EXPORT void JSRemoteInspectorSetInspectionFollowsInternalPolicies(bool) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/Scripts/postprocess-header-rule
+++ b/Source/JavaScriptCore/Scripts/postprocess-header-rule
@@ -33,16 +33,6 @@ if [[ "${JSC_FRAMEWORK_HEADER_POSTPROCESSING_DISABLED}" == "YES" ]]; then
     exit 0
 fi
 
-function process_definitions () {
-    local DEFINITIONS_FILE=$1
-
-    if [[ ! -f "${DEFINITIONS_FILE}" ]]; then
-        return 1
-    fi
-
-    source "${DEFINITIONS_FILE}"
-}
-
 function rewrite_headers () {
     local SOURCE_FILE="${1}"
     local WORK_FILE="${2}.tmp"
@@ -90,15 +80,9 @@ function rewrite_headers () {
         )
     fi
 
-    SED_OPTIONS+=(${OTHER_SED_OPTIONS[*]})
-
     sed -E "${SED_OPTIONS[@]}" "${SOURCE_FILE}" > "${WORK_FILE}" || exit $?
     cmp -s "${WORK_FILE}" "${DEST_FILE}" && rm -f "${WORK_FILE}" || mv "${WORK_FILE}" "${DEST_FILE}"
     [[ "${SOURCE_FILE}" -nt "${DEST_FILE}" ]] && touch "${DEST_FILE}" || true
 }
-
-DEFINITIONS_PATH=usr/local/include/WebKitAdditions/Scripts/postprocess-framework-headers-definitions
-
-process_definitions "${BUILT_PRODUCTS_DIR}/${DEFINITIONS_PATH}" || process_definitions "${SDKROOT}/${DEFINITIONS_PATH}"
 
 rewrite_headers "${SCRIPT_INPUT_FILE}" "${SCRIPT_OUTPUT_FILE_0}"

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -211,7 +211,7 @@ bool JSGlobalObjectInspectorController::developerExtrasEnabled() const
     if (!RemoteInspector::singleton().enabled())
         return false;
 
-    if (!m_globalObject.inspectorDebuggable().inspectable())
+    if (!m_globalObject.inspectorDebuggable().allowsInspectionByPolicy())
         return false;
 #endif
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 
+#include "JSRemoteInspector.h"
 #include "RemoteControllableTarget.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
@@ -40,6 +41,8 @@ class JS_EXPORT_PRIVATE RemoteInspectionTarget : public RemoteControllableTarget
 public:
     bool inspectable() const;
     void setInspectable(bool);
+
+    bool allowsInspectionByPolicy() const;
 
 #if USE(CF)
     CFRunLoopRef targetRunLoop() const final { return m_runLoop.get(); }
@@ -60,7 +63,16 @@ public:
     bool remoteControlAllowed() const final;
 
 private:
-    bool m_inspectable { false };
+    enum class Inspectable : uint8_t {
+        Yes,
+        No,
+
+        // For WebKit internal proxies and wrappers, we want to always disable inspection even when internal policies
+        // would otherwise enable inspection.
+        NoIgnoringInternalPolicies,
+    };
+    Inspectable m_inspectable { JSRemoteInspectorGetInspectionFollowsInternalPolicies() ? Inspectable::No : Inspectable::NoIgnoringInternalPolicies };
+
 #if USE(CF)
     RetainPtr<CFRunLoopRef> m_runLoop;
 #endif

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -458,7 +458,7 @@ RetainPtr<NSDictionary> RemoteInspector::listingForInspectionTarget(const Remote
     // Must collect target information on the WebThread, Main, or Worker thread since RemoteTargets are
     // implemented by non-threadsafe JSC / WebCore classes such as JSGlobalObject or WebCore::Page.
 
-    if (!target.inspectable())
+    if (!target.allowsInspectionByPolicy())
         return nil;
 
     RetainPtr<NSMutableDictionary> listing = adoptNS([[NSMutableDictionary alloc] init]);

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -170,7 +170,7 @@ static const char* targetDebuggableType(RemoteInspectionTarget::Type type)
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
 {
-    if (!target.inspectable())
+    if (!target.allowsInspectionByPolicy())
         return nullptr;
 
     return g_variant_new("(tsssb)", static_cast<guint64>(target.targetIdentifier()),

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -117,7 +117,7 @@ void RemoteInspector::stopInternal(StopSource)
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
 {
-    if (!target.inspectable())
+    if (!target.allowsInspectionByPolicy())
         return nullptr;
 
     // FIXME: Support remote debugging of a ServiceWorker.

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -75,6 +75,10 @@
 #include <JavaScriptCore/WeakGCMapInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
+#if ENABLE(REMOTE_INSPECTOR)
+#include <JavaScriptCore/JSRemoteInspector.h>
+#endif
+
 namespace WebCore {
 using namespace JSC;
 
@@ -288,22 +292,40 @@ SUPPRESS_ASAN void JSDOMGlobalObject::addBuiltinGlobals(VM& vm)
 
 void JSDOMGlobalObject::finishCreation(VM& vm)
 {
+#if ENABLE(REMOTE_INSPECTOR)
+    bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+#endif
+
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
     addBuiltinGlobals(vm);
 
     RELEASE_ASSERT(classInfo());
+
+#if ENABLE(REMOTE_INSPECTOR)
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
+#endif
 }
 
 void JSDOMGlobalObject::finishCreation(VM& vm, JSObject* thisValue)
 {
+#if ENABLE(REMOTE_INSPECTOR)
+    bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+#endif
+
     Base::finishCreation(vm, thisValue);
     ASSERT(inherits(info()));
 
     addBuiltinGlobals(vm);
 
     RELEASE_ASSERT(classInfo());
+
+#if ENABLE(REMOTE_INSPECTOR)
+    JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
+#endif
 }
 
 ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -49,6 +49,9 @@ public:
     {
         m_lastUseTime = MonotonicTime::now();
         if (!m_context) {
+            bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+            JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+
             // FIXME: rdar://100738357 Remote Web Inspector: Remove use of JSRemoteInspectorGetInspectionEnabledByDefault
             // and JSRemoteInspectorSetInspectionEnabledByDefault once the default state is always false.
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -57,6 +60,8 @@ public:
             m_context = adoptNS([[JSContext alloc] init]);
             JSRemoteInspectorSetInspectionEnabledByDefault(previous);
             ALLOW_DEPRECATED_DECLARATIONS_END
+
+            JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
 
             m_timer.startOneShot(sharedJSContextMaxIdleTime);
         }


### PR DESCRIPTION
#### a79898f51c577e596d64b53d834e13b6e10824ce
<pre>
Clean up WebKitAdditions logic in postprocess-header-rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=250740">https://bugs.webkit.org/show_bug.cgi?id=250740</a>
rdar://104354248

Reviewed by NOBODY (OOPS!).

postprocess-framework-headers-definitions is no longer needed for
internal builds.

* Source/JavaScriptCore/Scripts/postprocess-header-rule:

Reland 259000@main, which is fixed in internal builds by the underlying
change.

* Source/JavaScriptCore/API/JSRemoteInspector.cpp:
(JSRemoteInspectorGetInspectionFollowsInternalPolicies):
(JSRemoteInspectorSetInspectionFollowsInternalPolicies):
* Source/JavaScriptCore/API/JSRemoteInspector.h:
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::developerExtrasEnabled const):
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
(Inspector::RemoteInspectionTarget::remoteControlAllowed const):
(Inspector::RemoteInspectionTarget::allowsInspectionByPolicy const):
(Inspector::RemoteInspectionTarget::inspectable const):
(Inspector::RemoteInspectionTarget::setInspectable):
(Inspector::RemoteInspectionTarget::pauseWaitingForAutomaticInspection):
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::listingForInspectionTarget const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::finishCreation):
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
(API::SharedJSContext::ensureContext):

Co-authored-by: Patrick Angle &lt;pangle@apple.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a79898f51c577e596d64b53d834e13b6e10824ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112889 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173219 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3675 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112044 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38360 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80011 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6145 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26698 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90230 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3908 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3228 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29809 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46212 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98835 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8079 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24877 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->