### PR TITLE
[ATSPI] Make `Atspi::CoordinateType` an enum class

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
@@ -229,7 +229,7 @@ enum class Relation {
     ErrorFor,
 };
 
-enum CoordinateType {
+enum class CoordinateType {
     ScreenCoordinates,
     WindowCoordinates,
     ParentCoordinates,

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -95,10 +95,10 @@ public:
     WEBCORE_EXPORT HashMap<String, String> attributes() const;
     WEBCORE_EXPORT RelationMap relationMap() const;
 
-    WEBCORE_EXPORT AccessibilityObjectAtspi* hitTest(const IntPoint&, uint32_t) const;
-    WEBCORE_EXPORT IntRect elementRect(uint32_t) const;
+    WEBCORE_EXPORT AccessibilityObjectAtspi* hitTest(const IntPoint&, Atspi::CoordinateType) const;
+    WEBCORE_EXPORT IntRect elementRect(Atspi::CoordinateType) const;
     WEBCORE_EXPORT void scrollToMakeVisible(uint32_t) const;
-    WEBCORE_EXPORT void scrollToPoint(const IntPoint&, uint32_t) const;
+    WEBCORE_EXPORT void scrollToPoint(const IntPoint&, Atspi::CoordinateType) const;
 
     WEBCORE_EXPORT String text() const;
     enum class TextGranularity {
@@ -112,7 +112,7 @@ public:
         Paragraph
     };
     WEBCORE_EXPORT IntPoint boundaryOffset(unsigned, TextGranularity) const;
-    WEBCORE_EXPORT IntRect boundsForRange(unsigned, unsigned, uint32_t) const;
+    WEBCORE_EXPORT IntRect boundsForRange(unsigned, unsigned, Atspi::CoordinateType) const;
     struct TextAttributes {
         HashMap<String, String> attributes;
         int startOffset;
@@ -189,14 +189,14 @@ private:
     int characterAtOffset(int) const;
     std::optional<unsigned> characterOffset(UChar, int) const;
     std::optional<unsigned> characterIndex(UChar, unsigned) const;
-    IntRect textExtents(int, int, uint32_t) const;
-    int offsetAtPoint(const IntPoint&, uint32_t) const;
+    IntRect textExtents(int, int, Atspi::CoordinateType) const; 
+    int offsetAtPoint(const IntPoint&, Atspi::CoordinateType) const;
     IntPoint boundsForSelection(const VisibleSelection&) const;
     bool selectionBounds(int&, int&) const;
     bool selectRange(int, int);
     TextAttributes textAttributesWithUTF8Offset(std::optional<int> = std::nullopt, bool = false) const;
     bool scrollToMakeVisible(int, int, uint32_t) const;
-    bool scrollToPoint(int, int, uint32_t, int, int) const;
+    bool scrollToPoint(int, int, Atspi::CoordinateType, int, int) const;
 
     unsigned offsetInParent() const;
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -41,22 +41,22 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_componentFunctions = {
             int x, y;
             uint32_t coordinateType;
             g_variant_get(parameters, "(iiu)", &x, &y, &coordinateType);
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", !!atspiObject->hitTest({ x, y }, coordinateType)));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", !!atspiObject->hitTest({ x, y }, static_cast<Atspi::CoordinateType>(coordinateType))));
         } else if (!g_strcmp0(methodName, "GetAccessibleAtPoint")) {
             int x, y;
             uint32_t coordinateType;
             g_variant_get(parameters, "(iiu)", &x, &y, &coordinateType);
-            auto* wrapper = atspiObject->hitTest({ x, y }, coordinateType);
+            auto* wrapper = atspiObject->hitTest({ x, y }, static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(@(so))", wrapper ? wrapper->reference() : AccessibilityAtspi::singleton().nullReference()));
         } else if (!g_strcmp0(methodName, "GetExtents")) {
             uint32_t coordinateType;
             g_variant_get(parameters, "(u)", &coordinateType);
-            auto rect = atspiObject->elementRect(coordinateType);
+            auto rect = atspiObject->elementRect(static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("((iiii))", rect.x(), rect.y(), rect.width(), rect.height()));
         } else if (!g_strcmp0(methodName, "GetPosition")) {
             uint32_t coordinateType;
             g_variant_get(parameters, "(u)", &coordinateType);
-            auto rect = atspiObject->elementRect(coordinateType);
+            auto rect = atspiObject->elementRect(static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(ii)", rect.x(), rect.y()));
         } else if (!g_strcmp0(methodName, "GetSize")) {
             auto rect = atspiObject->elementRect(Atspi::CoordinateType::ParentCoordinates);
@@ -78,7 +78,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_componentFunctions = {
             int x, y;
             uint32_t coordinateType;
             g_variant_get(parameters, "(uii)", &coordinateType, &x, &y);
-            atspiObject->scrollToPoint({ x, y }, coordinateType);
+            atspiObject->scrollToPoint({ x, y }, static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", TRUE));
         } else if (!g_strcmp0(methodName, "SetExtents") || !g_strcmp0(methodName, "SetPosition") || !g_strcmp0(methodName, "SetSize"))
             g_dbus_method_invocation_return_error_literal(invocation, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED, "");
@@ -91,7 +91,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_componentFunctions = {
     { nullptr }
 };
 
-AccessibilityObjectAtspi* AccessibilityObjectAtspi::hitTest(const IntPoint& point, uint32_t coordinateType) const
+AccessibilityObjectAtspi* AccessibilityObjectAtspi::hitTest(const IntPoint& point, Atspi::CoordinateType coordinateType) const
 {
     if (!m_coreObject)
         return nullptr;
@@ -117,7 +117,7 @@ AccessibilityObjectAtspi* AccessibilityObjectAtspi::hitTest(const IntPoint& poin
     return nullptr;
 }
 
-IntRect AccessibilityObjectAtspi::elementRect(uint32_t coordinateType) const
+IntRect AccessibilityObjectAtspi::elementRect(Atspi::CoordinateType coordinateType) const
 {
     if (!m_coreObject)
         return { };
@@ -198,7 +198,7 @@ void AccessibilityObjectAtspi::scrollToMakeVisible(uint32_t scrollType) const
     liveObject->scrollToMakeVisible({ SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::Yes });
 }
 
-void AccessibilityObjectAtspi::scrollToPoint(const IntPoint& point, uint32_t coordinateType) const
+void AccessibilityObjectAtspi::scrollToPoint(const IntPoint& point, Atspi::CoordinateType coordinateType) const
 {
     if (!m_coreObject)
         return;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectImageAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectImageAtspi.cpp
@@ -37,12 +37,12 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_imageFunctions = {
         if (!g_strcmp0(methodName, "GetImageExtents")) {
             uint32_t coordinateType;
             g_variant_get(parameters, "(u)", &coordinateType);
-            auto rect = atspiObject->elementRect(coordinateType);
+            auto rect = atspiObject->elementRect(static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("((iiii))", rect.x(), rect.y(), rect.width(), rect.height()));
         } else if (!g_strcmp0(methodName, "GetImagePosition")) {
             uint32_t coordinateType;
             g_variant_get(parameters, "(u)", &coordinateType);
-            auto rect = atspiObject->elementRect(coordinateType);
+            auto rect = atspiObject->elementRect(static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(ii)", rect.x(), rect.y()));
         } else if (!g_strcmp0(methodName, "GetImageSize")) {
             auto rect = atspiObject->elementRect(Atspi::CoordinateType::ParentCoordinates);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -147,19 +147,19 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_textFunctions = {
             int offset;
             uint32_t coordinateType;
             g_variant_get(parameters, "(iu)", &offset, &coordinateType);
-            auto extents = atspiObject->textExtents(offset, offset + 1, coordinateType);
+            auto extents = atspiObject->textExtents(offset, offset + 1, static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(iiii)", extents.x(), extents.y(), extents.width(), extents.height()));
         } else if (!g_strcmp0(methodName, "GetRangeExtents")) {
             int start, end;
             uint32_t coordinateType;
             g_variant_get(parameters, "(iiu)", &start, &end, &coordinateType);
-            auto extents = atspiObject->textExtents(start, end, coordinateType);
+            auto extents = atspiObject->textExtents(start, end, static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(iiii)", extents.x(), extents.y(), extents.width(), extents.height()));
         } else if (!g_strcmp0(methodName, "GetOffsetAtPoint")) {
             int x, y;
             uint32_t coordinateType;
             g_variant_get(parameters, "(iiu)", &x, &y, &coordinateType);
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(i)", atspiObject->offsetAtPoint(IntPoint(x, y), coordinateType)));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(i)", atspiObject->offsetAtPoint(IntPoint(x, y), static_cast<Atspi::CoordinateType>(coordinateType))));
         } else if (!g_strcmp0(methodName, "GetNSelections")) {
             int start, end;
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(i)", atspiObject->selectionBounds(start, end) && start != end ? 1 : 0));
@@ -204,7 +204,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_textFunctions = {
             int start, end, x, y;
             uint32_t coordinateType;
             g_variant_get(parameters, "(iiuii)", &start, &end, &coordinateType, &x, &y);
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", atspiObject->scrollToPoint(start, end, coordinateType, x, y)));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", atspiObject->scrollToPoint(start, end, static_cast<Atspi::CoordinateType>(coordinateType), x, y)));
         } else if (!g_strcmp0(methodName, "GetBoundedRanges") || !g_strcmp0(methodName, "ScrollSubstringToPoint"))
             g_dbus_method_invocation_return_error_literal(invocation, G_DBUS_ERROR, G_DBUS_ERROR_NOT_SUPPORTED, "");
     },
@@ -548,7 +548,7 @@ std::optional<unsigned> AccessibilityObjectAtspi::characterIndex(UChar character
     return index;
 }
 
-IntRect AccessibilityObjectAtspi::boundsForRange(unsigned utf16Offset, unsigned length, uint32_t coordinateType) const
+IntRect AccessibilityObjectAtspi::boundsForRange(unsigned utf16Offset, unsigned length, Atspi::CoordinateType coordinateType) const
 {
     if (!m_coreObject)
         return { };
@@ -571,7 +571,7 @@ IntRect AccessibilityObjectAtspi::boundsForRange(unsigned utf16Offset, unsigned 
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-IntRect AccessibilityObjectAtspi::textExtents(int startOffset, int endOffset, uint32_t coordinateType) const
+IntRect AccessibilityObjectAtspi::textExtents(int startOffset, int endOffset, Atspi::CoordinateType coordinateType) const
 {
     auto utf16Text = text();
     auto utf8Text = utf16Text.utf8();
@@ -593,7 +593,7 @@ IntRect AccessibilityObjectAtspi::textExtents(int startOffset, int endOffset, ui
     return boundsForRange(utf16StartOffset, utf16EndOffset - utf16StartOffset, coordinateType);
 }
 
-int AccessibilityObjectAtspi::offsetAtPoint(const IntPoint& point, uint32_t coordinateType) const
+int AccessibilityObjectAtspi::offsetAtPoint(const IntPoint& point, Atspi::CoordinateType coordinateType) const
 {
     auto utf16Text = text();
     auto utf8Text = utf16Text.utf8();
@@ -997,7 +997,7 @@ bool AccessibilityObjectAtspi::scrollToMakeVisible(int startOffset, int endOffse
     return true;
 }
 
-bool AccessibilityObjectAtspi::scrollToPoint(int startOffset, int endOffset, uint32_t coordinateType, int x, int y) const
+bool AccessibilityObjectAtspi::scrollToPoint(int startOffset, int endOffset, Atspi::CoordinateType coordinateType, int x, int y) const
 {
     auto utf16Text = text();
     auto utf8Text = utf16Text.utf8();

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
@@ -266,12 +266,12 @@ GDBusInterfaceVTable AccessibilityRootAtspi::s_componentFunctions = {
         else if (!g_strcmp0(methodName, "GetExtents")) {
             uint32_t coordinateType;
             g_variant_get(parameters, "(u)", &coordinateType);
-            auto rect = rootObject.frameRect(coordinateType);
+            auto rect = rootObject.frameRect(static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("((iiii))", rect.x(), rect.y(), rect.width(), rect.height()));
         } else if (!g_strcmp0(methodName, "GetPosition")) {
             uint32_t coordinateType;
             g_variant_get(parameters, "(u)", &coordinateType);
-            auto rect = rootObject.frameRect(coordinateType);
+            auto rect = rootObject.frameRect(static_cast<Atspi::CoordinateType>(coordinateType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("((ii))", rect.x(), rect.y()));
         } else if (!g_strcmp0(methodName, "GetSize")) {
             auto rect = rootObject.frameRect(Atspi::CoordinateType::ParentCoordinates);
@@ -295,7 +295,7 @@ GDBusInterfaceVTable AccessibilityRootAtspi::s_componentFunctions = {
     { nullptr }
 };
 
-IntRect AccessibilityRootAtspi::frameRect(uint32_t coordinateType) const
+IntRect AccessibilityRootAtspi::frameRect(Atspi::CoordinateType coordinateType) const
 {
     if (!m_page)
         return { };

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #if USE(ATSPI)
+#include "AccessibilityAtspiEnums.h"
 #include "IntRect.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/RefCounted.h>
@@ -56,7 +57,7 @@ private:
     explicit AccessibilityRootAtspi(Page&);
 
     void embedded(const char* parentUniqueName, const char* parentPath);
-    IntRect frameRect(uint32_t) const;
+    IntRect frameRect(Atspi::CoordinateType) const;
 
     static GDBusInterfaceVTable s_accessibleFunctions;
     static GDBusInterfaceVTable s_socketFunctions;


### PR DESCRIPTION
#### 8f7a326cdc70f9469a1f52448f3ee5017e2f0d9b
<pre>
[ATSPI] Make `Atspi::CoordinateType` an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250834">https://bugs.webkit.org/show_bug.cgi?id=250834</a>

Reviewed by Michael Catanzaro.

It should improve code readability.

* Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::hitTest const):
(WebCore::AccessibilityObjectAtspi::elementRect const):
(WebCore::AccessibilityObjectAtspi::scrollToPoint const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectImageAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::boundsForRange const):
(WebCore::AccessibilityObjectAtspi::textExtents const):
(WebCore::AccessibilityObjectAtspi::offsetAtPoint const):
(WebCore::AccessibilityObjectAtspi::scrollToPoint const):
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp:
(WebCore::AccessibilityRootAtspi::frameRect const):
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h:

Canonical link: <a href="https://commits.webkit.org/259111@main">https://commits.webkit.org/259111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccd462cdab5afc1b82f95298375cb74972d39703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113125 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173425 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3905 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112228 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38535 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80184 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3414 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6271 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8303 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->