### PR TITLE
Unreviewed, land Big Sur-specific baselines for some WebSocket tests after 259006@main

### DIFF
--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/005_wss&wpt_flags=https-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/005_wss&wpt_flags=https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL WebSockets: setting HttpOnly cookies in ws response, checking ws request assert_regexp_match: expected object "/ws_test_1674067354688.0.6339140815552681=test/" but got "(none)"
+

--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/007_wss&wpt_flags=https-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/007_wss&wpt_flags=https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS WebSockets: when to process set-cookie fields in ws response
+

--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-arraybuffer_wss-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-arraybuffer_wss-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL WebSockets: bufferedAmount for ArrayBuffer assert_equals: expected 10 but got 0
+

--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-blob_wss-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-blob_wss-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL WebSockets: bufferedAmount for blob assert_equals: expected 10 but got 0
+

--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-getting_wss-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-getting_wss-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL WebSockets: bufferedAmount after send()ing assert_equals: bufferedAmount after sent "x" expected 1 but got 0
+

--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large_wss-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large_wss-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL WebSockets: bufferedAmount for 65K data assert_equals: expected 0 but got 65000
+

--- a/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-unicode_wss-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-unicode_wss-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL WebSockets: bufferedAmount for unicode data assert_equals: expected 0 but got 12
+


### PR DESCRIPTION
#### eb3ab881eb8e1722786cfeded61f811d369c1cf1
<pre>
Unreviewed, land Big Sur-specific baselines for some WebSocket tests after 259006@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=250848">https://bugs.webkit.org/show_bug.cgi?id=250848</a>

* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/005_wss&amp;wpt_flags=https-expected.txt: Added.
* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/007_wss&amp;wpt_flags=https-expected.txt: Added.
* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-arraybuffer_wss-expected.txt: Added.
* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-blob_wss-expected.txt: Added.
* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-getting_wss-expected.txt: Added.
* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large_wss-expected.txt: Added.
* LayoutTests/platform/mac-bigsur/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-unicode_wss-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/259090@main">https://commits.webkit.org/259090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22f4a63a8e8d89396f6a14b3916ada4b4aa66ac1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13041 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113153 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3934 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109694 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6397 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6559 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12550 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8331 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3320 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->