### PR TITLE
REGRESSION(258644@main): The <select> control looks dark when zooming in

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -374,9 +374,9 @@ void GraphicsContext::drawPattern(ImageBuffer& image, const FloatRect& destRect,
     image.drawPattern(*this, destRect, tileRect, patternTransform, phase, spacing, options);
 }
 
-void GraphicsContext::drawControlPart(ControlPart& part, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void GraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    part.draw(*this, rect, deviceScaleFactor, style);
+    part.draw(*this, borderRect, deviceScaleFactor, style);
 }
 
 void GraphicsContext::clipRoundedRect(const FloatRoundedRect& rect)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -272,7 +272,7 @@ public:
     virtual void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& = { }) = 0;
     WEBCORE_EXPORT virtual void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& = { });
 
-    WEBCORE_EXPORT virtual void drawControlPart(ControlPart&, const FloatRect&, float deviceScaleFactor, const ControlStyle&);
+    WEBCORE_EXPORT virtual void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&);
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT virtual void paintFrameForMedia(MediaPlayer&, const FloatRect& destination);

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -27,6 +27,7 @@
 #include "ControlPart.h"
 
 #include "ControlFactory.h"
+#include "FloatRoundedRect.h"
 #include "GraphicsContext.h"
 
 namespace WebCore {
@@ -68,7 +69,7 @@ FloatRect ControlPart::rectForBounds(const FloatRect& bounds, const ControlStyle
     return platformControl->rectForBounds(bounds, style);
 }
 
-void ControlPart::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style) const
+void ControlPart::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style) const
 {
     auto platformControl = this->platformControl();
     if (!platformControl)
@@ -78,8 +79,8 @@ void ControlPart::draw(GraphicsContext& context, const FloatRect& rect, float de
     // smaller than the layer bounds (e.g. tiled layers)
     platformControl->setFocusRingClipRect(context.clipBounds());
 
-    platformControl->updateCellStates(rect, style);
-    platformControl->draw(context, rect, deviceScaleFactor, style);
+    platformControl->updateCellStates(borderRect.rect(), style);
+    platformControl->draw(context, borderRect, deviceScaleFactor, style);
 
     platformControl->setFocusRingClipRect({ });
 }

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -47,7 +47,7 @@ public:
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&);
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) const;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) const;
 
 protected:
     WEBCORE_EXPORT ControlPart(StyleAppearance);

--- a/Source/WebCore/platform/graphics/controls/PlatformControl.h
+++ b/Source/WebCore/platform/graphics/controls/PlatformControl.h
@@ -33,6 +33,7 @@ namespace WebCore {
 class ControlPart;
 class GraphicsContext;
 class FloatRect;
+class FloatRoundedRect;
 
 class PlatformControl {
     WTF_MAKE_FAST_ALLOCATED;
@@ -53,7 +54,7 @@ public:
 
     virtual FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const { return bounds; }
 
-    virtual void draw(GraphicsContext&, const FloatRect&, float, const ControlStyle&) { }
+    virtual void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) { }
 
 protected:
     ControlPart& m_owningPart;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -413,9 +413,9 @@ void ClearRect::apply(GraphicsContext& context) const
     context.clearRect(m_rect);
 }
 
-DrawControlPart::DrawControlPart(ControlPart& part, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+DrawControlPart::DrawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
     : m_part(part)
-    , m_rect(rect)
+    , m_borderRect(borderRect)
     , m_deviceScaleFactor(deviceScaleFactor)
     , m_style(style)
 {
@@ -423,7 +423,7 @@ DrawControlPart::DrawControlPart(ControlPart& part, const FloatRect& rect, float
 
 void DrawControlPart::apply(GraphicsContext& context)
 {
-    context.drawControlPart(m_part, m_rect, m_deviceScaleFactor, m_style);
+    context.drawControlPart(m_part, m_borderRect, m_deviceScaleFactor, m_style);
 }
 
 void BeginTransparencyLayer::apply(GraphicsContext& context) const
@@ -868,7 +868,7 @@ void dumpItem(TextStream& ts, const ClearRect& item, OptionSet<AsTextFlag>)
 void dumpItem(TextStream& ts, const DrawControlPart& item, OptionSet<AsTextFlag>)
 {
     ts.dumpProperty("type", item.type());
-    ts.dumpProperty("rect", item.rect());
+    ts.dumpProperty("border-rect", item.borderRect());
     ts.dumpProperty("device-scale-factor", item.deviceScaleFactor());
     ts.dumpProperty("style", item.style());
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1822,10 +1822,10 @@ public:
     static constexpr bool isInlineItem = false;
     static constexpr bool isDrawingItem = true;
 
-    WEBCORE_EXPORT DrawControlPart(ControlPart&, const FloatRect&, float deviceScaleFactor, const ControlStyle&);
+    WEBCORE_EXPORT DrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&);
 
     StyleAppearance type() const { return m_part->type(); }
-    FloatRect rect() const { return m_rect; }
+    FloatRoundedRect borderRect() const { return m_borderRect; }
     float deviceScaleFactor() const { return m_deviceScaleFactor; }
     const ControlStyle& style() const { return m_style; }
 
@@ -1833,7 +1833,7 @@ public:
 
 private:
     Ref<ControlPart> m_part;
-    FloatRect m_rect;
+    FloatRoundedRect m_borderRect;
     float m_deviceScaleFactor;
     ControlStyle m_style;
 };

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -513,10 +513,10 @@ void Recorder::applyFillPattern()
 }
 #endif
 
-void Recorder::drawControlPart(ControlPart& part, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void Recorder::drawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     appendStateChangeItemIfNecessary();
-    recordDrawControlPart(part, rect, deviceScaleFactor, style);
+    recordDrawControlPart(part, borderRect, deviceScaleFactor, style);
 }
 
 void Recorder::clip(const FloatRect& rect)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -133,7 +133,7 @@ protected:
     virtual void recordStrokeEllipse(const FloatRect&) = 0;
     virtual void recordClearRect(const FloatRect&) = 0;
 
-    virtual void recordDrawControlPart(ControlPart&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) = 0;
+    virtual void recordDrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) = 0;
 
 #if USE(CG)
     virtual void recordApplyStrokePattern() = 0;
@@ -222,7 +222,7 @@ private:
     WEBCORE_EXPORT void applyFillPattern() final;
 #endif
 
-    WEBCORE_EXPORT void drawControlPart(ControlPart&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    WEBCORE_EXPORT void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 
     WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -374,9 +374,9 @@ void RecorderImpl::recordClearRect(const FloatRect& rect)
     append<ClearRect>(rect);
 }
 
-void RecorderImpl::recordDrawControlPart(ControlPart& part, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void RecorderImpl::recordDrawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    append<DrawControlPart>(part, rect, deviceScaleFactor, style);
+    append<DrawControlPart>(part, borderRect, deviceScaleFactor, style);
 }
 
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -111,7 +111,7 @@ private:
     void recordStrokePath(const Path&) final;
     void recordStrokeEllipse(const FloatRect&) final;
     void recordClearRect(const FloatRect&) final;
-    void recordDrawControlPart(ControlPart&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void recordDrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 #if USE(CG)
     void recordApplyStrokePattern() final;
     void recordApplyFillPattern() final;

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.h
@@ -38,16 +38,16 @@ public:
     ButtonMac(ButtonPart& owningPart, ControlFactoryMac&, NSButtonCell *);
 
 private:
-    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
-    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const final;
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
 
     NSBezelStyle bezelStyle(const FloatRect&, const ControlStyle&) const;
 
-    void updateCellStates(const FloatRect&, const ControlStyle&) final;
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
-    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const final;
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -112,7 +112,7 @@ FloatRect ButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& 
     return inflatedRect(rect, size, outsets, style);
 }
 
-void ButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void ButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -120,14 +120,14 @@ void ButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float devi
 
     GraphicsContextStateSaver stateSaver(context);
 
-    auto inflatedRect = rectForBounds(rect, style);
+    auto inflatedRect = rectForBounds(borderRect.rect(), style);
 
     if (style.zoomFactor != 1) {
         inflatedRect.scale(1 / style.zoomFactor);
         context.scale(style.zoomFactor);
     }
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
     auto *window = [view window];
     auto *previousDefaultButtonCell = [window defaultButtonCell];
 

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h
@@ -33,14 +33,14 @@ namespace WebCore {
 
 class ColorWellPart;
 
-class ColorWellMac : public ButtonControlMac {
+class ColorWellMac final : public ButtonControlMac {
 public:
     ColorWellMac(ColorWellPart& owningPart, ControlFactoryMac&, NSButtonCell *);
 
 private:
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm
@@ -46,7 +46,7 @@ void ColorWellMac::updateCellStates(const FloatRect& rect, const ControlStyle& s
     [m_buttonCell setBezelStyle:NSBezelStyleTexturedSquare];
 }
 
-void ColorWellMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void ColorWellMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -55,7 +55,7 @@ void ColorWellMac::draw(GraphicsContext& context, const FloatRect& rect, float d
     GraphicsContextStateSaver stateSaver(context);
     LocalCurrentGraphicsContext localContext(context);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
     auto *window = [view window];
     auto *previousDefaultButtonCell = [window defaultButtonCell];
 
@@ -63,7 +63,7 @@ void ColorWellMac::draw(GraphicsContext& context, const FloatRect& rect, float d
     if ([previousDefaultButtonCell isEqual:m_buttonCell.get()])
         [window setDefaultButtonCell:nil];
 
-    drawCell(context, rect, deviceScaleFactor, style, m_buttonCell.get(), view, true);
+    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_buttonCell.get(), view, true);
 
     // Restore the window default button cell.
     if (![previousDefaultButtonCell isEqual:m_buttonCell.get()])

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h
@@ -35,14 +35,14 @@ namespace WebCore {
 
 class ImageControlsButtonPart;
 
-class ImageControlsButtonMac : public ControlMac {
+class ImageControlsButtonMac final : public ControlMac {
 public:
     ImageControlsButtonMac(ImageControlsButtonPart&, ControlFactoryMac&, NSServicesRolloverButtonCell *);
 
     static IntSize servicesRolloverButtonCellSize();
 
 private:
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
     RetainPtr<NSServicesRolloverButtonCell> m_servicesRolloverButtonCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -48,16 +48,16 @@ IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
     return { };
 }
 
-void ImageControlsButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void ImageControlsButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     LocalCurrentGraphicsContext localContext(context);
     GraphicsContextStateSaver stateSaver(context);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
     
-    drawCell(context, rect, deviceScaleFactor, style, m_servicesRolloverButtonCell.get(), view, true);
+    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_servicesRolloverButtonCell.get(), view, true);
     
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h
@@ -33,14 +33,14 @@ namespace WebCore {
 
 class InnerSpinButtonPart;
 
-class InnerSpinButtonMac : public ControlMac {
+class InnerSpinButtonMac final : public ControlMac {
 public:
     InnerSpinButtonMac(InnerSpinButtonPart&, ControlFactoryMac&);
 
 private:
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "InnerSpinButtonPart.h"
 #import "LocalCurrentGraphicsContext.h"
@@ -54,7 +55,7 @@ IntSize InnerSpinButtonMac::cellSize(NSControlSize controlSize, const ControlSty
     return sizes[controlSize];
 }
 
-void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float, const ControlStyle& style)
+void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -73,7 +74,7 @@ void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRect& rect, f
         coreUIState = (__bridge NSString *)kCUIStateActive;
 
     NSString *coreUISize;
-    auto controlSize = controlSizeForSize(rect.size(), style);
+    auto controlSize = controlSizeForSize(borderRect.rect().size(), style);
     if (controlSize == NSControlSizeMini)
         coreUISize = (__bridge NSString *)kCUISizeMini;
     else if (controlSize == NSControlSizeSmall)
@@ -81,7 +82,7 @@ void InnerSpinButtonMac::draw(GraphicsContext& context, const FloatRect& rect, f
     else
         coreUISize = (__bridge NSString *)kCUISizeRegular;
 
-    IntRect logicalRect(rect);
+    IntRect logicalRect(borderRect.rect());
 
     GraphicsContextStateSaver stateSaver(context);
     if (style.zoomFactor != 1) {

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h
@@ -38,7 +38,7 @@ public:
     MenuListButtonMac(MenuListButtonPart&, ControlFactoryMac&);
 
 private:
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class MenuListPart;
 
-class MenuListMac : public ControlMac {
+class MenuListMac final : public ControlMac {
 public:
     MenuListMac(MenuListPart& owningPart, ControlFactoryMac&, NSPopUpButtonCell *);
 
@@ -45,7 +45,7 @@ private:
 
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
     RetainPtr<NSPopUpButtonCell> m_popUpButtonCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -103,13 +103,13 @@ FloatRect MenuListMac::rectForBounds(const FloatRect& bounds, const ControlStyle
     return inflatedRect(bounds, size, outsets, style);
 }
 
-void MenuListMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void MenuListMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     LocalCurrentGraphicsContext localContext(context);
 
-    auto inflatedRect = rectForBounds(rect, style);
+    auto inflatedRect = rectForBounds(borderRect.rect(), style);
 
     GraphicsContextStateSaver stateSaver(context);
 
@@ -120,7 +120,7 @@ void MenuListMac::draw(GraphicsContext& context, const FloatRect& rect, float de
 
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
 
     drawCell(context, inflatedRect, deviceScaleFactor, style, m_popUpButtonCell.get(), view, true);
 

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class MeterMac : public ControlMac {
+class MeterMac final : public ControlMac {
 public:
     MeterMac(MeterPart& owningMeterPart, ControlFactoryMac&, NSLevelIndicatorCell*);
 
@@ -43,7 +43,7 @@ private:
 
     FloatSize sizeForBounds(const FloatRect& bounds) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
     RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -88,13 +88,13 @@ FloatSize MeterMac::sizeForBounds(const FloatRect& bounds) const
     return { std::max<float>(bounds.width(), cellSize.width), std::max<float>(bounds.height(), cellSize.height) };
 }
 
-void MeterMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void MeterMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
 
-    drawCell(context, rect, deviceScaleFactor, style, m_levelIndicatorCell.get(), view);
+    drawCell(context, borderRect.rect(), deviceScaleFactor, style, m_levelIndicatorCell.get(), view);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -34,19 +34,19 @@ namespace WebCore {
 
 class ProgressBarPart;
 
-class ProgressBarMac : public ControlMac {
+class ProgressBarMac final : public ControlMac {
 public:
     ProgressBarMac(ProgressBarPart&, ControlFactoryMac&);
 
 private:
     const ProgressBarPart& owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart); }
 
-    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
-    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const final;
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
 
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -83,11 +83,11 @@ FloatRect ProgressBarMac::rectForBounds(const FloatRect& bounds, const ControlSt
     return inflatedRect(bounds, size, outsets, style);
 }
 
-void ProgressBarMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    auto inflatedRect = rectForBounds(rect, style);
+    auto inflatedRect = rectForBounds(borderRect.rect(), style);
     auto imageBuffer = context.createImageBuffer(inflatedRect.size(), deviceScaleFactor);
     if (!imageBuffer)
         return;

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.h
@@ -33,18 +33,18 @@ namespace WebCore {
 
 class SearchFieldCancelButtonPart;
 
-class SearchFieldCancelButtonMac : public SearchControlMac {
+class SearchFieldCancelButtonMac final : public SearchControlMac {
 public:
     SearchFieldCancelButtonMac(SearchFieldCancelButtonPart& owningPart, ControlFactoryMac&, NSSearchFieldCell *);
 
 private:
-    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
 
-    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const final;
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
-    void updateCellStates(const FloatRect&, const ControlStyle&) final;
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
@@ -78,7 +78,7 @@ void SearchFieldCancelButtonMac::updateCellStates(const FloatRect& rect, const C
     SearchControlMac::updateCellStates(rect, style);
 }
 
-void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
@@ -86,7 +86,7 @@ void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRect&
 
     GraphicsContextStateSaver stateSaver(context);
 
-    auto logicalRect = rectForBounds(rect, style);
+    auto logicalRect = rectForBounds(borderRect.rect(), style);
     if (style.zoomFactor != 1) {
         logicalRect.scale(1 / style.zoomFactor);
         context.scale(style.zoomFactor);
@@ -96,7 +96,7 @@ void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRect&
     auto styleForDrawing = style;
     styleForDrawing.states.remove(ControlStyle::State::Focused);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
 
     drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, [m_searchFieldCell cancelButtonCell], view, true);
 }

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.h
@@ -33,12 +33,12 @@ namespace WebCore {
 
 class SearchFieldPart;
 
-class SearchFieldMac : public SearchControlMac {
+class SearchFieldMac final : public SearchControlMac {
 public:
     SearchFieldMac(SearchFieldPart& owningPart, ControlFactoryMac&, NSSearchFieldCell *);
 
 private:
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
@@ -42,7 +42,7 @@ SearchFieldMac::SearchFieldMac(SearchFieldPart& owningPart, ControlFactoryMac& c
     ASSERT(searchFieldCell);
 }
 
-void SearchFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void SearchFieldMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
@@ -50,13 +50,13 @@ void SearchFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float
 
     GraphicsContextStateSaver stateSaver(context);
 
-    auto logicalRect = rect;
+    auto logicalRect = borderRect.rect();
     if (style.zoomFactor != 1) {
         logicalRect.scale(1 / style.zoomFactor);
         context.scale(style.zoomFactor);
     }
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
 
     [m_searchFieldCell setSearchButtonCell:nil];
 
@@ -65,7 +65,7 @@ void SearchFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float
     [m_searchFieldCell resetSearchButtonCell];
     
 #if ENABLE(DATALIST_ELEMENT)
-    drawListButton(context, rect, deviceScaleFactor, style);
+    drawListButton(context, borderRect.rect(), deviceScaleFactor, style);
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class SliderThumbPart;
 
-class SliderThumbMac : public ControlMac {
+class SliderThumbMac final : public ControlMac {
 public:
     SliderThumbMac(SliderThumbPart&, ControlFactoryMac&, NSSliderCell *);
 
@@ -42,7 +42,7 @@ private:
 
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
     RetainPtr<NSSliderCell> m_sliderCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
@@ -68,12 +69,12 @@ FloatRect SliderThumbMac::rectForBounds(const FloatRect& bounds, const ControlSt
     return { bounds.location(), bounds.size() + FloatSize { 0, verticalSliderHeightPadding * style.zoomFactor } };
 }
 
-void SliderThumbMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void SliderThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
     LocalCurrentGraphicsContext localContext(context);
     
-    auto logicalRect = rectForBounds(rect, style);
+    auto logicalRect = rectForBounds(borderRect.rect(), style);
 
     GraphicsContextStateSaver stateSaver(context);
 
@@ -86,7 +87,7 @@ void SliderThumbMac::draw(GraphicsContext& context, const FloatRect& rect, float
     auto styleForDrawing = style;
     styleForDrawing.states.remove(ControlStyle::State::Focused);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
 
     drawCell(context, logicalRect, deviceScaleFactor, styleForDrawing, m_sliderCell.get(), view, true);
 }

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class SliderTrackMac : public ControlMac {
+class SliderTrackMac final : public ControlMac {
 public:
     SliderTrackMac(SliderTrackPart&, ControlFactoryMac&);
 
@@ -41,7 +41,7 @@ private:
 
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -69,7 +69,7 @@ static void trackGradientInterpolate(void*, const CGFloat* inData, CGFloat* outD
         outData[i] = (1.0f - a) * dark[i] + a * light[i];
 }
 
-void SliderTrackMac::draw(GraphicsContext& context, const FloatRect& rect, float, const ControlStyle& style)
+void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {
     static constexpr int sliderTrackRadius = 2;
     static constexpr IntSize sliderRadius(sliderTrackRadius, sliderTrackRadius);
@@ -81,12 +81,12 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRect& rect, float
     auto& sliderTrackPart = owningSliderTrackPart();
 
 #if ENABLE(DATALIST_ELEMENT)
-    sliderTrackPart.drawTicks(context, rect, style);
+    sliderTrackPart.drawTicks(context, borderRect.rect(), style);
 #endif
 
     GraphicsContextStateSaver stateSaver(context);
 
-    auto logicalRect = rectForBounds(rect, style);
+    auto logicalRect = rectForBounds(borderRect.rect(), style);
     CGContextClipToRect(cgContext, logicalRect);
 
     struct CGFunctionCallbacks mainCallbacks = { 0, trackGradientInterpolate, NULL };

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h
@@ -38,7 +38,7 @@ public:
     TextAreaMac(TextAreaPart&);
 
 private:
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
@@ -40,14 +40,14 @@ TextAreaMac::TextAreaMac(TextAreaPart& owningPart)
     ASSERT(owningPart.type() == StyleAppearance::Listbox || owningPart.type() == StyleAppearance::TextArea);
 }
 
-void TextAreaMac::draw(GraphicsContext& context, const FloatRect& rect, float, const ControlStyle& style)
+void TextAreaMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {
     LocalCurrentGraphicsContext localContext(context);
 
     bool enabled = style.states.contains(ControlStyle::State::Enabled);
     bool readOnly = style.states.contains(ControlStyle::State::ReadOnly);
 
-    _NSDrawCarbonThemeListBox(rect, enabled && !readOnly, YES, YES);
+    _NSDrawCarbonThemeListBox(borderRect.rect(), enabled && !readOnly, YES, YES);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
@@ -40,7 +40,7 @@ public:
 private:
     static bool shouldPaintCustomTextField(const ControlStyle&);
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
     RetainPtr<NSTextFieldCell> m_textFieldCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
@@ -49,7 +49,7 @@ bool TextFieldMac::shouldPaintCustomTextField(const ControlStyle& style)
     return userPrefersContrast() && !style.states.contains(ControlStyle::State::DarkAppearance);
 }
 
-void TextFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void TextFieldMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     const auto& states = style.states;
     auto enabled = states.contains(ControlStyle::State::Enabled) && !states.contains(ControlStyle::State::ReadOnly);
@@ -57,7 +57,7 @@ void TextFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float d
     LocalCurrentGraphicsContext localContext(context);
     GraphicsContextStateSaver stateSaver(context);
 
-    FloatRect paintRect(rect);
+    FloatRect paintRect(borderRect.rect());
 
     if (shouldPaintCustomTextField(style)) {
         constexpr int strokeThickness = 1;
@@ -78,7 +78,7 @@ void TextFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float d
             paintRect.move(0, -1 / transform.yScale());
         }
         
-        auto *view = m_controlFactory.drawingView(rect, style);
+        auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
         
         [m_textFieldCell.get() setEnabled:enabled];
         [m_textFieldCell.get() drawWithFrame:NSRect(paintRect) inView:view];
@@ -86,7 +86,7 @@ void TextFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float d
     }
 
 #if ENABLE(DATALIST_ELEMENT)
-    drawListButton(context, rect, deviceScaleFactor, style);
+    drawListButton(context, borderRect.rect(), deviceScaleFactor, style);
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
@@ -38,13 +38,12 @@ public:
     ToggleButtonMac(ToggleButtonPart& owningPart, ControlFactoryMac&, NSButtonCell *);
 
 private:
-    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
-    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const final;
+    IntSize cellSize(NSControlSize, const ControlStyle&) const override;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 
 } // namespace WebCore
 
 #endif // PLATFORM(MAC)
-

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -95,7 +95,7 @@ IntOutsets ToggleButtonMac::cellOutsets(NSControlSize controlSize, const Control
     return (m_owningPart.type() == StyleAppearance::Checkbox ? checkboxOutsets : radioOutsets)[controlSize];
 }
 
-void ToggleButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void ToggleButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -114,7 +114,7 @@ void ToggleButtonMac::draw(GraphicsContext& context, const FloatRect& rect, floa
         outsets.left() * style.zoomFactor
     };
 
-    auto logicalRect = rect;
+    auto logicalRect = borderRect.rect();
     logicalRect.setSize(zoomedSize);
     logicalRect.expand(zoomedOutsets);
 
@@ -125,7 +125,7 @@ void ToggleButtonMac::draw(GraphicsContext& context, const FloatRect& rect, floa
 
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
-    auto *view = m_controlFactory.drawingView(rect, style);
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
 
     if ([m_buttonCell _stateAnimationRunning]) {
         context.translate(logicalRect.location());

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -741,10 +741,11 @@ bool RenderTheme::paint(const RenderBox& box, ControlPart& part, const PaintInfo
 
     float deviceScaleFactor = box.document().deviceScaleFactor();
     auto zoomedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
+    auto borderRect = FloatRoundedRect(box.style().getRoundedBorderFor(LayoutRect(zoomedRect)));
     auto controlStyle = extractControlStyleForRenderer(box);
     auto& context = paintInfo.context();
 
-    context.drawControlPart(part, zoomedRect, deviceScaleFactor, controlStyle);
+    context.drawControlPart(part, borderRect, deviceScaleFactor, controlStyle);
     return false;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -556,12 +556,12 @@ void RemoteDisplayListRecorder::clearRect(const FloatRect& rect)
     handleItem(DisplayList::ClearRect(rect));
 }
 
-void RemoteDisplayListRecorder::drawControlPart(Ref<ControlPart> part, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void RemoteDisplayListRecorder::drawControlPart(Ref<ControlPart> part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     if (!m_controlFactory)
         m_controlFactory = ControlFactory::createControlFactory();
     part->setControlFactory(m_controlFactory.get());
-    handleItem(DisplayList::DrawControlPart(WTFMove(part), rect, deviceScaleFactor, style));
+    handleItem(DisplayList::DrawControlPart(WTFMove(part), borderRect, deviceScaleFactor, style));
 }
 
 #if USE(CG)

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -127,7 +127,7 @@ public:
     void strokePath(const WebCore::Path&);
     void strokeEllipse(const WebCore::FloatRect&);
     void clearRect(const WebCore::FloatRect&);
-    void drawControlPart(Ref<WebCore::ControlPart>, const WebCore::FloatRect&, float deviceScaleFactor, const WebCore::ControlStyle&);
+    void drawControlPart(Ref<WebCore::ControlPart>, const WebCore::FloatRoundedRect& borderRect, float deviceScaleFactor, const WebCore::ControlStyle&);
 #if USE(CG)
     void applyStrokePattern();
     void applyFillPattern();

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -89,7 +89,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     StrokePath(WebCore::Path path) StreamBatched
     StrokeEllipse(WebCore::FloatRect rect) StreamBatched
     ClearRect(WebCore::FloatRect rect)
-    DrawControlPart(Ref<WebCore::ControlPart> part, WebCore::FloatRect rect, float deviceScaleFactor, WebCore::ControlStyle style)
+    DrawControlPart(Ref<WebCore::ControlPart> part, WebCore::FloatRoundedRect borderRect, float deviceScaleFactor, WebCore::ControlStyle style)
 #if USE(CG)
     ApplyStrokePattern()
     ApplyFillPattern()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -407,9 +407,9 @@ void RemoteDisplayListRecorderProxy::recordClearRect(const FloatRect& rect)
     send(Messages::RemoteDisplayListRecorder::ClearRect(rect));
 }
 
-void RemoteDisplayListRecorderProxy::recordDrawControlPart(ControlPart& part, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+void RemoteDisplayListRecorderProxy::recordDrawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    send(Messages::RemoteDisplayListRecorder::DrawControlPart(part, rect, deviceScaleFactor, style));
+    send(Messages::RemoteDisplayListRecorder::DrawControlPart(part, borderRect, deviceScaleFactor, style));
 }
 
 #if USE(CG)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -127,7 +127,7 @@ private:
     void recordStrokePath(const WebCore::Path&) final;
     void recordStrokeEllipse(const WebCore::FloatRect&) final;
     void recordClearRect(const WebCore::FloatRect&) final;
-    void recordDrawControlPart(WebCore::ControlPart&, const WebCore::FloatRect&, float deviceScaleFactor, const WebCore::ControlStyle&) final;
+    void recordDrawControlPart(WebCore::ControlPart&, const WebCore::FloatRoundedRect& borderRect, float deviceScaleFactor, const WebCore::ControlStyle&) final;
 #if USE(CG)
     void recordApplyStrokePattern() final;
     void recordApplyFillPattern() final;


### PR DESCRIPTION
#### b6af447cab8cbceedc894aaf219b4ce25d6724b8
<pre>
REGRESSION(258644@main): The &lt;select&gt; control looks dark when zooming in
<a href="https://bugs.webkit.org/show_bug.cgi?id=250798">https://bugs.webkit.org/show_bug.cgi?id=250798</a>
rdar://104196022

Reviewed by Simon Fraser.

Calling getRoundedBorderFor() was dropped in 258644@main when refactoring the
MenuListButton drawing to go through GraphicsContext. This caused the left and
right border gradients to be not clipped. And this made the background of the
control part to be filled with the border gradient which is dark gray.

Because we do not have access to the RenderStyle in platform/graphics, we have to
calculate getRoundedBorderFor() the control part rect in RenderTheme::paint() and
pass it all the way to GraphicsContext and to DisplayList::Recorder.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawControlPart):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::draw const):
* Source/WebCore/platform/graphics/controls/ControlPart.h:
* Source/WebCore/platform/graphics/controls/PlatformControl.h:
(WebCore::PlatformControl::draw):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawControlPart::DrawControlPart):
(WebCore::DisplayList::DrawControlPart::apply):
(WebCore::DisplayList::dumpItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::DrawControlPart::borderRect const):
(WebCore::DisplayList::DrawControlPart::rect const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawControlPart):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordDrawControlPart):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm:
(WebCore::ButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.h:
* Source/WebCore/platform/graphics/mac/controls/ColorWellMac.mm:
(WebCore::ColorWellMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
(WebCore::ImageControlsButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm:
(WebCore::InnerSpinButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::drawMenuListBackground):
(WebCore::MenuListButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.h:
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
(WebCore::MenuListMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
(WebCore::MeterMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
(WebCore::ProgressBarMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm:
(WebCore::SearchFieldCancelButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.h:
* Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm:
(WebCore::SearchFieldMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm:
(WebCore::SliderThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
(WebCore::SliderTrackMac::draw):
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h:
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm:
(WebCore::TextAreaMac::draw):
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h:
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm:
(WebCore::TextFieldMac::draw):
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm:
(WebCore::ToggleButtonMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawControlPart):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordDrawControlPart):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Canonical link: <a href="https://commits.webkit.org/259325@main">https://commits.webkit.org/259325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2413e3b1999eb5d1eaaa25d19c82772593856f8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13715 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113916 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4646 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110404 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/108113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7072 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92533 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/103470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101219 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6430 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->