### PR TITLE
[Flatpak SDK] Update Mold to version 1.9.0

### DIFF
--- a/Tools/buildstream/elements/sdk/hwloc.bst
+++ b/Tools/buildstream/elements/sdk/hwloc.bst
@@ -13,5 +13,11 @@ variables:
 
 sources:
 - kind: tar
-  url: https://download.open-mpi.org/release/hwloc/v2.8/hwloc-2.8.0.tar.bz2
-  ref: 348a72fcd48c32a823ee1da149ae992203e7ad033549e64aed6ea6eeb01f42c1
+  url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.0.tar.bz2
+  ref: 2070e963596a2421b9af8eca43bdec113ee1107aaf7ccb475d4d3767a8856887
+
+public:
+  bst:
+    integration-commands:
+    - |
+      hwloc-info --version

--- a/Tools/buildstream/elements/sdk/mold.bst
+++ b/Tools/buildstream/elements/sdk/mold.bst
@@ -1,11 +1,22 @@
-kind: make
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+
 depends:
 - freedesktop-sdk.bst:bootstrap-import.bst
-- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+- freedesktop-sdk.bst:components/zstd.bst
 - sdk/tbb.bst
 
 variables:
-  make: make PREFIX="%{prefix}" LTO=1 SYSTEM_TBB=1
+  cmake-local: |
+    -DMOLD_USE_MOLD=OFF \
+    -DMOLD_USE_ASAN=OFF \
+    -DMOLD_USE_TSAN=OFF \
+    -DMOLD_USE_SYSTEM_MIMALLOC=OFF \
+    -DMOLD_USE_SYSTEM_TBB=ON \
+    -DMOLD_LTO=ON \
+    -DMOLD_MOSTLY_STATIC=OFF
 
 sources:
 - kind: git_tag
@@ -13,4 +24,10 @@ sources:
   checkout-submodules: false
   track-tags: true
   track: main
-  ref: v1.5.1-0-g1ed941f3f0c3a7e55ba5d34a9f9f0fe7f67cb90d
+  ref: v1.9.0-0-gad0b6d0ac6a9b269935c3fbf4dae2815395431a4
+
+public:
+  bst:
+    integration-commands:
+    - |
+      mold --version


### PR DESCRIPTION
#### 892b93e3e0432a317e69130f7bc18d9375021ac8
<pre>
[Flatpak SDK] Update Mold to version 1.9.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=250796">https://bugs.webkit.org/show_bug.cgi?id=250796</a>

Reviewed by Philippe Normand.

Update Mold and the hwloc dependency to their latest versions, and add
integration commands. The Mold element needed a few additional changes
due to upstream changing their build system from plain Make to CMake.
While at it, properly separate the element&apos;s build dependency, and add
the zstd one, which is now required by Mold.

* Tools/buildstream/elements/sdk/hwloc.bst: Bump version, add
  integration command.
* Tools/buildstream/elements/sdk/mold.bst: Bump version, update to the
  new CMake build system, fix dependencies, and add integration command.

Canonical link: <a href="https://commits.webkit.org/259073@main">https://commits.webkit.org/259073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc58fc9af38387b2239caae544ed1f4bc8944b73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113029 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173342 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3815 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96051 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112142 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38467 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80118 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26817 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3349 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46340 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6241 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8213 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->