### PR TITLE
[WebGPU] Delete some dead code in the compositing flow

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
@@ -56,12 +56,6 @@ void SurfaceImpl::setLabelInternal(const String& label)
     UNUSED_PARAM(label);
 }
 
-MachSendRight SurfaceImpl::displayBufferHandle() const
-{
-    IOSurfaceRef displayBuffer = wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(m_backing);
-    return MachSendRight::adopt(IOSurfaceCreateMachPort(displayBuffer));
-}
-
 IOSurfaceRef SurfaceImpl::drawingBuffer() const
 {
     return wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(m_backing);

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
@@ -49,7 +49,6 @@ public:
     virtual ~SurfaceImpl();
 
     WGPUSurface backing() const { return m_backing; }
-    MachSendRight displayBufferHandle() const;
     IOSurfaceRef drawingBuffer() const;
 
 private:


### PR DESCRIPTION
#### a075eeac2a7fb1b380625e55414eb425d40a736d
<pre>
[WebGPU] Delete some dead code in the compositing flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=250825">https://bugs.webkit.org/show_bug.cgi?id=250825</a>
rdar://104416728

Reviewed by Tadeu Zagallo.

No need for dead code.

No tests because there is no behavior change.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp:
(PAL::WebGPU::SurfaceImpl::displayBufferHandle const): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h:

Canonical link: <a href="https://commits.webkit.org/259075@main">https://commits.webkit.org/259075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4ffa17a205369508eb133122a4e02b34ae486bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113096 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173396 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3878 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112202 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109641 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93865 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25476 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46387 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6243 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8276 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->