### PR TITLE
Remove duplicate isLeapYear

### DIFF
--- a/Source/WebCore/platform/DateComponents.cpp
+++ b/Source/WebCore/platform/DateComponents.cpp
@@ -53,17 +53,6 @@ static constexpr int maximumWeekInMaximumYear = 37; // The week of 275760-09-13
 
 static constexpr int daysInMonth[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
-static bool isLeapYear(int year)
-{
-    if (year % 4)
-        return false;
-    if (!(year % 400))
-        return true;
-    if (!(year % 100))
-        return false;
-    return true;
-}
-
 // 'month' is 0-based.
 static int maxDayOfMonth(int year, int month)
 {


### PR DESCRIPTION
#### 0b9c23b10f386f8262dcb852744e7e28e77b3c72
<pre>
Remove duplicate isLeapYear

Remove duplicate isLeapYear
<a href="https://bugs.webkit.org/show_bug.cgi?id=250802">https://bugs.webkit.org/show_bug.cgi?id=250802</a>

Reviewed by Brent Fulgham and Alexey Proskuryakov.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/ecbe8115cc1f014eb61dff29b96e405a0ab3ef51">https://chromium.googlesource.com/chromium/blink/+/ecbe8115cc1f014eb61dff29b96e405a0ab3ef51</a>

This patch is to remove duplicate function, which is already available from DateMath.h.

* Source/WebCore/platform/DateComponents.cpp:
(isLeapYear): Removed

Canonical link: <a href="https://commits.webkit.org/259080@main">https://commits.webkit.org/259080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ce8a265fd24384be05b7b662145b135e37d9c9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113116 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173416 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3897 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112220 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109660 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93880 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25491 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6361 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46402 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6248 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8295 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->