### PR TITLE
Use WeakPtr to store CSSFontFace::Client and FontSelector

### DIFF
--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -52,10 +52,10 @@ namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFace);
 
-template<typename T> void iterateClients(HashSet<CSSFontFace::Client*>& clients, T callback)
+template<typename T> void iterateClients(WeakHashSet<CSSFontFace::Client>& clients, T callback)
 {
-    for (auto& client : copyToVectorOf<RefPtr<CSSFontFace::Client>>(clients))
-        callback(*client);
+    for (auto& client : copyToVectorOf<Ref<CSSFontFace::Client>>(clients))
+        callback(client);
 }
 
 void CSSFontFace::appendSources(CSSFontFace& fontFace, CSSValueList& srcList, ScriptExecutionContext* context, bool isInitiatingElementInUserAgentShadowTree)
@@ -458,13 +458,13 @@ bool CSSFontFace::computeFailureState() const
 
 void CSSFontFace::addClient(Client& client)
 {
-    m_clients.add(&client);
+    m_clients.add(client);
 }
 
 void CSSFontFace::removeClient(Client& client)
 {
-    ASSERT(m_clients.contains(&client));
-    m_clients.remove(&client);
+    ASSERT(m_clients.contains(client));
+    m_clients.remove(client);
 }
 
 void CSSFontFace::initializeWrapper()

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -121,7 +122,7 @@ public:
 
     static void appendSources(CSSFontFace&, CSSValueList&, ScriptExecutionContext*, bool isInitiatingElementInUserAgentShadowTree);
 
-    class Client {
+    class Client : public CanMakeWeakPtr<Client> {
     public:
         virtual ~Client() = default;
         virtual void fontLoaded(CSSFontFace&) { }
@@ -187,7 +188,7 @@ private:
     FontLoadingBehavior m_loadingBehavior { FontLoadingBehavior::Auto };
 
     Vector<std::unique_ptr<CSSFontFaceSource>, 0, CrashOnOverflow, 0> m_sources;
-    HashSet<Client*> m_clients;
+    WeakHashSet<Client> m_clients;
     WeakPtr<FontFace> m_wrapper;
     FontSelectionSpecifiedCapabilities m_fontSelectionCapabilities;
     

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -50,11 +50,15 @@ class StyleRuleFontFace;
 class StyleRuleFontFeatureValues;
 class StyleRuleFontPaletteValues;
 
-class CSSFontSelector final : public FontSelector, public CSSFontFace::Client, public CanMakeWeakPtr<CSSFontSelector>, public ActiveDOMObject {
+class CSSFontSelector final : public FontSelector, public CSSFontFace::Client, public ActiveDOMObject {
 public:
+    using FontSelector::weakPtrFactory;
+    using FontSelector::WeakValueType;
+    using FontSelector::WeakPtrImplType;
+
     static Ref<CSSFontSelector> create(ScriptExecutionContext&);
     virtual ~CSSFontSelector();
-    
+
     unsigned version() const final { return m_version; }
     unsigned uniqueId() const final { return m_uniqueId; }
 

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -43,7 +43,7 @@ namespace WebCore {
 
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 
-class FontFace final : public RefCounted<FontFace>, public CanMakeWeakPtr<FontFace>, public ActiveDOMObject, private CSSFontFace::Client {
+class FontFace final : public RefCounted<FontFace>, public ActiveDOMObject, public CSSFontFace::Client {
 public:
     struct Descriptors {
         String style;

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -372,15 +372,14 @@ size_t FontCache::inactiveFontCount()
 
 void FontCache::addClient(FontSelector& client)
 {
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 }
 
 void FontCache::removeClient(FontSelector& client)
 {
-    ASSERT(m_clients.contains(&client));
-
-    m_clients.remove(&client);
+    ASSERT(m_clients.contains(client));
+    m_clients.remove(client);
 }
 
 void FontCache::invalidate()
@@ -397,7 +396,7 @@ void FontCache::invalidate()
 
     ++m_generation;
 
-    for (auto& client : copyToVectorOf<RefPtr<FontSelector>>(m_clients))
+    for (auto& client : copyToVectorOf<Ref<FontSelector>>(m_clients))
         client->fontCacheInvalidated();
 
     purgeInactiveFontData();

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -221,7 +221,7 @@ private:
 
     Timer m_purgeTimer;
 
-    HashSet<FontSelector*> m_clients;
+    WeakHashSet<FontSelector> m_clients;
     struct FontDataCaches;
     UniqueRef<FontDataCaches> m_fontDataCaches;
     FontCascadeCache m_fontCascadeCache;

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -44,7 +44,7 @@ public:
     virtual bool isLoading() const = 0;
 };
 
-class FontSelector : public RefCounted<FontSelector> {
+class FontSelector : public RefCounted<FontSelector>, public CanMakeWeakPtr<FontSelector> {
 public:
     virtual ~FontSelector() = default;
 


### PR DESCRIPTION
#### 0b2ad9a154b0e9e3b86c932f976164c2cbbfc90f
<pre>
Use WeakPtr to store CSSFontFace::Client and FontSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=250756">https://bugs.webkit.org/show_bug.cgi?id=250756</a>

Reviewed by Chris Dumez.

Use WeakPtr instead of raw pointers to keep track of CSSFontFace::Client and FontSelector.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::iterateClients):
(WebCore::CSSFontFace::addClient):
(WebCore::CSSFontFace::removeClient):
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::addClient):
(WebCore::FontCache::removeClient):
(WebCore::FontCache::invalidate):
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/FontSelector.h:

Canonical link: <a href="https://commits.webkit.org/259118@main">https://commits.webkit.org/259118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b5e8edc2fa889caf1e8bfe8052237dac6bf7110

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112965 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173286 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3750 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95992 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112099 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38418 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80072 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26766 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3288 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46285 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8150 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3328 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->