### PR TITLE
Safari 16.2 broken by some Flex/Snap CSS

### DIFF
--- a/LayoutTests/fast/scrolling/mac/sroll-snap-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/sroll-snap-crash-expected.txt
@@ -1,0 +1,5 @@
+Test passes if it does not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/sroll-snap-crash.html
+++ b/LayoutTests/fast/scrolling/mac/sroll-snap-crash.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+        }
+        
+        .scroller {
+            display: flex;
+            scroll-snap-type: both;
+            width: 0;
+            height: 0;
+            overflow: auto;
+        }
+        
+        .contents {
+            width: 200%;
+            scroll-snap-align: center;
+            width: 100%;
+
+        }
+        
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        debug('Test passes if it does not crash');
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents">
+        </div>
+    </div>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -486,14 +486,20 @@ std::pair<UnitType, std::optional<unsigned>> static ensureVisibleTarget(const In
 {
     const auto& snapOffsetsHorizontal = info.offsetsForAxis(ScrollEventAxis::Horizontal);
     const auto& snapOffsetsVertical = info.offsetsForAxis(ScrollEventAxis::Vertical);
-
+    
     if (horizontal.second && vertical.second && !offsetHasVisibleSnapArea(info, snapOffsetsHorizontal[*horizontal.second], snapOffsetsVertical[*vertical.second], ScrollEventAxis::Horizontal, viewportSize) && !offsetHasVisibleSnapArea(info, snapOffsetsVertical[*vertical.second], snapOffsetsHorizontal[*horizontal.second], ScrollEventAxis::Vertical, viewportSize)) {
-        auto horizontalSnapArea = info.snapAreas[snapOffsetsHorizontal[*horizontal.second].snapAreaIndices[findCompatibleSnapArea(info, snapOffsetsHorizontal[*horizontal.second], ScrollEventAxis::Horizontal, viewportSize, scrollDestinationOffset)]];
-        auto verticalSnapArea = info.snapAreas[snapOffsetsVertical[*vertical.second].snapAreaIndices[findCompatibleSnapArea(info, snapOffsetsVertical[*vertical.second], ScrollEventAxis::Vertical, viewportSize, scrollDestinationOffset)]];
         
-        auto closerSnapArea = (horizontalSnapArea.x() - scrollDestinationOffset.x()) * (horizontalSnapArea.x() - scrollDestinationOffset.x()) + (horizontalSnapArea.y() - scrollDestinationOffset.y()) * (horizontalSnapArea.y() - scrollDestinationOffset.y()) > (verticalSnapArea.x() - scrollDestinationOffset.x()) * (verticalSnapArea.x() - scrollDestinationOffset.x()) + (verticalSnapArea.y() - scrollDestinationOffset.y()) * (verticalSnapArea.y() - scrollDestinationOffset.y()) ? verticalSnapArea : horizontalSnapArea;
-        horizontal = { closerSnapArea.x(), std::nullopt };
-        vertical = { closerSnapArea.y(), std::nullopt };
+        auto compatibleHorizontalSnapArea = findCompatibleSnapArea(info, snapOffsetsHorizontal[*horizontal.second], ScrollEventAxis::Horizontal, viewportSize, scrollDestinationOffset);
+        auto compatibleVerticalSnapArea = findCompatibleSnapArea(info, snapOffsetsVertical[*vertical.second], ScrollEventAxis::Vertical, viewportSize, scrollDestinationOffset);
+
+        if (compatibleHorizontalSnapArea != notFound && compatibleVerticalSnapArea != notFound) {
+            auto horizontalSnapArea = info.snapAreas[snapOffsetsHorizontal[*horizontal.second].snapAreaIndices[compatibleHorizontalSnapArea]];
+            auto verticalSnapArea = info.snapAreas[snapOffsetsVertical[*vertical.second].snapAreaIndices[compatibleVerticalSnapArea]];
+            
+            auto closerSnapArea = (horizontalSnapArea.x() - scrollDestinationOffset.x()) * (horizontalSnapArea.x() - scrollDestinationOffset.x()) + (horizontalSnapArea.y() - scrollDestinationOffset.y()) * (horizontalSnapArea.y() - scrollDestinationOffset.y()) > (verticalSnapArea.x() - scrollDestinationOffset.x()) * (verticalSnapArea.x() - scrollDestinationOffset.x()) + (verticalSnapArea.y() - scrollDestinationOffset.y()) * (verticalSnapArea.y() - scrollDestinationOffset.y()) ? verticalSnapArea : horizontalSnapArea;
+            horizontal = { closerSnapArea.x(), std::nullopt };
+            vertical = { closerSnapArea.y(), std::nullopt };
+        }
     }
     return axis == ScrollEventAxis::Horizontal ? horizontal : vertical;
 }


### PR DESCRIPTION
#### ca36a098506482eaa75f60b5997236e0583e828d
<pre>
Safari 16.2 broken by some Flex/Snap CSS
<a href="https://bugs.webkit.org/show_bug.cgi?id=249575">https://bugs.webkit.org/show_bug.cgi?id=249575</a>
rdar://103517033

Reviewed by Simon Fraser.

Add check for if a compatible snap area not found in ensureVisibleTarget.

* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::ensureVisibleTarget):

Canonical link: <a href="https://commits.webkit.org/259095@main">https://commits.webkit.org/259095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d8bdb64a1a89818fc6ee80faba819b3b12b7aff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113039 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173349 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3825 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96061 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112150 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38478 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80130 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3360 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46346 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8222 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3321 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->