### PR TITLE
add WKNavigationAction._hasOpener SPI

### DIFF
--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -114,6 +114,9 @@ public:
     bool openedByDOMWithOpener() const { return m_openedByDOMWithOpener; }
     void setOpenedByDOMWithOpener() { m_openedByDOMWithOpener = true; }
 
+    NewFrameOpenerPolicy newFrameOpenerPolicy() const { return m_newFrameOpenerPolicy; }
+    void setNewFrameOpenerPolicy(NewFrameOpenerPolicy newFrameOpenerPolicy) { m_newFrameOpenerPolicy = newFrameOpenerPolicy; }
+
     void setTargetBackForwardItem(HistoryItem&);
     const std::optional<BackForwardItemIdentifier>& targetBackForwardItemIdentifier() const { return m_targetBackForwardItemIdentifier; }
 
@@ -163,6 +166,7 @@ private:
     LockBackForwardList m_lockBackForwardList { LockBackForwardList::No };
     std::optional<PrivateClickMeasurement> m_privateClickMeasurement;
     ShouldReplaceDocumentIfJavaScriptURL m_shouldReplaceDocumentIfJavaScriptURL { ReplaceDocumentIfJavaScriptURL };
+    NewFrameOpenerPolicy m_newFrameOpenerPolicy { NewFrameOpenerPolicy::Allow };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/NavigationActionData.cpp
+++ b/Source/WebKit/Shared/NavigationActionData.cpp
@@ -48,6 +48,7 @@ void NavigationActionData::encode(IPC::Encoder& encoder) const
     encoder << treatAsSameOriginNavigation;
     encoder << hasOpenedFrames;
     encoder << openedByDOMWithOpener;
+    encoder << hasOpener;
     encoder << requesterOrigin;
     encoder << targetBackForwardItemIdentifier;
     encoder << sourceBackForwardItemIdentifier;
@@ -124,6 +125,11 @@ std::optional<NavigationActionData> NavigationActionData::decode(IPC::Decoder& d
     if (!openedByDOMWithOpener)
         return std::nullopt;
 
+    std::optional<bool> hasOpener;
+    decoder >> hasOpener;
+    if (!hasOpener)
+        return std::nullopt;
+
     std::optional<WebCore::SecurityOriginData> requesterOrigin;
     decoder >> requesterOrigin;
     if (!requesterOrigin)
@@ -171,7 +177,7 @@ std::optional<NavigationActionData> NavigationActionData::decode(IPC::Decoder& d
 
     return { { WTFMove(navigationType), modifiers, WTFMove(*mouseButton), WTFMove(*syntheticClickType), WTFMove(*userGestureTokenIdentifier),
         WTFMove(*canHandleRequest), WTFMove(shouldOpenExternalURLsPolicy), WTFMove(*downloadAttribute), WTFMove(clickLocationInRootViewCoordinates),
-        WTFMove(*isRedirect), *treatAsSameOriginNavigation, *hasOpenedFrames, *openedByDOMWithOpener, WTFMove(*requesterOrigin),
+        WTFMove(*isRedirect), *treatAsSameOriginNavigation, *hasOpenedFrames, *openedByDOMWithOpener, *hasOpener, WTFMove(*requesterOrigin),
         WTFMove(*targetBackForwardItemIdentifier), WTFMove(*sourceBackForwardItemIdentifier), lockHistory, lockBackForwardList, WTFMove(*clientRedirectSourceForHistory), *effectiveSandboxFlags, WTFMove(*privateClickMeasurement),
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
         WTFMove(*webHitTestResultData),

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -61,6 +61,7 @@ struct NavigationActionData {
     bool treatAsSameOriginNavigation { false };
     bool hasOpenedFrames { false };
     bool openedByDOMWithOpener { false };
+    bool hasOpener { false };
     WebCore::SecurityOriginData requesterOrigin;
     std::optional<WebCore::BackForwardItemIdentifier> targetBackForwardItemIdentifier;
     std::optional<WebCore::BackForwardItemIdentifier> sourceBackForwardItemIdentifier;

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -63,6 +63,7 @@ public:
     bool shouldOpenAppLinks() const { return m_shouldOpenAppLinks && m_navigationActionData.shouldOpenExternalURLsPolicy == WebCore::ShouldOpenExternalURLsPolicy::ShouldAllow; }
     bool shouldPerformDownload() const { return !m_navigationActionData.downloadAttribute.isNull(); }
     bool isRedirect() const { return m_navigationActionData.isRedirect; }
+    bool hasOpener() const { return m_navigationActionData.hasOpener; }
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy() const { return m_navigationActionData.shouldOpenExternalURLsPolicy; }
 
     bool isProcessingUserGesture() const { return m_userInitiatedAction; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -253,4 +253,9 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 #endif
 }
 
+- (BOOL)_hasOpener
+{
+    return _navigationAction->hasOpener();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
@@ -65,4 +65,6 @@ typedef NS_ENUM(NSInteger, WKSyntheticClickType) {
 
 @property (nonatomic, readonly) _WKHitTestResult *_hitTestResult WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+@property (nonatomic, readonly) BOOL _hasOpener WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @end

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -300,18 +300,35 @@ Page* WebChromeClient::createWindow(Frame& frame, const WindowFeatures& windowFe
 
     auto& webProcess = WebProcess::singleton();
 
-    NavigationActionData navigationActionData;
-    navigationActionData.navigationType = navigationAction.type();
-    navigationActionData.modifiers = modifiersForNavigationAction(navigationAction);
-    navigationActionData.mouseButton = mouseButton(navigationAction);
-    navigationActionData.syntheticClickType = syntheticClickType(navigationAction);
-    if (auto& data = navigationAction.mouseEventData())
-        navigationActionData.clickLocationInRootViewCoordinates = data->locationInRootViewCoordinates;
-    navigationActionData.userGestureTokenIdentifier = webProcess.userGestureTokenIdentifier(navigationAction.userGestureToken());
-    navigationActionData.canHandleRequest = m_page.canHandleRequest(navigationAction.resourceRequest());
-    navigationActionData.shouldOpenExternalURLsPolicy = navigationAction.shouldOpenExternalURLsPolicy();
-    navigationActionData.downloadAttribute = navigationAction.downloadAttribute();
-    navigationActionData.privateClickMeasurement = navigationAction.privateClickMeasurement();
+    auto& mouseEventData = navigationAction.mouseEventData();
+
+    NavigationActionData navigationActionData {
+        navigationAction.type(),
+        modifiersForNavigationAction(navigationAction),
+        mouseButton(navigationAction),
+        syntheticClickType(navigationAction),
+        webProcess.userGestureTokenIdentifier(navigationAction.userGestureToken()),
+        m_page.canHandleRequest(navigationAction.resourceRequest()),
+        navigationAction.shouldOpenExternalURLsPolicy(),
+        navigationAction.downloadAttribute(),
+        mouseEventData ? mouseEventData->locationInRootViewCoordinates : FloatPoint { },
+        false, /* isRedirect */
+        false, /* treatAsSameOriginNavigation */
+        false, /* hasOpenedFrames */
+        false, /* openedByDOMWithOpener */
+        navigationAction.newFrameOpenerPolicy() == NewFrameOpenerPolicy::Allow, /* hasOpener */
+        { }, /* requesterOrigin */
+        std::nullopt, /* targetBackForwardItemIdentifier */
+        std::nullopt, /* sourceBackForwardItemIdentifier */
+        WebCore::LockHistory::No,
+        WebCore::LockBackForwardList::No,
+        { }, /* clientRedirectSourceForHistory */
+        0, /* effectiveSandboxFlags */
+        navigationAction.privateClickMeasurement(),
+#if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
+        std::nullopt, /* webHitTestResultData */
+#endif
+    };
 
     WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
 


### PR DESCRIPTION
#### 08b7e0857290106be51955e6dc17e66c5e79dcdf
<pre>
add WKNavigationAction._hasOpener SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=250774">https://bugs.webkit.org/show_bug.cgi?id=250774</a>
rdar://101651907

Reviewed by Alex Christensen.

Add WKNavigationAction._hasOpener SPI so that the client can know the opener
policy when creating a new popup or doing a navigation in that popup.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::createWindow):
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::newFrameOpenerPolicy const):
(WebCore::NavigationAction::setNewFrameOpenerPolicy):
* Source/WebKit/Shared/NavigationActionData.cpp:
(WebKit::NavigationActionData::encode const):
(WebKit::NavigationActionData::decode):
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _hasOpener]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/259085@main">https://commits.webkit.org/259085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cf13e75912c2298e596812e2c327a0dbe9a561b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113038 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173348 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3824 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96060 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112149 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38475 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25434 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80129 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6285 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26820 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3357 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46344 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8221 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3317 "Failed to find identifier") | | | | 
<!--EWS-Status-Bubble-End-->