### PR TITLE
fast/scrolling/mac/momentum-animator-end-event-stops.html fails with UI-side compositing

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -113,9 +113,7 @@ private:
     void dispatchGestureEvent(WebCore::PageIdentifier, const WebGestureEvent&);
 #endif
 
-#if ENABLE(ASYNC_SCROLLING)
     static void sendDidReceiveEvent(WebCore::PageIdentifier, WebEventType, bool didHandleEvent);
-#endif
 
 #if PLATFORM(MAC)
     void displayWasRefreshed(WebCore::PlatformDisplayID, const WebCore::DisplayUpdate&, bool sendToMainThread);


### PR DESCRIPTION
#### 0c37f44f19d67ecb8a1cb74ec221d82129db7c6d
<pre>
fast/scrolling/mac/momentum-animator-end-event-stops.html fails with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250752">https://bugs.webkit.org/show_bug.cgi?id=250752</a>
rdar://104364303

Reviewed by Dean Jackson.

Each wheel event that comes from the UI process has to have a corresponding
WebPageProxy::DidReceiveEvent() IPC back to the UI process, otherwise events will accumulate in the
WebWheelEventCoalescer and WebPageProxy::handleWheelEvent() won&apos;t send any new events to the web
process.

WebPage::wheelEvent() only sent WebPageProxy::DidReceiveEvent() for certain combinations of
processingSteps, in a way that only worked with non-UI-side compositing (i.e. wheel events coming
via EventDispatcher). So move the calls to `send(Messages::WebPageProxy::DidReceiveEvent())` to the
callers of WebPage::wheelEvent(), namely WebPage::handleWheelEvent(), which is called with UI-side
compositing, and EventDispatcher::dispatchWheelEvent(), which is called for non-UI-side compositing.

* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::dispatchWheelEvent):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::handleWheelEvent):
(WebKit::WebPage::wheelEvent):
(WebKit::WebPage::dispatchWheelEventWithoutScrolling):

Canonical link: <a href="https://commits.webkit.org/259063@main">https://commits.webkit.org/259063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51c83cee0a5bc55a43874ecc0645aa4567cdca93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112962 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3745 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112094 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38426 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6212 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26765 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3285 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6233 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8146 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->