### PR TITLE
scrollTop and scrollLeft always 0 in DOMContentLoaded handler on a scrolled page

### DIFF
--- a/LayoutTests/fast/loader/scroll-position-restored-on-back-at-load-event-expected.txt
+++ b/LayoutTests/fast/loader/scroll-position-restored-on-back-at-load-event-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test ensures that scrollingElement.scrollTop/Left properties are available by the time DOMContentLoaded event fires.
+

--- a/LayoutTests/fast/loader/scroll-position-restored-on-back-at-load-event.html
+++ b/LayoutTests/fast/loader/scroll-position-restored-on-back-at-load-event.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src='../../resources/testharness.js'></script>
+<script src='../../resources/testharnessreport.js'></script>
+<style>
+  #overflow {
+    width: 9999px;
+    height: 9999px;
+    float: left;
+  }
+</style>
+<div id='overflow'></div>
+<script>
+  // Navigation steps:
+  // 1- page gets first loaded and scrolled.
+  // 2- loaded page away and then 'back'.
+  // Test: ensure that by the time DOMContenLoaded fires (after a back navigation), scrollingElement.scrollTop/Left are set.
+  let t = async_test('Test ensures that scrollingElement.scrollTop/Left properties are available by the time DOMContentLoaded event fires.');
+  function init() {
+    t.step(() => {
+      if (window.name == 'second/load') {
+        assert_equals(document.scrollingElement.scrollTop, 2000);
+        assert_equals(document.scrollingElement.scrollLeft, 1000);
+        window.name = '';
+        t.done();
+      } else {
+        window.scrollTo(1000, 2000);
+        window.name = 'second/load';
+        setTimeout(() => { window.location = '../../resources/back.html'; }, 0);
+      }
+    });
+  }
+  window.addEventListener('DOMContentLoaded', init, true);
+</script>

--- a/LayoutTests/fast/loader/scroll-position-restored-on-reload-at-load-event-expected.txt
+++ b/LayoutTests/fast/loader/scroll-position-restored-on-reload-at-load-event-expected.txt
@@ -1,0 +1,16 @@
+main frame "second/load" - has 1 onunload handler(s)
+main frame - has 1 onunload handler(s)
+Test ensures that scrollingElement.scrollTop/Left properties are available by the time DOMContentLoaded event fires.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.scrollingElement.scrollTop is 2000
+PASS document.scrollingElement.scrollLeft is 1000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+
+

--- a/LayoutTests/fast/loader/scroll-position-restored-on-reload-at-load-event.html
+++ b/LayoutTests/fast/loader/scroll-position-restored-on-reload-at-load-event.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+    description('Test ensures that scrollingElement.scrollTop/Left properties are available by the time DOMContentLoaded event fires.');
+    // Navigation steps:
+    // 1- page gets first loaded and scrolled.
+    // 2- reload is performed.
+    // Test: ensure that by the time DOMContenLoaded fires (after a reload navigation), scrollingElement.scrollTop/Left are set.
+
+    function init(evt) {
+        if (window.name == 'second/load') {
+            shouldBe('document.scrollingElement.scrollTop', '2000');
+            shouldBe('document.scrollingElement.scrollLeft', '1000');
+            window.name = "";
+
+            if (window.testRunner)
+                finishJSTest();
+        } else {
+            window.scrollTo(1000, 2000);
+
+            window.name = "second/load";
+            setTimeout('location.reload(true)', 0);
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', init, true);
+    window.onunload = function() {}  // prevent caching
+
+    var jsTestIsAsync = true;
+    </script>
+    <body>
+        <div style='width: 9999px; height:9999px; float:left;'></div>
+        <h1 id='console'/>
+    </body>
+</html>

--- a/LayoutTests/resources/back.html
+++ b/LayoutTests/resources/back.html
@@ -1,0 +1,1 @@
+<script>history.back()</script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2008 Alp Toker <alp@atoker.com>
  * Copyright (C) Research In Motion Limited 2009. All rights reserved.
  * Copyright (C) 2011 Kris Jordan <krisjordan@gmail.com>
- * Copyright (C) 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2011-2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2745,7 +2745,10 @@ void FrameLoader::didFirstLayout()
     if (&m_frame != &m_frame.page()->mainFrame())
         return;
 #endif
-    if (m_frame.page() && isBackForwardLoadType(m_loadType))
+    if (!m_frame.page())
+        return;
+
+    if (isBackForwardLoadType(m_loadType) || m_loadType == FrameLoadType::ReloadFromOrigin || m_loadType == FrameLoadType::Reload)
         history().restoreScrollPositionAndViewState();
 
     if (m_stateMachine.committedFirstRealDocumentLoad() && !m_stateMachine.isDisplayingInitialEmptyDocument() && !m_stateMachine.firstLayoutDone())


### PR DESCRIPTION
<pre>
scrollTop and scrollLeft always 0 in DOMContentLoaded handler on a scrolled page
<a href="https://bugs.webkit.org/show_bug.cgi?id=250814">https://bugs.webkit.org/show_bug.cgi?id=250814</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/3ad81cf0b724a2a25ee5cc79a09541d9a971ae15">https://chromium.googlesource.com/chromium/blink/+/3ad81cf0b724a2a25ee5cc79a09541d9a971ae15</a>

Currently, when performing a "back" navigation, the scroll position
is restored at the time the first layout happens (see
FrameLoader::didFirstLayout). If that does not go through, another
attempt to restore the scroll position is made when the frame
completes loading (see FrameLoader::checkLoadCompleteForThisFrame).

In a closer look, one might notice that in the later, not only the
"back" navigation case is covered, but also "reload".

Patch makes these two attempts of restore the scroll position to
operate under the same circumstances: back and reload.

Apart from bringing them in pair, it also makes it possible to
query the scroll position at the time DOMContentLoaded fires, as
Gecko and Blink (Presto in the past as well) engines do.

* Source/WebCore/loader/FrameLoader.cpp:
(FrameLoader::didFirstLayout):
(1) Add early return, if not presnet "m_frame.page()"
(2) Accounted for Reload types during back navigation
* LayoutTests/fast/loader/scroll-position-restored-on-reload-at-load-event.html: Add Test Case
* LayoutTests/fast/loader/scroll-position-restored-on-reload-at-load-event-expected.txt: Add Test Case Expectation
* LayoutTests/fast/loader/fast/loader/scroll-position-restored-on-back-at-load-event.html: Add Test Case
* LayoutTests/fast/loader/fast/loader/scroll-position-restored-on-back-at-load-event-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a592af34194a086e3e714b446b105bd209370989

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115997 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7050 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99002 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112582 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13128 "Found 2 new test failures: fast/loader/scroll-position-restored-on-back-at-load-event.html, fast/loader/scroll-position-restored-on-reload-at-load-event.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40719 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82451 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6139 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48732 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11107 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->