### PR TITLE
[ATSPI] Make `Atspi::Relation` an enum class

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
@@ -203,7 +203,7 @@ enum class State : uint64_t {
     ReadOnly                = 1LLU << 43,
 };
 
-enum Relation {
+enum class Relation {
     Null,
     LabelFor,
     LabelledBy,
@@ -227,7 +227,6 @@ enum Relation {
     DetailsFor,
     ErrorMessage,
     ErrorFor,
-    LastDefinedRelation,
 };
 
 enum CoordinateType {

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -1037,9 +1037,9 @@ void AccessibilityObjectAtspi::buildAttributes(GVariantBuilder* builder) const
         g_variant_builder_add(builder, "{ss}", it.key.utf8().data(), it.value.utf8().data());
 }
 
-HashMap<uint32_t, Vector<RefPtr<AccessibilityObjectAtspi>>> AccessibilityObjectAtspi::relationMap() const
+RelationMap AccessibilityObjectAtspi::relationMap() const
 {
-    HashMap<uint32_t, Vector<RefPtr<AccessibilityObjectAtspi>>> map;
+    RelationMap map;
     if (!m_coreObject)
         return map;
 
@@ -1067,32 +1067,32 @@ HashMap<uint32_t, Vector<RefPtr<AccessibilityObjectAtspi>>> AccessibilityObjectA
         }
     } else if (!m_coreObject->correspondingControlForLabelElement())
         ariaLabelledByElements = m_coreObject->labelledByObjects();
-    addRelation(Atspi::LabelledBy, ariaLabelledByElements);
+    addRelation(Atspi::Relation::LabelledBy, ariaLabelledByElements);
 
     AccessibilityObject::AccessibilityChildrenVector labelForObjects;
     if (auto* control = m_coreObject->correspondingControlForLabelElement())
         labelForObjects.append(control);
     else
         labelForObjects = m_coreObject->labelForObjects();
-    addRelation(Atspi::LabelFor, labelForObjects);
+    addRelation(Atspi::Relation::LabelFor, labelForObjects);
 
-    addRelation(Atspi::FlowsTo, m_coreObject->flowToObjects());
-    addRelation(Atspi::FlowsFrom, m_coreObject->flowFromObjects());
+    addRelation(Atspi::Relation::FlowsTo, m_coreObject->flowToObjects());
+    addRelation(Atspi::Relation::FlowsFrom, m_coreObject->flowFromObjects());
 
-    addRelation(Atspi::DescribedBy, m_coreObject->describedByObjects());
-    addRelation(Atspi::DescriptionFor, m_coreObject->descriptionForObjects());
+    addRelation(Atspi::Relation::DescribedBy, m_coreObject->describedByObjects());
+    addRelation(Atspi::Relation::DescriptionFor, m_coreObject->descriptionForObjects());
 
-    addRelation(Atspi::ControllerFor, m_coreObject->controlledObjects());
-    addRelation(Atspi::ControlledBy, m_coreObject->controllers());
+    addRelation(Atspi::Relation::ControllerFor, m_coreObject->controlledObjects());
+    addRelation(Atspi::Relation::ControlledBy, m_coreObject->controllers());
 
-    addRelation(Atspi::NodeParentOf, m_coreObject->ownedObjects());
-    addRelation(Atspi::NodeChildOf, m_coreObject->owners());
+    addRelation(Atspi::Relation::NodeParentOf, m_coreObject->ownedObjects());
+    addRelation(Atspi::Relation::NodeChildOf, m_coreObject->owners());
 
-    addRelation(Atspi::Details, m_coreObject->detailedByObjects());
-    addRelation(Atspi::DetailsFor, m_coreObject->detailsForObjects());
+    addRelation(Atspi::Relation::Details, m_coreObject->detailedByObjects());
+    addRelation(Atspi::Relation::DetailsFor, m_coreObject->detailsForObjects());
 
-    addRelation(Atspi::ErrorMessage, m_coreObject->errorMessageObjects());
-    addRelation(Atspi::ErrorFor, m_coreObject->errorMessageForObjects());
+    addRelation(Atspi::Relation::ErrorMessage, m_coreObject->errorMessageObjects());
+    addRelation(Atspi::Relation::ErrorFor, m_coreObject->errorMessageForObjects());
 
     return map;
 }
@@ -1103,7 +1103,7 @@ void AccessibilityObjectAtspi::buildRelationSet(GVariantBuilder* builder) const
         GVariantBuilder arrayBuilder = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE("a(so)"));
         for (const auto& atspiObject : it.value)
             g_variant_builder_add(&arrayBuilder, "@(so)", atspiObject->reference());
-        g_variant_builder_add(builder, "(ua(so))", it.key, &arrayBuilder);
+        g_variant_builder_add(builder, "(ua(so))", static_cast<unsigned>(it.key), &arrayBuilder);
     }
 }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -36,6 +36,8 @@ namespace WebCore {
 class AXCoreObject;
 class AccessibilityRootAtspi;
 
+using RelationMap = HashMap<Atspi::Relation, Vector<RefPtr<AccessibilityObjectAtspi>>, IntHash<Atspi::Relation>, WTF::StrongEnumHashTraits<Atspi::Relation>>;
+
 class AccessibilityObjectAtspi final : public RefCounted<AccessibilityObjectAtspi> {
 public:
     static Ref<AccessibilityObjectAtspi> create(AXCoreObject*, AccessibilityRootAtspi*);
@@ -91,7 +93,7 @@ public:
     bool isDefunct() const;
     void stateChanged(const char*, bool);
     WEBCORE_EXPORT HashMap<String, String> attributes() const;
-    WEBCORE_EXPORT HashMap<uint32_t, Vector<RefPtr<AccessibilityObjectAtspi>>> relationMap() const;
+    WEBCORE_EXPORT RelationMap relationMap() const;
 
     WEBCORE_EXPORT AccessibilityObjectAtspi* hitTest(const IntPoint&, uint32_t) const;
     WEBCORE_EXPORT IntRect elementRect(uint32_t) const;


### PR DESCRIPTION
#### 432a3a94294a0c78d5297d9ff556c4e07edcd23b
<pre>
[ATSPI] Make `Atspi::Relation` an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250763">https://bugs.webkit.org/show_bug.cgi?id=250763</a>

Reviewed by Michael Catanzaro.

It should improve code readability.

* Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::relationMap const):
(WebCore::AccessibilityObjectAtspi::buildRelationSet const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:

Canonical link: <a href="https://commits.webkit.org/259052@main">https://commits.webkit.org/259052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17ba0c221d2ecc3fd80da096322446940d4afa6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112972 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3757 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95999 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112105 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109518 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93772 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25378 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6222 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3294 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6228 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8157 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->