### PR TITLE
[WGSL] Add pass to rewrite entry points to be compatible with Metal

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTAttribute.h
@@ -27,17 +27,16 @@
 
 #include "ASTNode.h"
 
-#include <wtf/UniqueRef.h>
-#include <wtf/UniqueRefVector.h>
+#include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 
 namespace WGSL::AST {
 
-class Attribute : public Node {
+class Attribute : public Node, public RefCounted<Attribute> {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    using List = UniqueRefVector<Attribute, 2>;
+    using List = Vector<Ref<Attribute>, 2>;
 
     Attribute(SourceSpan span)
         : Node(span)

--- a/Source/WebGPU/WGSL/AST/ASTBuiltinAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuiltinAttribute.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include <wtf/text/WTFString.h>
 
 namespace WGSL::AST {
 

--- a/Source/WebGPU/WGSL/AST/ASTCallableExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallableExpression.h
@@ -41,7 +41,7 @@ class CallableExpression final : public Expression {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    CallableExpression(SourceSpan span, UniqueRef<TypeDecl>&& target, Expression::List&& arguments)
+    CallableExpression(SourceSpan span, Ref<TypeDecl>&& target, Expression::List&& arguments)
         : Expression(span)
         , m_target(WTFMove(target))
         , m_arguments(WTFMove(arguments))
@@ -49,7 +49,7 @@ public:
     }
 
     Kind kind() const override;
-    TypeDecl& target() { return m_target; }
+    TypeDecl& target() { return m_target.get(); }
     Expression::List& arguments() { return m_arguments; }
 
 private:
@@ -57,7 +57,7 @@ private:
     //   * Type that does not accept parameters (bool, i32, u32, ...)
     //   * Identifier that refers to a type alias.
     //   * Identifier that refers to a function.
-    UniqueRef<TypeDecl> m_target;
+    Ref<TypeDecl> m_target;
     Expression::List m_arguments;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -66,6 +66,8 @@ class TypeDecl;
 class ArrayType;
 class NamedType;
 class ParameterizedType;
+class StructType;
+class TypeReference;
 
 class Parameter;
 class StructMember;

--- a/Source/WebGPU/WGSL/AST/ASTFunctionDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunctionDecl.h
@@ -41,7 +41,7 @@ class Parameter final : public Node {
 public:
     using List = UniqueRefVector<Parameter>;
 
-    Parameter(SourceSpan span, const String& name, UniqueRef<TypeDecl>&& type, Attribute::List&& attributes)
+    Parameter(SourceSpan span, const String& name, Ref<TypeDecl>&& type, Attribute::List&& attributes)
         : Node(span)
         , m_name(name)
         , m_type(WTFMove(type))
@@ -51,12 +51,12 @@ public:
 
     Kind kind() const override;
     const String& name() const { return m_name; }
-    TypeDecl& type() { return m_type; }
+    TypeDecl& type() { return m_type.get(); }
     Attribute::List& attributes() { return m_attributes; }
 
 private:
     String m_name;
-    UniqueRef<TypeDecl> m_type;
+    Ref<TypeDecl> m_type;
     Attribute::List m_attributes;
 };
 
@@ -66,7 +66,7 @@ class FunctionDecl final : public Decl {
 public:
     using List = UniqueRefVector<FunctionDecl>;
 
-    FunctionDecl(SourceSpan sourceSpan, const String& name, Parameter::List&& parameters, std::unique_ptr<TypeDecl>&& returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
+    FunctionDecl(SourceSpan sourceSpan, const String& name, Parameter::List&& parameters, RefPtr<TypeDecl>&& returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
         : Decl(sourceSpan)
         , m_name(name)
         , m_parameters(WTFMove(parameters))
@@ -90,7 +90,7 @@ private:
     Parameter::List m_parameters;
     Attribute::List m_attributes;
     Attribute::List m_returnAttributes;
-    std::unique_ptr<TypeDecl> m_returnType;
+    RefPtr<TypeDecl> m_returnType;
     CompoundStatement m_body;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -77,6 +77,8 @@ public:
         ArrayType,
         NamedType,
         ParameterizedType,
+        StructType,
+        TypeReference,
 
         Parameter,
         StructMember,

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -359,6 +359,16 @@ void StringDumper::visit(ParameterizedType& type)
     m_out.print(">");
 }
 
+void StringDumper::visit(StructType& type)
+{
+    m_out.print(type.structDecl().name());
+}
+
+void StringDumper::visit(TypeReference& type)
+{
+    visit(type.type());
+}
+
 void StringDumper::visit(Parameter& parameter)
 {
     m_out.print(m_indent);

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -79,6 +79,8 @@ public:
     void visit(ArrayType&) override;
     void visit(NamedType&) override;
     void visit(ParameterizedType&) override;
+    void visit(StructType&) override;
+    void visit(TypeReference&) override;
 
     void visit(Parameter&) override;
     void visit(StructMember&) override;

--- a/Source/WebGPU/WGSL/AST/ASTStructureDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureDecl.h
@@ -38,7 +38,7 @@ class StructMember final : public Node {
 public:
     using List = UniqueRefVector<StructMember>;
 
-    StructMember(SourceSpan span, const String& name, UniqueRef<TypeDecl>&& type, Attribute::List&& attributes)
+    StructMember(SourceSpan span, const String& name, Ref<TypeDecl>&& type, Attribute::List&& attributes)
         : Node(span)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
@@ -54,7 +54,7 @@ public:
 private:
     String m_name;
     Attribute::List m_attributes;
-    UniqueRef<TypeDecl> m_type;
+    Ref<TypeDecl> m_type;
 };
 
 class StructDecl final : public Decl {

--- a/Source/WebGPU/WGSL/AST/ASTVariableDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariableDecl.h
@@ -42,7 +42,7 @@ class VariableDecl final : public Decl {
 public:
     using List = UniqueRefVector<VariableDecl>;
 
-    VariableDecl(SourceSpan span, const String& name, std::unique_ptr<VariableQualifier>&& qualifier, std::unique_ptr<TypeDecl>&& type, std::unique_ptr<Expression>&& initializer, Attribute::List&& attributes)
+    VariableDecl(SourceSpan span, const String& name, std::unique_ptr<VariableQualifier>&& qualifier, RefPtr<TypeDecl>&& type, std::unique_ptr<Expression>&& initializer, Attribute::List&& attributes)
         : Decl(span)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
@@ -66,7 +66,7 @@ private:
     // Each of the following may be null
     // But at least one of type and initializer must be non-null
     std::unique_ptr<VariableQualifier> m_qualifier;
-    std::unique_ptr<TypeDecl> m_type;
+    RefPtr<TypeDecl> m_type;
     std::unique_ptr<Expression> m_initializer;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -312,6 +312,12 @@ void Visitor::visit(TypeDecl& typeDecl)
     case Node::Kind::ParameterizedType:
         checkErrorAndVisit(downcast<ParameterizedType>(typeDecl));
         break;
+    case Node::Kind::StructType:
+        checkErrorAndVisit(downcast<StructType>(typeDecl));
+        break;
+    case Node::Kind::TypeReference:
+        checkErrorAndVisit(downcast<TypeReference>(typeDecl));
+        break;
     default:
         ASSERT_NOT_REACHED("Unhandled type declaration kind");
     }
@@ -330,6 +336,14 @@ void Visitor::visit(NamedType&)
 void Visitor::visit(ParameterizedType& parameterizedType)
 {
     checkErrorAndVisit(parameterizedType.elementType());
+}
+
+void Visitor::visit(StructType&)
+{
+}
+
+void Visitor::visit(TypeReference&)
+{
 }
 
 //

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -81,6 +81,8 @@ public:
     virtual void visit(ArrayType&);
     virtual void visit(NamedType&);
     virtual void visit(ParameterizedType&);
+    virtual void visit(StructType&);
+    virtual void visit(TypeReference&);
 
     virtual void visit(Parameter&);
     virtual void visit(StructMember&);

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EntryPointRewriter.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+
+namespace WGSL {
+
+class EntryPointRewriter {
+public:
+    EntryPointRewriter(AST::ShaderModule& shaderModule, AST::FunctionDecl& functionDecl)
+        : m_shaderModule(shaderModule)
+        , m_functionDecl(functionDecl)
+        , m_emptySourceSpan(0, 0, 0, 0)
+    {
+    }
+
+    void rewrite();
+
+private:
+    struct MemberOrParameter {
+        String m_name;
+        Ref<AST::TypeDecl> m_type;
+        AST::Attribute::List m_attributes;
+    };
+
+    enum class IsBuiltin {
+        No = 0,
+        Yes = 1,
+    };
+
+    static AST::TypeDecl& getResolvedType(AST::TypeDecl&);
+
+    void collectParameters();
+    void constructInputStruct();
+    void materialize(Vector<String>& path, MemberOrParameter&, IsBuiltin);
+    void visit(Vector<String>& path, MemberOrParameter&&);
+    void appendBuiltins();
+
+    AST::ShaderModule& m_shaderModule;
+    AST::FunctionDecl& m_functionDecl;
+
+    const SourceSpan m_emptySourceSpan;
+    Vector<MemberOrParameter> m_builtins;
+    Vector<MemberOrParameter> m_parameters;
+    AST::Statement::List m_materializations;
+    String m_structTypeName;
+    String m_structParameterName;
+};
+
+AST::TypeDecl& EntryPointRewriter::getResolvedType(AST::TypeDecl& type)
+{
+    if (type.kind() == AST::Node::Kind::TypeReference)
+        return getResolvedType(downcast<AST::TypeReference>(type).type());
+
+    if (type.kind() == AST::Node::Kind::NamedType) {
+        if (auto* resolvedType = downcast<AST::NamedType>(type).maybeResolvedReference())
+            return getResolvedType(*resolvedType);
+    }
+
+    return type;
+}
+
+void EntryPointRewriter::rewrite()
+{
+    m_structTypeName = makeString("__", m_functionDecl.name(), "_inT");
+    m_structParameterName = makeString("__", m_functionDecl.name(), "_in");
+
+    collectParameters();
+
+    // nothing to rewrite
+    if (m_parameters.isEmpty()) {
+        appendBuiltins();
+        return;
+    }
+
+    // add parameter to builtins: ${structName} : ${structType}
+    m_builtins.append({
+        m_structParameterName,
+        adoptRef(*new AST::NamedType(m_emptySourceSpan, m_structTypeName)),
+        AST::Attribute::List { }
+    });
+
+    constructInputStruct();
+    appendBuiltins();
+
+    while (m_materializations.size())
+        m_functionDecl.body().statements().insert(0, m_materializations.takeLast());
+}
+
+void EntryPointRewriter::collectParameters()
+{
+    while (m_functionDecl.parameters().size()) {
+        auto parameter = m_functionDecl.parameters().takeLast();
+        Vector<String> path;
+        visit(path, MemberOrParameter { parameter->name(), parameter->type(), WTFMove(parameter->attributes()) });
+    }
+}
+
+void EntryPointRewriter::constructInputStruct()
+{
+    // insert `var ${parameter.name()} = ${structName}.${parameter.name()}`
+    AST::StructMember::List structMembers;
+    for (auto& parameter : m_parameters) {
+        auto parameterType = adoptRef(*new AST::TypeReference(m_emptySourceSpan, parameter.m_type.copyRef()));
+
+        structMembers.append(makeUniqueRef<AST::StructMember>(
+            m_emptySourceSpan,
+            parameter.m_name,
+            parameterType.copyRef(),
+            WTFMove(parameter.m_attributes)
+        ));
+    }
+
+    m_shaderModule.structs().append(makeUniqueRef<AST::StructDecl>(
+        m_emptySourceSpan,
+        m_structTypeName,
+        WTFMove(structMembers),
+        AST::Attribute::List { }
+    ));
+}
+
+void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& data, IsBuiltin isBuiltin)
+{
+    std::unique_ptr<AST::Expression> rhs;
+    if (isBuiltin == IsBuiltin::Yes)
+        rhs = makeUnique<AST::IdentifierExpression>(m_emptySourceSpan, data.m_name);
+    else {
+        rhs = makeUnique<AST::StructureAccess>(
+            m_emptySourceSpan,
+            makeUniqueRef<AST::IdentifierExpression>(m_emptySourceSpan, m_structParameterName),
+            data.m_name
+        );
+    }
+
+    if (!path.size()) {
+        m_materializations.append(makeUniqueRef<AST::VariableStatement>(
+            m_emptySourceSpan,
+            AST::VariableDecl(
+                m_emptySourceSpan,
+                data.m_name,
+                nullptr, // TODO: do we need a VariableQualifier?
+                data.m_type.copyRef(),
+                WTFMove(rhs),
+                AST::Attribute::List { }
+            )
+        ));
+        return;
+    }
+
+    path.append(data.m_name);
+    unsigned i = 0;
+    UniqueRef<AST::Expression> lhs = makeUniqueRef<AST::IdentifierExpression>(m_emptySourceSpan, path[i++]);
+    while (i < path.size()) {
+        lhs = makeUniqueRef<AST::StructureAccess>(
+            m_emptySourceSpan,
+            WTFMove(lhs),
+            path[i++]
+        );
+    }
+    path.removeLast();
+    m_materializations.append(makeUniqueRef<AST::AssignmentStatement>(
+        m_emptySourceSpan,
+        lhs.moveToUniquePtr(),
+        makeUniqueRefFromNonNullUniquePtr(WTFMove(rhs))
+    ));
+}
+
+void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
+{
+    auto& type = getResolvedType(data.m_type);
+
+    if (type.kind() == AST::Node::Kind::StructType) {
+        m_materializations.append(makeUniqueRef<AST::VariableStatement>(
+            m_emptySourceSpan,
+            AST::VariableDecl(
+                m_emptySourceSpan,
+                data.m_name,
+                nullptr,
+                &type,
+                nullptr,
+                AST::Attribute::List { }
+            )
+        ));
+        path.append(data.m_name);
+        for (auto& member : downcast<AST::StructType>(type).structDecl().members())
+            visit(path, MemberOrParameter { member.name(), member.type(), member.attributes() });
+        path.removeLast();
+        return;
+    }
+
+    bool isBuiltin = false;
+    for (auto& attribute : data.m_attributes) {
+        if (attribute->kind() == AST::Node::Kind::BuiltinAttribute) {
+            isBuiltin = true;
+            break;
+        }
+    }
+
+    if (isBuiltin) {
+        // if path is empty, then it was already a parameter and there's nothing to do
+        if (!path.isEmpty())
+            materialize(path, data, IsBuiltin::Yes);
+
+        // builtin was hoisted from a struct into a parameter, we need to reconstruct the struct
+        // ${path}.${data.m_name} = ${data.name}
+        m_builtins.append(WTFMove(data));
+        return;
+    }
+
+    // parameter was moved into a struct, so we need to reload it
+    // ${path}.${data.m_name} = ${struct}.${data.name}
+    materialize(path, data, IsBuiltin::No);
+    m_parameters.append(WTFMove(data));
+}
+
+void EntryPointRewriter::appendBuiltins()
+{
+    for (auto& data : m_builtins) {
+        m_functionDecl.parameters().append(makeUniqueRef<AST::Parameter>(
+            m_emptySourceSpan,
+            data.m_name,
+            WTFMove(data.m_type),
+            WTFMove(data.m_attributes)
+        ));
+    }
+}
+
+class RewriteEntryPoints : public AST::Visitor {
+public:
+    RewriteEntryPoints(AST::ShaderModule& shaderModule)
+        : AST::Visitor()
+        , m_shaderModule(shaderModule)
+    {
+    }
+
+    void visit(AST::FunctionDecl&) override;
+
+private:
+    AST::ShaderModule& m_shaderModule;
+};
+
+void RewriteEntryPoints::visit(AST::FunctionDecl& functionDecl)
+{
+    for (auto& attribute : functionDecl.attributes()) {
+        if (attribute->kind() == AST::Node::Kind::StageAttribute) {
+            EntryPointRewriter(m_shaderModule, functionDecl).rewrite();
+            return;
+        }
+    }
+
+}
+
+void rewriteEntryPoints(AST::ShaderModule& shaderModule)
+{
+    RewriteEntryPoints(shaderModule).AST::Visitor::visit(shaderModule);
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/EntryPointRewriter.h
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WGSL {
+
+namespace AST {
+class ShaderModule;
+}
+
+void rewriteEntryPoints(AST::ShaderModule&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -54,10 +54,13 @@ namespace WGSL {
     } while (false)
 
 #define RETURN_NODE_REF(type, ...) \
+    return { adoptRef(*new AST::type(CURRENT_SOURCE_SPAN(), __VA_ARGS__)) };
+
+#define RETURN_NODE_UNIQUE_REF(type, ...) \
     return { makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN(), __VA_ARGS__) };
 
-// Passing 0 arguments beyond the type to RETURN_NODE_REF is invalid because of a stupid limitation of the C preprocessor
-#define RETURN_NODE_REF_NO_ARGS(type) \
+// Passing 0 arguments beyond the type to RETURN_NODE_UNIQUE_REF is invalid because of a stupid limitation of the C preprocessor
+#define RETURN_NODE_UNIQUE_REF_NO_ARGS(type) \
     return { makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN()) };
 
 #define FAIL(string) \
@@ -191,7 +194,7 @@ Expected<AST::Attribute::List, Error> Parser<Lexer>::parseAttributes()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
+Expected<Ref<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
 {
     START_PARSE();
 
@@ -278,7 +281,7 @@ Expected<AST::StructMember, Error> Parser<Lexer>::parseStructMember()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDecl()
+Expected<Ref<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDecl()
 {
     START_PARSE();
 
@@ -309,7 +312,7 @@ Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDecl()
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDeclAfterIdentifier(String&& name, SourcePosition _startOfElementPosition)
+Expected<Ref<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDeclAfterIdentifier(String&& name, SourcePosition _startOfElementPosition)
 {
     if (auto kind = AST::ParameterizedType::stringToKind(name)) {
         CONSUME_TYPE(LT);
@@ -321,13 +324,13 @@ Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseTypeDeclAfterIdent
 }
 
 template<typename Lexer>
-Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseArrayType()
+Expected<Ref<AST::TypeDecl>, Error> Parser<Lexer>::parseArrayType()
 {
     START_PARSE();
 
     CONSUME_TYPE(KeywordArray);
 
-    std::unique_ptr<AST::TypeDecl> maybeElementType;
+    RefPtr<AST::TypeDecl> maybeElementType;
     std::unique_ptr<AST::Expression> maybeElementCount;
 
     if (current().m_type == TokenType::LT) {
@@ -336,7 +339,7 @@ Expected<UniqueRef<AST::TypeDecl>, Error> Parser<Lexer>::parseArrayType()
         consume();
 
         PARSE(elementType, TypeDecl);
-        maybeElementType = elementType.moveToUniquePtr();
+        maybeElementType = WTFMove(elementType);
 
         if (current().m_type == TokenType::Comma) {
             consume();
@@ -376,11 +379,11 @@ Expected<AST::VariableDecl, Error> Parser<Lexer>::parseVariableDeclWithAttribute
 
     CONSUME_TYPE_NAMED(name, Identifier);
 
-    std::unique_ptr<AST::TypeDecl> maybeType = nullptr;
+    RefPtr<AST::TypeDecl> maybeType = nullptr;
     if (current().m_type == TokenType::Colon) {
         consume();
         PARSE(typeDecl, TypeDecl);
-        maybeType = typeDecl.moveToUniquePtr();
+        maybeType = WTFMove(typeDecl);
     }
 
     std::unique_ptr<AST::Expression> maybeInitializer = nullptr;
@@ -485,13 +488,13 @@ Expected<AST::FunctionDecl, Error> Parser<Lexer>::parseFunctionDecl(AST::Attribu
     CONSUME_TYPE(ParenRight);
 
     AST::Attribute::List returnAttributes;
-    std::unique_ptr<AST::TypeDecl> maybeReturnType = nullptr;
+    RefPtr<AST::TypeDecl> maybeReturnType = nullptr;
     if (current().m_type == TokenType::Arrow) {
         consume();
         PARSE(parsedReturnAttributes, Attributes);
         returnAttributes = WTFMove(parsedReturnAttributes);
         PARSE(type, TypeDecl);
-        maybeReturnType = type.moveToUniquePtr();
+        maybeReturnType = WTFMove(type);
     }
 
     PARSE(body, CompoundStatement);
@@ -543,7 +546,7 @@ Expected<UniqueRef<AST::Statement>, Error> Parser<Lexer>::parseStatement()
         CONSUME_TYPE(Equal);
         PARSE(rhs, Expression);
         CONSUME_TYPE(Semicolon);
-        RETURN_NODE_REF(AssignmentStatement, lhs.moveToUniquePtr(), WTFMove(rhs));
+        RETURN_NODE_UNIQUE_REF(AssignmentStatement, lhs.moveToUniquePtr(), WTFMove(rhs));
     }
     default:
         FAIL("Not a valid statement"_s);
@@ -605,7 +608,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseAdditiveExpressi
     if (current().m_type == TokenType::Plus) {
         consume();
         PARSE(rhs, UnaryExpression);
-        RETURN_NODE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), AST::BinaryOperation::Add);
+        RETURN_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), AST::BinaryOperation::Add);
     }
     return parseMultiplicativeExpression(WTFMove(lhs));
 }
@@ -625,7 +628,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseUnaryExpression(
     if (current().m_type == TokenType::Minus) {
         consume();
         PARSE(expression, SingularExpression);
-        RETURN_NODE_REF(UnaryExpression, WTFMove(expression), AST::UnaryOperation::Negate);
+        RETURN_NODE_UNIQUE_REF(UnaryExpression, WTFMove(expression), AST::UnaryOperation::Negate);
     }
 
     return parseSingularExpression();
@@ -699,42 +702,42 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePrimaryExpressio
         if (current().m_type == TokenType::LT || current().m_type == TokenType::ParenLeft) {
             PARSE(type, TypeDeclAfterIdentifier, WTFMove(ident.m_ident), _startOfElementPosition);
             PARSE(arguments, ArgumentExpressionList);
-            RETURN_NODE_REF(CallableExpression, WTFMove(type), WTFMove(arguments));
+            RETURN_NODE_UNIQUE_REF(CallableExpression, WTFMove(type), WTFMove(arguments));
         }
-        RETURN_NODE_REF(IdentifierExpression, ident.m_ident);
+        RETURN_NODE_UNIQUE_REF(IdentifierExpression, ident.m_ident);
     }
     case TokenType::KeywordArray: {
         PARSE(arrayType, ArrayType);
         PARSE(arguments, ArgumentExpressionList);
-        RETURN_NODE_REF(CallableExpression, WTFMove(arrayType), WTFMove(arguments));
+        RETURN_NODE_UNIQUE_REF(CallableExpression, WTFMove(arrayType), WTFMove(arguments));
     }
 
     // const_literal
     case TokenType::LiteralTrue:
         consume();
-        RETURN_NODE_REF(BoolLiteral, true);
+        RETURN_NODE_UNIQUE_REF(BoolLiteral, true);
     case TokenType::LiteralFalse:
         consume();
-        RETURN_NODE_REF(BoolLiteral, false);
+        RETURN_NODE_UNIQUE_REF(BoolLiteral, false);
     case TokenType::IntegerLiteral: {
         CONSUME_TYPE_NAMED(lit, IntegerLiteral);
-        RETURN_NODE_REF(AbstractIntLiteral, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(AbstractIntLiteral, lit.m_literalValue);
     }
     case TokenType::IntegerLiteralSigned: {
         CONSUME_TYPE_NAMED(lit, IntegerLiteralSigned);
-        RETURN_NODE_REF(Int32Literal, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(Int32Literal, lit.m_literalValue);
     }
     case TokenType::IntegerLiteralUnsigned: {
         CONSUME_TYPE_NAMED(lit, IntegerLiteralUnsigned);
-        RETURN_NODE_REF(Uint32Literal, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(Uint32Literal, lit.m_literalValue);
     }
     case TokenType::DecimalFloatLiteral: {
         CONSUME_TYPE_NAMED(lit, DecimalFloatLiteral);
-        RETURN_NODE_REF(AbstractFloatLiteral, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.m_literalValue);
     }
     case TokenType::HexFloatLiteral: {
         CONSUME_TYPE_NAMED(lit, HexFloatLiteral);
-        RETURN_NODE_REF(AbstractFloatLiteral, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.m_literalValue);
     }
     // TODO: bitcast expression
 
@@ -777,7 +780,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parseCoreLHSExpressio
     }
     case TokenType::Identifier: {
         CONSUME_TYPE_NAMED(ident, Identifier);
-        RETURN_NODE_REF(IdentifierExpression, ident.m_ident);
+        RETURN_NODE_UNIQUE_REF(IdentifierExpression, ident.m_ident);
     }
     default:
         break;

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -29,6 +29,7 @@
 #include "ASTExpression.h"
 #include "CompilationMessage.h"
 #include "Lexer.h"
+#include <wtf/Ref.h>
 
 namespace WGSL {
 
@@ -65,12 +66,12 @@ public:
     // UniqueRef whenever it can return multiple types.
     Expected<UniqueRef<AST::Decl>, Error> parseGlobalDecl();
     Expected<AST::Attribute::List, Error> parseAttributes();
-    Expected<UniqueRef<AST::Attribute>, Error> parseAttribute();
+    Expected<Ref<AST::Attribute>, Error> parseAttribute();
     Expected<AST::StructDecl, Error> parseStructDecl(AST::Attribute::List&&);
     Expected<AST::StructMember, Error> parseStructMember();
-    Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDecl();
-    Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDeclAfterIdentifier(String&&, SourcePosition start);
-    Expected<UniqueRef<AST::TypeDecl>, Error> parseArrayType();
+    Expected<Ref<AST::TypeDecl>, Error> parseTypeDecl();
+    Expected<Ref<AST::TypeDecl>, Error> parseTypeDeclAfterIdentifier(String&&, SourcePosition start);
+    Expected<Ref<AST::TypeDecl>, Error> parseArrayType();
     Expected<AST::VariableDecl, Error> parseVariableDecl();
     Expected<AST::VariableDecl, Error> parseVariableDeclWithAttributes(AST::Attribute::List&&);
     Expected<AST::VariableQualifier, Error> parseVariableQualifier();

--- a/Source/WebGPU/WGSL/PhaseTimer.h
+++ b/Source/WebGPU/WGSL/PhaseTimer.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTStringDumper.h"
+#include <wtf/DataLog.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/Seconds.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WGSL {
+
+namespace AST {
+class ShaderModule;
+}
+
+static constexpr bool dumpASTBeforeEachPass = false;
+static constexpr bool dumpASTAfterParsing = false;
+static constexpr bool dumpASTAtEnd = false;
+static constexpr bool alwaysDumpPassFailures = false;
+static constexpr bool dumpPassFailure = dumpASTBeforeEachPass || dumpASTAfterParsing || dumpASTAtEnd || alwaysDumpPassFailures;
+static constexpr bool dumpPhaseTimes = false;
+
+static inline bool dumpASTIfNeeded(bool shouldDump, AST::ShaderModule& program, const char* message)
+{
+    if (UNLIKELY(shouldDump)) {
+        dataLogLn(message);
+        dumpAST(program);
+        return true;
+    }
+
+    return false;
+}
+
+static inline bool dumpASTAfterParsingIfNeeded(AST::ShaderModule& program)
+{
+    return dumpASTIfNeeded(dumpASTAfterParsing, program, "AST after parsing");
+}
+
+static inline bool dumpASTBetweenEachPassIfNeeded(AST::ShaderModule& program, const char* message)
+{
+    return dumpASTIfNeeded(dumpASTBeforeEachPass, program, message);
+}
+
+static inline bool dumpASTAtEndIfNeeded(AST::ShaderModule& program)
+{
+    return dumpASTIfNeeded(dumpASTAtEnd, program, "AST at end");
+}
+
+using PhaseTimes = Vector<std::pair<const char*, Seconds>>;
+
+static inline void logPhaseTimes(PhaseTimes& phaseTimes)
+{
+    if (LIKELY(!dumpPhaseTimes))
+        return;
+
+    for (auto& entry : phaseTimes)
+        dataLogLn(entry.first, ": ", entry.second.milliseconds(), " ms");
+}
+
+class PhaseTimer {
+public:
+    PhaseTimer(const char* phaseName, PhaseTimes& phaseTimes)
+        : m_phaseTimes(phaseTimes)
+    {
+        if (dumpPhaseTimes) {
+            m_phaseName = phaseName;
+            m_start = MonotonicTime::now();
+        }
+    }
+
+    ~PhaseTimer()
+    {
+        if (dumpPhaseTimes) {
+            auto totalTime = MonotonicTime::now() - m_start;
+            m_phaseTimes.append({ m_phaseName, totalTime });
+        }
+    }
+
+private:
+    const char* m_phaseName;
+    PhaseTimes& m_phaseTimes;
+    MonotonicTime m_start;
+};
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/ResolveTypeReferences.cpp
+++ b/Source/WebGPU/WGSL/ResolveTypeReferences.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ResolveTypeReferences.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+#include <wtf/HashMap.h>
+#include <wtf/Ref.h>
+
+namespace WGSL {
+
+class ResolveTypeReferences : public AST::Visitor {
+public:
+    ResolveTypeReferences()
+        : AST::Visitor()
+    {
+    }
+
+    void visit(AST::StructDecl&) override;
+    void visit(AST::NamedType&) override;
+
+private:
+    HashMap<String, Ref<AST::TypeDecl>> m_typeContext;
+};
+
+
+void ResolveTypeReferences::visit(AST::StructDecl& structDecl)
+{
+    m_typeContext.add(structDecl.name(), adoptRef(*new AST::StructType(structDecl.span(), structDecl)));
+}
+
+void ResolveTypeReferences::visit(AST::NamedType& namedType)
+{
+    auto it = m_typeContext.find(namedType.name());
+    if (it != m_typeContext.end())
+        namedType.resolveTypeReference(it->value.copyRef());
+}
+
+void resolveTypeReferences(AST::ShaderModule& shaderModule)
+{
+    ResolveTypeReferences().AST::Visitor::visit(shaderModule);
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/ResolveTypeReferences.h
+++ b/Source/WebGPU/WGSL/ResolveTypeReferences.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WGSL {
+
+namespace AST {
+class ShaderModule;
+}
+
+void resolveTypeReferences(AST::ShaderModule&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -88,6 +88,11 @@
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
 		979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B5297018290050EA2C /* MetalFunctionWriter.cpp */; };
+		979240C029753B2A0050EA2C /* PhaseTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240BC29753B2A0050EA2C /* PhaseTimer.h */; };
+		979240C4297558F10050EA2C /* ResolveTypeReferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240C2297558F10050EA2C /* ResolveTypeReferences.cpp */; };
+		979240C5297558F10050EA2C /* ResolveTypeReferences.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C3297558F10050EA2C /* ResolveTypeReferences.h */; };
+		979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C629769AC00050EA2C /* EntryPointRewriter.h */; };
+		979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240C729769AC00050EA2C /* EntryPointRewriter.cpp */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
 
@@ -332,6 +337,11 @@
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
 		979240B5297018290050EA2C /* MetalFunctionWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalFunctionWriter.cpp; sourceTree = "<group>"; };
+		979240BC29753B2A0050EA2C /* PhaseTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhaseTimer.h; sourceTree = "<group>"; };
+		979240C2297558F10050EA2C /* ResolveTypeReferences.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResolveTypeReferences.cpp; sourceTree = "<group>"; };
+		979240C3297558F10050EA2C /* ResolveTypeReferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResolveTypeReferences.h; sourceTree = "<group>"; };
+		979240C629769AC00050EA2C /* EntryPointRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntryPointRewriter.h; sourceTree = "<group>"; };
+		979240C729769AC00050EA2C /* EntryPointRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntryPointRewriter.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -608,11 +618,16 @@
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
+				979240C729769AC00050EA2C /* EntryPointRewriter.cpp */,
+				979240C629769AC00050EA2C /* EntryPointRewriter.h */,
 				338BB2D527B6B68700E066AB /* Lexer.cpp */,
 				338BB2D327B6B66C00E066AB /* Lexer.h */,
 				339B7B1A27D800090072BF9A /* Parser.cpp */,
 				339B7B1727D7FFA40072BF9A /* Parser.h */,
 				66DC575428627E0B0014CABD /* ParserPrivate.h */,
+				979240BC29753B2A0050EA2C /* PhaseTimer.h */,
+				979240C2297558F10050EA2C /* ResolveTypeReferences.cpp */,
+				979240C3297558F10050EA2C /* ResolveTypeReferences.h */,
 				338BB2D127B6B63F00E066AB /* SourceSpan.h */,
 				338BB2CF27B6B61B00E066AB /* Token.cpp */,
 				338BB2CD27B6B60200E066AB /* Token.h */,
@@ -747,11 +762,14 @@
 				3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */,
 				3A1337E828FBD56400F29B73 /* ASTVisitor.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
+				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
 				979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */,
 				979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */,
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
 				66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */,
+				979240C029753B2A0050EA2C /* PhaseTimer.h in Headers */,
+				979240C5297558F10050EA2C /* ResolveTypeReferences.h in Headers */,
 				338BB2D227B6B63F00E066AB /* SourceSpan.h in Headers */,
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
@@ -947,10 +965,12 @@
 				3ADB94442900F7D700CFFDC2 /* ASTStringDumper.cpp in Sources */,
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
+				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
 				979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */,
 				979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,
+				979240C4297558F10050EA2C /* ResolveTypeReferences.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,
 			);

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -136,10 +136,10 @@ TEST(WGSLParserTests, GlobalVariable)
     EXPECT_TRUE(shader->functions().isEmpty());
     auto& var = shader->globalVars()[0];
     EXPECT_EQ(var.attributes().size(), 2u);
-    EXPECT_TRUE(is<WGSL::AST::GroupAttribute>(var.attributes()[0]));
-    EXPECT_FALSE(downcast<WGSL::AST::GroupAttribute>(var.attributes()[0]).group());
-    EXPECT_TRUE(is<WGSL::AST::BindingAttribute>(var.attributes()[1]));
-    EXPECT_FALSE(downcast<WGSL::AST::BindingAttribute>(var.attributes()[1]).binding());
+    EXPECT_TRUE(is<WGSL::AST::GroupAttribute>(var.attributes()[0].get()));
+    EXPECT_FALSE(downcast<WGSL::AST::GroupAttribute>(var.attributes()[0].get()).group());
+    EXPECT_TRUE(is<WGSL::AST::BindingAttribute>(var.attributes()[1].get()));
+    EXPECT_FALSE(downcast<WGSL::AST::BindingAttribute>(var.attributes()[1].get()).binding());
     EXPECT_EQ(var.name(), "x"_s);
     EXPECT_TRUE(var.maybeQualifier());
     EXPECT_EQ(var.maybeQualifier()->storageClass(), WGSL::AST::StorageClass::Storage);
@@ -167,8 +167,8 @@ TEST(WGSLParserTests, FunctionDecl)
     EXPECT_EQ(shader->functions().size(), 1u);
     auto& func = shader->functions()[0];
     EXPECT_EQ(func.attributes().size(), 1u);
-    EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0]));
-    EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Compute);
+    EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0].get()));
+    EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Compute);
     EXPECT_EQ(func.name(), "main"_s);
     EXPECT_TRUE(func.parameters().isEmpty());
     EXPECT_TRUE(func.returnAttributes().isEmpty());
@@ -210,21 +210,21 @@ TEST(WGSLParserTests, TrivialGraphicsShader)
     {
         auto& func = shader->functions()[0];
         EXPECT_EQ(func.attributes().size(), 1u);
-        EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0]));
-        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
+        EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0].get()));
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
         EXPECT_EQ(func.name(), "vertexShader"_s);
         EXPECT_EQ(func.parameters().size(), 1u);
         EXPECT_EQ(func.parameters()[0].name(), "x"_s);
         EXPECT_EQ(func.parameters()[0].attributes().size(), 1u);
-        EXPECT_TRUE(is<WGSL::AST::LocationAttribute>(func.parameters()[0].attributes()[0]));
-        EXPECT_EQ(downcast<WGSL::AST::LocationAttribute>(func.parameters()[0].attributes()[0]).location(), 0U);
+        EXPECT_TRUE(is<WGSL::AST::LocationAttribute>(func.parameters()[0].attributes()[0].get()));
+        EXPECT_EQ(downcast<WGSL::AST::LocationAttribute>(func.parameters()[0].attributes()[0].get()).location(), 0U);
         EXPECT_TRUE(is<WGSL::AST::ParameterizedType>(func.parameters()[0].type()));
         auto& paramType = downcast<WGSL::AST::ParameterizedType>(func.parameters()[0].type());
         EXPECT_EQ(paramType.base(), WGSL::AST::ParameterizedType::Base::Vec4);
         EXPECT_TRUE(is<WGSL::AST::NamedType>(paramType.elementType()));
         EXPECT_EQ(downcast<WGSL::AST::NamedType>(paramType.elementType()).name(), "f32"_s);
         EXPECT_EQ(func.returnAttributes().size(), 1u);
-        checkBuiltin(func.returnAttributes()[0], "position"_s);
+        checkBuiltin(func.returnAttributes()[0].get(), "position"_s);
         EXPECT_TRUE(func.maybeReturnType());
         EXPECT_TRUE(is<WGSL::AST::ParameterizedType>(func.maybeReturnType()));
         EXPECT_EQ(func.body().statements().size(), 1u);
@@ -237,13 +237,13 @@ TEST(WGSLParserTests, TrivialGraphicsShader)
     {
         auto& func = shader->functions()[1];
         EXPECT_EQ(func.attributes().size(), 1u);
-        EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0]));
-        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Fragment);
+        EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0].get()));
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Fragment);
         EXPECT_EQ(func.name(), "fragmentShader"_s);
         EXPECT_TRUE(func.parameters().isEmpty());
         EXPECT_EQ(func.returnAttributes().size(), 1u);
-        EXPECT_TRUE(is<WGSL::AST::LocationAttribute>(func.returnAttributes()[0]));
-        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.returnAttributes()[0]).location());
+        EXPECT_TRUE(is<WGSL::AST::LocationAttribute>(func.returnAttributes()[0].get()));
+        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.returnAttributes()[0].get()).location());
         EXPECT_TRUE(func.maybeReturnType());
         EXPECT_TRUE(is<WGSL::AST::ParameterizedType>(func.maybeReturnType()));
         EXPECT_EQ(func.body().statements().size(), 1u);
@@ -284,8 +284,8 @@ TEST(WGSLParserTests, LocalVariable)
         auto& func = shader->functions()[0];
         // @vertex
         EXPECT_EQ(func.attributes().size(), 1u);
-        EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0]));
-        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
+        EXPECT_TRUE(is<WGSL::AST::StageAttribute>(func.attributes()[0].get()));
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
 
         // fn main() -> vec4<f32> {
         EXPECT_EQ(func.name(), "main"_s);
@@ -482,7 +482,7 @@ TEST(WGSLParserTests, TriangleVert)
         EXPECT_TRUE(func.maybeReturnType());
         checkVec4F32Type(*func.maybeReturnType());
         EXPECT_EQ(func.returnAttributes().size(), 1u);
-        checkBuiltin(func.returnAttributes()[0], "position"_s);
+        checkBuiltin(func.returnAttributes()[0].get(), "position"_s);
     }
 
     // var pos = array<vec2<f32>, 3>(...);

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
@@ -28,52 +28,32 @@ async function helloTriangle() {
     const pipelineLayoutDesc = { bindGroupLayouts: [uniformBindGroupLayout] };
     const layout = device.createPipelineLayout(pipelineLayoutDesc);
 /*
-    FIXME: Use WGSL once compiler is brought up
+    FIXME: Add support for binary expressions to match the metal code
+*/
     const wgslSource = `
-                     @vertex fn vsmain(@builtin(vertex_index) VertexIndex: u32) -> @builtin(position) vec4<f32>
+                     struct Vertex {
+                         @builtin(position) Position: vec4<f32>,
+                         @location(0) color: vec4<f32>,
+                     }
+
+                     @vertex fn vsmain(@builtin(vertex_index) VertexIndex: u32) -> Vertex
                      {
                          var pos: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                              vec2<f32>( 0.0,  0.5),
                              vec2<f32>(-0.5, -0.5),
                              vec2<f32>( 0.5, -0.5)
                          );
-                         return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                         var vertex_out : Vertex;
+                         vertex_out.Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                         vertex_out.color = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                         return vertex_out;
                      }
 
-                     @fragment fn fsmain() -> @location(0) vec4<f32>
+                     @fragment fn fsmain(in: Vertex) -> @location(0) vec4<f32>
                      {
-                         return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+                         return in.color;
                      }
     `;
- */
-    const wgslSource = `
-                #include <metal_stdlib>
-                using namespace metal;
-                struct Vertex {
-                   float4 position [[position]];
-                   float4 color;
-                };
-
-                vertex Vertex vsmain(unsigned VertexIndex [[vertex_id]])
-                {
-                   float2 pos[3] = {
-                       float2( 0.0,  0.5),
-                       float2(-0.5, -0.5),
-                       float2( 0.5, -0.5),
-                   };
-
-                   Vertex vout;
-                   vout.position = float4(pos[VertexIndex], 0.0, 1.0);
-                   vout.color = float4(pos[VertexIndex] + float2(0.5, 0.5), 0.0, 1.0);
-                   return vout;
-                }
-
-                fragment float4 fsmain(Vertex in [[stage_in]])
-                {
-                    return in.color;
-                }
-    `;
-
     const shaderModule = device.createShaderModule({ code: wgslSource, isWHLSL: false, hints: [ {layout: layout }, ] });
     
     /* GPUPipelineStageDescriptors */


### PR DESCRIPTION
#### 021a45c18eba49cfc45b5cad694f05095c138414
<pre>
[WGSL] Add pass to rewrite entry points to be compatible with Metal
<a href="https://bugs.webkit.org/show_bug.cgi?id=250832">https://bugs.webkit.org/show_bug.cgi?id=250832</a>
&lt;rdar://problem/104425157&gt;

Reviewed by Myles C. Maxfield.

For entry point function, builtin inputs contained in structs must be hoisted
into function parameters, and any non-builtin parameters must be moved into a
`stage_in` struct.

The implementation can&apos;t quite handle absolutely every use case yet, but the
patch was getting pretty large so I thought I pause here and commit something
that works.

A couple other things had to happen to get this initial implementation working:
- I needed some basic type information, so I added a very rudimentary pass to
  resolve type names and a new struct type.
- I also had to modify the AST to use `Ref`/`RefPtr` instead of `UniqueRef`/`unique_ptr`
  for types, since we need to be able to copy nodes when moving parameters around.
- Fixed a couple small serialization bugs with missing semicolons in MetalFunctionWriter
  and added serialization for matrix types.

* Source/WebGPU/WGSL/AST/ASTAttribute.h:
* Source/WebGPU/WGSL/AST/ASTBuiltinAttribute.h:
* Source/WebGPU/WGSL/AST/ASTCallableExpression.h:
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTFunctionDecl.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTStructureDecl.h:
* Source/WebGPU/WGSL/AST/ASTTypeDecl.h:
(WGSL::AST::ParameterizedType::ParameterizedType):
(isType):
* Source/WebGPU/WGSL/AST/ASTVariableDecl.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp: Added.
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::EntryPointRewriter::getResolvedType):
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::collectParameters):
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::appendBuiltins):
(WGSL::RewriteEntryPoints::RewriteEntryPoints):
(WGSL::RewriteEntryPoints::visit):
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/EntryPointRewriter.h: Added.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseTypeDecl):
(WGSL::Parser&lt;Lexer&gt;::parseTypeDeclAfterIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseVariableDeclWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseFunctionDecl):
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseUnaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parseCoreLHSExpression):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/PhaseTimer.h: Added.
(WGSL::dumpASTIfNeeded):
(WGSL::dumpASTAfterParsingIfNeeded):
(WGSL::dumpASTBetweenEachPassIfNeeded):
(WGSL::dumpASTAtEndIfNeeded):
(WGSL::logPhaseTimes):
(WGSL::PhaseTimer::PhaseTimer):
(WGSL::PhaseTimer::~PhaseTimer):
* Source/WebGPU/WGSL/ResolveTypeReferences.cpp: Added.
(WGSL::ResolveTypeReferences::ResolveTypeReferences):
(WGSL::ResolveTypeReferences::visit):
(WGSL::resolveTypeReferences):
* Source/WebGPU/WGSL/ResolveTypeReferences.h: Added.
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepare):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):
* Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js:
(async helloTriangle):

Canonical link: <a href="https://commits.webkit.org/259149@main">https://commits.webkit.org/259149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/978fcfeff1b3d74ab0ad5cb46b1272d34bd91d82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104058 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113270 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173577 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4065 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112351 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109828 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38626 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80283 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27004 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3544 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6301 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8444 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->