### PR TITLE
Remove repaint logging from MockPageOverlayClient::drawRect()

### DIFF
--- a/LayoutTests/pageoverlay/overlay-installation-expected.txt
+++ b/LayoutTests/pageoverlay/overlay-installation-expected.txt
@@ -1,5 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 800, 600)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 800, 600)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/pageoverlay/overlay-large-document-expected.txt
+++ b/LayoutTests/pageoverlay/overlay-large-document-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 785, 585)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/pageoverlay/overlay-large-document-scrolled-expected.txt
+++ b/LayoutTests/pageoverlay/overlay-large-document-scrolled-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 785, 585)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4608, 4608, 400, 408)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4096, 4608, 512, 408)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4608, 4096, 400, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4096, 4096, 512, 512)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/pageoverlay/overlay-remove-reinsert-view-expected.txt
+++ b/LayoutTests/pageoverlay/overlay-remove-reinsert-view-expected.txt
@@ -1,8 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 785, 585)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
 Initial layers
 
 View-relative:

--- a/LayoutTests/pageoverlay/overlay-small-frame-mouse-events-expected.txt
+++ b/LayoutTests/pageoverlay/overlay-small-frame-mouse-events-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: MockPageOverlayClient::mouseEvent location (105, 105)
 CONSOLE MESSAGE: MockPageOverlayClient::mouseEvent location (105, 105)
 CONSOLE MESSAGE: MockPageOverlayClient::mouseEvent location (105, 105)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 10, 10)
 View-relative:
 (GraphicsLayer
 )

--- a/LayoutTests/pageoverlay/overlay-small-frame-paints-expected.txt
+++ b/LayoutTests/pageoverlay/overlay-small-frame-paints-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 10, 10)
 View-relative:
 (GraphicsLayer
 )

--- a/LayoutTests/platform/ios-wk2/pageoverlay/overlay-installation-expected.txt
+++ b/LayoutTests/platform/ios-wk2/pageoverlay/overlay-installation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 800, 600)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/platform/ios-wk2/pageoverlay/overlay-large-document-expected.txt
+++ b/LayoutTests/platform/ios-wk2/pageoverlay/overlay-large-document-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/platform/ios-wk2/pageoverlay/overlay-large-document-scrolled-expected.txt
+++ b/LayoutTests/platform/ios-wk2/pageoverlay/overlay-large-document-scrolled-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/platform/ios-wk2/pageoverlay/overlay-remove-reinsert-view-expected.txt
+++ b/LayoutTests/platform/ios-wk2/pageoverlay/overlay-remove-reinsert-view-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
 Initial layers
 
 View-relative:

--- a/LayoutTests/platform/mac-wk1/pageoverlay/overlay-installation-expected.txt
+++ b/LayoutTests/platform/mac-wk1/pageoverlay/overlay-installation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 800, 600)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/platform/mac-wk1/pageoverlay/overlay-large-document-expected.txt
+++ b/LayoutTests/platform/mac-wk1/pageoverlay/overlay-large-document-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/platform/mac-wk1/pageoverlay/overlay-large-document-scrolled-expected.txt
+++ b/LayoutTests/platform/mac-wk1/pageoverlay/overlay-large-document-scrolled-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4608, 4608, 400, 408)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4096, 4608, 512, 408)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4608, 4096, 400, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (4096, 4096, 512, 512)
 View-relative:
 (GraphicsLayer
   (children 1

--- a/LayoutTests/platform/mac-wk1/pageoverlay/overlay-remove-reinsert-view-expected.txt
+++ b/LayoutTests/platform/mac-wk1/pageoverlay/overlay-remove-reinsert-view-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 512, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (512, 0, 512, 512)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 512, 512)
 Initial layers
 
 View-relative:

--- a/LayoutTests/platform/mac-wk1/pageoverlay/overlay-small-frame-mouse-events-expected.txt
+++ b/LayoutTests/platform/mac-wk1/pageoverlay/overlay-small-frame-mouse-events-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: MockPageOverlayClient::mouseEvent location (105, 495)
 CONSOLE MESSAGE: MockPageOverlayClient::mouseEvent location (105, 495)
 CONSOLE MESSAGE: MockPageOverlayClient::mouseEvent location (105, 495)
-CONSOLE MESSAGE: MockPageOverlayClient::drawRect dirtyRect (0, 0, 10, 10)
 View-relative:
 (GraphicsLayer
 )

--- a/Source/WebCore/testing/MockPageOverlayClient.cpp
+++ b/Source/WebCore/testing/MockPageOverlayClient.cpp
@@ -86,11 +86,8 @@ void MockPageOverlayClient::didMoveToPage(PageOverlay& overlay, Page* page)
         overlay.setNeedsDisplay();
 }
 
-void MockPageOverlayClient::drawRect(PageOverlay& overlay, GraphicsContext& context, const IntRect& dirtyRect)
+void MockPageOverlayClient::drawRect(PageOverlay& overlay, GraphicsContext& context, const IntRect&)
 {
-    overlay.page()->mainFrame().document()->addConsoleMessage(MessageSource::Other, MessageLevel::Debug,
-        makeString("MockPageOverlayClient::drawRect dirtyRect (", dirtyRect.x(), ", ", dirtyRect.y(), ", ", dirtyRect.width(), ", ", dirtyRect.height(), ')'));
-
     GraphicsContextStateSaver stateSaver(context);
 
     FloatRect insetRect = overlay.bounds();


### PR DESCRIPTION
#### ae45341c029bb9e7696a8419a75c76c17eb301dd
<pre>
Remove repaint logging from MockPageOverlayClient::drawRect()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250818">https://bugs.webkit.org/show_bug.cgi?id=250818</a>
rdar://104407435

Reviewed by Tim Horton.

Remove &quot;dirtyRect&quot; console logging from MockPageOverlayClient::drawRect(), since the order of paints
is not predictable (e.g. when tiled), and differs between UI-side compositing and non-UI-side.

* LayoutTests/pageoverlay/overlay-installation-expected.txt:
* LayoutTests/pageoverlay/overlay-large-document-expected.txt:
* LayoutTests/pageoverlay/overlay-large-document-scrolled-expected.txt:
* LayoutTests/pageoverlay/overlay-remove-reinsert-view-expected.txt:
* LayoutTests/pageoverlay/overlay-small-frame-mouse-events-expected.txt:
* LayoutTests/pageoverlay/overlay-small-frame-paints-expected.txt:
* LayoutTests/platform/ios-wk2/pageoverlay/overlay-installation-expected.txt:
* LayoutTests/platform/ios-wk2/pageoverlay/overlay-large-document-expected.txt:
* LayoutTests/platform/ios-wk2/pageoverlay/overlay-large-document-scrolled-expected.txt:
* LayoutTests/platform/ios-wk2/pageoverlay/overlay-remove-reinsert-view-expected.txt:
* LayoutTests/platform/mac-wk1/pageoverlay/overlay-installation-expected.txt:
* LayoutTests/platform/mac-wk1/pageoverlay/overlay-large-document-expected.txt:
* LayoutTests/platform/mac-wk1/pageoverlay/overlay-large-document-scrolled-expected.txt:
* LayoutTests/platform/mac-wk1/pageoverlay/overlay-remove-reinsert-view-expected.txt:
* LayoutTests/platform/mac-wk1/pageoverlay/overlay-small-frame-mouse-events-expected.txt:
* Source/WebCore/testing/MockPageOverlayClient.cpp:
(WebCore::MockPageOverlayClient::drawRect):

Canonical link: <a href="https://commits.webkit.org/259098@main">https://commits.webkit.org/259098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49784da20f9b928de6e410e5a81dcd657b5953c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113067 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173374 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3852 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112178 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38489 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25453 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80141 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6314 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26837 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3376 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46363 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6261 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8248 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->