### PR TITLE
Image controls should not be web exposed

### DIFF
--- a/LayoutTests/fast/images/mac/image-controls-button-is-not-exposed-expected.html
+++ b/LayoutTests/fast/images/mac/image-controls-button-is-not-exposed-expected.html
@@ -1,0 +1,1 @@
+<button></button>

--- a/LayoutTests/fast/images/mac/image-controls-button-is-not-exposed.html
+++ b/LayoutTests/fast/images/mac/image-controls-button-is-not-exposed.html
@@ -1,0 +1,1 @@
+<button id="image-controls-button"></button>

--- a/Source/WebCore/dom/mac/ImageControlsMac.h
+++ b/Source/WebCore/dom/mac/ImageControlsMac.h
@@ -37,7 +37,6 @@ namespace ImageControlsMac {
 
 #if ENABLE(SERVICE_CONTROLS)
 
-bool hasControls(const HTMLElement&);
 bool isImageControlsButtonElement(const Node&);
 bool isInsideImageControls(const Node&);
 void createImageControls(HTMLElement&);
@@ -46,6 +45,7 @@ void updateImageControls(HTMLElement&);
 void tryCreateImageControls(HTMLElement&);
 void destroyImageControls(HTMLElement&);
 WEBCORE_EXPORT bool hasImageControls(const HTMLElement&);
+
 #endif // ENABLE(SERVICE_CONTROLS)
 
 } // namespace ImageControlsMac

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -374,11 +374,6 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
     if (!elementPtr)
         return StyleAppearance::None;
 
-#if ENABLE(SERVICE_CONTROLS)
-    if (isImageControl(*elementPtr))
-        return StyleAppearance::ImageControlsButton;
-#endif
-
     Ref element = *elementPtr;
 
     if (is<HTMLInputElement>(element)) {
@@ -419,8 +414,14 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
         return StyleAppearance::None;
     }
 
-    if (is<HTMLButtonElement>(element))
+    if (is<HTMLButtonElement>(element)) {
+#if ENABLE(SERVICE_CONTROLS)
+        if (isImageControlsButton(element.get()))
+            return StyleAppearance::ImageControlsButton;
+#endif
+
         return StyleAppearance::Button;
+    }
 
     if (is<HTMLSelectElement>(element)) {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -354,7 +354,7 @@ protected:
 #if ENABLE(SERVICE_CONTROLS)
     virtual void adjustImageControlsButtonStyle(RenderStyle&, const Element*) const;
     virtual bool paintImageControlsButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
-    virtual bool isImageControl(const Element&) const { return false; }
+    virtual bool isImageControlsButton(const Element&) const { return false; }
 #endif
 
     virtual void adjustProgressBarStyle(RenderStyle&, const Element*) const;

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -185,7 +185,7 @@ private:
 
 #if ENABLE(SERVICE_CONTROLS)
     IntSize imageControlsButtonSize() const final;
-    bool isImageControl(const Element&) const final;
+    bool isImageControlsButton(const Element&) const final;
 #endif
 
     mutable RetainPtr<NSPopUpButtonCell> m_popupButton;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1470,9 +1470,9 @@ IntSize RenderThemeMac::imageControlsButtonSize() const
     return ImageControlsButtonMac::servicesRolloverButtonCellSize();
 }
 
-bool RenderThemeMac::isImageControl(const Element& elementPtr) const
+bool RenderThemeMac::isImageControlsButton(const Element& element) const
 {
-    return ImageControlsMac::isImageControlsButtonElement(elementPtr);
+    return ImageControlsMac::isImageControlsButtonElement(element);
 }
 #endif
 


### PR DESCRIPTION
#### ac4e9ee871bebc572bd839c246ef9ff83d44fb7c
<pre>
Image controls should not be web exposed
<a href="https://bugs.webkit.org/show_bug.cgi?id=250729">https://bugs.webkit.org/show_bug.cgi?id=250729</a>
rdar://104352792

Reviewed by Wenson Hsieh, Tim Nguyen and Ryosuke Niwa.

Following 245760@main, any `&lt;button&gt;` element that has the ID &quot;image-controls-button&quot;
paints an NSServicesRolloverButtonCell. This issue occurs due to the fact that
`ImageControlsMac::isImageControlsButtonElement` simply checks the ID of the element
parameter, and `RenderTheme` applies the internal image controls `appearance` value
when that method returns true.

To fix, update `ImageControlsMac::isImageControlsButtonElement` to only return
true, if the ID matches, and the element is in the user-agent shadow tree.
Additionally, perform some cleanup around related code.

* LayoutTests/fast/images/mac/image-controls-button-is-not-exposed-expected.html: Added.
* LayoutTests/fast/images/mac/image-controls-button-is-not-exposed.html: Added.
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::hasImageControls):
(WebCore::ImageControlsMac::imageControlsHost):
(WebCore::ImageControlsMac::isImageControlsButtonElement):
(WebCore::ImageControlsMac::isInsideImageControls):

Update the implementation to actually check whether the element is inside the
image controls shadow tree. Previously this method simply checked that the
element is equal to the image controls container.

(WebCore::ImageControlsMac::destroyImageControls):
(WebCore::ImageControlsMac::hasControls): Deleted.

Remove redundant method in favor of `hasImageControls`, which has a more descriptive name.

* Source/WebCore/dom/mac/ImageControlsMac.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):

Move the image controls check further down, since in the majority of cases it is
unlikely we have an image controls button. Prioritize determining the appearance
of input element, which are more frequently observed in web content.

* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::isImageControlsButton const):
(WebCore::RenderTheme::isImageControl const): Deleted.

Renamed this method to `isImageControlsButton`, since that is what it is actually checking.

* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::isImageControlsButton const):
(WebCore::RenderThemeMac::isImageControl const): Deleted.

Canonical link: <a href="https://commits.webkit.org/259126@main">https://commits.webkit.org/259126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/256a7780572f1b503bc347c6c50174835b055f4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113196 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173502 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3981 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112287 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38588 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25563 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94058 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26944 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90550 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4213 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6599 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3480 "Found 1 new test failure: fast/images/background-image-relative-url-changes-document.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29881 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46474 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/99158 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8373 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24953 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3330 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->