### PR TITLE
REGRESSION (250910@main): [ macOS wk1 ] fast/canvas/canvas-createPattern-video-loading.html is a flaky timeout

### DIFF
--- a/LayoutTests/fast/canvas/canvas-createPattern-video-loading.html
+++ b/LayoutTests/fast/canvas/canvas-createPattern-video-loading.html
@@ -68,10 +68,8 @@
     {
         drawImageToCanvasAndCheckPixels();
 
-        video.currentTime = 1;
-        video.play();
-        await waitForVideoFrameUntil(video, 1);
-        video.pause();
+        video.currentTime = 0.996;
+        await once(video, 'seeked');
 
         drawImageToCanvasAndCheckPixels();
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2497,8 +2497,6 @@ webkit.org/b/244277 http/tests/webgpu/webgpu/api/validation/createTexture.html [
 
 webkit.org/b/241253 fast/text/bulgarian-system-language-shaping.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/244336 fast/canvas/canvas-createPattern-video-loading.html [ Pass Timeout ]
-
 webkit.org/b/244347 storage/domstorage/sessionstorage/window-open-remove-item.html [ Pass Failure ]
 
 webkit.org/b/244372 imported/w3c/web-platform-tests/intersection-observer/target-in-different-window.html [ Pass Failure ]


### PR DESCRIPTION
#### d783b5c13cf92d178837e054f56eef867e89bb65
<pre>
REGRESSION (250910@main): [ macOS wk1 ] fast/canvas/canvas-createPattern-video-loading.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=244336">https://bugs.webkit.org/show_bug.cgi?id=244336</a>
rdar://99140960

Reviewed by Eric Carlson and Youenn Fablet.

Prior the rewrite using video.requestVideoFrameCallback, the test would simply seek to currentTime = 1s.
The video doesn&apos;t have a frame at 1s, they are located at 0.996s and 1.021678s on either side of 1s.

The test checks a particular location of the image that doesn&apos;t change over time, as such, there&apos;s no much
point waiting for new frames to come.

We can simplify the test and seek to the actual time.

* LayoutTests/fast/canvas/canvas-createPattern-video-loading.html:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259058@main">https://commits.webkit.org/259058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616bafa4f3a3d558b9fe974a05d7611b5fff3223

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112908 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173234 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3695 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112059 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38377 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3244 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46237 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6232 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8098 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->