### PR TITLE
Followup (258794@main): Add a mismatch test to ensure that the form control focus ring is drawn

### DIFF
--- a/LayoutTests/fast/forms/input-text-focus-ring-expected-mismatch.html
+++ b/LayoutTests/fast/forms/input-text-focus-ring-expected-mismatch.html
@@ -1,0 +1,9 @@
+<style>
+    input {
+        caret-color: transparent;
+    }
+</style>
+<body>
+    <p>Verifies a focus ring is drawn around an &lt;input&gt; element if it is focused.</p>
+    <input type="text" name="text" value="Text">
+</body>

--- a/LayoutTests/fast/forms/input-text-focus-ring.html
+++ b/LayoutTests/fast/forms/input-text-focus-ring.html
@@ -1,0 +1,9 @@
+<style>
+    input {
+        caret-color: transparent;
+    }
+</style>
+<body>
+    <p>Verifies a focus ring is drawn around an &lt;input&gt; element if it is focused.</p>
+    <input type="text" name="text" value="Text" autofocus>
+</body>


### PR DESCRIPTION
#### 43a3e4fee80f5636e453e632a72ea572ce86043f
<pre>
Followup (258794@main): Add a mismatch test to ensure that the form control focus ring is drawn
<a href="https://bugs.webkit.org/show_bug.cgi?id=250850">https://bugs.webkit.org/show_bug.cgi?id=250850</a>
rdar://104432889

Reviewed by Aditya Keerthi.

This verifies the test and the expected mismatch result wil differ as intended.

* LayoutTests/fast/forms/input-text-focus-ring-expected-mismatch.html: Added.
* LayoutTests/fast/forms/input-text-focus-ring.html: Added.

Canonical link: <a href="https://commits.webkit.org/259129@main">https://commits.webkit.org/259129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8364ec8d7014b8da5ec11f558c9fca77366dcd2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113184 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173486 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3965 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112276 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38577 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80228 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3465 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6290 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8361 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->