### PR TITLE
[WebGPU] Implement PresentationContextCoreAnimation

### DIFF
--- a/Source/WebGPU/WebGPU/HardwareCapabilities.h
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.h
@@ -39,6 +39,10 @@ struct HardwareCapabilities {
         bool supportsNonPrivateDepthStencilTextures { false };
         id<MTLCounterSet> timestampCounterSet { nil };
         id<MTLCounterSet> statisticCounterSet { nil };
+        // FIXME: canPresentRGB10A2PixelFormats isn't actually a _hardware_ capability,
+        // as all hardware can render to this format. It's unclear whether this should
+        // apply to _all_ PresentationContexts or just PresentationContextCoreAnimation.
+        bool canPresentRGB10A2PixelFormats { false };
     } baseCapabilities;
 };
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -96,6 +96,7 @@ static HardwareCapabilities apple3(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
+    baseCapabilities.canPresentRGB10A2PixelFormats = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -145,6 +146,7 @@ static HardwareCapabilities apple4(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
+    baseCapabilities.canPresentRGB10A2PixelFormats = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -194,6 +196,7 @@ static HardwareCapabilities apple5(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
+    baseCapabilities.canPresentRGB10A2PixelFormats = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -244,6 +247,7 @@ static HardwareCapabilities apple6(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
+    baseCapabilities.canPresentRGB10A2PixelFormats = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -293,6 +297,7 @@ static HardwareCapabilities apple7(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = true;
+    baseCapabilities.canPresentRGB10A2PixelFormats = false;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -343,6 +348,7 @@ static HardwareCapabilities mac2(id<MTLDevice> device)
     auto baseCapabilities = WebGPU::baseCapabilities(device);
 
     baseCapabilities.supportsNonPrivateDepthStencilTextures = false;
+    baseCapabilities.canPresentRGB10A2PixelFormats = true;
 
     auto features = WebGPU::baseFeatures(device, baseCapabilities);
 
@@ -467,6 +473,7 @@ static HardwareCapabilities::BaseCapabilities mergeBaseCapabilities(const Hardwa
         previous.supportsNonPrivateDepthStencilTextures || next.supportsNonPrivateDepthStencilTextures,
         previous.timestampCounterSet,
         previous.statisticCounterSet,
+        previous.canPresentRGB10A2PixelFormats || next.canPresentRGB10A2PixelFormats,
     };
 }
 

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
@@ -27,6 +27,10 @@
 
 #import "PresentationContext.h"
 
+#import <QuartzCore/QuartzCore.h>
+#import <optional>
+#import <wtf/text/WTFString.h>
+
 namespace WebGPU {
 
 class Device;
@@ -51,6 +55,35 @@ public:
 
 private:
     PresentationContextCoreAnimation(const WGPUSurfaceDescriptor&);
+
+    struct Configuration {
+        Configuration(uint32_t width, uint32_t height, String&& label, WGPUTextureFormat format, Device& device)
+            : width(width)
+            , height(height)
+            , label(WTFMove(label))
+            , format(format)
+            , device(device)
+        {
+        }
+
+        struct FrameState {
+            id<CAMetalDrawable> currentDrawable;
+            RefPtr<TextureView> currentTextureView;
+        };
+
+        FrameState generateCurrentFrameState(CAMetalLayer *);
+
+        std::optional<FrameState> currentFrameState;
+        uint32_t width { 0 };
+        uint32_t height { 0 };
+        String label;
+        WGPUTextureFormat format { WGPUTextureFormat_Undefined };
+        Ref<Device> device;
+    };
+
+
+    CAMetalLayer *m_layer { nil };
+    std::optional<Configuration> m_configuration;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -27,7 +27,6 @@
 #import "PresentationContextIOSurface.h"
 
 #import "APIConversions.h"
-#import "Adapter.h"
 
 // borrowed from pal/spi/cocoa/IOTypesSPI.h
 #if PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)

--- a/Tools/WebGPUPlayground/AppPlayground/WebGPUCoordinator.m
+++ b/Tools/WebGPUPlayground/AppPlayground/WebGPUCoordinator.m
@@ -224,6 +224,7 @@
         WGPUPresentMode_Immediate
     };
     swapChain = wgpuDeviceCreateSwapChain(device, surface, &swapChainDescriptor);
+    view.device = ((CAMetalLayer *)view.layer).device;
 }
 
 @end


### PR DESCRIPTION
#### 626bc3146478155fc72b5c49b5282e5032a864d1
<pre>
[WebGPU] Implement PresentationContextCoreAnimation
<a href="https://bugs.webkit.org/show_bug.cgi?id=250775">https://bugs.webkit.org/show_bug.cgi?id=250775</a>
rdar://104388628

Reviewed by Dean Jackson.

This is enough for us to be able to use WebGPUPlayground&apos;s AppPlayground for
WebGPU development.

No tests because there is no behavior change (from WebKit&apos;s perspective).

* Source/WebGPU/WebGPU/HardwareCapabilities.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::apple3):
(WebGPU::apple4):
(WebGPU::apple5):
(WebGPU::apple6):
(WebGPU::apple7):
(WebGPU::mac2):
(WebGPU::mergeBaseCapabilities):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h:
(WebGPU::PresentationContextCoreAnimation::Configuration::Configuration):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm:
(WebGPU::layerFromSurfaceDescriptor):
(WebGPU::PresentationContextCoreAnimation::PresentationContextCoreAnimation):
(WebGPU::PresentationContextCoreAnimation::configure):
(WebGPU::PresentationContextCoreAnimation::Configuration::generateCurrentFrameState):
(WebGPU::PresentationContextCoreAnimation::present):
(WebGPU::PresentationContextCoreAnimation::getCurrentTextureView):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Tools/WebGPUPlayground/AppPlayground/WebGPUCoordinator.m:
(-[WebGPUCoordinator mtkView:drawableSizeWillChange:]):

Canonical link: <a href="https://commits.webkit.org/259055@main">https://commits.webkit.org/259055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6c825bb30ce83b43808d59e5b6cf106742b84c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113008 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3795 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96033 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109555 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6258 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6427 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46315 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6229 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8194 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->