### PR TITLE
CG display list graphics contexts are sometimes still flipped

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -60,8 +60,10 @@ public:
     GraphicsContextCGDisplayList(const CGDisplayListImageBufferBackend::Parameters& parameters)
         : GraphicsContextCG(adoptCF(WKCGCommandsContextCreate(parameters.logicalSize, makeContextOptions(parameters))).autorelease())
     {
+#if !HAVE(CG_DISPLAY_LIST_RESPECTING_CONTENTS_FLIPPED)
         m_immutableBaseTransform.scale(1, -1);
         m_immutableBaseTransform.translate(0, -ceilf(parameters.logicalSize.height() * parameters.resolutionScale));
+#endif
         m_immutableBaseTransform.scale(parameters.resolutionScale);
         m_inverseImmutableBaseTransform = *m_immutableBaseTransform.inverse();
         m_resolutionScale = parameters.resolutionScale;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -168,7 +168,7 @@ public:
 private:
     RemoteLayerBackingStoreCollection* backingStoreCollection() const;
 
-    void drawInContext(WebCore::GraphicsContext&);
+    void drawInContext(WebCore::GraphicsContext&, WTF::Function<void()>&& additionalContextSetupCallback = nullptr);
 
     struct Buffer {
         RefPtr<WebCore::ImageBuffer> imageBuffer;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -430,14 +430,13 @@ void RemoteLayerBackingStore::paintContents()
     if (m_parameters.includeDisplayList == IncludeDisplayList::Yes) {
         auto& displayListContext = m_displayListBuffer->context();
 
-#if HAVE(CG_DISPLAY_LIST_RESPECTING_CONTENTS_FLIPPED)
-        GraphicsContextStateSaver stateSaver(displayListContext);
-        displayListContext.scale(FloatSize(1, -1));
-        displayListContext.translate(0, -m_parameters.size.height());
-#endif
-
         BifurcatedGraphicsContext context(m_frontBuffer.imageBuffer->context(), displayListContext);
-        drawInContext(context);
+        drawInContext(context, [&] {
+#if HAVE(CG_DISPLAY_LIST_RESPECTING_CONTENTS_FLIPPED)
+            displayListContext.scale(FloatSize(1, -1));
+            displayListContext.translate(0, -m_parameters.size.height());
+#endif
+        });
         return;
     }
 #endif
@@ -446,9 +445,12 @@ void RemoteLayerBackingStore::paintContents()
     drawInContext(context);
 }
 
-void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
+void RemoteLayerBackingStore::drawInContext(GraphicsContext& context, WTF::Function<void()>&& additionalContextSetupCallback)
 {
     GraphicsContextStateSaver stateSaver(context);
+
+    if (additionalContextSetupCallback)
+        additionalContextSetupCallback();
 
     // If we have less than webLayerMaxRectsToPaint rects to paint and they cover less
     // than webLayerWastedSpaceThreshold of the total dirty area, we'll repaint each rect separately.


### PR DESCRIPTION
#### 9502f8564a09c70c745630ae35bf1ee90bf21395
<pre>
CG display list graphics contexts are sometimes still flipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=250816">https://bugs.webkit.org/show_bug.cgi?id=250816</a>
rdar://104388673

Reviewed by Dean Jackson.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
Remove the workaround introduced in r252402@main, since we have reinstated the toplevel
context flip in 258997@main. I missed this in 258997@main because it only affects
cases where we end up doing setCTM(getCTM()), which is just rare enough to miss
with cursory testing.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::paintContents):
(WebKit::RemoteLayerBackingStore::drawInContext):
While debugging the above, I also noticed that we were leaving the display
list context with a missing trailing `restore` operation, because we encode the
display list inside drawInContext. To avoid this, move the flip inside our existing
state saver, which is popped before encoding the display list. This has no
actual effect at the moment (except making the dumped list look more correct),
but will eventually be necessary when the replayed destination context is reused.

Canonical link: <a href="https://commits.webkit.org/259076@main">https://commits.webkit.org/259076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/178d35220be5581b349cf9aa17dab39f4586fc68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113064 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3850 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96088 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112176 "Hash 178d3522 for PR 8810 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109610 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38490 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80142 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6311 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3374 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46359 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6244 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8246 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->