### PR TITLE
Replace uses of CallFrame::iterate() with StackVisitor::visit().

### DIFF
--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -367,7 +367,7 @@ JSStringRef JSContextCreateBacktrace(JSContextRef ctx, unsigned maxStackSize)
 
     ASSERT(maxStackSize);
     BacktraceFunctor functor(builder, maxStackSize);
-    frame->iterate(vm, functor);
+    StackVisitor::visit(frame, vm, functor);
 
     return OpaqueJSString::tryCreate(builder.toString()).leakRef();
 }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2425,8 +2425,9 @@ void CodeBlock::noticeIncomingCall(CallFrame* callerFrame)
     }
 
     // Recursive calls won't be inlined.
+    VM& vm = this->vm();
     RecursionCheckFunctor functor(callerFrame, this, Options::maximumInliningDepth());
-    vm().topCallFrame->iterate(vm(), functor);
+    StackVisitor::visit(vm.topCallFrame, vm, functor);
 
     if (functor.didRecurse()) {
         dataLogLnIf(Options::verboseCallLink(), "    Clearing SABI because recursion was detected.");

--- a/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
@@ -116,7 +116,7 @@ Ref<ScriptCallStack> createScriptCallStack(JSC::JSGlobalObject* globalObject, si
         return ScriptCallStack::create();
 
     CreateScriptCallStackFunctor functorIncludingFirstFrame(globalObject, false, maxStackSize);
-    frame->iterate(vm, functorIncludingFirstFrame);
+    StackVisitor::visit(frame, vm, functorIncludingFirstFrame);
     return functorIncludingFirstFrame.takeStack();
 }
 
@@ -133,11 +133,11 @@ Ref<ScriptCallStack> createScriptCallStackForConsole(JSC::JSGlobalObject* global
         return ScriptCallStack::create();
 
     CreateScriptCallStackFunctor functorSkippingFirstFrame(globalObject, true, maxStackSize);
-    frame->iterate(vm, functorSkippingFirstFrame);
+    StackVisitor::visit(frame, vm, functorSkippingFirstFrame);
     auto stack = functorSkippingFirstFrame.takeStack();
     if (!stack->size()) {
         CreateScriptCallStackFunctor functorIncludingFirstFrame(globalObject, false, maxStackSize);
-        frame->iterate(vm, functorIncludingFirstFrame);
+        StackVisitor::visit(frame, vm, functorIncludingFirstFrame);
         stack = functorIncludingFirstFrame.takeStack();
     }
     return stack;

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -319,19 +319,6 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         JS_EXPORT_PRIVATE static JSGlobalObject* globalObjectOfClosestCodeBlock(VM&, CallFrame*);
         String friendlyFunctionName();
 
-        // CallFrame::iterate() expects a Functor that implements the following method:
-        //     IterationStatus operator()(StackVisitor&) const;
-        // FIXME: This method is improper. We rely on the fact that we can call it with a null
-        // receiver. We should always be using StackVisitor directly.
-        // It's only valid to call this from a non-wasm top frame.
-        template <StackVisitor::EmptyEntryFrameAction action = StackVisitor::ContinueIfTopEntryFrameIsEmpty, typename Functor> void iterate(VM& vm, const Functor& functor)
-        {
-            void* rawThis = this;
-            if (!!rawThis)
-                RELEASE_ASSERT(callee().isCell());
-            StackVisitor::visit<action, Functor>(this, vm, functor);
-        }
-
         void dump(PrintStream&) const;
 
         // This function is used in LLDB btjs.

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1508,7 +1508,7 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCStack, (JSGlobalObject* globalObject, CallFr
     trace.append("--> Stack trace:\n");
 
     FunctionJSCStackFunctor functor(trace);
-    callFrame->iterate(vm, functor);
+    StackVisitor::visit(callFrame, vm, functor);
     fprintf(stderr, "%s", trace.toString().utf8().data());
     return JSValue::encode(jsUndefined());
 }

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -148,7 +148,7 @@ static JSValue retrieveArguments(VM& vm, CallFrame* callFrame, JSFunction* funct
 {
     RetrieveArgumentsFunctor functor(vm, functionObj);
     if (callFrame)
-        callFrame->iterate(vm, functor);
+        StackVisitor::visit(callFrame, vm, functor);
     return functor.result();
 }
 
@@ -217,7 +217,7 @@ static JSValue retrieveCallerFunction(VM& vm, CallFrame* callFrame, JSFunction* 
 {
     RetrieveCallerFunctionFunctor functor(functionObj);
     if (callFrame)
-        callFrame->iterate(vm, functor);
+        StackVisitor::visit(callFrame, vm, functor);
     return functor.result();
 }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -442,7 +442,7 @@ JSC_DEFINE_HOST_FUNCTION(assertCall, (JSGlobalObject* globalObject, CallFrame* c
     bool iteratedOnce = false;
     CodeBlock* codeBlock = nullptr;
     unsigned line;
-    callFrame->iterate(globalObject->vm(), [&] (StackVisitor& visitor) {
+    StackVisitor::visit(callFrame, globalObject->vm(), [&] (StackVisitor& visitor) {
         if (!iteratedOnce) {
             iteratedOnce = true;
             return IterationStatus::Continue;

--- a/Source/JavaScriptCore/runtime/NullSetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/NullSetterFunction.cpp
@@ -67,7 +67,7 @@ private:
 static bool callerIsStrict(VM& vm, CallFrame* callFrame)
 {
     GetCallerStrictnessFunctor iter;
-    callFrame->iterate(vm, iter);
+    StackVisitor::visit(callFrame, vm, iter);
     return iter.callerIsStrict();
 }
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -171,7 +171,7 @@ public:
 
         unsigned frameIndex = 0;
         bool isValid = false;
-        callFrame->iterate(vm, [&] (StackVisitor& visitor) {
+        StackVisitor::visit(callFrame, vm, [&] (StackVisitor& visitor) {
             DollarVMAssertScope assertScope;
 
             if (frameIndex++ != requestedFrameIndex)
@@ -2439,7 +2439,7 @@ JSC_DEFINE_HOST_FUNCTION(functionLLintTrue, (JSGlobalObject* globalObject, CallF
     if (!callFrame)
         return JSValue::encode(jsUndefined());
     CallerFrameJITTypeFunctor functor;
-    callFrame->iterate(vm, functor);
+    StackVisitor::visit(callFrame, vm, functor);
     return JSValue::encode(jsBoolean(functor.jitType() == JITType::InterpreterThunk));
 }
 
@@ -2452,7 +2452,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBaselineJITTrue, (JSGlobalObject* globalObject,
     if (!callFrame)
         return JSValue::encode(jsUndefined());
     CallerFrameJITTypeFunctor functor;
-    callFrame->iterate(vm, functor);
+    StackVisitor::visit(callFrame, vm, functor);
     return JSValue::encode(jsBoolean(functor.jitType() == JITType::BaselineJIT));
 }
 
@@ -2697,7 +2697,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDumpRegisters, (JSGlobalObject* globalObject, C
     }
 
     unsigned frameIndex = 0;
-    callFrame->iterate(vm, [&] (StackVisitor& visitor) {
+    StackVisitor::visit(callFrame, vm, [&] (StackVisitor& visitor) {
         DollarVMAssertScope assertScope;
         if (frameIndex++ != requestedFrameIndex)
             return IterationStatus::Continue;

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -315,7 +315,7 @@ CodeBlock* VMInspector::codeBlockForFrame(VM* vm, CallFrame* topCallFrame, unsig
     };
 
     FetchCodeBlockFunctor functor(frameNumber);
-    topCallFrame->iterate(*vm, functor);
+    StackVisitor::visit(topCallFrame, *vm, functor);
     return functor.codeBlock;
 }
 
@@ -356,7 +356,7 @@ void VMInspector::dumpCallFrame(VM* vm, CallFrame* callFrame, unsigned framesToS
     if (!ensureCurrentThreadOwnsJSLock(vm))
         return;
     DumpFrameFunctor functor(DumpFrameFunctor::DumpOne, framesToSkip);
-    callFrame->iterate(*vm, functor);
+    StackVisitor::visit(callFrame, *vm, functor);
 }
 
 void VMInspector::dumpRegisters(CallFrame* callFrame)
@@ -394,7 +394,7 @@ void VMInspector::dumpRegisters(CallFrame* callFrame)
     dataLogF("-----------------------------------------------------------------------------\n");
     dataLogF("[ArgumentCount]            | %10p | %lu \n", it, (unsigned long) callFrame->argumentCount());
 
-    callFrame->iterate(vm, [&] (StackVisitor& visitor) {
+    StackVisitor::visit(callFrame, vm, [&] (StackVisitor& visitor) {
         if (visitor->callFrame() == callFrame) {
             unsigned line = 0;
             unsigned unusedColumn = 0;
@@ -443,7 +443,7 @@ void VMInspector::dumpRegisters(CallFrame* callFrame)
     CallFrame* nextCallFrame = nullptr;
 
     if (topCallFrame) {
-        topCallFrame->iterate(vm, [&] (StackVisitor& visitor) {
+        StackVisitor::visit(topCallFrame, vm, [&] (StackVisitor& visitor) {
             if (callFrame == visitor->callFrame())
                 return IterationStatus::Done;
             nextCallFrame = visitor->callFrame();
@@ -478,7 +478,7 @@ void VMInspector::dumpStack(VM* vm, CallFrame* topCallFrame, unsigned framesToSk
     if (!topCallFrame)
         return;
     DumpFrameFunctor functor(DumpFrameFunctor::DumpAll, framesToSkip);
-    topCallFrame->iterate(*vm, functor);
+    StackVisitor::visit(topCallFrame, *vm, functor);
 }
 
 void VMInspector::dumpValue(JSValue value)

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -735,7 +735,7 @@ static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalO
         };
 
         GetCallerGlobalObjectFunctor iter(skipFirstFrame);
-        callFrame->iterate(vm, iter);
+        StackVisitor::visit(callFrame, vm, iter);
         if (iter.globalObject())
             return *jsCast<JSDOMGlobalObject*>(iter.globalObject());
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2531,7 +2531,7 @@ String Internals::parserMetaData(JSC::JSValue code)
     ScriptExecutable* executable;
     if (!code || code.isNull() || code.isUndefined()) {
         GetCallerCodeBlockFunctor iter;
-        callFrame->iterate(vm, iter);
+        StackVisitor::visit(callFrame, vm, iter);
         executable = iter.codeBlock()->ownerExecutable();
     } else if (code.isCallable())
         executable = JSC::jsCast<JSFunction*>(code.toObject(globalObject))->jsExecutable();


### PR DESCRIPTION
#### 59c35e2316675987a5d58a42addebc1f69bfff95
<pre>
Replace uses of CallFrame::iterate() with StackVisitor::visit().
<a href="https://bugs.webkit.org/show_bug.cgi?id=250751">https://bugs.webkit.org/show_bug.cgi?id=250751</a>
&lt;rdar://problem/104363671&gt;

Reviewed by Yusuke Suzuki.

An assertion in CallFrame::iterate() is blocking StackVisitor from dumping the JS stack
when we encounter Wasm frames.  The assertion was from back when Wasm frames didn&apos;t exist.

This patch removes CallFrame::iterate() completely, and changes all callsites to call
StackVisitor::visit() instead.

* Source/JavaScriptCore/API/JSContextRef.cpp:
(JSContextCreateBacktrace):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::noticeIncomingCall):
* Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp:
(Inspector::createScriptCallStack):
(Inspector::createScriptCallStackForConsole):
* Source/JavaScriptCore/interpreter/CallFrame.h:
(JSC::CallFrame::iterate): Deleted.
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::retrieveArguments):
(JSC::retrieveCallerFunction):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/NullSetterFunction.cpp:
(JSC::callerIsStrict):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::codeBlockForFrame):
(JSC::VMInspector::dumpCallFrame):
(JSC::VMInspector::dumpRegisters):
(JSC::VMInspector::dumpStack):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::callerGlobalObject):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::parserMetaData):

Canonical link: <a href="https://commits.webkit.org/259027@main">https://commits.webkit.org/259027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba379bc206977decfda409e9307cb47d53a3856b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112917 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173240 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3704 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112065 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109465 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38388 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80038 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93825 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26724 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90260 "Failed to checkout and rebase branch from PR 8755") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3936 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3249 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29820 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46247 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98868 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8106 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24889 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3296 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->