### PR TITLE
[GTK][WPE] Use base data and cache directories for tests website data configuration

### DIFF
--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -120,23 +120,9 @@ public:
 
     Test()
     {
-        GUniquePtr<char> localStorageDirectory(g_build_filename(dataDirectory(), "local-storage", nullptr));
-        GUniquePtr<char> indexedDBDirectory(g_build_filename(dataDirectory(), "indexeddb", nullptr));
-        GUniquePtr<char> diskCacheDirectory(g_build_filename(dataDirectory(), "disk-cache", nullptr));
-        GUniquePtr<char> applicationCacheDirectory(g_build_filename(dataDirectory(), "appcache", nullptr));
-        GUniquePtr<char> webSQLDirectory(g_build_filename(dataDirectory(), "websql", nullptr));
-        GUniquePtr<char> hstsDirectory(g_build_filename(dataDirectory(), "hsts", nullptr));
-        GUniquePtr<char> itpDirectory(g_build_filename(dataDirectory(), "itp", nullptr));
-        GUniquePtr<char> swRegistrationsDirectory(g_build_filename(dataDirectory(), "serviceworkers", nullptr));
-        GUniquePtr<char> domCacheDirectory(g_build_filename(dataDirectory(), "dom-cache", nullptr));
         GRefPtr<WebKitWebsiteDataManager> websiteDataManager = adoptGRef(webkit_website_data_manager_new(
-#if !ENABLE(2022_GLIB_API)
-            "local-storage-directory", localStorageDirectory.get(), "indexeddb-directory", indexedDBDirectory.get(),
-            "disk-cache-directory", diskCacheDirectory.get(), "offline-application-cache-directory", applicationCacheDirectory.get(),
-            "websql-directory", webSQLDirectory.get(), "hsts-cache-directory", hstsDirectory.get(),
-            "itp-directory", itpDirectory.get(), "service-worker-registrations-directory", swRegistrationsDirectory.get(),
-            "dom-cache-directory", domCacheDirectory.get(), 
-#endif
+            "base-data-directory", dataDirectory(),
+            "base-cache-directory", dataDirectory(),
             nullptr));
 
         m_webContext = adoptGRef(WEBKIT_WEB_CONTEXT(g_object_new(WEBKIT_TYPE_WEB_CONTEXT,


### PR DESCRIPTION
#### cf13243c111ffef61183fe7e10b6f0c23657a800
<pre>
[GTK][WPE] Use base data and cache directories for tests website data configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=250830">https://bugs.webkit.org/show_bug.cgi?id=250830</a>

Reviewed by Michael Catanzaro.

Instead of using deprecated api to set individual directories.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(testWebsiteDataConfiguration):
(prepopulateHstsData):
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::Test):

Canonical link: <a href="https://commits.webkit.org/259132@main">https://commits.webkit.org/259132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15656533761dd05ae62d3b826fb7fdc88bdaf1fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113238 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/107971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4034 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96260 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6491 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/26979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6636 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12633 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8411 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3331 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->