### PR TITLE
REGRESSION?: [iOS] media/mediacapabilities/mediacapabilities-allowed-codecs.html and media/mediacapabilities/mediacapabilities-allowed-containers.html consistently failing

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3865,8 +3865,9 @@ webkit.org/b/247831 fast/images/avif-heif-container-as-image.html [ ImageOnlyFai
 webkit.org/b/247831 fast/images/avif-image-decoding.html [ Failure ]
 webkit.org/b/247831 fast/images/animated-avif.html [ Timeout ]
 
-webkit.org/b/250768 media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Failure ]
-webkit.org/b/250768 media/mediacapabilities/mediacapabilities-allowed-containers.html [ Failure ]
+# MSE isn't supported on iPhone at this time.
+media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Failure ]
+media/mediacapabilities/mediacapabilities-allowed-containers.html [ Failure ]
 
 # Screen Orientation API doesn't support nested frames yet
 imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Skip ]

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -120,3 +120,6 @@ webkit.org/b/229656 fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass T
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-databases-opaque-origin.html [ Pass Failure ]
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-deleteDatabase-opaque-origin.html [ Pass Failure ]
 
+media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Pass ]
+media/mediacapabilities/mediacapabilities-allowed-containers.html [ Pass ]
+


### PR DESCRIPTION
#### 6b73d6bc5ea18ab6b955e45a11b5a06b12d79734
<pre>
REGRESSION?: [iOS] media/mediacapabilities/mediacapabilities-allowed-codecs.html and media/mediacapabilities/mediacapabilities-allowed-containers.html consistently failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250768">https://bugs.webkit.org/show_bug.cgi?id=250768</a>
rdar://104383574

Reviewed by Ryan Haddad.

Bug 250367 properly made Media Capabilities return that MSE wasn&apos;t supported on iPhone. Adjust expectations:
test is failing on iPhone but pass on iPad.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ipad/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259116@main">https://commits.webkit.org/259116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b82661c800cd4aab4020d27b46108414583c87a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113072 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173379 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3857 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112183 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38492 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25458 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80144 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26841 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3378 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6275 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8253 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->