### PR TITLE
[ews-build.webkit.org] Use super for parent class invocations

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -798,7 +798,7 @@ class ShowIdentifier(shell.ShellCommand):
     haltOnFailure = False
 
     def __init__(self, **kwargs):
-        shell.ShellCommand.__init__(self, timeout=5 * 60, logEnviron=False, **kwargs)
+        super().__init__(timeout=5 * 60, logEnviron=False, **kwargs)
 
     def start(self):
         self.log_observer = logobserver.BufferLogObserver()
@@ -813,10 +813,10 @@ class ShowIdentifier(shell.ShellCommand):
                 break
 
         self.setCommand(['python3', 'Tools/Scripts/git-webkit', 'find', revision])
-        return shell.ShellCommand.start(self)
+        return super().start()
 
     def evaluateCommand(self, cmd):
-        rc = shell.ShellCommand.evaluateCommand(self, cmd)
+        rc = super().evaluateCommand(cmd)
         if rc != SUCCESS:
             return rc
 
@@ -851,7 +851,7 @@ class ShowIdentifier(shell.ShellCommand):
     def getResultSummary(self):
         if self.results != SUCCESS:
             return {'step': 'Failed to find identifier'}
-        return shell.ShellCommand.getResultSummary(self)
+        return super().getResultSummary()
 
     def hideStepIf(self, results, step):
         return results == SUCCESS
@@ -1232,7 +1232,7 @@ class FindModifiedLayoutTests(AnalyzeChange):
 
     def __init__(self, skipBuildIfNoResult=True):
         self.skipBuildIfNoResult = skipBuildIfNoResult
-        buildstep.BuildStep.__init__(self)
+        super().__init__()
 
     def find_test_names_from_patch(self, patch):
         tests = []
@@ -1584,7 +1584,7 @@ class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
         self.verifyNoDraftForMergeQueue = verifyNoDraftForMergeQueue
         self.enableSkipEWSLabel = enableSkipEWSLabel
         self.addURLs = addURLs
-        buildstep.BuildStep.__init__(self)
+        super().__init__()
 
     def getResultSummary(self):
         if self.results == FAILURE:
@@ -2880,7 +2880,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin):
     NUM_FAILURES_TO_DISPLAY_IN_STATUS = 5
 
     def __init__(self, **kwargs):
-        shell.Test.__init__(self, logEnviron=False, sigtermTime=10, **kwargs)
+        super().__init__(logEnviron=False, sigtermTime=10, **kwargs)
         self.binaryFailures = []
         self.stressTestFailures = []
         self.flaky = {}
@@ -2907,10 +2907,10 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin):
 
         self.setCommand(self.command + customBuildFlag(self.getProperty('platform'), self.getProperty('fullPlatform')))
         self.command.extend(self.command_extra)
-        return shell.Test.start(self)
+        return super().start()
 
     def evaluateCommand(self, cmd):
-        rc = shell.Test.evaluateCommand(self, cmd)
+        rc = super().evaluateCommand(cmd)
         if rc == SUCCESS or rc == WARNINGS:
             message = 'Passed JSC tests'
             self.descriptionDone = message
@@ -2928,7 +2928,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin):
         return rc
 
     def commandComplete(self, cmd):
-        shell.Test.commandComplete(self, cmd)
+        super().commandComplete(cmd)
         logLines = self.log_observer_json.getStdout()
         json_text = ''.join([line for line in logLines.splitlines()])
         try:
@@ -2976,7 +2976,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin):
         elif self.results == SUCCESS and self.flaky:
             return {'step': "Passed JSC tests (%d flaky)" % len(self.flaky)}
 
-        return shell.Test.getResultSummary(self)
+        return super().getResultSummary()
 
 
 class RunJSCTestsWithoutChange(RunJavaScriptCoreTests):
@@ -3193,7 +3193,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
                WithProperties('--%(configuration)s')]
 
     def __init__(self, **kwargs):
-        shell.Test.__init__(self, logEnviron=False, **kwargs)
+        super().__init__(logEnviron=False, **kwargs)
         self.incorrectLayoutLines = []
         self.failing_tests_filtered = []
         self.preexisting_failures_in_results_db = []
@@ -3233,7 +3233,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
         self.log_observer_json = logobserver.BufferLogObserver()
         self.addLogObserver('json', self.log_observer_json)
         self.setLayoutTestCommand()
-        return shell.Test.start(self)
+        return super().start()
 
     # FIXME: This will break if run-webkit-tests changes its default log formatter.
     nrwt_log_message_regexp = re.compile(r'\d{2}:\d{2}:\d{2}(\.\d+)?\s+\d+\s+(?P<message>.*)')
@@ -3274,7 +3274,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
 
     @defer.inlineCallbacks
     def runCommand(self, command):
-        yield shell.Test.runCommand(self, command)
+        yield super().runCommand(command)
 
         logText = self.log_observer.getStdout() + self.log_observer.getStderr()
         logTextJson = self.log_observer_json.getStdout()
@@ -4237,7 +4237,7 @@ class UploadBuiltProduct(transfer.FileUpload):
         kwargs['masterdest'] = self.masterdest
         kwargs['mode'] = 0o0644
         kwargs['blocksize'] = 1024 * 256
-        transfer.FileUpload.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def getResultSummary(self):
         if self.results != SUCCESS:
@@ -4258,7 +4258,7 @@ class TransferToS3(master.MasterShellCommand):
 
     def __init__(self, **kwargs):
         kwargs['command'] = self.command
-        master.MasterShellCommand.__init__(self, logEnviron=False, **kwargs)
+        super().__init__(logEnviron=False, **kwargs)
 
     def start(self):
         self.log_observer = logobserver.BufferLogObserver(wantStderr=True)
@@ -4333,7 +4333,7 @@ class DownloadBuiltProductFromMaster(transfer.FileDownload):
         kwargs['workerdest'] = self.workerdest
         kwargs['mode'] = 0o0644
         kwargs['blocksize'] = 1024 * 256
-        transfer.FileDownload.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def getResultSummary(self):
         if self.results != SUCCESS:
@@ -4599,7 +4599,7 @@ class UploadTestResults(transfer.FileUpload):
         kwargs['masterdest'] = Interpolate('public_html/results/%(prop:buildername)s/%(prop:change_id)s-%(prop:buildnumber)s{}.zip'.format(identifier))
         kwargs['mode'] = 0o0644
         kwargs['blocksize'] = 1024 * 256
-        transfer.FileUpload.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
 
 class ExtractTestResults(master.MasterShellCommand):
@@ -4617,7 +4617,7 @@ class ExtractTestResults(master.MasterShellCommand):
         self.resultDirectory = Interpolate('public_html/results/%(prop:buildername)s/%(prop:change_id)s-%(prop:buildnumber)s{}'.format(identifier))
         self.command = ['unzip', '-q', '-o', self.zipFile, '-d', self.resultDirectory]
 
-        master.MasterShellCommand.__init__(self, command=self.command, logEnviron=False)
+        super().__init__(command=self.command, logEnviron=False)
 
     def resultDirectoryURL(self):
         path = self.resultDirectory.replace('public_html/results/', '') + '/'
@@ -4769,7 +4769,7 @@ class ApplyWatchList(shell.ShellCommand):
     flunkOnFailure = True
 
     def __init__(self, **kwargs):
-        shell.ShellCommand.__init__(self, timeout=2 * 60, logEnviron=False, **kwargs)
+        super().__init__(timeout=2 * 60, logEnviron=False, **kwargs)
 
     def getResultSummary(self):
         if self.results != SUCCESS:


### PR DESCRIPTION
#### 419bb9a7d871315e65087dc79d8d0971db5acb82
<pre>
[ews-build.webkit.org] Use super for parent class invocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250799">https://bugs.webkit.org/show_bug.cgi?id=250799</a>
rdar://104400449

Reviewed by Aakash Jain.

As we change classes to new-style for our work migrating to Twisted
defer, we should have classes invoke methods via &apos;super&apos; so that
code breaks quickly if we change the parent class.

* Tools/CISupport/ews-build/steps.py:
(ShowIdentifier.__init__): Use super instead of directly invoking a class method.
(ShowIdentifier.start): Ditto.
(ShowIdentifier.evaluateCommand): Ditto.
(ShowIdentifier.getResultSummary): Ditto.
(FindModifiedLayoutTests.__init__): Ditto.
(ValidateChange): Ditto.
(RunJavaScriptCoreTests.__init__): Ditto.
(RunJavaScriptCoreTests.start): Ditto.
(RunJavaScriptCoreTests.evaluateCommand): Ditto.
(RunJavaScriptCoreTests.commandComplete): Ditto.
(RunJavaScriptCoreTests.getResultSummary): Ditto.
(RunJSCTestsWithoutChange.evaluateCommand): Ditto.
(RunWebKitTests.__init__): Ditto.
(RunWebKitTests.start): Ditto.
(RunWebKitTests.runCommand): Ditto.
(UploadBuiltProduct.__init__): Ditto.
(TransferToS3.__init__): Ditto.
(DownloadBuiltProductFromMaster.__init__): Ditto.
(UploadTestResults.__init__): Ditto.
(ExtractTestResults.__init__): Ditto.
(ApplyWatchList.__init__): Ditto.

Canonical link: <a href="https://commits.webkit.org/259233@main">https://commits.webkit.org/259233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7417b647ca4be7a8983a6ccef5d94573c888a1dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113616 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4395 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96627 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110167 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93103 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6839 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103244 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12995 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3364 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->