### PR TITLE
Allow to initialize LibWebRTCProvider just before creating its factory

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -326,6 +326,8 @@ void LibWebRTCProvider::clearFactory()
 
 rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> LibWebRTCProvider::createPeerConnectionFactory(rtc::Thread* networkThread, rtc::Thread* signalingThread)
 {
+    willCreatePeerConnectionFactory();
+
     ASSERT(!m_audioModule);
     auto audioModule = rtc::make_ref_counted<LibWebRTCAudioModule>();
     m_audioModule = audioModule.get();

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -142,6 +142,8 @@ private:
     void initializeAudioEncodingCapabilities() final;
     void initializeVideoEncodingCapabilities() final;
 
+    virtual void willCreatePeerConnectionFactory();
+
     std::optional<MediaCapabilitiesDecodingInfo> videoDecodingCapabilitiesOverride(const VideoConfiguration&) final;
     std::optional<MediaCapabilitiesEncodingInfo> videoEncodingCapabilitiesOverride(const VideoConfiguration&) final;
 
@@ -149,6 +151,10 @@ private:
     bool m_useDTLS10 { false };
     bool m_disableNonLocalhostConnections { false };
 };
+
+inline void LibWebRTCProvider::willCreatePeerConnectionFactory()
+{
+}
 
 inline LibWebRTCAudioModule* LibWebRTCProvider::audioModule()
 {

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/CVUtilities.h>
 #include <WebCore/LibWebRTCDav1dDecoder.h>
 #include <WebCore/LibWebRTCMacros.h>
+#include <WebCore/Page.h>
 #include <WebCore/PlatformMediaSessionManager.h>
 #include <WebCore/VP9UtilitiesCocoa.h>
 #include <WebCore/VideoFrameCV.h>
@@ -94,6 +95,11 @@ std::optional<VideoCodecType> LibWebRTCCodecs::videoCodecTypeFromWebCodec(const 
 
     // FIXME: Expose H265 if available.
     return { };
+}
+
+void LibWebRTCCodecs::setHasVP9ExtensionSupport(bool hasVP9ExtensionSupport)
+{
+    m_hasVP9ExtensionSupport = hasVP9ExtensionSupport;
 }
 
 #endif
@@ -190,7 +196,11 @@ void LibWebRTCCodecs::initializeIfNeeded()
     static std::once_flag doInitializationOnce;
     std::call_once(doInitializationOnce, [] {
         callOnMainRunLoopAndWait([] {
+#if HAVE(AUDIT_TOKEN)
+            WebProcess::singleton().ensureGPUProcessConnection().auditToken();
+#else
             WebProcess::singleton().ensureGPUProcessConnection();
+#endif
         });
     });
 }

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -148,7 +148,7 @@ public:
     bool supportVP9VTB() const { return m_supportVP9VTB; }
     void setLoggingLevel(WTFLogLevel);
 
-    void setHasVP9ExtensionSupport(bool hasVP9ExtensionSupport) { m_hasVP9ExtensionSupport = hasVP9ExtensionSupport; }
+    void setHasVP9ExtensionSupport(bool);
     bool hasVP9ExtensionSupport() const { return m_hasVP9ExtensionSupport; }
 
 private:

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -175,6 +175,13 @@ void LibWebRTCProvider::setLoggingLevel(WTFLogLevel level)
 #endif
 }
 
+void LibWebRTCProvider::willCreatePeerConnectionFactory()
+{
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA) && !PLATFORM(MACCATALYST)
+    LibWebRTCCodecs::initializeIfNeeded();
+#endif
+}
+
 } // namespace WebKit
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -72,6 +72,8 @@ private:
     RefPtr<WebCore::RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
     void setLoggingLevel(WTFLogLevel) final;
 
+    void willCreatePeerConnectionFactory() final;
+
     WebPage& m_webPage;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -43,6 +43,7 @@
 #include "InjectUserScriptImmediately.h"
 #include "InjectedBundle.h"
 #include "InjectedBundleScriptWorld.h"
+#include "LibWebRTCCodecs.h"
 #include "LibWebRTCProvider.h"
 #include "LoadParameters.h"
 #include "Logging.h"
@@ -4328,6 +4329,10 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
     if (settings.showMediaStatsContextMenuItemEnabled())
         settings.setTrackConfigurationEnabled(true);
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/WebPageUpdatePreferencesAdditions.cpp>
+#endif
 
     m_page->settingsDidChange();
 }


### PR DESCRIPTION
#### 1257206f7c78dbedea538ecffe784717d6aa0a62
<pre>
Allow to initialize LibWebRTCProvider just before creating its factory
<a href="https://bugs.webkit.org/show_bug.cgi?id=250827">https://bugs.webkit.org/show_bug.cgi?id=250827</a>
rdar://104419959

Reviewed by Eric Carlson.

Just before creating LibWebRTCProvider factory we call willInitializeFactory.
This allows WebKit to do further initialization of LibWebRTCCodecs.

* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::createPeerConnectionFactory):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::setHasVP9ExtensionSupport):
(WebKit::LibWebRTCCodecs::initializeIfNeeded):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::setHasVP9ExtensionSupport): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::willCreatePeerConnectionFactory):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):

Canonical link: <a href="https://commits.webkit.org/259083@main">https://commits.webkit.org/259083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4c80807acc8b3b599b55d33605740234e0e8680

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113100 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173400 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3882 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112206 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109645 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38514 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25479 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80165 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6345 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26861 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3399 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6250 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8280 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->