### PR TITLE
De-duplicate feature flags from Settings.yaml that are provided by UnifiedWebPreferences.yaml

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (c) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1591,11 +1591,11 @@ DataDetectorTypes:
   condition: ENABLE(DATA_DETECTION)
   defaultValue:
     WebKitLegacy:
-      default: 0
+      default: DataDetectorType::None
     WebKit:
-      default: 0
+      default: DataDetectorType::None
     WebCore:
-      default: '{ }'
+      default: DataDetectorType::None
 
 # FIXME: This is on by default in WebKit2 (for everything but WatchOS). Perhaps we should consider turning it on for WebKitLegacy as well.
 DataListElementEnabled:
@@ -5677,9 +5677,9 @@ SystemLayoutDirection:
   status: embedder
   defaultValue:
     WebKitLegacy:
-      default: 0
+      default: TextDirection::LTR
     WebKit:
-      default: 0
+      default: TextDirection::LTR
     WebCore:
       default: TextDirection::LTR
 
@@ -6154,9 +6154,9 @@ UserInterfaceDirectionPolicy:
   status: embedder
   defaultValue:
     WebKitLegacy:
-      default: 0
+      default: UserInterfaceDirectionPolicy::Content
     WebKit:
-      default: 0
+      default: UserInterfaceDirectionPolicy::Content
     WebCore:
       default: UserInterfaceDirectionPolicy::Content
 

--- a/Source/WebCore/editing/cocoa/DataDetectorType.h
+++ b/Source/WebCore/editing/cocoa/DataDetectorType.h
@@ -30,6 +30,7 @@
 namespace WebCore {
 
 enum class DataDetectorType : uint8_t {
+    None = 0,
     PhoneNumber = 1 << 0,
     Link = 1 << 1,
     Address = 1 << 2,

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Apple Inc. All rights reserved.
+# Copyright (c) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -82,14 +82,6 @@ CrossOriginCheckInGetMatchedCSSRulesDisabled:
     WebCore:
       default: false
 
-DataDetectorTypes:
-  type: uint32_t
-  refinedType: DataDetectorType
-  condition: ENABLE(DATA_DETECTION)
-  defaultValue:
-    WebCore:
-      default: '{ }'
-
 DefaultVideoPosterURL:
   comment: >-
     Some apps could have a default video poster if it is not set.
@@ -97,12 +89,6 @@ DefaultVideoPosterURL:
   defaultValue:
     WebCore:
       default: '{ }'
-
-DisableScreenSizeOverride:
-  type: bool
-  defaultValue:
-    WebCore:
-      default: false
 
 DownloadableBinaryFontAllowedTypes:
   comment: >-
@@ -114,13 +100,6 @@ DownloadableBinaryFontAllowedTypes:
     WebCore:
       PLATFORM(WATCHOS): DownloadableBinaryFontAllowedTypes::None
       default: DownloadableBinaryFontAllowedTypes::Any
-
-EditableLinkBehavior:
-  type: uint32_t
-  refinedType: EditableLinkBehavior
-  defaultValue:
-    WebCore:
-      default: EditableLinkBehavior::Default
 
 EditingBehaviorType:
   type: uint32_t
@@ -253,12 +232,6 @@ ImagesEnabled:
     WebCore:
       default: true
 
-IsAccessibilityIsolatedTreeEnabled:
-  type: bool
-  defaultValue:
-    WebCore:
-      default: false
-
 IsPerActivityStateCPUUsageMeasurementEnabled:
   type: bool
   defaultValue:
@@ -294,13 +267,6 @@ IsPostLoadMemoryUsageMeasurementEnabled:
       PLATFORM(COCOA): true
       default: false
 
-JavaScriptRuntimeFlags:
-  type: uint32_t
-  refinedType: JSC::RuntimeFlags
-  defaultValue:
-    WebCore:
-      default: '{ }'
-
 LangAttributeAwareFormControlUIEnabled:
   type: bool
   defaultValue:
@@ -334,13 +300,6 @@ MaximumSourceBufferSize:
   defaultValue:
     WebCore:
       default: 318767104
-
-MediaDeviceIdentifierStorageDirectory:
-  type: String
-  condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebCore:
-      default: '{ }'
 
 MediaKeysStorageDirectory:
   type: String
@@ -483,13 +442,6 @@ StorageBlockingPolicy:
     WebCore:
       default: StorageBlockingPolicy::AllowAll
 
-SystemLayoutDirection:
-  type: uint32_t
-  refinedType: TextDirection
-  defaultValue:
-    WebCore:
-      default: TextDirection::LTR
-
 TextAutosizingWindowSizeOverrideHeight:
   type: uint32_t
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
@@ -552,13 +504,6 @@ UseAnonymousModeWhenFetchingMaskImages:
   defaultValue:
     WebCore:
       default: true
-
-UserInterfaceDirectionPolicy:
-  type: uint32_t
-  refinedType: UserInterfaceDirectionPolicy
-  defaultValue:
-    WebCore:
-      default: UserInterfaceDirectionPolicy::Content
 
 UserStyleSheetLocation:
   type: String

--- a/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
+++ b/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
@@ -36,7 +36,7 @@
 #if <%= @pref.condition %>
 <%-   end -%>
 <%-   if @pref.defaultValues.size() == 1 -%>
-#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= @pref.defaultValues['default'] %>
+#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= @pref.downcast %><%= @pref.defaultValues['default'] %><%= ")" if @pref.downcast %>
 <%-   else -%>
 <%-     @pref.defaultValues.each_with_index do |(key, value), index| -%>
 <%-       if index == 0 -%>
@@ -46,7 +46,7 @@
 <%-       else -%>
 #else
 <%-       end -%>
-#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= value %>
+#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= @pref.downcast %><%= value %><%= ")" if @pref.downcast %>
 <%-     end -%>
 #endif
 <%-   end -%>


### PR DESCRIPTION
#### 6eb6b7e29314edc08edee2733bb39e89b27d31c4
<pre>
De-duplicate feature flags from Settings.yaml that are provided by UnifiedWebPreferences.yaml
<a href="https://bugs.webkit.org/show_bug.cgi?id=250778">https://bugs.webkit.org/show_bug.cgi?id=250778</a>
&lt;rdar://problem/104389479&gt;

Reviewed by Elliott Williams.

A number of preferences defined in UnifiedWebPreferences.yaml are duplicated in Settings.yaml.
The generator handles this case properly, but it&apos;s confusing to developers.

This patch also removed the unused MediaDeviceIdentifierStorageDirectory item.

It also restores the &apos;Settings.yaml&apos; file to the Xcode project so that search will
locate items within it.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Clean up duplicates.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Add missing Settings.yaml file.
* Source/WebCore/editing/cocoa/DataDetectorType.h: Add a &apos;None&apos; case.
* Source/WebCore/page/Settings.yaml: Remove duplicates.
* Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb: Downcast enums to integral types.

Canonical link: <a href="https://commits.webkit.org/259101@main">https://commits.webkit.org/259101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/033302471d6306f80bc1cda4cb69749fe9ef3aa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113041 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173351 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3827 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96063 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112152 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38479 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80132 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93928 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26819 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90384 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4056 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3358 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29843 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46342 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98993 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6266 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8224 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24913 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->