### PR TITLE
[WK2] Use Spans in remaining cases of moving memory spans through IPC

### DIFF
--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -69,18 +69,6 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
     return create(format, size, data.releaseNonNull());
 }
 
-RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size, unsigned dataByteLength)
-{
-    ASSERT(supportedPixelFormat(format.pixelFormat));
-    ASSERT(computeBufferSize(format, size) == dataByteLength);
-
-    auto data = Uint8ClampedArray::tryCreateUninitialized(dataByteLength);
-    if (!data)
-        return nullptr;
-
-    return create(format, size, data.releaseNonNull());
-}
-
 ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::Uint8ClampedArray>&& data)
     : PixelBuffer(format, size, data->data(), data->byteLength())
     , m_data(WTFMove(data))


### PR DESCRIPTION
#### 8efbac52b8cdb3d666f71d2f602d350a08c8c0f4
<pre>
[WK2] Use Spans in remaining cases of moving memory spans through IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=250761">https://bugs.webkit.org/show_bug.cgi?id=250761</a>

Reviewed by Kimmo Kinnunen.

Adopt Spans or encodeSpan()-and-decodeSpan() pairings on the remaining uses
of copying memory spans across IPC channels. Spans are mostly adopted to replace
the combination of the length value and the fixed-length data. encodeSpan() and
decodeSpan() are used where only fixed-length data is operated-with.

Especially in decoding this helps reduce the necessary logic, since all the
overflow and buffer size validation is packed inside Decoder::decodeSpan().

An exception to this is ByteArrayPixelBuffer, which now encodes a complete Span
object. Upon decoding, the Span size is validated to match the buffer size
that&apos;s computed from the buffer&apos;s format and width-and-height size.

Additionally, in AppHighlight and Model classes, direct encoding and decoding
of memory spans is replaced by simply encoding and decoding the SharedBuffer and
FragmentedSharedBuffer objects.

Finally, FragmentedSharedBuffer encoding and decoding now passes the buffer size
as a size_t value, avoiding widening and narrowing the value through uint64_t.

* Source/WebCore/Modules/highlight/AppHighlight.h:
(WebCore::AppHighlight::encode const):
(WebCore::AppHighlight::decode):
* Source/WebCore/Modules/webauthn/AuthenticatorResponseData.h:
(WebCore::encodeArrayBuffer):
(WebCore::decodeArrayBuffer):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::BufferSource::encode const):
(WebCore::BufferSource::decode):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::encode const):
(WebCore::SerializedScriptValue::decode):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(WebCore::ByteArrayPixelBuffer::encode const):
(WebCore::ByteArrayPixelBuffer::decode):
* Source/WebCore/platform/graphics/Model.h:
(WebCore::Model::encode const):
(WebCore::Model::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/259131@main">https://commits.webkit.org/259131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5062ac00a38e885f769218597db12d9c9029f1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113230 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173536 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4027 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96252 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109790 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93982 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25594 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26971 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6629 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6287 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8403 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->