### PR TITLE
[GTK][WPE] Fix compilation with  ENABLE_WEBGL=OFF

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -155,8 +155,10 @@ void CanvasCaptureMediaStreamTrack::Source::canvasResized(CanvasBase& canvas)
 void CanvasCaptureMediaStreamTrack::Source::canvasChanged(CanvasBase& canvas, const std::optional<FloatRect>&)
 {
     ASSERT_UNUSED(canvas, m_canvas == &canvas);
+#if ENABLE(WEBGL)
     if (m_canvas->renderingContext() && m_canvas->renderingContext()->needsPreparationForDisplay())
         return;
+#endif
     scheduleCaptureCanvas();
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -138,12 +138,14 @@ static const char* hardwareAccelerationPolicy(WebKitURISchemeRequest* request)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+#if ENABLE(WEBGL)
 static bool webGLEnabled(WebKitURISchemeRequest* request)
 {
     auto* webView = webkit_uri_scheme_request_get_web_view(request);
     ASSERT(webView);
     return webkit_settings_get_enable_webgl(webkit_web_view_get_settings(webView));
 }
+#endif
 
 static const char* openGLAPI(bool isEGL)
 {


### PR DESCRIPTION
#### 7014a00d589b4bb4385e9e7489293d523ed608dd
<pre>
[GTK][WPE] Fix compilation with  ENABLE_WEBGL=OFF
<a href="https://bugs.webkit.org/show_bug.cgi?id=250783">https://bugs.webkit.org/show_bug.cgi?id=250783</a>

Reviewed by Adrian Perez de Castro.

Add guards to a couple of code sections that depend on WebGL
functions.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::canvasChanged):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:

Canonical link: <a href="https://commits.webkit.org/259065@main">https://commits.webkit.org/259065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc4f8f7701c184d60b3bd7dbd6aeba8d7094b57f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113004 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173325 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3791 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96030 "Failed to checkout and rebase branch from PR 8788") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112125 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93794 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96030 "Failed to checkout and rebase branch from PR 8788") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25401 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96030 "Failed to checkout and rebase branch from PR 8788") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3327 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6236 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8190 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->