### PR TITLE
Make it possible to temporarily store RefCounted object in a Ref/RefPtr inside its destructor

### DIFF
--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -43,7 +43,6 @@ public:
         applyRefDerefThreadingCheck();
 
 #if CHECK_REF_COUNTED_LIFECYCLE
-        ASSERT_WITH_SECURITY_IMPLICATION(!m_deletionHasBegun);
         ASSERT(!m_adoptionIsRequired);
 #endif
         ++m_refCount;
@@ -51,9 +50,6 @@ public:
 
     bool hasOneRef() const
     {
-#if CHECK_REF_COUNTED_LIFECYCLE
-        ASSERT(!m_deletionHasBegun);
-#endif
         return m_refCount == 1;
     }
 
@@ -118,6 +114,7 @@ protected:
 
     ~RefCountedBase()
     {
+        RELEASE_ASSERT(m_refCount == 1);
 #if CHECK_REF_COUNTED_LIFECYCLE
         ASSERT(m_deletionHasBegun);
         ASSERT(!m_adoptionIsRequired);
@@ -130,7 +127,6 @@ protected:
         applyRefDerefThreadingCheck();
 
 #if CHECK_REF_COUNTED_LIFECYCLE
-        ASSERT_WITH_SECURITY_IMPLICATION(!m_deletionHasBegun);
         ASSERT(!m_adoptionIsRequired);
 #endif
 

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -47,6 +47,7 @@ public:
 #if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
     ~ThreadSafeRefCountedBase()
     {
+        RELEASE_ASSERT(m_refCount == 1);
         // When this ThreadSafeRefCounted object is a part of another object, derefBase() is never called on this object.
         m_deletionHasBegun = true;
     }
@@ -54,17 +55,11 @@ public:
 
     void ref() const
     {
-#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
-        ASSERT_WITH_SECURITY_IMPLICATION(!m_deletionHasBegun);
-#endif
         ++m_refCount;
     }
 
     bool hasOneRef() const
     {
-#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
-        ASSERT(!m_deletionHasBegun);
-#endif
         return refCount() == 1;
     }
 
@@ -77,11 +72,7 @@ protected:
     // Returns whether the pointer should be freed or not.
     bool derefBase() const
     {
-        ASSERT(m_refCount);
-
-#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
-        ASSERT_WITH_SECURITY_IMPLICATION(!m_deletionHasBegun);
-#endif
+        ASSERT_WITH_SECURITY_IMPLICATION(m_refCount);
 
         if (UNLIKELY(!--m_refCount)) {
             // Setting m_refCount to 1 here prevents double delete within the destructor but not from another thread

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -391,7 +391,7 @@ Node::Node(Document& document, ConstructionType type)
 Node::~Node()
 {
     ASSERT(isMainThread());
-    ASSERT(m_refCountAndParentBit == s_refCountIncrement);
+    RELEASE_ASSERT(m_refCountAndParentBit == s_refCountIncrement);
     ASSERT(m_deletionHasBegun);
     ASSERT(!m_adoptionIsRequired);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -800,8 +800,6 @@ inline void adopted(Node* node)
 ALWAYS_INLINE void Node::ref() const
 {
     ASSERT(isMainThread());
-    ASSERT(!m_deletionHasBegun);
-    ASSERT(!m_inRemovedLastRefFunction);
     ASSERT(!m_adoptionIsRequired);
     m_refCountAndParentBit += s_refCountIncrement;
 }
@@ -810,8 +808,6 @@ ALWAYS_INLINE void Node::deref() const
 {
     ASSERT(isMainThread());
     ASSERT(refCount());
-    ASSERT(!m_deletionHasBegun);
-    ASSERT(!m_inRemovedLastRefFunction);
     ASSERT(!m_adoptionIsRequired);
     auto updatedRefCount = m_refCountAndParentBit - s_refCountIncrement;
     if (!updatedRefCount) {

--- a/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
@@ -549,6 +549,31 @@ TEST(WTF_RefPtr, ReleaseNonNullBeforeDeref)
     EXPECT_STREQ("ref(a) slot=null deref(a) ", takeLogStr().c_str());
 }
 
+struct StoreRefInDestructor : RefCounted<StoreRefInDestructor> {
+    static Ref<StoreRefInDestructor> create()
+    {
+        return adoptRef(*new StoreRefInDestructor);
+    }
+    
+    ~StoreRefInDestructor()
+    {
+        RefPtr<StoreRefInDestructor> protectedThis = this;
+        helperFunction(*this);
+    }
+
+    static void helperFunction(StoreRefInDestructor& obj)
+    {
+        Ref protectedObj = obj;
+    }
+};
+
+TEST(WTF_RefPtr, RefInDestructor)
+{
+    // This test passes if it compiles without an error.
+    RefPtr a = StoreRefInDestructor::create();
+    a = nullptr;
+}
+
 // FIXME: Enable these tests once Win platform supports TestWebKitAPI::Util::run
 #if! PLATFORM(WIN)
 


### PR DESCRIPTION
#### fdc168d427369b3b6416866508d17353727293ed
<pre>
Make it possible to temporarily store RefCounted object in a Ref/RefPtr inside its destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=250746">https://bugs.webkit.org/show_bug.cgi?id=250746</a>

Reviewed by NOBODY (OOPS!).

This patch removes debug / security assertion that m_deletionHasBegun is not set in ref() / deref()
to allow temporarily storing a RefCounted object in a Ref/RefPtr inside its destructor.

Instead, assert that m_refCount is 1 at the end of destructor to make sure there is no outstanding
external references at the end of its destruction.

Apply the same fix to ThreadSafeRefCounted as well as Node.

* Source/WTF/wtf/RefCounted.h:
(WTF::RefCountedBase::ref const):
(WTF::RefCountedBase::hasOneRef const):
(WTF::RefCountedBase::~RefCountedBase):
(WTF::RefCountedBase::derefBase const):
* Source/WTF/wtf/ThreadSafeRefCounted.h:
(WTF::ThreadSafeRefCountedBase::~ThreadSafeRefCountedBase):
(WTF::ThreadSafeRefCountedBase::ref const):
(WTF::ThreadSafeRefCountedBase::hasOneRef const):
(WTF::ThreadSafeRefCountedBase::derefBase const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::~Node):
* Source/WebCore/dom/Node.h:
(WebCore::Node::ref const):
(WebCore::Node::deref const):
* Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp:
(TestWebKitAPI::StoreRefInDestructor::create):
(TestWebKitAPI::StoreRefInDestructor::~StoreRefInDestructor):
(TestWebKitAPI::StoreRefInDestructor::helperFunction):
(TestWebKitAPI::WTF_RefPtr.RefInDestructor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdc168d427369b3b6416866508d17353727293ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103667 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112892 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173222 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3680 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112047 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38366 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80017 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93801 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26706 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90234 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3912 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3235 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29812 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46222 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98840 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8084 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24880 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->