### PR TITLE
Updating allowed fonts in lockdown mode

### DIFF
--- a/Source/WebCore/loader/cache/AllowedFonts.cpp
+++ b/Source/WebCore/loader/cache/AllowedFonts.cpp
@@ -778,7 +778,37 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& allowedFontHas
         "cbPOcmgPQYPSjbhrGEVCBR/VM7sRRpMyM+T2ogz5jLo="_s,
         "oDdcBUoAQb1Y4qC/f6PffDkEv8T3kP0k4y/z7nD9Du8="_s,
         "QE1ggxk+VpvFwox7G8DhPs6AxuD1pQrY6WM/SPPAkVU="_s,
-        "+YU60zfVI8CzX+esMGJopwNc4P92JHEO2LOcK4iyCjM="_s });
+        "+YU60zfVI8CzX+esMGJopwNc4P92JHEO2LOcK4iyCjM="_s,
+        // font-awesome 4.7.0
+        "qljzPyOaD7AvXHpsRcBD16msmgkzNYBmlOzW1O3A1qg="_s,
+        "Kt78vAQefRj88tQXh53FoJmXqmTWdbejxLbOM9oT8/4="_s,
+        "RE3UNmYV/8ShbQErL6kBNwZdPMtBD6b9Xk3de15P/NU="_s,
+        "ugxZ3rVFD1y0Gz+TYJ7i0NmVQVh33foiPoqKdTNHTwc="_s,
+        "e/yrbbmdXPvxcFygU23ceFhUMsxfpBu9etDwCQM7KXk="_s,
+        "rWFXkmwWIrpOHQPUePFUE2hSS/xG9R5C/g2UX37zI+Q="_s,
+        // font-awesome 3.2.1
+        "GOa1/1EbkO3wmOYqxF7Z1mc6Pu4QFl0N5BZNTQKjp38="_s,
+        "YckPeDM0c8QPlRJ4lwjNzYIG3SaUARA/M9Q4zYOLsfA="_s,
+        "qVleW/O227wHaQK5q96jVgU9aaL+ZlBnBt6bs5oSa48="_s,
+        "FNy48Cs7gcK6qyMGEMNJqUKCu9l2aTdZ6bSoaU1IZFE="_s,
+        "hE8tLlXUXqIk12XzvzO0z9QWsMC9ayZ+FvjH+/bd4sE="_s,
+        // font-awesome 2.0.0
+        "+AOWr19Kg+TClydZbWr6XGkJMldfDP+gTsxQuEI2j/E="_s,
+        "qIyr/3Pxuda3SAYznoLyut+MR33D4ciYbVBCNjztqFw="_s,
+        "WjelroPmneBGeHFs8oeDdIxV3ig/PNu+viyXwV+AIeA="_s,
+        "tNJIRHp7jTHskJs6WfAucrVRJpqjCuXPJu8afrq5qME="_s,
+        // font-awesome 1.0.0
+        "aJmXHqcFloA3EYjbk8dvbFIWqF7D4SnUblDcuHJRYzg="_s,
+        "vQ47JwN2wtUCrB4QocyfnFX52oyW35K8KdREcYGq2u8="_s,
+        "V9tA0sas96RD7azKpRswnWdOs/eTf7tshAo1U7gIBIU="_s,
+        "dF+idgSeiO6zxDQWPk2vXzzWiidIaXARyz8Y6JCWXyU="_s,
+        "2q/PWx1LWzvU8MbfMEXcypiltHdu51Z+gD27SLtlax8="_s,
+        // internal build website fonts/appleicons_ultralight.woff
+        "0vR/heBF2lpWdK/on1m+u85WzVNGnaDe6lilZrVGYgw="_s,
+        // internal build website fonts/appleicons_text.woff
+        "tIMv6b3XcFfkujgiwBrBz8x/PLespHnG6XOfQDsl5Po="_s,
+        // internal build website fonts/appleicons_thin.woff
+        "BeSxgqYI30lPA9+4OhNV5gZdbPSOmr1Uc3Pfh+zxgwY="_s });
 
     return allowedFontHashes;
 }


### PR DESCRIPTION
#### e6ff9ff596a32c757bffe00b5f161d89f97a2b1c
<pre>
Updating allowed fonts in lockdown mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=250770">https://bugs.webkit.org/show_bug.cgi?id=250770</a>
rdar://102435997

Reviewed by Brent Fulgham.

Adding new target binaries to allowed fonts in lockdown mode.
Targeting fonts:

- AppleIcon fonts hosted by Apple&apos;s internal build website.
- font-awesome 4.7.0, 3.2.1, 2.0.0 and 1.0.0 from <a href="https://fontawesome.com">https://fontawesome.com</a>

* Source/WebCore/loader/cache/AllowedFonts.cpp:
(WebCore::allowedFontHashesInLockdownMode):

Canonical link: <a href="https://commits.webkit.org/259148@main">https://commits.webkit.org/259148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b9ebbd56b34a049cd7e665f12551968148e5f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113250 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173556 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4045 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112332 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38614 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80272 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26986 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3526 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6300 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8423 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->