### PR TITLE
REGRESSION({257865,259017}@main: [JSC] fix ENABLE(WEBASSEMBLY{_B3JIT}) 

### DIFF
--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -47,6 +47,12 @@
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/CString.h>
 
+#if ENABLE(WEBASSEMBLY) && ENABLE(WEBASSEMBLY_B3JIT)
+#define simdScalarTypeToB3Type(type) toB3Type(Wasm::simdScalarType(type))
+#else
+#define simdScalarTypeToB3Type(type) B3::Type()
+#endif
+
 namespace JSC { namespace B3 {
 
 namespace {
@@ -452,7 +458,7 @@ public:
             case VectorExtractLane:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 1, ("At ", *value));
-                VALIDATE(value->type() == toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
+                VALIDATE(value->type() == simdScalarTypeToB3Type(value->asSIMDValue()->simdLane()), ("At ", *value));
                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
                 break;
             case VectorReplaceLane:
@@ -460,7 +466,7 @@ public:
                 VALIDATE(value->numChildren() == 2, ("At ", *value));
                 VALIDATE(value->type() == V128, ("At ", *value));
                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
-                VALIDATE(value->child(1)->type() == toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
+                VALIDATE(value->child(1)->type() == simdScalarTypeToB3Type(value->asSIMDValue()->simdLane()), ("At ", *value));
                 break;
             case VectorDupElement:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
@@ -481,7 +487,7 @@ public:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 1, ("At ", *value));
                 VALIDATE(value->type() == V128, ("At ", *value));
-                VALIDATE(value->child(0)->type() == toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
+                VALIDATE(value->child(0)->type() == simdScalarTypeToB3Type(value->asSIMDValue()->simdLane()), ("At ", *value));
                 break;
 
             case VectorPopcnt:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -16074,9 +16074,9 @@ void SpeculativeJIT::compileGetPrototypeOf(Node* node)
     }
 }
 
+#if ENABLE(WEBASSEMBLY)
 void SpeculativeJIT::compileGetWebAssemblyInstanceExports(Node* node)
 {
-#if ENABLE(WEBASSEMBLY)
     SpeculateCellOperand base(this, node->child1());
     GPRTemporary result(this);
 
@@ -16087,10 +16087,8 @@ void SpeculativeJIT::compileGetWebAssemblyInstanceExports(Node* node)
     loadPtr(Address(resultGPR, WebAssemblyModuleRecord::offsetOfExportsObject()), resultGPR);
 
     cellResult(resultGPR, node);
-#else
-    UNUSED_PARAM(node);
-#endif
 }
+#endif
 
 void SpeculativeJIT::compileIdentity(Node* node)
 {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1303,7 +1303,9 @@ public:
     void compileLoadValueFromMapBucket(Node*);
     void compileExtractValueFromWeakMapGet(Node*);
     void compileGetPrototypeOf(Node*);
+#if ENABLE(WEBASSEMBLY)
     void compileGetWebAssemblyInstanceExports(Node*);
+#endif
     void compileIdentity(Node*);
     
     void compileContiguousPutByVal(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3441,7 +3441,11 @@ void SpeculativeJIT::compile(Node* node)
     }
 
     case GetWebAssemblyInstanceExports: {
+#if ENABLE(WEBASSEMBLY)
         compileGetWebAssemblyInstanceExports(node);
+#else
+        RELEASE_ASSERT_NOT_REACHED();
+#endif
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4593,7 +4593,11 @@ void SpeculativeJIT::compile(Node* node)
     }
 
     case GetWebAssemblyInstanceExports: {
+#if ENABLE(WEBASSEMBLY)
         compileGetWebAssemblyInstanceExports(node);
+#else
+        RELEASE_ASSERT_NOT_REACHED();
+#endif
         break;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -121,7 +121,6 @@ namespace JSC { namespace FTL {
     macro(JSRopeString_fiber2, JSRopeString::offsetOfFiber2()) \
     macro(JSScope_next, JSScope::offsetOfNext()) \
     macro(JSSymbolTableObject_symbolTable, JSSymbolTableObject::offsetOfSymbolTable()) \
-    macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord()) \
     macro(NativeExecutable_asString, NativeExecutable::offsetOfAsString()) \
     macro(RegExpObject_regExpAndFlags, RegExpObject::offsetOfRegExpAndFlags()) \
     macro(RegExpObject_lastIndex, RegExpObject::offsetOfLastIndex()) \
@@ -167,8 +166,15 @@ namespace JSC { namespace FTL {
     macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer()) \
     macro(WeakMapBucket_value, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfValue()) \
     macro(WeakMapBucket_key, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey()) \
-    macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject()) \
     macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl()) \
+
+#if ENABLE(WEBASSEMBLY)
+#define FOR_EACH_ABSTRACT_FIELD_WASM(macro) \
+    macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord()) \
+    macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject())
+#else
+#define FOR_EACH_ABSTRACT_FIELD_WASM(macro)
+#endif
 
 #define FOR_EACH_INDEXED_ABSTRACT_HEAP(macro) \
     macro(ArrayStorage_vector, ArrayStorage::vectorOffset(), sizeof(WriteBarrier<Unknown>)) \
@@ -210,6 +216,7 @@ public:
 
 #define ABSTRACT_FIELD_DECLARATION(name, offset) AbstractHeap name;
     FOR_EACH_ABSTRACT_FIELD(ABSTRACT_FIELD_DECLARATION)
+    FOR_EACH_ABSTRACT_FIELD_WASM(ABSTRACT_FIELD_DECLARATION)
 #undef ABSTRACT_FIELD_DECLARATION
     
     AbstractHeap& JSCell_freeListNext;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1204,7 +1204,11 @@ private:
             compileGetPrototypeOf();
             break;
         case GetWebAssemblyInstanceExports:
+#if ENABLE(WEBASSEMBLY)
             compileGetWebAssemblyInstanceExports();
+#else
+            RELEASE_ASSERT_NOT_REACHED();
+#endif
             break;
         case AllocatePropertyStorage:
             compileAllocatePropertyStorage();
@@ -1400,7 +1404,11 @@ private:
             compileCallDirectEval();
             break;
         case CallWasm:
+#if ENABLE(WEBASSEMBLY)
             compileCallWasm();
+#else
+            RELEASE_ASSERT_NOT_REACHED();
+#endif
             break;
         case VarargsLength:
             compileVarargsLength();
@@ -5190,12 +5198,14 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(m_out.phi(Int64, monoProto, polyProto, slowResult));
     }
 
+#if ENABLE(WEBASSEMBLY)
     void compileGetWebAssemblyInstanceExports()
     {
         LValue base = lowCell(m_node->child1());
         LValue moduleRecord = m_out.loadPtr(base, m_heaps.JSWebAssemblyInstance_moduleRecord);
         setJSValue(m_out.loadPtr(moduleRecord, m_heaps.WebAssemblyModuleRecord_exportsObject));
     }
+#endif
 
     LValue typedArrayLength(LValue base, bool acceptResizable, std::optional<TypedArrayType> typedArrayType)
     {
@@ -11627,6 +11637,7 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(patchpoint);
     }
 
+#if ENABLE(WEBASSEMBLY)
     void compileCallWasm()
     {
         Node* node = m_node;
@@ -11837,6 +11848,7 @@ IGNORE_CLANG_WARNINGS_END
             }
         }
     }
+#endif
 
     void compileVarargsLength()
     {


### PR DESCRIPTION
Two WEBASSEMBLY related commits.

The first was seen yesterday (webkitgtk-2.39.4).
The second today (webkitgtk-2.39.5). (yes, webkitgtk-2.39.5 was released today)
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c789e1fbd78b6a29e596ec80bb8e286b9fdf795c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114512 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174700 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5253 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97567 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114445 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39493 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81146 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95081 "Found 123 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.ftl-eager, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.ftl-eager, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-b3o0, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27963 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93135 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5397 "Found 134 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.ftl-eager, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-large.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.ftl-eager, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit, microbenchmarks/memcpy-wasm-medium.js.ftl-eager-no-cjit-b3o1, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-b3o0, microbenchmarks/memcpy-wasm-medium.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7761 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4562 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30337 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47518 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101837 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9550 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25414 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->