### PR TITLE
[WK2] Drop use of fixed-width types for size values in ArgumentCoder specializations

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -41,11 +41,11 @@ void ArgumentCoder<CString>::encode(Encoder& encoder, const CString& string)
 {
     // Special case the null string.
     if (string.isNull()) {
-        encoder << std::numeric_limits<uint32_t>::max();
+        encoder << std::numeric_limits<size_t>::max();
         return;
     }
 
-    encoder << static_cast<uint32_t>(string.length());
+    encoder << static_cast<size_t>(string.length());
     encoder.encodeSpan(string.bytes());
 }
 template void ArgumentCoder<CString>::encode<Encoder>(Encoder&, const CString&);
@@ -53,11 +53,11 @@ template void ArgumentCoder<CString>::encode<Encoder>(Encoder&, const CString&);
 template<typename Decoder>
 std::optional<CString> ArgumentCoder<CString>::decode(Decoder& decoder)
 {
-    auto length = decoder.template decode<uint32_t>();
+    auto length = decoder.template decode<size_t>();
     if (!length)
         return std::nullopt;
 
-    if (*length == std::numeric_limits<uint32_t>::max()) {
+    if (*length == std::numeric_limits<size_t>::max()) {
         // This is the null string.
         return CString();
     }
@@ -80,11 +80,11 @@ void ArgumentCoder<String>::encode(Encoder& encoder, const String& string)
 {
     // Special case the null string.
     if (string.isNull()) {
-        encoder << std::numeric_limits<uint32_t>::max();
+        encoder << std::numeric_limits<unsigned>::max();
         return;
     }
 
-    uint32_t length = string.length();
+    unsigned length = string.length();
     bool is8Bit = string.is8Bit();
 
     encoder << length << is8Bit;
@@ -100,7 +100,7 @@ template
 void ArgumentCoder<String>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, const String&);
 
 template<typename CharacterType, typename Decoder>
-static inline std::optional<String> decodeStringText(Decoder& decoder, uint32_t length)
+static inline std::optional<String> decodeStringText(Decoder& decoder, unsigned length)
 {
     auto data = decoder.template decodeSpan<CharacterType>(length);
     if (!data.data())
@@ -111,11 +111,11 @@ static inline std::optional<String> decodeStringText(Decoder& decoder, uint32_t 
 template<typename Decoder>
 WARN_UNUSED_RETURN std::optional<String> ArgumentCoder<String>::decode(Decoder& decoder)
 {
-    auto length = decoder.template decode<uint32_t>();
+    auto length = decoder.template decode<unsigned>();
     if (!length)
         return std::nullopt;
     
-    if (*length == std::numeric_limits<uint32_t>::max()) {
+    if (*length == std::numeric_limits<unsigned>::max()) {
         // This is the null string.
         return String();
     }
@@ -140,7 +140,7 @@ void ArgumentCoder<StringView>::encode(Encoder& encoder, StringView string)
         return;
     }
 
-    uint32_t length = string.length();
+    unsigned length = string.length();
     bool is8Bit = string.is8Bit();
 
     encoder << length << is8Bit;


### PR DESCRIPTION
#### d5514afba482699970de2ac435d31bb1c7acfc0b
<pre>
[WK2] Drop use of fixed-width types for size values in ArgumentCoder specializations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250777">https://bugs.webkit.org/show_bug.cgi?id=250777</a>

Reviewed by Kimmo Kinnunen.

Instead of finding better or worse fixed-sized-type matches for size values in
different ArgumentCoder specializations, the types of those size values should
be used. This means simply encoding values of size_t or unsigned types.

The target type of the size value should be noted in the code, just to provide
the necessary context of what is being encoded and have it match the decoding
side. This means the size type is explicitly used either in any temporary
variable where the value is stored, or an additional static_cast is used to
explicitly specify the type when the value is passed to the stream insertion
operator.

This still leaves open the possibility of using mismatched types, i.e. the
size value type not matching what the encoding enforces. Some sort of validation
could be implemented in the encoder class to make sure no undesired narrowing
conversions occur.

* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;CString&gt;::encode):
(IPC::ArgumentCoder&lt;CString&gt;::decode):
(IPC::ArgumentCoder&lt;String&gt;::encode):
(IPC::decodeStringText):
(IPC::ArgumentCoder&lt;String&gt;::decode):
(IPC::ArgumentCoder&lt;StringView&gt;::encode):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/259488@main">https://commits.webkit.org/259488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e44e2be5e91be15b0c858c05dc005c69c7709a50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113627 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4406 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112665 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38871 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25919 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80540 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6850 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6979 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3829 "Found 2 new test failures: fast/images/avif-as-image.html, fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46834 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6544 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8773 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->