### PR TITLE
Selector filter should include hashes from single argument :is()

### DIFF
--- a/Source/WebCore/css/SelectorFilter.h
+++ b/Source/WebCore/css/SelectorFilter.h
@@ -63,7 +63,8 @@ public:
 
 private:
     void initializeParentStack(Element& parent);
-    static CollectedSelectorHashes collectSelectorHashes(const CSSSelector& rightmostSelector);
+    enum class IncludeRightmost : bool { Yes, No };
+    static void collectSelectorHashes(CollectedSelectorHashes&, const CSSSelector& rightmostSelector, IncludeRightmost);
     static Hashes chooseSelectorHashesForFilter(const CollectedSelectorHashes&);
 
     struct ParentStackFrame {


### PR DESCRIPTION
#### 711c7abb5e9bc0be8a03503f6e3c811d1ec4be65
<pre>
Selector filter should include hashes from single argument :is()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250833">https://bugs.webkit.org/show_bug.cgi?id=250833</a>
&lt;rdar://problem/104425645&gt;

Reviewed by Alan Baradlay.

:is(foo) bar

should have the same filtering as

foo bar

This may be important with CSS nesting which is defined in terms of :is().

* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSimpleSelectorHash):

Collect from the selector list of a single argument :is/:where.

(WebCore::SelectorFilter::collectSelectorHashes):

Add an argument to include the rightmost component too.

(WebCore::SelectorFilter::collectHashes):
* Source/WebCore/css/SelectorFilter.h:

Canonical link: <a href="https://commits.webkit.org/259089@main">https://commits.webkit.org/259089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7412bed8a6a7ede08e01d24725cf1aca84dc0bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113128 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173427 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3910 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96149 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112230 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109670 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38542 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25501 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80189 "Failed to checkout and rebase branch from PR 8833") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26883 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3419 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6256 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8306 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->