### PR TITLE
[iOS] Fix release assertion in WebKit::ProcessThrottler::didConnectToProcess

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -232,7 +232,7 @@ void ProcessThrottler::didConnectToProcess(ProcessID pid)
 
     m_processIdentifier = pid;
     updateThrottleStateNow();
-    RELEASE_ASSERT(m_assertion);
+    RELEASE_ASSERT(m_assertion || (m_state == ProcessThrottleState::Suspended && !m_shouldTakeSuspendedAssertion));
 }
     
 void ProcessThrottler::prepareToSuspendTimeoutTimerFired()


### PR DESCRIPTION
#### 2663e6d98e20416821cc0c1bac5df85235e42342
<pre>
[iOS] Fix release assertion in WebKit::ProcessThrottler::didConnectToProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=250789">https://bugs.webkit.org/show_bug.cgi?id=250789</a>

Reviewed by Chris Dumez.

This assertion needs to be updated after adding the option to drop the
&apos;Suspended&apos; assertion.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::didConnectToProcess):

Canonical link: <a href="https://commits.webkit.org/259137@main">https://commits.webkit.org/259137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc769b8631f9f8b49551067fe935edd9824e5733

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113025 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3811 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96047 "Failed to checkout and rebase branch from PR 8793") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112138 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93813 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96047 "Failed to checkout and rebase branch from PR 8793") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25421 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96047 "Failed to checkout and rebase branch from PR 8793") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26808 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3347 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46331 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8209 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3334 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->