### PR TITLE
Require Int32 when constant-folding ParseInt in DFG

### DIFF
--- a/JSTests/stress/parse-int-negative-zero-key.js
+++ b/JSTests/stress/parse-int-negative-zero-key.js
@@ -1,0 +1,11 @@
+let k = 0;
+for (let i = 0; i < 2; i++) {
+  i = -{x: 0}.x;
+  for (let j = 0; j < 2; j++) {
+    parseInt(0, i);
+    new Set().add(i);
+  }
+  if (k++ > 15000)
+    break;
+}
+

--- a/JSTests/stress/parse-int-negative-zero.js
+++ b/JSTests/stress/parse-int-negative-zero.js
@@ -1,0 +1,10 @@
+let k = 0;
+for (let i = 0; i < 2; i++) {
+  i = -{x: 0}.x;
+  for (let j = 0; j < 2; j++) {
+    parseInt(0, i);
+  }
+  if (k++ > 15000)
+    break;
+}
+

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -940,7 +940,7 @@ private:
                 else
                     radix = m_state.forNode(node->child2()).m_value;
 
-                if (!radix.isNumber())
+                if (!radix.isInt32())
                     break;
 
                 if (radix.asNumber() == 0 || radix.asNumber() == 10) {


### PR DESCRIPTION
#### 47b456d4d7f328a0d75f974f351ed4cef9dd53b5
<pre>
Require Int32 when constant-folding ParseInt in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=250806">https://bugs.webkit.org/show_bug.cgi?id=250806</a>
rdar://104071090

Reviewed by Saam Barati and Yusuke Suzuki.

Currently, we fold any ParseInt node with a Number radix equal to zero in DFG. This
patch adds the requirement that the radix be an Int32 specifically, since that&apos;s the
speculation check we add to all ParseInt nodes in the DFG fixup phase.

* JSTests/stress/parse-int-negative-zero-key.js: Added.
* JSTests/stress/parse-int-negative-zero.js: Added.
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Canonical link: <a href="https://commits.webkit.org/259102@main">https://commits.webkit.org/259102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eb32eb533459cffac32917abe22dd381f89e7a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113045 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173355 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3831 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96073 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112156 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38481 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25437 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80134 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93932 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6292 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26823 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90388 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4060 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3362 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29845 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46347 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/98997 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6263 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8228 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24915 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->