### PR TITLE
[ResizeObserver] The initial value of the last reported size should be -1x-1

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-expected.txt
@@ -19,7 +19,7 @@ PASS test12: no observation is fired after the change of writing mode when box's
 PASS test13: an observation is fired after the change of writing mode when box's specified size comes from physical size properties.
 PASS test14: observe the same target but using a different box should override the previous one
 PASS test15: an observation is fired with box dimensions 0 when element's display property is set to inline
-FAIL test16: observations fire once with 0x0 size for non-replaced inline elements assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test16: observations fire once with 0x0 size for non-replaced inline elements
 PASS test17: Box sizing snd Resize Observer notifications
 FAIL test18: an observation is fired when device-pixel-content-box is being observed assert_unreached: Caught a throw, possible syntax error Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
@@ -19,5 +19,10 @@ PASS test7: observe svg:polyline
 PASS test8: observe svg:rect
 PASS test9: observe svg:text
 PASS test10: observe svg:svg, top/left is 0 even with padding
-FAIL test11: observe svg non-displayable element assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test11: observe svg non-displayable element
+PASS test12: observe svg:rect content box
+PASS test13: observe svg:rect border box
+PASS test14: observe g:rect content and border box
+PASS test15: observe svg:text content and border box
+FAIL test16: observe g:rect content, border and device-pixel-content boxes assert_unreached: Caught a throw, possible syntax error Reached unreachable code
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt
@@ -13,7 +13,7 @@ PASS test2: remove/appendChild trigger notification
 PASS test3: dimensions match
 PASS test4: transform do not cause notifications
 PASS test5: moving an element does not trigger notifications
-PASS test6: inline element notifies once with 0x0.
+FAIL test6: inline element notifies once with 0x0. assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
 PASS test7: unobserve inside notify callback
 PASS test8: observe inside notify callback
 PASS test9: disconnect inside notify callback

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
@@ -19,5 +19,10 @@ PASS test7: observe svg:polyline
 PASS test8: observe svg:rect
 PASS test9: observe svg:text
 PASS test10: observe svg:svg, top/left is 0 even with padding
-FAIL test11: observe svg non-displayable element assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test11: observe svg non-displayable element
+PASS test12: observe svg:rect content box
+PASS test13: observe svg:rect border box
+PASS test14: observe g:rect content and border box
+FAIL test15: observe svg:text content and border box assert_equals: expected 30 but got 30.015625
+FAIL test16: observe g:rect content, border and device-pixel-content boxes assert_unreached: Caught a throw, possible syntax error Reached unreachable code
 

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -41,6 +41,7 @@ Ref<ResizeObservation> ResizeObservation::create(Element& target, ResizeObserver
 
 ResizeObservation::ResizeObservation(Element& element, ResizeObserverBoxOptions observedBox)
     : m_target { element }
+    , m_lastObservationSizes { LayoutSize(-1, -1), LayoutSize(-1, -1), LayoutSize(-1, -1) }
     , m_observedBox { observedBox }
 {
 }


### PR DESCRIPTION
#### 91f24ff5be182c5595eec41e8e4718c94ae0db64
<pre>
[ResizeObserver] The initial value of the last reported size should be -1x-1
<a href="https://bugs.webkit.org/show_bug.cgi?id=250836">https://bugs.webkit.org/show_bug.cgi?id=250836</a>

Reviewed by NOBODY (OOPS!).

The conclusion of [1] indicates that when first observing an element with ResizeObserver,
lastReportedSize gets initialized with a -1 x -1 size.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/3664">https://github.com/w3c/csswg-drafts/issues/3664</a>

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt:
* Source/WebCore/page/ResizeObservation.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91f24ff5be182c5595eec41e8e4718c94ae0db64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104378 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113595 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173888 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4374 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112635 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38853 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80522 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6949 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3802 "Found 2 new test failures: fast/images/avif-heif-container-as-image.html, resize-observer/observe-disconnected-target-crash.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46810 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8742 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->