### PR TITLE
Use consistent settings between WebKit/WebKitLegacy/WebCore for audio and video gesture requirements

### DIFF
--- a/LayoutTests/http/tests/cache/disk-cache/disk-cache-media-small.html
+++ b/LayoutTests/http/tests/cache/disk-cache/disk-cache-media-small.html
@@ -2,7 +2,7 @@
 <div id=logdiv></div>
 <script>
 if (window.internals) {
-    internals.settings.setVideoPlaybackRequiresUserGesture(false);
+    internals.settings.setRequiresUserGestureForVideoPlayback(false);
     internals.settings.setRequiresUserGestureToLoadVideo(false);
 }
 

--- a/LayoutTests/media/ios/autoplay-only-in-main-document.html
+++ b/LayoutTests/media/ios/autoplay-only-in-main-document.html
@@ -7,7 +7,7 @@ iframe {
 </style>
 <script>
 if (window.testRunner) {
-    internals.settings.setVideoPlaybackRequiresUserGesture(true);
+    internals.settings.setRequiresUserGestureForVideoPlayback(true);
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }

--- a/LayoutTests/media/loadedmetadata-fires-without-user-gesture-when-setRequiresUserGestureToLoadVideo-false.html
+++ b/LayoutTests/media/loadedmetadata-fires-without-user-gesture-when-setRequiresUserGestureToLoadVideo-false.html
@@ -5,7 +5,7 @@
 <script src="video-test.js"></script>
 <script>
 if (window.internals) {
-    internals.settings.setVideoPlaybackRequiresUserGesture(true);
+    internals.settings.setRequiresUserGestureForVideoPlayback(true);
     internals.settings.setRequiresUserGestureToLoadVideo(false);
 }
 

--- a/LayoutTests/media/no-autoplay-with-user-gesture-requirement.html
+++ b/LayoutTests/media/no-autoplay-with-user-gesture-requirement.html
@@ -5,7 +5,7 @@
         <script src=video-test.js></script>
         <script>
             if (window.internals) 
-                window.internals.settings.setVideoPlaybackRequiresUserGesture(true);
+                window.internals.settings.setRequiresUserGestureForVideoPlayback(true);
 
             function testPlay()
             {

--- a/LayoutTests/media/playlist-inherits-user-gesture-expected.txt
+++ b/LayoutTests/media/playlist-inherits-user-gesture-expected.txt
@@ -1,5 +1,5 @@
 ** Start first video with user gesture.
-RUN(window.internals.settings.setVideoPlaybackRequiresUserGesture(true);)
+RUN(window.internals.settings.setRequiresUserGestureForVideoPlayback(true);)
 RUN(video1 = document.createElement("video"))
 RUN(video1.src = findMediaFile("video", "content/test"))
 RUN(document.body.appendChild(video1))

--- a/LayoutTests/media/playlist-inherits-user-gesture.html
+++ b/LayoutTests/media/playlist-inherits-user-gesture.html
@@ -8,7 +8,7 @@
     async function runTest() {
         consoleWrite("** Start first video with user gesture.")
         if (window.internals)
-            run('window.internals.settings.setVideoPlaybackRequiresUserGesture(true);');
+            run('window.internals.settings.setRequiresUserGestureForVideoPlayback(true);');
         run('video1 = document.createElement("video")');
         run('video1.src = findMediaFile("video", "content/test")');
         video1.controls = 1;

--- a/LayoutTests/media/video-add-autoplay-user-gesture-expected.txt
+++ b/LayoutTests/media/video-add-autoplay-user-gesture-expected.txt
@@ -1,4 +1,4 @@
-RUN(window.internals.settings.setVideoPlaybackRequiresUserGesture(true);)
+RUN(window.internals.settings.setRequiresUserGestureForVideoPlayback(true);)
 RUN(video = document.createElement("video"))
 RUN(video.src = findMediaFile("video", "content/test"))
 RUN(video.setAttribute("autoplay", ""))

--- a/LayoutTests/media/video-add-autoplay-user-gesture.html
+++ b/LayoutTests/media/video-add-autoplay-user-gesture.html
@@ -6,7 +6,7 @@
     <script src=video-test.js></script>
     <script>
     function runTest() {
-        run('window.internals.settings.setVideoPlaybackRequiresUserGesture(true);');
+        run('window.internals.settings.setRequiresUserGestureForVideoPlayback(true);');
         run('video = document.createElement("video")');
         run('video.src = findMediaFile("video", "content/test")');
         runWithKeyDown(() => {

--- a/LayoutTests/media/video-create-with-user-gesture-expected.txt
+++ b/LayoutTests/media/video-create-with-user-gesture-expected.txt
@@ -1,4 +1,4 @@
-RUN(window.internals.settings.setVideoPlaybackRequiresUserGesture(true);)
+RUN(window.internals.settings.setRequiresUserGestureForVideoPlayback(true);)
 RUN(video = document.createElement("video"))
 RUN(video.src = findMediaFile("video", "content/test"))
 RUN(video.setAttribute("autoplay", ""))

--- a/LayoutTests/media/video-create-with-user-gesture.html
+++ b/LayoutTests/media/video-create-with-user-gesture.html
@@ -6,7 +6,7 @@
     <script src=video-test.js></script>
     <script>
     function runTest() {
-        run('window.internals.settings.setVideoPlaybackRequiresUserGesture(true);');
+        run('window.internals.settings.setRequiresUserGestureForVideoPlayback(true);');
         runWithKeyDown(() => {
             run('video = document.createElement("video")');
         });

--- a/LayoutTests/media/video-load-require-user-gesture.html
+++ b/LayoutTests/media/video-load-require-user-gesture.html
@@ -7,7 +7,7 @@
             var userGestureInitiated = 0;
 
             if (window.internals) {
-                window.internals.settings.setVideoPlaybackRequiresUserGesture(true);
+                window.internals.settings.setRequiresUserGestureForVideoPlayback(true);
                 window.internals.settings.setRequiresUserGestureToLoadVideo(true);
             }
 

--- a/LayoutTests/media/video-source-before-src-expected.txt
+++ b/LayoutTests/media/video-source-before-src-expected.txt
@@ -1,5 +1,5 @@
 Append source element before setting src attribute.
-Platforms that support setVideoPlaybackRequiresUserGesture will have the expected, empty, currentSrc. Platforms that don't should have the unexpected "src.mp4".
+Platforms that support setRequiresUserGestureForVideoPlayback will have the expected, empty, currentSrc. Platforms that don't should have the unexpected "src.mp4".
 
 EXPECTED (relativeURL(video.currentSrc) == ''), OBSERVED 'src.mp4' FAIL
 

--- a/LayoutTests/media/video-source-before-src.html
+++ b/LayoutTests/media/video-source-before-src.html
@@ -4,7 +4,7 @@
 <script>
 
 if (window.testRunner) {
-    internals.settings.setVideoPlaybackRequiresUserGesture(true);
+    internals.settings.setRequiresUserGestureForVideoPlayback(true);
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
@@ -29,7 +29,7 @@ window.onload = () => {
 </head>
 <body>
 Append source element before setting src attribute.<br>
-Platforms that support setVideoPlaybackRequiresUserGesture
+Platforms that support setRequiresUserGestureForVideoPlayback
 will have the expected, empty, currentSrc. Platforms that don't should
 have the unexpected "src.mp4".<br>
 <video width=320 height=240></video>

--- a/LayoutTests/media/video-user-gesture-tracking-expected.txt
+++ b/LayoutTests/media/video-user-gesture-tracking-expected.txt
@@ -1,4 +1,4 @@
-RUN(window.internals.settings.setVideoPlaybackRequiresUserGesture(true);)
+RUN(window.internals.settings.setRequiresUserGestureForVideoPlayback(true);)
 RUN(video = document.createElement("video"))
 RUN(video.src = findMediaFile("video", "content/test"))
 RUN(document.body.appendChild(video))

--- a/LayoutTests/media/video-user-gesture-tracking.html
+++ b/LayoutTests/media/video-user-gesture-tracking.html
@@ -6,7 +6,7 @@
     <script src=video-test.js></script>
     <script>
     function runTest() {
-        run('window.internals.settings.setVideoPlaybackRequiresUserGesture(true);');
+        run('window.internals.settings.setRequiresUserGestureForVideoPlayback(true);');
         run('video = document.createElement("video")');
         run('video.src = findMediaFile("video", "content/test")');
         run('document.body.appendChild(video)');

--- a/LayoutTests/platform/ios/media/video-source-before-src-expected.txt
+++ b/LayoutTests/platform/ios/media/video-source-before-src-expected.txt
@@ -1,5 +1,5 @@
 Append source element before setting src attribute.
-Platforms that support setVideoPlaybackRequiresUserGesture will have the expected, empty, currentSrc. Platforms that don't should have the unexpected "src.mp4".
+Platforms that support setRequiresUserGestureForVideoPlayback will have the expected, empty, currentSrc. Platforms that don't should have the unexpected "src.mp4".
 
 EXPECTED (relativeURL(video.currentSrc) == '') OK
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4782,19 +4782,21 @@ RequiresUserGestureForAudioPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitAudioPlaybackRequiresUserGesture
-  webcoreBinding: custom
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": true
       default: false
+    WebCore:
+      PLATFORM(IOS_FAMILY): true
+      default: false
 
 RequiresUserGestureForMediaPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitMediaPlaybackRequiresUserGesture
-  webcoreBinding: custom
+  webcoreBinding: none
   defaultValue:
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
@@ -4806,11 +4808,12 @@ RequiresUserGestureForVideoPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitVideoPlaybackRequiresUserGesture
-  webcoreBinding: custom
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
+      default: false
+    WebCore:
       default: false
 
 RequiresUserGestureToLoadVideo:

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -60,7 +60,7 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
 {
     if (context.isDocument()) {
 #if PLATFORM(IOS_FAMILY)
-        if (downcast<Document>(context).audioPlaybackRequiresUserGesture())
+        if (downcast<Document>(context).requiresUserGestureForAudioPlayback())
             m_restrictions = RequireUserGestureForSpeechStartRestriction;
 #endif
         m_speechSynthesisClient = downcast<Document>(context).frame()->page()->speechSynthesisClient();

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -138,7 +138,7 @@ AudioContext::AudioContext(Document& document, const AudioContextOptions& contex
 void AudioContext::constructCommon()
 {
     ASSERT(document());
-    if (document()->topDocument().audioPlaybackRequiresUserGesture())
+    if (document()->topDocument().requiresUserGestureForAudioPlayback())
         addBehaviorRestriction(RequireUserGestureForAudioStartRestriction);
     else
         m_restrictions = NoRestrictions;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5908,7 +5908,7 @@ void Document::unregisterForDocumentSuspensionCallbacks(Element& element)
     m_documentSuspensionCallbackElements.remove(element);
 }
 
-bool Document::audioPlaybackRequiresUserGesture() const
+bool Document::requiresUserGestureForAudioPlayback() const
 {
     if (DocumentLoader* loader = this->loader()) {
         // If an audio playback policy was set during navigation, use it. If not, use the global settings.
@@ -5917,10 +5917,10 @@ bool Document::audioPlaybackRequiresUserGesture() const
             return policy == AutoplayPolicy::AllowWithoutSound || policy == AutoplayPolicy::Deny;
     }
 
-    return settings().audioPlaybackRequiresUserGesture();
+    return settings().requiresUserGestureForAudioPlayback();
 }
 
-bool Document::videoPlaybackRequiresUserGesture() const
+bool Document::requiresUserGestureForVideoPlayback() const
 {
     if (DocumentLoader* loader = this->loader()) {
         // If a video playback policy was set during navigation, use it. If not, use the global settings.
@@ -5929,7 +5929,7 @@ bool Document::videoPlaybackRequiresUserGesture() const
             return policy == AutoplayPolicy::Deny;
     }
 
-    return settings().videoPlaybackRequiresUserGesture();
+    return settings().requiresUserGestureForVideoPlayback();
 }
 
 bool Document::mediaDataLoadsAutomatically() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1180,8 +1180,8 @@ public:
     void unregisterMediaElement(HTMLMediaElement&);
 #endif
 
-    bool audioPlaybackRequiresUserGesture() const;
-    bool videoPlaybackRequiresUserGesture() const;
+    bool requiresUserGestureForAudioPlayback() const;
+    bool requiresUserGestureForVideoPlayback() const;
     bool mediaDataLoadsAutomatically() const;
 
     void privateBrowsingStateDidChange(PAL::SessionID);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -473,8 +473,8 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_tracksAreReady(true)
     , m_haveVisibleTextTrack(false)
     , m_processingPreferenceChange(false)
-    , m_shouldAudioPlaybackRequireUserGesture(document.topDocument().audioPlaybackRequiresUserGesture() && !processingUserGestureForMedia())
-    , m_shouldVideoPlaybackRequireUserGesture(document.topDocument().videoPlaybackRequiresUserGesture() && !processingUserGestureForMedia())
+    , m_shouldAudioPlaybackRequireUserGesture(document.topDocument().requiresUserGestureForAudioPlayback() && !processingUserGestureForMedia())
+    , m_shouldVideoPlaybackRequireUserGesture(document.topDocument().requiresUserGestureForVideoPlayback() && !processingUserGestureForMedia())
     , m_volumeLocked(defaultVolumeLocked())
     , m_opaqueRootProvider([this] { return opaqueRoot(); })
 #if USE(AUDIO_SESSION)
@@ -545,8 +545,8 @@ void HTMLMediaElement::initializeMediaSession()
     }
 
 #if PLATFORM(IOS_FAMILY)
-    if (!document.settings().videoPlaybackRequiresUserGesture() && !document.settings().audioPlaybackRequiresUserGesture()) {
-        // Relax RequireUserGestureForFullscreen when videoPlaybackRequiresUserGesture and audioPlaybackRequiresUserGesture is not set:
+    if (!document.requiresUserGestureForVideoPlayback() && !document.requiresUserGestureForAudioPlayback()) {
+        // Relax RequireUserGestureForFullscreen when requiresUserGestureForVideoPlayback and requiresUserGestureForAudioPlayback is not set:
         m_mediaSession->removeBehaviorRestriction(MediaElementSession::RequireUserGestureForFullscreen);
     }
 #endif
@@ -7878,12 +7878,12 @@ void HTMLMediaElement::updateRateChangeRestrictions()
         return;
 
     const auto& topDocument = document.topDocument();
-    if (topDocument.videoPlaybackRequiresUserGesture())
+    if (topDocument.requiresUserGestureForVideoPlayback())
         mediaSession().addBehaviorRestriction(MediaElementSession::RequireUserGestureForVideoRateChange);
     else
         mediaSession().removeBehaviorRestriction(MediaElementSession::RequireUserGestureForVideoRateChange);
 
-    if (topDocument.audioPlaybackRequiresUserGesture())
+    if (topDocument.requiresUserGestureForAudioPlayback())
         mediaSession().addBehaviorRestriction(MediaElementSession::RequireUserGestureForAudioRateChange);
     else
         mediaSession().removeBehaviorRestriction(MediaElementSession::RequireUserGestureForAudioRateChange);

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -35,13 +35,6 @@ AnimatedImageDebugCanvasDrawingEnabled:
     WebCore:
       default: false
 
-AudioPlaybackRequiresUserGesture:
-  type: bool
-  defaultValue:
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
-
 AutoscrollForDragAndDropEnabled:
   type: bool
   defaultValue:
@@ -523,13 +516,6 @@ ValidationMessageTimerMagnification:
   defaultValue:
     WebCore:
       default: 50
-
-VideoPlaybackRequiresUserGesture:
-  type: bool
-  defaultValue:
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
 
 WebGLErrorsToConsoleEnabled:
   type: bool

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4210,8 +4210,8 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 #endif
 
     bool requiresUserGestureForMedia = store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForMediaPlaybackKey());
-    settings.setVideoPlaybackRequiresUserGesture(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForVideoPlaybackKey()));
-    settings.setAudioPlaybackRequiresUserGesture(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForAudioPlaybackKey()));
+    settings.setRequiresUserGestureForVideoPlayback(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForVideoPlaybackKey()));
+    settings.setRequiresUserGestureForAudioPlayback(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForAudioPlaybackKey()));
     settings.setUserInterfaceDirectionPolicy(static_cast<WebCore::UserInterfaceDirectionPolicy>(store.getUInt32ValueForKey(WebPreferencesKey::userInterfaceDirectionPolicyKey())));
     settings.setSystemLayoutDirection(static_cast<TextDirection>(store.getUInt32ValueForKey(WebPreferencesKey::systemLayoutDirectionKey())));
     settings.setJavaScriptRuntimeFlags(static_cast<RuntimeFlags>(store.getUInt32ValueForKey(WebPreferencesKey::javaScriptRuntimeFlagsKey())));

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2931,8 +2931,8 @@ static bool needsSelfRetainWhileLoadingQuirk()
     settings.setDeveloperExtrasEnabled([preferences developerExtrasEnabled]);
 
     BOOL mediaPlaybackRequiresUserGesture = [preferences mediaPlaybackRequiresUserGesture];
-    settings.setVideoPlaybackRequiresUserGesture(mediaPlaybackRequiresUserGesture || [preferences videoPlaybackRequiresUserGesture]);
-    settings.setAudioPlaybackRequiresUserGesture(mediaPlaybackRequiresUserGesture || [preferences audioPlaybackRequiresUserGesture]);
+    settings.setRequiresUserGestureForVideoPlayback(mediaPlaybackRequiresUserGesture || [preferences videoPlaybackRequiresUserGesture]);
+    settings.setRequiresUserGestureForAudioPlayback(mediaPlaybackRequiresUserGesture || [preferences audioPlaybackRequiresUserGesture]);
 
     DeprecatedGlobalSettings::setWebSQLEnabled([preferences webSQLEnabled]);
     DatabaseManager::singleton().setIsAvailable([preferences databasesEnabled]);

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -5322,8 +5322,8 @@ HRESULT WebView::notifyPreferencesChanged(IWebNotification* notification)
     hr = prefsPrivate->mediaPlaybackRequiresUserGesture(&enabled);
     if (FAILED(hr))
         return hr;
-    settings.setVideoPlaybackRequiresUserGesture(enabled);
-    settings.setAudioPlaybackRequiresUserGesture(enabled);
+    settings.setRequiresUserGestureForVideoPlayback(enabled);
+    settings.setRequiresUserGestureForAudioPlayback(enabled);
 
     hr = prefsPrivate->mediaPlaybackAllowsInline(&enabled);
     if (FAILED(hr))


### PR DESCRIPTION
#### 27ac548bef6ea93a00857b33ca9bbefa811391ef
<pre>
Use consistent settings between WebKit/WebKitLegacy/WebCore for audio and video gesture requirements
<a href="https://bugs.webkit.org/show_bug.cgi?id=250858">https://bugs.webkit.org/show_bug.cgi?id=250858</a>
&lt;rdar://problem/104440786&gt;

Reviewed by Jer Noble.

We currently have different names used for WebCore-related media gesture requirements, and the
preferences in WebKitLegacy and WebKit with custom code to toggle the WebCore bits in response
to the WebKit/WebKitLegacy settings.

Instead, we should let the generator code create the WebCore settings code, which will
automatically sync it when WebKit/WebKitLegacy preferences are adjusted.

Since the internal keys used to control the settings are unchanged, this should not
modify behavior.

* LayoutTests/http/tests/cache/disk-cache/disk-cache-media-small.html: Update generated &apos;internals&apos;
method call to match Settings.
* LayoutTests/media/ios/autoplay-only-in-main-document.html: Ditto.
* LayoutTests/media/loadedmetadata-fires-without-user-gesture-when-setRequiresUserGestureToLoadVideo-false.html: Ditto.
* LayoutTests/media/no-autoplay-with-user-gesture-requirement.html: Ditto.
* LayoutTests/media/playlist-inherits-user-gesture-expected.txt: Ditto.
* LayoutTests/media/playlist-inherits-user-gesture.html: Ditto.
* LayoutTests/media/video-add-autoplay-user-gesture-expected.txt: Ditto.
* LayoutTests/media/video-add-autoplay-user-gesture.html: Ditto.
* LayoutTests/media/video-create-with-user-gesture-expected.txt: Ditto.
* LayoutTests/media/video-create-with-user-gesture.html: Ditto.
* LayoutTests/media/video-load-require-user-gesture.html: Ditto.
* LayoutTests/media/video-source-before-src-expected.txt: Ditto.
* LayoutTests/media/video-source-before-src.html: Ditto.
* LayoutTests/media/video-user-gesture-tracking-expected.txt: Ditto.
* LayoutTests/media/video-user-gesture-tracking.html: Ditto.
* LayoutTests/platform/ios/media/video-source-before-src-expected.txt: Ditto.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::SpeechSynthesis):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::constructCommon):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::requiresUserGestureForAudioPlayback const):
(WebCore::Document::requiresUserGestureForVideoPlayback const):
(WebCore::Document::audioPlaybackRequiresUserGesture const): Deleted.
(WebCore::Document::videoPlaybackRequiresUserGesture const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::HTMLMediaElement):
(WebCore::HTMLMediaElement::initializeMediaSession):
(WebCore::HTMLMediaElement::updateRateChangeRestrictions):
* Source/WebCore/page/Settings.yaml:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences): Update for generated Settings labels.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _preferencesChanged:]): Ditto.
* Source/WebKitLegacy/win/WebView.cpp:
(WebView::notifyPreferencesChanged): Ditto.

Canonical link: <a href="https://commits.webkit.org/259163@main">https://commits.webkit.org/259163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6791b6ecdb587eb1d529ecabbddfde5d60199e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113336 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173636 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4134 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112403 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109898 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38677 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80335 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27053 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4363 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3593 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29915 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46591 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/99325 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6312 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8503 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24983 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->