### PR TITLE
[WebGPU] RenderPipeline::getBindGroupLayout can result in out of bounds access (250747)

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -199,7 +199,8 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
     m_primitiveType = pipeline.primitiveType();
     m_vertexShaderInputBufferCount = pipeline.vertexShaderInputBufferCount();
 
-    [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];
+    if (pipeline.renderPipelineState())
+        [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];
     if (pipeline.depthStencilState())
         [m_renderCommandEncoder setDepthStencilState:pipeline.depthStencilState()];
     [m_renderCommandEncoder setCullMode:pipeline.cullMode()];

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -544,7 +544,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
     WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };
     bindGroupLayoutDescriptor.label = "getBindGroup() generated layout";
     bindGroupLayoutDescriptor.entryCount = entries.size();
-    bindGroupLayoutDescriptor.entries = &entries[0];
+    bindGroupLayoutDescriptor.entries = entries.size() ? &entries[0] : nullptr;
     auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
     m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
 


### PR DESCRIPTION
#### 3a1c2fbdbe3d348b35dea3f3d2d914929fdd7d2e
<pre>
[WebGPU] RenderPipeline::getBindGroupLayout can result in out of bounds access (250747)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250747">https://bugs.webkit.org/show_bug.cgi?id=250747</a>
&lt;radar://104359389&gt;

Reviewed by Myles C. Maxfield.

Fix two additional errors noticed while looking at
<a href="https://playground.babylonjs.com/">https://playground.babylonjs.com/</a>

(1) If there are no buffer entries in the shader then getBindGroupLayout
will result in an out of bounds access. The value is never read from
in this case, but it will assert in Debug.

(2) If the pipeline configuration is invalid then setRenderPipeline
will assert in debug, which is not expected since some configuration
of shaders could generate an invalid pipeline.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setPipeline):
setRenderPipelineState requires the pipeline to be non-nil.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):
Fix out of bounds.

Canonical link: <a href="https://commits.webkit.org/259043@main">https://commits.webkit.org/259043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64cd4a4c493bc7af6cb1d37f69cc8b7598cb58ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112897 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3684 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112051 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25310 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80016 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6153 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26709 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3234 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6219 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8088 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->