### PR TITLE
defau[Cocoa] Netflix sometimes fails to start playback

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-into-unbuffered-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-into-unbuffered-expected.txt
@@ -1,0 +1,10 @@
+
+EVENT(sourceopen)
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(canplay)
+RUN(video.currentTime = video.buffered.end(0) + 0.5)
+Did not issue "seeked" event OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-into-unbuffered.html
+++ b/LayoutTests/media/media-source/media-source-seek-into-unbuffered.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-seek-into-unbuffered</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    window.addEventListener('load', async event => {
+        try {
+            mediaElement = video = document.querySelector('video');
+
+            loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+            await loader.load();
+
+            source = new MediaSource();
+            video.src = URL.createObjectURL(source);
+            await waitFor(source, 'sourceopen');
+
+            source.duration = loader.duration();
+            sourceBuffer = source.addSourceBuffer(loader.type());
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await waitFor(video, 'canplay');
+
+            run('video.currentTime = video.buffered.end(0) + 0.5');
+            waitFor(video, 'seeked').then(() => { failTest('Should not issue "seeked" event'); });
+
+            await sleepFor(100);
+
+            logResult(Success, 'Did not issue "seeked" event');
+
+            endTest();
+        } catch(e) {
+            failTest(e);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video muted playsinline></video>
+    <div id="canvases"></canvas>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -166,6 +166,7 @@ public:
 #endif
 
     enum SeekState {
+        WaitingToSeek,
         Seeking,
         WaitingForAvailableFame,
         SeekCompleted,
@@ -352,7 +353,7 @@ private:
     FloatSize m_naturalSize;
     double m_rate;
     bool m_playing;
-    bool m_seeking;
+    bool m_synchronizerSeeking;
     SeekState m_seekCompleted { SeekCompleted };
     mutable bool m_loadingProgressed;
 #if !HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)


### PR DESCRIPTION
#### 0773c9839a9a2baece6bcd80248bdfe90aefca84
<pre>
defau[Cocoa] Netflix sometimes fails to start playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=250844">https://bugs.webkit.org/show_bug.cgi?id=250844</a>
rdar://102426333

Reviewed by Eric Carlson.

Before moving MediaSource into the GPU process, a seek command would result in a lot of
synchronous calls between the HTMLMediaElement, MediaSource, and MediaPlayerPrivate. Now
that those classes exist on the far side of an XPC boundary from one another, those calls
have become async.

One problem is that the seek command will result in asking the AVSampleBufferRenderSynchronizer&apos;s
timebase to seek, and the notification of that seek&apos;s completion will occur _before_ the
command from the WebContent process to wait for seek completion. So seeking outside a buffered
range will appear to succeed when it should fail (until data for that location is appended).

Secondly, the second time this happens, the wait for seek completion command is ignored because
the m_seeking flag has already been cleared by the time this message is received.

Because we know that the we will always be issued a command to wait for seek completion after
a command to issue a seek, just call waitForSeekCompleted() from within the seekInternal() method.
Secondly, remove the requirement for m_seeking to be set.

In LayoutTests/media/media-source/media-source-loader.js, update the MediaSourceLoaded class to
use and return promises.

* LayoutTests/media/media-source/media-source-loader.js:
(MediaSourceLoader):
(MediaSourceLoader.prototype.async if):
(MediaSourceLoader.prototype.load):
(MediaSourceLoader.prototype.async try):
(MediaSourceLoader.prototype.loadManifest):
(MediaSourceLoader.prototype.loadMediaData):
(MediaSourceLoader.prototype.loadManifestSucceeded): Deleted.
(MediaSourceLoader.prototype.loadManifestFailed): Deleted.
(MediaSourceLoader.prototype.loadMediaDataSucceeded): Deleted.
(MediaSourceLoader.prototype.loadMediaDataFailed): Deleted.
* LayoutTests/media/media-source/media-source-seek-into-unbuffered-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-into-unbuffered.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::waitForSeekCompleted):

Canonical link: <a href="https://commits.webkit.org/259219@main">https://commits.webkit.org/259219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cbe46af6cc5020c38f60c279c16079572e67e23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104327 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113542 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173834 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4327 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112586 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94234 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80521 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27202 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3757 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46760 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6356 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8694 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->