### PR TITLE
[WGSL] Add support for binary add

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,31 +25,36 @@
 
 #pragma once
 
-#include "ASTArrayAccess.h"
-#include "ASTAssignmentStatement.h"
-#include "ASTAttribute.h"
-#include "ASTBinaryExpression.h"
-#include "ASTBindingAttribute.h"
-#include "ASTBuiltinAttribute.h"
-#include "ASTCallableExpression.h"
-#include "ASTCompoundStatement.h"
-#include "ASTDecl.h"
 #include "ASTExpression.h"
-#include "ASTFunctionDecl.h"
-#include "ASTGlobalDirective.h"
-#include "ASTGroupAttribute.h"
-#include "ASTIdentifierExpression.h"
-#include "ASTLiteralExpressions.h"
-#include "ASTLocationAttribute.h"
-#include "ASTNode.h"
-#include "ASTReturnStatement.h"
-#include "ASTShaderModule.h"
-#include "ASTStageAttribute.h"
-#include "ASTStatement.h"
-#include "ASTStructureAccess.h"
-#include "ASTStructureDecl.h"
-#include "ASTTypeDecl.h"
-#include "ASTUnaryExpression.h"
-#include "ASTVariableDecl.h"
-#include "ASTVariableQualifier.h"
-#include "ASTVariableStatement.h"
+
+namespace WGSL::AST {
+
+enum class BinaryOperation : uint8_t {
+    Add,
+};
+    
+class BinaryExpression final : public Expression {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    BinaryExpression(SourceSpan span, UniqueRef<Expression>&& lhs, UniqueRef<Expression>&& rhs, BinaryOperation operation)
+        : Expression(span)
+        , m_lhs(WTFMove(lhs))
+        , m_rhs(WTFMove(rhs))
+        , m_operation(operation)
+    {
+    }
+
+    Kind kind() const override;
+    BinaryOperation operation() const { return m_operation; }
+    Expression& lhs() { return m_lhs.get(); }
+    Expression& rhs() { return m_rhs.get(); }
+
+private:
+    UniqueRef<Expression> m_lhs;
+    UniqueRef<Expression> m_rhs;
+    BinaryOperation m_operation;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(BinaryExpression)

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -54,6 +54,7 @@ class Int32Literal;
 class StructureAccess;
 class Uint32Literal;
 class UnaryExpression;
+class BinaryExpression;
 
 class Statement;
 class AssignmentStatement;

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -63,6 +63,7 @@ public:
         StructureAccess,
         Uint32Literal,
         UnaryExpression,
+        BinaryExpression,
 
         ShaderModule,
 

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -265,6 +265,15 @@ void StringDumper::visit(UnaryExpression& expression)
     visit(expression.expression());
 }
 
+void StringDumper::visit(BinaryExpression& expression)
+{
+    constexpr ASCIILiteral binaryOperator[] = { "+"_s };
+    auto op = WTF::enumToUnderlyingType(expression.operation());
+    visit(expression.lhs());
+    m_out.print(" ", binaryOperator[op], " ");
+    visit(expression.rhs());
+}
+
 // Statement
 void StringDumper::visit(AssignmentStatement& statement)
 {

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -67,6 +67,7 @@ public:
     void visit(StructureAccess&) override;
     void visit(Uint32Literal&) override;
     void visit(UnaryExpression&) override;
+    void visit(BinaryExpression&) override;
 
     // Statement
     void visit(AssignmentStatement&) override;

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -189,6 +189,9 @@ void Visitor::visit(Expression& expression)
     case Expression::Kind::UnaryExpression:
         checkErrorAndVisit(downcast<UnaryExpression>(expression));
         break;
+    case Expression::Kind::BinaryExpression:
+        checkErrorAndVisit(downcast<BinaryExpression>(expression));
+        break;
     default:
         ASSERT_NOT_REACHED("Unhandled expression kind");
     }
@@ -243,6 +246,12 @@ void Visitor::visit(Uint32Literal&)
 void Visitor::visit(UnaryExpression& unaryExpression)
 {
     checkErrorAndVisit(unaryExpression.expression());
+}
+
+void Visitor::visit(BinaryExpression& binaryExpression)
+{
+    checkErrorAndVisit(binaryExpression.lhs());
+    checkErrorAndVisit(binaryExpression.rhs());
 }
 
 // Statement

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -67,6 +67,7 @@ public:
     virtual void visit(StructureAccess&);
     virtual void visit(Uint32Literal&);
     virtual void visit(UnaryExpression&);
+    virtual void visit(BinaryExpression&);
 
     // Statement
     virtual void visit(Statement&);

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -108,6 +108,14 @@ Token Lexer<T>::lex()
         }
         return makeToken(TokenType::Minus);
         break;
+    case '+':
+        shift();
+        if (m_current == '+') {
+            shift();
+            return makeToken(TokenType::PlusPlus);
+        }
+        return makeToken(TokenType::Plus);
+        break;
     case '0': {
         shift();
         double literalValue = 0;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -69,6 +69,7 @@ public:
     void visit(AST::Int32Literal&) override;
     void visit(AST::StructureAccess&) override;
     void visit(AST::UnaryExpression&) override;
+    void visit(AST::BinaryExpression&) override;
 
     void visit(AST::Statement&) override;
     void visit(AST::AssignmentStatement&) override;
@@ -314,6 +315,16 @@ void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
         m_stringBuilder.append("-");
     }
     visit(unary.expression());
+}
+
+void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
+{
+    visit(binary.lhs());
+    switch (binary.operation()) {
+    case AST::BinaryOperation::Add:
+        m_stringBuilder.append(" + ");
+    }
+    visit(binary.rhs());
 }
 
 void FunctionDefinitionWriter::visit(AST::ArrayAccess& access)

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -81,11 +81,10 @@ public:
     Expected<UniqueRef<AST::Statement>, Error> parseStatement();
     Expected<AST::CompoundStatement, Error> parseCompoundStatement();
     Expected<AST::ReturnStatement, Error> parseReturnStatement();
-    Expected<UniqueRef<AST::Expression>, Error> parseShortCircuitOrExpression();
-    Expected<UniqueRef<AST::Expression>, Error> parseRelationalExpression();
-    Expected<UniqueRef<AST::Expression>, Error> parseShiftExpression();
-    Expected<UniqueRef<AST::Expression>, Error> parseAdditiveExpression();
-    Expected<UniqueRef<AST::Expression>, Error> parseMultiplicativeExpression();
+    Expected<UniqueRef<AST::Expression>, Error> parseRelationalExpression(UniqueRef<AST::Expression>&&);
+    Expected<UniqueRef<AST::Expression>, Error> parseShiftExpression(UniqueRef<AST::Expression>&&);
+    Expected<UniqueRef<AST::Expression>, Error> parseAdditiveExpression(UniqueRef<AST::Expression>&&);
+    Expected<UniqueRef<AST::Expression>, Error> parseMultiplicativeExpression(UniqueRef<AST::Expression>&&);
     Expected<UniqueRef<AST::Expression>, Error> parseUnaryExpression();
     Expected<UniqueRef<AST::Expression>, Error> parseSingularExpression();
     Expected<UniqueRef<AST::Expression>, Error> parsePostfixExpression(UniqueRef<AST::Expression>&& base, SourcePosition startPosition);

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -113,6 +113,10 @@ String toString(TokenType type)
         return "-"_s;
     case TokenType::MinusMinus:
         return "--"_s;
+    case TokenType::Plus:
+        return "+"_s;
+    case TokenType::PlusPlus:
+        return "++"_s;
     case TokenType::Period:
         return "."_s;
     case TokenType::ParenLeft:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -83,6 +83,8 @@ enum class TokenType: uint32_t {
     LT,
     Minus,
     MinusMinus,
+    Plus,
+    PlusPlus,
     Period,
     ParenLeft,
     ParenRight,

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -349,7 +349,7 @@ TEST(WGSLLexerTests, TriangleVert)
         "        vec2<f32>(-0.5, -0.5),\n"
         "        vec2<f32>(0.5, -0.5)\n"
         "    );\n\n"
-        "    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);\n"
+        "    return vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), 0.0, 1.0);\n"
         "}\n"_s);
 
     unsigned lineNumber = 0;
@@ -445,7 +445,7 @@ TEST(WGSLLexerTests, TriangleVert)
     checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
 
     lineNumber += 2;
-    //    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+    //    return vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), 0.0, 1.0);
     checkNextTokenIs(lexer, WGSL::TokenType::KeywordReturn, lineNumber);
     checkNextTokenIsIdentifier(lexer, "vec4"_s, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
@@ -456,6 +456,16 @@ TEST(WGSLLexerTests, TriangleVert)
     checkNextTokenIs(lexer, WGSL::TokenType::BracketLeft, lineNumber);
     checkNextTokenIsIdentifier(lexer, "VertexIndex"_s, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::BracketRight, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Plus, lineNumber);
+    checkNextTokenIsIdentifier(lexer, "vec2"_s, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::LT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::GT, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
     checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.0, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);


### PR DESCRIPTION
#### 243c46b4a2b383e9224f4794a489bde1cd185a9a
<pre>
[WGSL] Add support for binary add
<a href="https://bugs.webkit.org/show_bug.cgi?id=250849">https://bugs.webkit.org/show_bug.cgi?id=250849</a>
&lt;rdar://problem/104432245&gt;

Reviewed by Myles C. Maxfield.

Add lexing for `+` and `++`, add a new BinaryExpression AST node,
implement parsing and codegen for add.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTBinaryExpression.h: Copied from Source/WebGPU/WGSL/AST/AST.h.
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseReturnStatement):
(WGSL::Parser&lt;Lexer&gt;::parseRelationalExpression):
(WGSL::Parser&lt;Lexer&gt;::parseShiftExpression):
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpression):
(WGSL::Parser&lt;Lexer&gt;::parseMultiplicativeExpression):
(WGSL::Parser&lt;Lexer&gt;::parseExpression):
(WGSL::Parser&lt;Lexer&gt;::parseShortCircuitOrExpression): Deleted.
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/259133@main">https://commits.webkit.org/259133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a6c33364d6fbab302b84d5aecffeeb27c1d9c9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113239 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173545 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4035 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96261 "Reverted pull request changes (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112323 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109798 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93992 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96261 "Reverted pull request changes (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25604 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96261 "Reverted pull request changes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6492 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3518 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6293 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8412 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->