### PR TITLE
[WK2] Provide IPC encoding, decoding helper methods for objects

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -80,16 +80,16 @@ private:
 template<class Encoder>
 void CAAudioStreamDescription::encode(Encoder& encoder) const
 {
-    encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&m_streamDescription), sizeof(m_streamDescription), 1);
+    encoder.encodeObject(m_streamDescription);
 }
 
 template<class Decoder>
 std::optional<CAAudioStreamDescription> CAAudioStreamDescription::decode(Decoder& decoder)
 {
-    AudioStreamBasicDescription asbd { };
-    if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&asbd), sizeof(asbd), 1))
+    auto asbd = decoder.template decodeObject<AudioStreamBasicDescription>();
+    if (!asbd)
         return std::nullopt;
-    return CAAudioStreamDescription { asbd };
+    return CAAudioStreamDescription { *asbd };
 }
 
 inline CAAudioStreamDescription toCAAudioStreamDescription(const AudioStreamDescription& description)

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -62,12 +62,12 @@ template<typename T> struct SimpleArgumentCoder {
     template<typename Encoder>
     static void encode(Encoder& encoder, const T& t)
     {
-        encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&t), sizeof(T), alignof(T));
+        encoder.encodeObject(t);
     }
 
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, T& t)
+    static std::optional<T> decode(Decoder& decoder)
     {
-        return decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&t), sizeof(T), alignof(T));
+        return decoder.decodeObject<T>();
     }
 };
 

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -96,6 +96,9 @@ public:
     WARN_UNUSED_RETURN Span<const T> decodeSpan(size_t);
 
     template<typename T>
+    WARN_UNUSED_RETURN std::optional<T> decodeObject();
+
+    template<typename T>
     WARN_UNUSED_RETURN bool decode(T& t)
     {
         using Impl = ArgumentCoder<std::remove_cvref_t<T>, void>;
@@ -242,6 +245,18 @@ inline Span<const T> Decoder::decodeSpan(size_t size)
 
     m_bufferPos = alignedPosition + size * sizeof(T);
     return { reinterpret_cast<const T*>(alignedPosition), size };
+}
+
+template<typename T>
+inline std::optional<T> Decoder::decodeObject()
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+
+    auto data = decodeSpan<T>(1);
+    if (!data.data())
+        return std::nullopt;
+
+    return data[0];
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -70,6 +70,8 @@ public:
     void encodeFixedLengthData(const uint8_t* data, size_t, size_t alignment);
     template<typename T, size_t Extent>
     void encodeSpan(const Span<T, Extent>&);
+    template<typename T>
+    void encodeObject(const T&);
 
     template<typename T>
     Encoder& operator<<(T&& t)
@@ -114,6 +116,13 @@ template<typename T, size_t Extent>
 inline void Encoder::encodeSpan(const Span<T, Extent>& data)
 {
     encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.data()), data.size_bytes(), alignof(T));
+}
+
+template<typename T>
+inline void Encoder::encodeObject(const T& object)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    encodeSpan(Span { std::addressof(object), 1 });
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -76,6 +76,13 @@ public:
     }
 
     template<typename T>
+    bool encodeObject(const T& object)
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        return encodeSpan(Span { std::addressof(object), 1 });
+    }
+
+    template<typename T>
     StreamConnectionEncoder& operator<<(T&& t)
     {
         ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -262,9 +262,9 @@ void ArgumentCoder<RectEdges<bool>>::encode(Encoder& encoder, const RectEdges<bo
     SimpleArgumentCoder<RectEdges<bool>>::encode(encoder, boxEdges);
 }
     
-bool ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder, RectEdges<bool>& boxEdges)
+std::optional<RectEdges<bool>> ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder)
 {
-    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder, boxEdges);
+    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder);
 }
 
 #if ENABLE(META_VIEWPORT)
@@ -273,17 +273,9 @@ void ArgumentCoder<ViewportArguments>::encode(Encoder& encoder, const ViewportAr
     SimpleArgumentCoder<ViewportArguments>::encode(encoder, viewportArguments);
 }
 
-bool ArgumentCoder<ViewportArguments>::decode(Decoder& decoder, ViewportArguments& viewportArguments)
-{
-    return SimpleArgumentCoder<ViewportArguments>::decode(decoder, viewportArguments);
-}
-
 std::optional<ViewportArguments> ArgumentCoder<ViewportArguments>::decode(Decoder& decoder)
 {
-    ViewportArguments viewportArguments;
-    if (!SimpleArgumentCoder<ViewportArguments>::decode(decoder, viewportArguments))
-        return std::nullopt;
-    return viewportArguments;
+    return SimpleArgumentCoder<ViewportArguments>::decode(decoder);
 }
 
 #endif // ENABLE(META_VIEWPORT)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -222,13 +222,12 @@ template<> struct ArgumentCoder<WebCore::DOMCacheEngine::Record> {
 
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::RectEdges<bool>&);
+    static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
 };
 
 #if ENABLE(META_VIEWPORT)
 template<> struct ArgumentCoder<WebCore::ViewportArguments> {
     static void encode(Encoder&, const WebCore::ViewportArguments&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ViewportArguments&);
     static std::optional<WebCore::ViewportArguments> decode(Decoder&);
 };
 #endif

--- a/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
+++ b/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
@@ -39,14 +39,11 @@ using namespace WebCore;
 template<> struct ArgumentCoder<LOGFONT> {
     static void encode(Encoder& encoder, const LOGFONT& logFont)
     {
-        encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&logFont), sizeof logFont, 1);
+        encoder.encodeObject(logFont);
     }
     static std::optional<LOGFONT> decode(Decoder& decoder)
     {
-        LOGFONT logFont;
-        if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&logFont), sizeof(logFont), 1))
-            return std::nullopt;
-        return logFont;
+        return decoder.decodeObject<LOGFONT>();
     }
 };
 


### PR DESCRIPTION
#### 4e2a24122f1668f09693e0df1510bd07da46fe46
<pre>
[WK2] Provide IPC encoding, decoding helper methods for objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=250785">https://bugs.webkit.org/show_bug.cgi?id=250785</a>

Reviewed by Kimmo Kinnunen.

Provide helper methods for encoding trivially-copyable objects on the IPC
encoder and decoder classes. These would be used instead of encoding and
decoding these objects as fixed-length data. That would of course still be done
internally, but through a nicer interface.

encodeObject() on the IPC::Encoder and IPC::StreamConnectionEncoder classes
takes a given object of a trivially-copyable type and encodes it as fixed-length
data through a single-element Span. decodeObject() on the IPC::Decoder class
reverses that, decoding a single-element Span and returning an object of a
trivially-copyable type.

Remaining uses of encodeFixedLengthData() and decodeFixedLengthData() methods
are replaced with the new alternatives.

* Source/WTF/wtf/ArgumentCoder.h:
(IPC::ArgumentCoder&lt;bool&gt;::decode):
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
(WebCore::CAAudioStreamDescription::encode const):
(WebCore::CAAudioStreamDescription::decode):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::CapabilityValueOrRange::encode const):
(WebCore::CapabilityValueOrRange::decode):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::SimpleArgumentCoder::encode):
(IPC::SimpleArgumentCoder::decode):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decodeObject):
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::encodeObject):
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RectEdges&lt;bool&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;ViewportArguments&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp:
(IPC::ArgumentCoder&lt;LOGFONT&gt;::encode):
(IPC::ArgumentCoder&lt;LOGFONT&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/259638@main">https://commits.webkit.org/259638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f405164a7daa15ace4e4e4ffebaf901470d31f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114742 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15868 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97777 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95148 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26783 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28139 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93368 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5631 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30375 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47682 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102075 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6649 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25457 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->