### PR TITLE
Safari local video element pauses after bluetooth audioinput is disconnected

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4592,6 +4592,12 @@ void Document::updateIsPlayingMedia()
     state.add(MediaStreamTrack::captureState(*this));
     if (m_activeSpeechRecognition)
         state.add(MediaProducerMediaState::HasActiveAudioCaptureDevice);
+
+    m_activeMediaElementsWithMediaStreamCount = 0;
+    forEachMediaElement([&](auto& element) {
+        if (element.hasMediaStreamSrcObject() && element.isPlaying())
+            ++m_activeMediaElementsWithMediaStreamCount;
+    });
 #endif
 
     if (m_userHasInteractedWithMediaElement)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1525,6 +1525,7 @@ public:
     bool hasHadCaptureMediaStreamTrack() const { return m_hasHadCaptureMediaStreamTrack; }
     void stopMediaCapture(MediaProducerMediaCaptureKind);
     void mediaStreamCaptureStateChanged();
+    size_t activeMediaElementsWithMediaStreamCount() const { return m_activeMediaElementsWithMediaStreamCount; }
 #endif
 
 // FIXME: Find a better place for this functionality.
@@ -2265,6 +2266,7 @@ private:
 #if ENABLE(MEDIA_STREAM)
     String m_idHashSalt;
     bool m_hasHadCaptureMediaStreamTrack { false };
+    size_t m_activeMediaElementsWithMediaStreamCount { 0 };
 #endif
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -341,13 +341,8 @@ static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOptio
     if (!_playbackSessionInterfaceMac)
         return;
 
-    if (auto* model = _playbackSessionInterfaceMac->playbackSessionModel()) {
-        BOOL isCurrentlyPlaying = model->isPlaying();
-        if (!isCurrentlyPlaying && _playing)
-            model->sendRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType::PlayCommand, { });
-        else if (isCurrentlyPlaying && !_playing)
-            model->sendRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType::PauseCommand, { });
-    }
+    if (auto* model = _playbackSessionInterfaceMac->playbackSessionModel())
+        model->sendRemoteCommand(_playing ? WebCore::PlatformMediaSession::RemoteControlCommandType::PlayCommand : WebCore::PlatformMediaSession::RemoteControlCommandType::PauseCommand, { });
 }
 
 - (BOOL)isPlaying

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		076E507F1F4513D6006E9F5A /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 076E507E1F45031E006E9F5A /* Logging.cpp */; };
 		077A5AF3230638A600A7105C /* AccessibilityTestPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0746645822FF630500E3451A /* AccessibilityTestPlugin.mm */; };
 		0794742D25CB33FD00C597EB /* media-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EB /* media-remote.html */; };
+		0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EC /* webrtc-remote.html */; };
 		0799C34B1EBA3301003B7532 /* disableGetUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */; };
 		07C046CA1E4262A8007201E7 /* CARingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBuffer.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
@@ -1887,6 +1888,7 @@
 				F45C640128178AD70090DFAB /* webp-image.html in Copy Resources */,
 				51714EB41CF8C78C004723C4 /* WebProcessKillIDBCleanup-1.html in Copy Resources */,
 				51714EB51CF8C78C004723C4 /* WebProcessKillIDBCleanup-2.html in Copy Resources */,
+				0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */,
 				536770361CC81B6100D425B1 /* WebScriptObjectDescription.html in Copy Resources */,
 				5120C83E1E67678F0025B250 /* WebsiteDataStoreCustomPaths.html in Copy Resources */,
 				93F79A5A28E64A06003E7CEB /* websql-database-tracker.db in Copy Resources */,
@@ -1943,6 +1945,7 @@
 		076E507E1F45031E006E9F5A /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
 		0794740C25CA0BDE00C597EB /* MediaSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSession.mm; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EB /* media-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-remote.html"; sourceTree = "<group>"; };
+		0794742C25CB33B000C597EC /* webrtc-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote.html"; sourceTree = "<group>"; };
 		0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = disableGetUserMedia.html; sourceTree = "<group>"; };
 		07C046C91E42573E007201E7 /* CARingBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBuffer.cpp; sourceTree = "<group>"; };
 		07CC7DFD2266330800E39181 /* MediaBufferingPolicy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaBufferingPolicy.mm; sourceTree = "<group>"; };
@@ -4801,6 +4804,7 @@
 				F45C63FE28178A530090DFAB /* webp-image.html */,
 				51714EB21CF8C761004723C4 /* WebProcessKillIDBCleanup-1.html */,
 				51714EB31CF8C761004723C4 /* WebProcessKillIDBCleanup-2.html */,
+				0794742C25CB33B000C597EC /* webrtc-remote.html */,
 				5120C83B1E674E350025B250 /* WebsiteDataStoreCustomPaths.html */,
 				93F79A5928E649EC003E7CEB /* websql-database-tracker.db */,
 				93F79A5128E649EB003E7CEB /* websql-database.db */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -45,6 +45,7 @@
 #import <WebKit/_WKFeature.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <pal/spi/mac/MediaRemoteSPI.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/WTFString.h>
 
@@ -1268,6 +1269,83 @@ TEST(WebKit2, DoNotUnmuteWhenTakingAThumbnail)
     EXPECT_TRUE(cameraCaptureState == WKMediaCaptureStateMuted);
 }
 #endif
+
+#if WK_HAVE_C_SPI
+TEST(WebKit2, WebRTCAndRemoteCommands)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
+    configuration.get().processPool = (WKProcessPool *)context.get();
+    configuration.get().processPool._configuration.shouldCaptureAudioInUIProcess = NO;
+
+    initializeMediaCaptureConfiguration(configuration.get());
+
+    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+
+    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+    [webView _setMediaCaptureReportingDelayForTesting:0];
+
+    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
+    [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
+
+    cameraCaptureStateChange = false;
+    microphoneCaptureStateChange = false;
+
+    done = false;
+    [webView loadTestPageNamed:@"webrtc-remote"];
+
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
+
+    done = false;
+    [webView stringByEvaluatingJavaScript:@"startTest()"];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    cameraCaptureStateChange = false;
+    microphoneCaptureStateChange = false;
+    [webView stringByEvaluatingJavaScript:@"sendCommand('pause')"];
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateMuted));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateMuted));
+
+    [webView stringByEvaluatingJavaScript:@"sendCommand('play')"];
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
+
+    [webView stringByEvaluatingJavaScript:@"sendCommand('toggleplaypause')"];
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateMuted));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateMuted));
+
+    [webView stringByEvaluatingJavaScript:@"sendCommand('toggleplaypause')"];
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
+
+    done = false;
+    // register handlers will catch commands, so capture should not muted.
+    [webView stringByEvaluatingJavaScript:@"registerHandlers()"];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    [webView stringByEvaluatingJavaScript:@"sendCommand('pause')"];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
+
+    [webView stringByEvaluatingJavaScript:@"sendCommand('play')"];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
+    EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
+}
+#endif // WK_HAVE_C_SPI
 
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body onload="startCapture()">
+    <video controls autoplay playsinline muted id="local"></video>
+    <br>
+    <video controls autoplay playsinline id="remote"></video>
+    <script>
+let stream;
+async function startCapture()
+{
+    stream = await navigator.mediaDevices.getUserMedia({audio:true, video: true});
+    local.srcObject = stream;
+    // We emulate the remote stream by cloning the local stream.
+    remote.srcObject = stream.clone();
+}
+
+async function startPlaying()
+{
+    await local.play();
+    await remote.play();
+    if (window.webkit)
+        window.webkit.messageHandlers.gum.postMessage("PASS");
+}
+
+function startTest()
+{
+    startPlaying();
+}
+
+let currentCommand;
+function sendCommand(command)
+{
+    if (!window.internals) {
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("FAIL");
+        return;
+    }
+    currentCommand = command;
+    if (window.webkit)
+        window.internals.postRemoteControlCommand(command);
+}
+
+function registerHandlers()
+{
+    navigator.mediaSession.setActionHandler("play", () => {
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage(currentCommand == "play" ? "PASS" : "FAIL, got play but expected " + currentCommand);
+    });
+    navigator.mediaSession.setActionHandler("pause", () => {
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage(currentCommand == "pause" ? "PASS" : "FAIL, got pause but expected " + currentCommand);
+    });
+    if (window.webkit)
+        window.webkit.messageHandlers.gum.postMessage("PASS");
+}
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### e32bbc1197b12a1e464ba1cef4e1267fafca77e9
<pre>
Safari local video element pauses after bluetooth audioinput is disconnected
<a href="https://bugs.webkit.org/show_bug.cgi?id=231787">https://bugs.webkit.org/show_bug.cgi?id=231787</a>
rdar://problem/84529041

Reviewed by Eric Carlson.

We receive a remote pause command when BT is disconnected.
We also get remote commands from keyboard and the current heuristic does not work well with video conference websites
that have multiple media elements playing at the same time.
We introduce a new heuristic in that case, where instead of pausing/playing media elements, we mute/unmute capture and audio rendering.
This allow users for instance to restart capture/audio using Safari UI.

We update WebPlaybackControlsManager setPlaying to always send an IPC message since calling playing may unmute WebProcess.

Covered by API test.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIsPlayingMedia):
* Source/WebCore/dom/Document.h:
(WebCore::Document::activeMediaElementsWithMediaStreamCount const):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isDocumentPlayingSeveralMediaStreams):
(WebCore::processRemoteControlCommandIfPlayingMediaStreams):
(WebCore::MediaElementSession::didReceiveRemoteControlCommand):
(WebCore::MediaElementSession::nowPlayingInfo const):
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:
(-[WebPlaybackControlsManager setPlaying:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote.html: Added.

Canonical link: <a href="https://commits.webkit.org/259415@main">https://commits.webkit.org/259415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/989f14d2fd649321977155a42294159c75b580e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113806 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174029 "Hash 989f14d2 for PR 8764 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4533 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112763 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38932 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27370 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3929 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8876 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->