### PR TITLE
HTMLFrameOwnerElement::getSVGDocument should return null rather than throwing

### DIFF
--- a/LayoutTests/svg/custom/getsvgdocument-null-expected.txt
+++ b/LayoutTests/svg/custom/getsvgdocument-null-expected.txt
@@ -1,0 +1,11 @@
+This tests that 'getSVGDocument' returns null on elements that don't contain SVG documents.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS document.createElement('object').getSVGDocument() is null
+PASS document.createElement('iframe').getSVGDocument() is null
+PASS document.createElement('embed').getSVGDocument() is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/custom/getsvgdocument-null.html
+++ b/LayoutTests/svg/custom/getsvgdocument-null.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+</head>
+<body>
+    <script>
+        description("This tests that 'getSVGDocument' returns null on elements that don't contain SVG documents.");
+
+        var types = ['object', 'iframe', 'embed'];
+
+        types.forEach(function(type) {
+            shouldBeNull("document.createElement('" + type + "').getSVGDocument()");
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -115,8 +115,7 @@ ExceptionOr<Document&> HTMLFrameOwnerElement::getSVGDocument() const
     auto* document = contentDocument();
     if (is<SVGDocument>(document))
         return *document;
-    // Spec: http://www.w3.org/TR/SVG/struct.html#InterfaceGetSVGDocument
-    return Exception { NotSupportedError };
+    return { };
 }
 
 void HTMLFrameOwnerElement::scheduleInvalidateStyleAndLayerComposition()


### PR DESCRIPTION
<pre>
HTMLFrameOwnerElement::getSVGDocument should return null rather than throwing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250758">https://bugs.webkit.org/show_bug.cgi?id=250758</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/cf7eb89e462b4f8b003025cab9c99a6770ef6c44">https://chromium.googlesource.com/chromium/blink/+/cf7eb89e462b4f8b003025cab9c99a6770ef6c44</a>

If the element's 'contentDocument' is not an SVG document (or does not exist) we currently
throw a NotSupportedError exception. This matches neither the spec[1] nor Firefox's /
Chrome's implementation.

This patch drops the exception and matches WebKit with other browser engines.

[1] <a href="https://www.w3.org/TR/SVG/struct.html#InterfaceGetSVGDocument">https://www.w3.org/TR/SVG/struct.html#InterfaceGetSVGDocument</a>

* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(HTMLFrameOwnerElement::getSVGDocument): Remove 'Exception' from function and also return 'nullptr' rather than 'exception'
* Source/WebCore/html/HTMLFrameOwnerElement.h: Remove 'Exception' from 'getSVGDocument' function
* LayoutTests/svg/custom/getsvgdocument-null.html: Add Test Case
* LayoutTests/svg/custom/getsvgdocument-null-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7cb1e4c579179e02d991b0cda6cf45e102bfdfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104362 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13444 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37272 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113578 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173871 "Hash c7cb1e4c for PR 8826 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108286 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14542 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4359 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96585 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112618 "Hash c7cb1e4c for PR 8826 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110129 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/14542 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/37272 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96585 "Hash c7cb1e4c for PR 8826 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/14542 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/37272 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96585 "Hash c7cb1e4c for PR 8826 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6804 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/37272 "Hash c7cb1e4c for PR 8826 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6934 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/4359 "Hash c7cb1e4c for PR 8826 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12957 "Hash c7cb1e4c for PR 8826 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/37272 "Hash c7cb1e4c for PR 8826 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8725 "Hash c7cb1e4c for PR 8826 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->