### PR TITLE
[ews-build.webkit.org] Use Twisted defer for reviewer queries

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -171,7 +171,27 @@ class GitHubMixin(object):
     PER_PAGE_LIMIT = 100
     NUM_PAGE_LIMIT = 10
 
+    @defer.inlineCallbacks
     def fetch_data_from_url_with_authentication_github(self, url):
+        headers = {'Accept': ['application/vnd.github.v3+json']}
+        username, access_token = GitHub.credentials(user=GitHub.user_for_queue(self.getProperty('buildername', '')))
+        if username and access_token:
+            auth_header = b64encode('{}:{}'.format(username, access_token).encode('utf-8')).decode('utf-8')
+            headers['Authorization'] = ['Basic {}'.format(auth_header)]
+
+        response = yield TwistedAdditions.request(
+            url, type=b'GET',
+            headers=headers,
+            logger=self._addToLog,
+        )
+        if response and response.status_code // 100 != 2:
+            yield self._addToLog('stdio', f'Accessed {url} with unexpected status code {response.status_code}.\n')
+            defer.returnValue(False if response.status_code // 100 == 4 else None)
+        else:
+            defer.returnValue(response)
+
+    # FIXME: Remove when all GitHub requests are using Twisted's deferred requests
+    def fetch_data_from_url_with_authentication_github_old(self, url):
         response = None
         try:
             username, access_token = GitHub.credentials(user=GitHub.user_for_queue(self.getProperty('buildername', '')))
@@ -195,7 +215,7 @@ class GitHubMixin(object):
             return None
 
         pr_url = '{}/pulls/{}'.format(api_url, pr_number)
-        content = self.fetch_data_from_url_with_authentication_github(pr_url)
+        content = self.fetch_data_from_url_with_authentication_github_old(pr_url)
         if not content:
             return content
 
@@ -216,15 +236,17 @@ class GitHubMixin(object):
 
         return None
 
+    @defer.inlineCallbacks
     def get_reviewers(self, pr_number, repository_url=None):
         api_url = GitHub.api_url(repository_url)
         if not api_url:
-            return []
+            defer.returnValue([])
+            return
 
         reviews = []
         reviews_url = f'{api_url}/pulls/{pr_number}/reviews?per_page={self.PER_PAGE_LIMIT}'
         for page in range(1, self.NUM_PAGE_LIMIT + 1):
-            content = self.fetch_data_from_url_with_authentication_github(
+            content = yield self.fetch_data_from_url_with_authentication_github(
                 f'{api_url}/pulls/{pr_number}/reviews?per_page={self.PER_PAGE_LIMIT}&page={page}'
             )
             if not content:
@@ -249,7 +271,7 @@ class GitHubMixin(object):
                 last_approved[reviewer] = max(review_id, last_approved.get(reviewer, 0))
             elif review.get('state') == 'CHANGES_REQUESTED':
                 last_rejected[reviewer] = max(review_id, last_rejected.get(reviewer, 0))
-        return sorted([reviewer for reviewer, _id in last_approved.items() if _id > last_rejected.get(reviewer, 0)])
+        defer.returnValue(sorted([reviewer for reviewer, _id in last_approved.items() if _id > last_rejected.get(reviewer, 0)]))
 
     def _is_pr_closed(self, pr_json):
         # If pr_json is "False", we received a 400 family error, which likely means the PR was deleted
@@ -338,7 +360,7 @@ class GitHubMixin(object):
             return False
 
         pr_label_url = f'{api_url}/issues/{pr_number}/labels'
-        content = self.fetch_data_from_url_with_authentication_github(pr_label_url)
+        content = self.fetch_data_from_url_with_authentication_github_old(pr_label_url)
         if not content:
             self._addToLog('stdio', "Failed to fetch existing labels, cannot remove labels\n")
             return True
@@ -1826,6 +1848,7 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
             return ''
         return contributor.get('name')
 
+    @defer.inlineCallbacks
     def run(self):
         self.contributors, errors = Contributors.load(use_network=True)
         for error in errors:
@@ -1835,7 +1858,8 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
         if not self.contributors:
             self.descriptionDone = 'Failed to get contributors information'
             self.build.buildFinished(['Failed to get contributors information'], FAILURE)
-            return FAILURE
+            defer.returnValue(FAILURE)
+            return
 
         pr_number = self.getProperty('github.number', '')
 
@@ -1849,7 +1873,7 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
         self._addToLog('stdio', f'{committer} is a valid commiter.\n')
 
         if pr_number:
-            reviewers = self.get_reviewers(pr_number, self.getProperty('repository', ''))
+            reviewers = yield self.get_reviewers(pr_number, self.getProperty('repository', ''))
         else:
             reviewer = self.getProperty('reviewer', '').lower()
             reviewers = [reviewer] if reviewer else []
@@ -1858,7 +1882,8 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
         validators = self.VALIDATORS_FOR.get(remote, [])
         lower_case_reviewers = [reviewer.lower() for reviewer in reviewers]
         if validators and not any([validator.lower() in lower_case_reviewers for validator in validators]):
-            return self.fail_build_due_to_no_validators(validators)
+            defer.returnValue(self.fail_build_due_to_no_validators(validators))
+            return
 
         if any([self.is_reviewer(reviewer) for reviewer in reviewers]):
             reviewers = list(filter(self.is_reviewer, reviewers))
@@ -1868,15 +1893,16 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
             # Change has not been reviewed in bug tracker. This is acceptable, since the ChangeLog might have 'Reviewed by' in it.
             self._addToLog('stdio', f'Reviewer not found. Commit message  will be checked for reviewer name in later steps\n')
             self.descriptionDone = 'Validated committer, reviewer not found'
-            return SUCCESS
+            defer.returnValue(SUCCESS)
+            return
 
         for reviewer in reviewers:
             if not self.is_reviewer(reviewer):
-                return self.fail_build_due_to_invalid_status(reviewer, 'reviewer')
+                defer.returnValue(self.fail_build_due_to_invalid_status(reviewer, 'reviewer'))
             self._addToLog('stdio', f'{reviewer} is a valid reviewer.\n')
         self.setProperty('reviewers_full_names', [self.full_name_from_email(reviewer) for reviewer in reviewers])
 
-        return SUCCESS
+        defer.returnValue(SUCCESS)
 
 
 class SetCommitQueueMinusFlagOnPatch(buildstep.BuildStep, BugzillaMixin):


### PR DESCRIPTION
#### 9b7933872a4ab7bc6617fd8b7ecd700331ac877a
<pre>
[ews-build.webkit.org] Use Twisted defer for reviewer queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=250765">https://bugs.webkit.org/show_bug.cgi?id=250765</a>
rdar://104382329

Reviewed by Aakash Jain.

Replace fetch_data_from_url_with_authentication_github with a Twisted
version of the same function, but keep around the old function while
we transition. Adopt the Twisted version of the function when listing
reviewers of a PR.

* Tools/CISupport/ews-build/steps.py:
(GitHubMixin):
(GitHubMixin.fetch_data_from_url_with_authentication_github): Convert to Twisted.
(GitHubMixin.fetch_data_from_url_with_authentication_github_old): Retain old
synchronous version.
(GitHubMixin.get_pr_json): Use old synchronous version.
(GitHubMixin.get_reviewers): Use new Twisted version.
(GitHubMixin.remove_labels): Use old synchronous version.
(ValidateCommitterAndReviewer.run): Use Twisted asynchronous requests.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestGitHubMixin.test_no_reviewers): Return defered to match API we&apos;re mocking.
(TestGitHubMixin.test_single_review): Ditto.
(TestGitHubMixin.test_multipe_reviews): Ditto.
(TestGitHubMixin.test_retracted_review): Ditto.
(TestGitHubMixin.test_pagination): Ditto.
(TestGitHubMixin.test_reviewers_invalid_response): Ditto.
(TestGitHubMixin.test_reviewers_error): Ditto.

Canonical link: <a href="https://commits.webkit.org/259427@main">https://commits.webkit.org/259427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/585dfcc89c078666fded86c7ff470aa03c22a01a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114165 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4902 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97224 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/113187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110658 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7322 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7415 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103700 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13473 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9207 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3450 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->