### PR TITLE
SHOULD NEVER BE REACHED in IPC::StreamClientConnection::trySendDestinationIDIfNeeded

### DIFF
--- a/LayoutTests/ipc/stream-buffer-read-write.html
+++ b/LayoutTests/ipc/stream-buffer-read-write.html
@@ -14,8 +14,8 @@ if (window.IPC) {
     let dataReadSuccess = false;
     let dataWriteSuccess = false;
 
-    const testBytes = Uint8Array.from({length: 16}, (x, i) => i + 0x41);
-    const bufferSizeLog2 = 4;
+    const testBytes = Uint8Array.from({length: 64}, (x, i) => i + 0x41);
+    const bufferSizeLog2 = 6;
     const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
     streamConnection.open();
 
@@ -46,7 +46,7 @@ if (window.IPC) {
 
     if(headerWriteSuccess && headerReadSuccess){
         streamBuffer.writeDataBytes(testBytes.slice(0,8), 0, 8);
-        streamBuffer.writeDataBytes(testBytes.slice(8,16), 8, 8);
+        streamBuffer.writeDataBytes(testBytes.slice(8,64), 8, 56);
         readResult = new Uint8Array(streamBuffer.readDataBytes(0));
 
         if(arraysAreEqual(readResult, testBytes)){

--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -81,6 +81,11 @@ inline StreamClientConnectionBuffer::StreamClientConnectionBuffer(unsigned dataS
     : StreamConnectionBuffer(createMemory(dataSizeLog2))
 {
     ASSERT(dataSizeLog2 < 31u); // Currently expected to be not that big, and offset to fit in size_t with the tag bits.
+    // Currently the minimum message size is 16, and as such 32 bytes is not enough to hold one message.
+    // The problem happens after initial write and read, because after the read the buffer is split between
+    // 15 free bytes and 15 free bytes.
+    ASSERT(dataSizeLog2 > 5);
+
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(sharedMemorySizeIsValid(m_sharedMemory->size()));
 
     // Read starts from 0 with limit of 0 and reader sleeping.

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -39,8 +39,9 @@ template<typename, typename> struct ArgumentCoder;
 //
 class StreamConnectionEncoder final {
 public:
-    // Stream message needs to be at least size of StreamSetDestinationID message.
-    static constexpr size_t minimumMessageSize = sizeof(MessageName) + sizeof(uint64_t);
+    // Stream allocation needs to be at least size of StreamSetDestinationID message at any offset % messageAlignment.
+    // StreamSetDestinationID has MessageName+uint64_t, where uint64_t is expected to to be aligned at 8.
+    static constexpr size_t minimumMessageSize = 16;
     static constexpr size_t messageAlignment = alignof(MessageName);
     static constexpr bool isIPCEncoder = true;
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
 		7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */; };
 		7B2739F32632AB640040F182 /* ThreadAssertionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */; };
+		7B2950E22972AFDE008CC225 /* StreamConnectionEncoderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */; };
 		7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */; };
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
 		7B636FC229700F0700F3670F /* StreamConnectionWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */; };
@@ -2741,6 +2742,7 @@
 		7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = CrossPartitionFileSchemeAccess.html; path = Tests/mac/CrossPartitionFileSchemeAccess.html; sourceTree = SOURCE_ROOT; };
 		7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferTests.cpp; sourceTree = "<group>"; };
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
+		7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionEncoderTests.cpp; sourceTree = "<group>"; };
 		7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConnectionTests.cpp; sourceTree = "<group>"; };
 		7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionWorkQueueTests.cpp; sourceTree = "<group>"; };
 		7B7392E128F849EC007297FC /* MessageSenderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageSenderTests.cpp; sourceTree = "<group>"; };
@@ -4430,6 +4432,7 @@
 				7B7392EA28F849F3007297FC /* IPCTestUtilities.h */,
 				7B7392E128F849EC007297FC /* MessageSenderTests.cpp */,
 				7B9FC58328A26792007570E7 /* StreamConnectionBufferTests.cpp */,
+				7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */,
 				7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */,
 				7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */,
 			);
@@ -6004,6 +6007,7 @@
 				7B9FC3A028A26137007570E7 /* mainMac.mm in Sources */,
 				7B7392E928F849EC007297FC /* MessageSenderTests.cpp in Sources */,
 				7B9FC58428A26792007570E7 /* StreamConnectionBufferTests.cpp in Sources */,
+				7B2950E22972AFDE008CC225 /* StreamConnectionEncoderTests.cpp in Sources */,
 				7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */,
 				7B636FC229700F0700F3670F /* StreamConnectionWorkQueueTests.cpp in Sources */,
 				7B9FC58C28A2717D007570E7 /* TestsController.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
@@ -127,7 +127,7 @@ TEST_P(StreamConnectionBufferTest, ClientWritesFullVisibleInServer)
 
 INSTANTIATE_TEST_SUITE_P(StreamConnectionBufferSizedTests,
     StreamConnectionBufferTest,
-    testing::Values(4, 5, 9, 14),
+    testing::Values(6, 9, 14),
     TestParametersToStringFormatter());
 
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionEncoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionEncoderTests.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "StreamConnectionEncoder.h"
+#include "Test.h"
+#include <memory>
+
+namespace TestWebKitAPI {
+
+TEST(StreamConnectionEncoderTest, MinimumMessageSizeCanEncodeExpectedMessageAtAnyOffset)
+{
+    uint8_t storage[200];
+    // IPC::Decoder, IPC::StreamConnectionEncoder expect the buffers to be aligned in the way that
+    // an aligned write is readable by an aligned read.
+    // In other words: (encoder buffer % max used align) == (decoder buffer % max used align).
+    constexpr size_t maxAlignment = alignof(std::max_align_t);
+    // Currently the implementation selects (buffer % max used align) == 0 as the starting
+    // point.
+    uint8_t* buffer = roundUpToMultipleOf<maxAlignment>(storage);
+    EXPECT_GT(sizeof(storage), 2 * maxAlignment + IPC::StreamConnectionEncoder::minimumMessageSize);
+
+    // Currently stream connection expects to be able to encode at least the SetStreamDestinationID message.
+    static_assert(2u == IPC::StreamConnectionEncoder::messageAlignment);
+    static_assert(10u == sizeof(IPC::MessageName) + sizeof(uint64_t)); // SetStreamDestinationID message structure.
+    static_assert(16u == IPC::StreamConnectionEncoder::minimumMessageSize); // SetStreamDestinationID fits here at any offset.
+
+    size_t minimumMessageSize = IPC::StreamConnectionEncoder::minimumMessageSize;
+    for (size_t i = 0; i < maxAlignment; i += IPC::StreamConnectionEncoder::messageAlignment) {
+        IPC::StreamConnectionEncoder encoder { IPC::MessageName::SetStreamDestinationID, buffer + i,  minimumMessageSize };
+        encoder << static_cast<int64_t>(0);
+        EXPECT_TRUE(encoder.isValid()) << i;
+    }
+}
+
+}


### PR DESCRIPTION
#### da8b5ed3e46e77b73d5eea1506ca091774d6c580
<pre>
SHOULD NEVER BE REACHED in IPC::StreamClientConnection::trySendDestinationIDIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=250318">https://bugs.webkit.org/show_bug.cgi?id=250318</a>
rdar://104027243

Reviewed by Matt Woodrow and Simon Fraser.

The stream IPC write and read both select the next offset
based on if minimumMessageSize can fit to the allocation. If it
does not fit between current position and buffer end, the index
is wrapped to 0.

The minimumMessageSize is currently expected to match the
SetStreamDestinationID message. The message size can vary between
10 and 16 bytes, since the uint64_t in it is encoded with uint64_t
alignment, 8 bytes.

If the SetStreamDestinationID did not fit to the allocation,
the send was returned as failed. The expectation was that callers
would mark the context lost. This doesn&apos;t happen for normal rendering.
Thus if this would happen for example at DisplayListRecorder creation
message, the client would continue sending messages to destinations
that did not exist at the server. In these cases the server does not
know how to parse the messages, and the expectation is that these
cases happen when the connection is being closed.

Adjust the minimumMessageSize to 16 for now. Add tests testing that
the encoding succeeds at any expected offset.

* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h:
(IPC::StreamClientConnectionBuffer::StreamClientConnectionBuffer):
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/259069@main">https://commits.webkit.org/259069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaa184a3c9046f2467e489810b63a243d9b1e6be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112971 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173292 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3756 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95998 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112104 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38430 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80079 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26773 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3290 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6238 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8156 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->