### PR TITLE
Implement `AccessibilityUIElement::sortDirection()`

### DIFF
--- a/LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt
+++ b/LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt
@@ -10,7 +10,7 @@ PASS accessibilityController.accessibleElementById("table-1").numberAttributeVal
 PASS accessibilityController.accessibleElementById("table-1").numberAttributeValue("AXARIARowCount") is 8
 PASS accessibilityController.accessibleElementById("row-header").role is "AXRole: AXRow"
 FAIL accessibilityController.accessibleElementById("header-1").role should be AXRole: AXCell. Was AXRole: AXColumnHeader.
-FAIL accessibilityController.accessibleElementById("header-1").sortDirection should be AXAscendingSortDirection (of type string). Was null (of type object).
+PASS accessibilityController.accessibleElementById("header-1").sortDirection is "AXAscendingSortDirection"
 PASS accessibilityController.accessibleElementById("row-1").role is "AXRole: AXRow"
 PASS accessibilityController.accessibleElementById("cell1").role is "AXRole: AXCell"
 PASS accessibilityController.accessibleElementById("cell1").numberAttributeValue("AXARIARowIndex") is 7

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -126,7 +126,6 @@ bool AccessibilityUIElement::isInDescriptionListDetail() const { return false; }
 bool AccessibilityUIElement::isInDescriptionListTerm() const { return false; }
 bool AccessibilityUIElement::isInCell() const { return false; }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const { return nullptr; }
 JSRetainPtr<JSStringRef> AccessibilityUIElement::lineRectsAndText() const { return { }; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -456,6 +456,21 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
     return OpaqueJSString::tryCreate(!value.isNull() ? value : "false"_s).leakRef();
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
+{
+    m_element->updateBackingStore();
+    auto sort = m_element->attributes().get("sort"_s);
+
+    if (sort == "ascending"_s)
+        return OpaqueJSString::tryCreate("AXAscendingSortDirection"_s).leakRef();
+    if (sort == "descending"_s)
+        return OpaqueJSString::tryCreate("AXDescendingSortDirection"_s).leakRef();
+    if (sort == "other"_s)
+        return OpaqueJSString::tryCreate("AXUnknownSortDirection"_s).leakRef();
+    
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
 {
     m_element->updateBackingStore();

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -196,6 +196,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
+{
+    notImplemented();
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeValue(JSStringRef)
 {
     notImplemented();


### PR DESCRIPTION
#### b7088f945a1cc5d57628937ee1361045f7dd6525
<pre>
Implement `AccessibilityUIElement::sortDirection()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250673">https://bugs.webkit.org/show_bug.cgi?id=250673</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

It is used by `accessibility/custom-elements/table.html`.

* LayoutTests/accessibility/custom-elements/table.html:
* LayoutTests/platform/gtk/accessibility/custom-elements/table-expected.txt:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::sortDirection const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElement::sortDirection const):
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
(WTR::AccessibilityUIElement::sortDirection const):

Canonical link: <a href="https://commits.webkit.org/259616@main">https://commits.webkit.org/259616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f948d45b141cc44e4924652ec7bae8c5fcdb4a28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113162 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173469 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3942 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112257 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38565 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80215 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26912 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3447 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46442 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8340 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3551 "Failed to checkout and rebase branch from PR 8844") | | | | 
<!--EWS-Status-Bubble-End-->