### PR TITLE
Fix style invalidation for ancestor documents of fullscreen element

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-enclosing-iframe-size-expected.html
+++ b/LayoutTests/fullscreen/fullscreen-enclosing-iframe-size-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+    body {
+        margin: 0;
+        padding: 0;
+    }
+    iframe {
+        border: none;
+        background-color: green;
+        width: 100vw;
+        height: 100vh;
+        box-sizing: border-box;
+        display: block;
+    }
+</style>
+</head>
+<body>
+    <iframe srcdoc="<button onclick='document.documentElement.requestFullscreen();'>Go fullscreen</button><p>This test passes if background is fully green with no red.</p>"></iframe>
+</body>
+</html>

--- a/LayoutTests/fullscreen/fullscreen-enclosing-iframe-size.html
+++ b/LayoutTests/fullscreen/fullscreen-enclosing-iframe-size.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="UTF-8">
+<style>
+    body, ::backdrop {
+        background: red;
+    }
+
+    iframe {
+        display: block;
+        background: green;
+    }
+
+    .container {
+        display: flex;
+        width: 400px;
+    }
+</style>
+</head>
+<body>
+<script src="../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+<script src="../imported/w3c/web-platform-tests/resources/testdriver-vendor.js"></script>
+<script>
+    addEventListener("load", () => {
+        document.addEventListener("fullscreenchange", () => {
+            document.documentElement.classList.remove("reftest-wait");
+        });
+        test_driver.bless("fullscreen", () => {
+            iframe.contentDocument.documentElement.requestFullscreen();
+        }, iframe.contentWindow);
+    });
+</script>
+<div class="container">
+    <iframe id="iframe" srcdoc="<button onclick='document.documentElement.requestFullscreen();'>Go fullscreen</button><p>This test passes if background is fully green with no red.</p>"></iframe>
+</div>
+</body>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -468,19 +468,19 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
         ancestorsInTreeOrder.prepend(ancestor);
     } while ((ancestor = ancestor->document().ownerElement()));
 
-    for (auto ancestor : ancestorsInTreeOrder) {
+    for (auto ancestor : makeReversedRange(ancestorsInTreeOrder)) {
         ancestor->setFullscreenFlag(true);
 
-        if (ancestor == &element)
-            document().resolveStyle(Document::ResolveStyleType::Rebuild);
+        ancestor->document().resolveStyle(Document::ResolveStyleType::Rebuild);
 
         // Remove before adding, so we always add at the end of the top layer.
         if (ancestor->isInTopLayer())
             ancestor->removeFromTopLayer();
         ancestor->addToTopLayer();
-
-        addDocumentToFullscreenChangeEventQueue(ancestor->document());
     }
+
+    for (auto ancestor : ancestorsInTreeOrder)
+        addDocumentToFullscreenChangeEventQueue(ancestor->document());
 
     if (is<HTMLIFrameElement>(element))
         element.setIFrameFullscreenFlag(true);


### PR DESCRIPTION
#### afc8fb2561c8dbe9ab8c68ad076285c2d8cd673a
<pre>
Fix style invalidation for ancestor documents of fullscreen element
<a href="https://bugs.webkit.org/show_bug.cgi?id=250750">https://bugs.webkit.org/show_bug.cgi?id=250750</a>
rdar://104238564

Reviewed by Darin Adler.

We were just calling `document().resolveStyle(Document::ResolveStyleType::Rebuild)` only on the document the fullscreen request came from,
the ancestor documents were not covered. We need to call that method for frames in reverse tree order, in order to have the correct sequence
of layouts:
1. Apply fullscreen styles to iframe contents
2. Append iframe contents to top layer
3. Apply fullscreen styles to iframe, make iframe contents dirty
4. Append iframe to top layer

As opposed to the incorrect sequence which leads to dirty renderers:
1. Apply fullscreen styles to iframe, make iframe contents dirty
2. Append iframe to top layer
3. Apply fullscreen styles to iframe contents
4. Append iframe contents to top layer (which is dirty because of step 1)

We preserve the tree order for queuing events as mandated by the spec.

* LayoutTests/fullscreen/fullscreen-enclosing-iframe-size-expected.html: Added.
* LayoutTests/fullscreen/fullscreen-enclosing-iframe-size.html: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):

Canonical link: <a href="https://commits.webkit.org/259032@main">https://commits.webkit.org/259032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23eec63bf8aa3aa2f4c46344a0be63cffe0b0705

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112899 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173228 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3686 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112053 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109445 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38369 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80020 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26711 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3238 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6208 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8090 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->