### PR TITLE
Improve VMInspector::dumpRegisters().

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -3160,7 +3160,7 @@ String CodeBlock::nameForRegister(VirtualRegister virtualRegister)
     if (virtualRegister == thisRegister())
         return "this"_s;
     if (virtualRegister.isArgument())
-        return makeString("arguments[", pad(' ', 3, virtualRegister.toArgument()), ']');
+        return makeString("arguments[", virtualRegister.toArgument(), ']');
 
     return emptyString();
 }

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -204,6 +204,7 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
 
         static ptrdiff_t callerFrameOffset() { return OBJECT_OFFSETOF(CallerFrameAndPC, callerFrame); }
 
+        void* rawReturnPCForInspection() const { return callerFrameAndPC().returnPC; }
         void* returnPCForInspection() const { return removeCodePtrTag(callerFrameAndPC().returnPC); }
         bool hasReturnPC() const { return !!callerFrameAndPC().returnPC; }
         void clearReturnPC() { callerFrameAndPC().returnPC = nullptr; }

--- a/Source/JavaScriptCore/interpreter/StackVisitor.h
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.h
@@ -65,6 +65,7 @@ public:
         size_t argumentCountIncludingThis() const { return m_argumentCountIncludingThis; }
         bool callerIsEntryFrame() const { return m_callerIsEntryFrame; }
         CallFrame* callerFrame() const { return m_callerFrame; }
+        EntryFrame* entryFrame() const { return m_entryFrame; }
         CalleeBits callee() const { return m_callee; }
         CodeBlock* codeBlock() const { return m_codeBlock; }
         BytecodeIndex bytecodeIndex() const { return m_bytecodeIndex; }

--- a/Source/JavaScriptCore/tools/VMInspector.h
+++ b/Source/JavaScriptCore/tools/VMInspector.h
@@ -67,6 +67,9 @@ public:
     JS_EXPORT_PRIVATE static void forEachVM(Function<IterationStatus(VM&)>&&);
     JS_EXPORT_PRIVATE static void dumpVMs();
 
+    // Returns null if the callFrame doesn't actually correspond to any active VM.
+    JS_EXPORT_PRIVATE static VM* vmForCallFrame(CallFrame*);
+
     Expected<bool, Error> isValidExecutableMemory(void*) WTF_REQUIRES_LOCK(m_lock);
     Expected<CodeBlock*, Error> codeBlockForMachinePC(void*) WTF_REQUIRES_LOCK(m_lock);
 


### PR DESCRIPTION
#### 90eb20a4e7fa6453033196cd5bb0f36ce2fab5d2
<pre>
Improve VMInspector::dumpRegisters().
<a href="https://bugs.webkit.org/show_bug.cgi?id=250823">https://bugs.webkit.org/show_bug.cgi?id=250823</a>
&lt;rdar://problem/104410526&gt;

Reviewed by Yusuke Suzuki.

1. Change the order of the dump to go from low memory to high memory.  This makes the dump more intuitive to read because:
   a. C++ structures are dumped that way in debuggers, and
   b. Dumping this way allows us to dump the caller frame next, and the memory dumps just stitches together naturally.

2. Add VMInspector::vmForCallFrame() to find the VM for a CallFrame instead of relying on a CodeBlock being present.
   This allows us to ...

3. Add rudimentary support for dumping EntryFrame, as well as Wasm and native frames.

4. Also changed the layout of the dumped CallFrame registers to have more useful info while being easier to read.

For example, an old dump looks like this:
```
-----------------------------------------------------------------------------
            use            |   address  |                value
-----------------------------------------------------------------------------
[r 10 arguments[  5]]      | 0x16fdfbfb0 | 0xa                Undefined
[r  9 arguments[  4]]      | 0x16fdfbfa8 | 0xfffe000000000000 Int32: 0
[r  8 arguments[  3]]      | 0x16fdfbfa0 | 0x10409c240        Object: 0x10409c240 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x30000afd0:[0xafd0/45008, Object, (2/6, 0/0){module:0, instance:1}, NonArray, Proto:0x103011968, Leaf]), StructureID: 45008
[r  7 arguments[  2]]      | 0x16fdfbf98 | 0xfffe000000000001 Int32: 1
[r  6 arguments[  1]]      | 0x16fdfbf90 | 0x103038de8        Object: 0x103038de8 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x3000077b0:[0x77b0/30640, Generator, (0/0, 0/0){}, NonArray, Proto:0x103012ae8, Leaf]), StructureID: 30640
[r  5           this]      | 0x16fdfbf88 | 0x10300e268        Object: 0x10300e268 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x300008720:[0x8720/34592, JSProxy, (0/0, 0/0){}, NonArray, Proto:0x103011968, Leaf]), StructureID: 34592
-----------------------------------------------------------------------------
[ArgumentCount]            | 0x16fdfbf80 | 5
[ReturnVPC]                | 0x16fdfbf80 | 399 (line 20)
[Callee]                   | 0x16fdfbf78 | 0x10408e100        Object: 0x10408e100 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x3000057c0:[0x57c0/22464, Function, (0/0, 0/0){}, NonArray, Proto:0x1030305a8, Leaf]), StructureID: 22464
[CodeBlock]                | 0x16fdfbf70 | 0x1040d8580        #Bhpb2b:[0x1040d8580-&gt;0x104099980, LLIntFunctionCall, 412]
[ReturnPC]                 | 0x16fdfbf68 | 0x11a470248
[CallerFrame]              | 0x16fdfbf60 | 0x16fdfc020
-----------------------------------------------------------------------------
[r -1  CalleeSaveReg]      | 0x16fdfbf58 | 0xfffe000000000002 Int32: 2
[r -2  CalleeSaveReg]      | 0x16fdfbf50 | 0xfffe000000000000 Int32: 0
[r -3  CalleeSaveReg]      | 0x16fdfbf48 | 0x103030f40
[r -4  CalleeSaveReg]      | 0x16fdfbf40 | 0x103059770
[r -5               ]      | 0x16fdfbf38 | 0xa                Undefined
[r -6               ]      | 0x16fdfbf30 | 0xa                Undefined
-----------------------------------------------------------------------------
-----------------------------------------------------------------------------
```

The new dump now looks like this:
```
Registers for JS frame 0x16fdfbfe0 (entryFrame 0x16fdfc2d0):
-----------------------------------------------------------------------------
   VirtualRegister     : address      value
---------------------------------------------------- Outgoing Args + Misc ---
------------------------------------------------------------------ Locals ---
  -6                   : 0x16fdfbfb0  0x102038428 Object: 0x102038428 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x300005520:[0x5520/21792, JSGlobalLexicalEnvironment, (0/0, 0/0){}, NonArray, Leaf]), StructureID: 21792
  -5                   : 0x16fdfbfb8  0x102038428 Object: 0x102038428 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x300005520:[0x5520/21792, JSGlobalLexicalEnvironment, (0/0, 0/0){}, NonArray, Leaf]), StructureID: 21792
------------------------------------------------------------ Callee Saves ---
  -4  CalleeSaveReg    : 0x16fdfbfc0  0x102059130
  -3  CalleeSaveReg    : 0x16fdfbfc8  0x102030f40
  -2  CalleeSaveReg    : 0x16fdfbfd0  0xfffe000000000000 Int32: 0
  -1  CalleeSaveReg    : 0x16fdfbfd8  0xfffe000000000002 Int32: 2
-------------------------------------------------------- CallFrame Header ---
   0  CallerFrame      : 0x16fdfbfe0  0x16fdfc0a0
   1  ReturnPC         : 0x16fdfbfe8  0x11a470248 (pac signed 0xff1c00011a470248)
   2  CodeBlock        : 0x16fdfbff0  0x1050d8580 #D6UySe:[0x1050d8580-&gt;0x105099980, LLIntFunctionCall, 644]
   3  Callee           : 0x16fdfbff8  0x10508e100 Object: 0x10508e100 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x3000057c0:[0x57c0/22464, Function, (0/0, 0/0){}, NonArray, Proto:0x1020305a8]), StructureID: 22464
 4.1  ReturnVPC        : 0x16fdfc000  632 (line 20)
 4.2  ArgumentCount    : 0x16fdfc000  5
--------------------------------------------------------------- Arguments ---
   5  this             : 0x16fdfc008  0x10200e1c8 Object: 0x10200e1c8 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x300008720:[0x8720/34592, JSProxy, (0/0, 0/0){}, NonArray, Proto:0x102011968, Leaf]), StructureID: 34592
   6  arguments[1]     : 0x16fdfc010  0x102038de8 Object: 0x102038de8 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x3000077b0:[0x77b0/30640, Generator, (0/0, 0/0){}, NonArray, Proto:0x102012ae8, Leaf]), StructureID: 30640
   7  arguments[2]     : 0x16fdfc018  0xfffe000000000001 Int32: 1
   8  arguments[3]     : 0x16fdfc020  0x10509c240 Object: 0x10509c240 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x30000b740:[0xb740/46912, Object, (2/6, 0/0){module:0, instance:1}, NonArray, Proto:0x102011968, Leaf]), StructureID: 46912
   9  arguments[4]     : 0x16fdfc028  0xfffe000000000000 Int32: 0
  10  arguments[5]     : 0x16fdfc030  0x1050e0130 Object: 0x1050e0130 with butterfly 0x0(base=0xfffffffffffffff8) (Structure 0x300005c20:[0x5c20/23584, JSLexicalEnvironment, (0/0, 0/0){}, NonArray, Leaf]), StructureID: 23584
--------------------------------------------------------------------- End ---
```

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::nameForRegister):
* Source/JavaScriptCore/interpreter/CallFrame.h:
(JSC::CallFrame::rawReturnPCForInspection const):
* Source/JavaScriptCore/interpreter/StackVisitor.h:
(JSC::StackVisitor::Frame::entryFrame const):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::vmForCallFrame):
(JSC::VMInspector::dumpRegisters):
* Source/JavaScriptCore/tools/VMInspector.h:

Canonical link: <a href="https://commits.webkit.org/259072@main">https://commits.webkit.org/259072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/642bc1e36fd30224d4290a7f1949187875c5aaac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113083 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3866 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112192 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93856 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25465 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/93960 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6329 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26848 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90425 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4097 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6494 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29853 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46376 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/99034 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6240 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8263 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24923 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->