### PR TITLE
Non-unified build fixes, mid-January 2023 edition (bis)

### DIFF
--- a/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "CSSBackgroundRepeatValue.h"
 
+#include "CSSValueKeywords.h"
+#include <wtf/text/WTFString.h>
+
 namespace WebCore {
 
 CSSBackgroundRepeatValue::CSSBackgroundRepeatValue(CSSValueID xValue, CSSValueID yValue)

--- a/Source/WebCore/css/CSSContentDistributionValue.cpp
+++ b/Source/WebCore/css/CSSContentDistributionValue.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "CSSContentDistributionValue.h"
 
+#include "CSSValueKeywords.h"
+#include <wtf/text/WTFString.h>
+
 namespace WebCore {
 
 CSSContentDistributionValue::CSSContentDistributionValue(CSSValueID distribution, CSSValueID position, CSSValueID overflow)

--- a/Source/WebCore/css/CSSContentDistributionValue.h
+++ b/Source/WebCore/css/CSSContentDistributionValue.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+enum CSSValueID : uint16_t;
+
 class CSSContentDistributionValue final : public CSSValue {
 public:
     static Ref<CSSContentDistributionValue> create(CSSValueID distribution, CSSValueID position, CSSValueID overflow);

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -27,6 +27,7 @@
 #include "CSSParserContext.h"
 
 #include "CSSPropertyNames.h"
+#include "CSSValuePool.h"
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Page.h"

--- a/Source/WebCore/html/HTMLMetaElement.h
+++ b/Source/WebCore/html/HTMLMetaElement.h
@@ -22,12 +22,11 @@
 
 #pragma once
 
+#include "Color.h"
 #include "HTMLElement.h"
 #include "MediaQuery.h"
 
 namespace WebCore {
-
-class Color;
 
 class HTMLMetaElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLMetaElement);


### PR DESCRIPTION
#### 3fb602411bd97e628684e1fce773fac7bc66b873
<pre>
Non-unified build fixes, mid-January 2023 edition (bis)

Unreviewed non-unified build fixes.

* Source/WebCore/css/CSSBackgroundRepeatValue.cpp: Add missing
  CSSValueKeywords.h and wtf/text/WTFString.h headers.
* Source/WebCore/css/CSSContentDistributionValue.cpp: Ditto.
* Source/WebCore/css/CSSContentDistributionValue.h: Add missing forward
  declaration for CSSValueID.
* Source/WebCore/css/parser/CSSParserContext.cpp: Add missing
  CSSValuePool.h header.
* Source/WebCore/html/HTMLMetaElement.h: Replace forward declaration
  of the Color type by an inclusion of the Color.h header; the full
  definition is needed by the std::optional&lt;&gt; template usage.

Canonical link: <a href="https://commits.webkit.org/259079@main">https://commits.webkit.org/259079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00106ec04be702fdd4e1b6498588f8722a6d337

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113111 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173411 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3892 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112215 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109655 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93878 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25489 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26871 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3406 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46400 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6247 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8290 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->