### PR TITLE
Enable AudioSession Web API by default, but only a reduced subset

### DIFF
--- a/LayoutTests/media/audioSession/audioSessionType.html
+++ b/LayoutTests/media/audioSession/audioSessionType.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ DOMAudioSessionFullEnabled=false ] -->
 <html>
     <head>
         <meta charset="utf-8">
@@ -26,7 +26,9 @@ async function ensureCategory(expected, counter)
 
 promise_test(async (test) => {
     assert_equals(navigator.audioSession.type, "auto");
-    
+    assert_equals(AudioSession.prototype.state, undefined);
+    assert_equals(AudioSession.prototype.onstatechange, undefined);
+
     if (!window.internals)
         return;
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1808,7 +1808,3 @@ webkit.org/b/250784 media/audio-session-category.html [ Pass Failure ]
 [ BigSur+ ] imported/w3c/web-platform-tests/service-workers/cache-storage/cross-partition.https.tentative.html [ Pass Failure Crash ]
 
 webkit.org/b/248997 [ BigSur+ ] http/tests/navigation/fragment-navigation-policy-ignore.html [ Pass Failure ]
-
-webkit.org/b/249407 [ BigSur+ ] media/audioSession/getUserMedia.html [ Failure ]
-
-webkit.org/b/249486 [ BigSur+ ] media/audioSession/audioSessionType.html [ Failure ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1507,8 +1507,22 @@ DNSPrefetchingEnabled:
 DOMAudioSessionEnabled:
   type: bool
   status: testable
-  humanReadableName: "AudioSession"
-  humanReadableDescription: "Enable AudioSession"
+  humanReadableName: "AudioSession API"
+  humanReadableDescription: "Enable AudioSession API"
+  condition: ENABLE(DOM_AUDIO_SESSION)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
+DOMAudioSessionFullEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "AudioSession full API"
+  humanReadableDescription: "Enable AudioSession full API"
   condition: ENABLE(DOM_AUDIO_SESSION)
   defaultValue:
     WebKitLegacy:

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.idl
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.idl
@@ -47,6 +47,6 @@ enum DOMAudioSessionType {
 ] interface DOMAudioSession : EventTarget {
     attribute DOMAudioSessionType type;
 
-    readonly attribute DOMAudioSessionState state;
-    attribute EventHandler onstatechange;
+    [EnabledBySetting=DOMAudioSessionFullEnabled] readonly attribute DOMAudioSessionState state;
+    [EnabledBySetting=DOMAudioSessionFullEnabled] attribute EventHandler onstatechange;
 };


### PR DESCRIPTION
#### c39358705b79ccf2da3b76a8be6334e7e3dfcfa6
<pre>
Enable AudioSession Web API by default, but only a reduced subset
<a href="https://bugs.webkit.org/show_bug.cgi?id=250764">https://bugs.webkit.org/show_bug.cgi?id=250764</a>
rdar://104381410

Reviewed by Eric Carlson.

Enable by default navigator.audioSession and navigator.audioSession.type but not the state/event API.
For that purpose, introduce a second flag for the extended API.

Update LayoutTests/media/audioSession/audioSessionType.html to cover the new flag.
Remove the flaky test expectations for two related audioSession tests since they are no longer flaky in bots.

* LayoutTests/media/audioSession/audioSessionType.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/audiosession/DOMAudioSession.idl:

Canonical link: <a href="https://commits.webkit.org/259074@main">https://commits.webkit.org/259074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b22fa98f099a975490740a546ca4224d0b082345

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112959 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173279 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3742 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112098 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38413 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25367 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80067 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93863 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26756 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90297 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/3974 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3286 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29825 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46282 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98906 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6242 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8143 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24894 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->