### PR TITLE
[GStreamer] Harness: Refactor output stream handling in preparation for "sometimes" pad support

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -171,7 +171,7 @@ GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder(const String& codec
     , m_postTaskCallback(WTFMove(postTaskCallback))
 {
     GRefPtr<GstElement> element = gst_element_factory_make("webkitvideoencoder", nullptr);
-    m_harness = GStreamerElementHarness::create(WTFMove(element), [protectedThis = Ref { *this }, this](const GRefPtr<GstBuffer>& outputBuffer) {
+    m_harness = GStreamerElementHarness::create(WTFMove(element), [protectedThis = Ref { *this }, this](auto&, const GRefPtr<GstBuffer>& outputBuffer) {
         if (protectedThis->m_isClosed)
             return;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -35,7 +35,40 @@ class GStreamerElementHarness : public ThreadSafeRefCounted<GStreamerElementHarn
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    using ProcessBufferCallback = Function<void(const GRefPtr<GstBuffer>&)>;
+    class Stream : public ThreadSafeRefCounted<Stream> {
+        WTF_MAKE_FAST_ALLOCATED;
+
+    public:
+        static Ref<Stream> create(GRefPtr<GstPad>&& pad)
+        {
+            return adoptRef(*new Stream(WTFMove(pad)));
+        }
+        ~Stream();
+
+        GRefPtr<GstBuffer> pullBuffer();
+        GRefPtr<GstEvent> pullEvent();
+
+        const GRefPtr<GstPad>& pad() const { return m_pad; }
+        const GRefPtr<GstCaps>& outputCaps();
+
+    private:
+        Stream(GRefPtr<GstPad>&&);
+        GstFlowReturn chainBuffer(GstBuffer*);
+        bool sinkQuery(GstPad*, GstObject*, GstQuery*);
+        bool sinkEvent(GstEvent*);
+
+        GRefPtr<GstPad> m_pad;
+        GRefPtr<GstPad> m_targetPad;
+        GRefPtr<GstCaps> m_outputCaps;
+
+        Lock m_bufferQueueLock;
+        Deque<GRefPtr<GstBuffer>> m_bufferQueue WTF_GUARDED_BY_LOCK(m_bufferQueueLock);
+
+        Lock m_sinkEventQueueLock;
+        Deque<GRefPtr<GstEvent>> m_sinkEventQueue WTF_GUARDED_BY_LOCK(m_sinkEventQueueLock);
+    };
+
+    using ProcessBufferCallback = Function<void(Stream&, const GRefPtr<GstBuffer>&)>;
     static Ref<GStreamerElementHarness> create(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback)
     {
         return adoptRef(*new GStreamerElementHarness(WTFMove(element), WTFMove(processOutputBufferCallback)));
@@ -48,10 +81,8 @@ public:
     bool pushBuffer(GstBuffer*);
     bool pushEvent(GstEvent*);
 
-    GRefPtr<GstBuffer> pullBuffer();
-    GRefPtr<GstEvent> pullEvent();
+    const Vector<RefPtr<Stream>>& outputStreams() const { return m_outputStreams; }
 
-    const GRefPtr<GstCaps>& outputCaps();
     GstElement* element() const { return m_element.get(); }
 
     void processOutputBuffers();
@@ -60,9 +91,6 @@ public:
 private:
     GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessBufferCallback&&);
 
-    GstFlowReturn chainBuffer(GstBuffer*);
-    bool sinkQuery(GstPad*, GstObject*, GstQuery*);
-    bool sinkEvent(GstEvent*);
     bool srcQuery(GstPad*, GstObject*, GstQuery*);
     bool srcEvent(GstEvent*);
 
@@ -72,19 +100,12 @@ private:
     ProcessBufferCallback m_processOutputBufferCallback;
 
     GRefPtr<GstCaps> m_inputCaps;
-    GRefPtr<GstCaps> m_outputCaps;
 
     GRefPtr<GstPad> m_srcPad;
-    GRefPtr<GstPad> m_sinkPad;
-
-    Lock m_bufferQueueLock;
-    Deque<GRefPtr<GstBuffer>> m_bufferQueue WTF_GUARDED_BY_LOCK(m_bufferQueueLock);
+    Vector<RefPtr<Stream>> m_outputStreams;
 
     Lock m_srcEventQueueLock;
     Deque<GRefPtr<GstEvent>> m_srcEventQueue WTF_GUARDED_BY_LOCK(m_srcEventQueueLock);
-
-    Lock m_sinkEventQueueLock;
-    Deque<GRefPtr<GstEvent>> m_sinkEventQueue WTF_GUARDED_BY_LOCK(m_sinkEventQueueLock);
 
     Atomic<bool> m_playing { false };
     Atomic<bool> m_stickyEventsSent { false };


### PR DESCRIPTION
#### 1a42a39e8f4097a91706ddd983c3dd16d8ecdc85
<pre>
[GStreamer] Harness: Refactor output stream handling in preparation for &quot;sometimes&quot; pad support
<a href="https://bugs.webkit.org/show_bug.cgi?id=250757">https://bugs.webkit.org/show_bug.cgi?id=250757</a>

Reviewed by Xabier Rodriguez-Calvar.

The harnessed output stream (corresponding to the element source pad) is now managed through a
dedicated Stream class embedded in the GStreamerElementHarness scope. This new architecture will be
useful for the upcoming support for &quot;sometimes&quot; src pads where the harness will be able to work on
auto-plugger elements such as parsebin and decodebin(3).

No change in functionality, covered by existing API and WebCodecs layout tests.

* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::GStreamerElementHarness::~GStreamerElementHarness):
(WebCore::GStreamerElementHarness::Stream::Stream):
(WebCore::GStreamerElementHarness::Stream::~Stream):
(WebCore::GStreamerElementHarness::Stream::pullBuffer):
(WebCore::GStreamerElementHarness::Stream::pullEvent):
(WebCore::GStreamerElementHarness::Stream::outputCaps):
(WebCore::GStreamerElementHarness::Stream::chainBuffer):
(WebCore::GStreamerElementHarness::Stream::sinkQuery):
(WebCore::GStreamerElementHarness::Stream::sinkEvent):
(WebCore::GStreamerElementHarness::processOutputBuffers):
(WebCore::GStreamerElementHarness::flush):
(WebCore::GStreamerElementHarness::pullBuffer): Deleted.
(WebCore::GStreamerElementHarness::pullEvent): Deleted.
(WebCore::GStreamerElementHarness::outputCaps): Deleted.
(WebCore::GStreamerElementHarness::chainBuffer): Deleted.
(WebCore::GStreamerElementHarness::sinkQuery): Deleted.
(WebCore::GStreamerElementHarness::sinkEvent): Deleted.
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
(WebCore::GStreamerElementHarness::Stream::create):
(WebCore::GStreamerElementHarness::Stream::pad const):
(WebCore::GStreamerElementHarness::outputStreams const):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/259077@main">https://commits.webkit.org/259077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a11610ee839d1c7fc502244eba0fe707884e3ad3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113108 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173408 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3889 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112212 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109652 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93871 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25482 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6353 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6517 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6245 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8287 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->