### PR TITLE
Interaction regions should support occlusions

### DIFF
--- a/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
@@ -11,7 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (0,0) width=100 height=100)
 )
         (borderRadius 10.00)])

--- a/LayoutTests/interaction-region/click-handler-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-expected.txt
@@ -11,7 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (0,0) width=100 height=100)
 )
         (borderRadius 10.00)])

--- a/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
@@ -20,7 +20,7 @@
             (rect (28,28) width=200 height=200)
 
           (interaction regions [
-            (region
+            (interaction
                 (rect (28,28) width=100 height=100)
 )
             (borderRadius 10.00)])

--- a/LayoutTests/interaction-region/event-region-overflow-expected.txt
+++ b/LayoutTests/interaction-region/event-region-overflow-expected.txt
@@ -12,7 +12,7 @@ Hi
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (29,21) width=50 height=50)
 )
         (borderRadius 8.75)])

--- a/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
+++ b/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
@@ -14,7 +14,7 @@ button
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (0,3) width=59 height=30)
 )
         (borderRadius 14.00)])

--- a/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
@@ -12,7 +12,7 @@ This is a link.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -12,7 +12,7 @@ This is a link.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])

--- a/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
@@ -13,7 +13,7 @@ This is a link, outside the frame.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
@@ -27,7 +27,7 @@ This is a link, outside the frame.
             (rect (2,2) width=200 height=200)
 
           (interaction regions [
-            (region
+            (interaction
                 (rect (7,7) width=35 height=25)
 )
             (borderRadius 0.00)])

--- a/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
@@ -13,7 +13,7 @@ This is a link, inside the layer.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
@@ -27,7 +27,7 @@ This is a link, inside the layer.
             (rect (0,0) width=200 height=200)
 
           (interaction regions [
-            (region
+            (interaction
                 (rect (-3,-3) width=35 height=25)
 )
             (borderRadius 0.00)])

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -13,12 +13,12 @@ This is a link, outside the frame.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
-            (rect (7,27) width=35 height=25)
+        (interaction
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00),
-        (region
-            (rect (-3,-3) width=35 height=25)
+        (interaction
+            (rect (7,27) width=35 height=25)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
@@ -12,7 +12,7 @@ Link Child Disabled Link
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (-3,-3) width=76 height=25)
 )
         (borderRadius 0.00)])

--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -12,7 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (1,2) width=84 height=18)
 )
         (borderRadius 9.00)])

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -12,7 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (58,2) width=17 height=16)
 )
         (borderRadius 8.00)])

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -1,0 +1,132 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer anchorPoint [x: 0 y: 0]))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                          (layer position [x: 400 y: 400]))))))))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer position [x: 400 y: 400])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (type interaction)
+                                      (layer bounds [x: 0 y: 0 width: 284 height: 192])
+                                      (layer position [x: 152 y: 152]))
+                                    (
+                                      (type interaction)
+                                      (layer bounds [x: 0 y: 0 width: 59 height: 20])
+                                      (layer position [x: 29.5 y: 29.5]))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer anchorPoint [x: 0 y: 0]))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer anchorPoint [x: 0 y: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400])
+                                          (sublayers
+                                            (
+                                              (type occlusion)
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                              (layer position [x: 400 y: 400]))
+                                            (
+                                              (type interaction)
+                                              (layer bounds [x: 0 y: 0 width: 31 height: 25])
+                                              (layer position [x: 12.5 y: 12.5]))
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                              (layer position [x: 400 y: 400]))))))))))))))))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (
+          (layer bounds [x: 0 y: 0 width: 794 height: 3])
+          (layer position [x: 400 y: 400])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 794 height: 3])
+              (layer position [x: 397 y: 397])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 794 height: 3])
+                  (layer position [x: 397 y: 397]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 794 height: 3])
+              (layer position [x: 397 y: 397]))))
+        (
+          (layer bounds [x: 0 y: 0 width: 3 height: 594])
+          (layer position [x: 795.5 y: 795.5])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 3 height: 594])
+              (layer position [x: 1.5 y: 1.5])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 3 height: 594])
+                  (layer position [x: 1.5 y: 1.5]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 3 height: 594])
+              (layer position [x: 1.5 y: 1.5]))))))))

--- a/LayoutTests/interaction-region/layer-tree.html
+++ b/LayoutTests/interaction-region/layer-tree.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    iframe {
+        width: 300px;
+        height: 200px;
+    }
+    #overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+
+        z-index: 10;
+        opacity: 0.8;
+        will-change: opacity;
+
+        background-color: #333;
+    }
+    #nested {
+        will-change: transform;
+    }
+
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+    <div>
+        <button>button</button>
+    </div>
+    <iframe></iframe>
+    <div id="overlay">
+        <a href="#">link</a>
+        <div id="nested">layered content</div>
+    </div>
+</div>
+
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.animationFrame();
+    document.querySelector("iframe").srcdoc = "<div style='cursor:pointer;width:100%;height:200px'; onclick='click()'>tappable</div>";
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getCALayerTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/interaction-region/overlay-expected.txt
+++ b/LayoutTests/interaction-region/overlay-expected.txt
@@ -1,5 +1,3 @@
-This is a link, outside the frame.
-This is a link, inside an aria-hidden div
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -13,8 +11,12 @@ This is a link, inside an aria-hidden div
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
-            (rect (-3,-3) width=35 height=25)
+        (occlusion
+            (rect (0,0) width=200 height=100)
+)
+        (borderRadius 0.00),
+        (occlusion
+            (rect (0,200) width=200 height=100)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/overlay.html
+++ b/LayoutTests/interaction-region/overlay.html
@@ -3,14 +3,21 @@
 <style>
     body { margin: 0; }
 
-    #page {
+    .overlay {
+        z-index: 1;
         width: 200px;
-        height: 200px;
+        height: 100px;
+        background-color: green;
+    }
+    #not-occlusion {
+        pointer-events: none;
+        background-color: red;
     }
 </style>
 <body>
-<a href="#">This</a> is a link, outside the frame.<br/>
-<div id="frame" aria-hidden="true"><a href="#">This</a> is a link, inside an aria-hidden div</div>
+<div class="overlay"></div>
+<div class="overlay" id="not-occlusion"></div>
+<div class="overlay" onclick="click()"></div>
 
 <pre id="results"></pre>
 <script>

--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -38,7 +38,7 @@
                     (rect (51,98) width=34 height=5)
 
                   (interaction regions [
-                    (region
+                    (interaction
                         (rect (33,33) width=70 height=70)
 )
                     (borderRadius 35.00)])

--- a/LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt
+++ b/LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt
@@ -1,14 +1,14 @@
  (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 135800.00 35018.00)
+  (bounds 135800.00 70018.00)
   (children 1
     (GraphicsLayer
-      (bounds 135800.00 35018.00)
+      (bounds 135800.00 70018.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=135800 height=35018)
+        (rect (0,0) width=135800 height=70018)
       )
     )
   )

--- a/LayoutTests/interaction-region/region-area-overflow-does-not-crash.html
+++ b/LayoutTests/interaction-region/region-area-overflow-does-not-crash.html
@@ -3,7 +3,7 @@
 <style>
     body { margin: 0; }
 
-    #button {
+    #button, #occlusion {
         display: inline-block;
         width: 135800px;
         height: 35000px;
@@ -11,9 +11,15 @@
         cursor: pointer;
         border-radius: 10px;
     }
+    #occlusion {
+        display: block;
+        z-index: 1;
+        cursor: auto;
+    }
 </style>
 <body>
 <div id="button" onclick="click()"></div>
+<div id="occlusion"></div>
 
 <pre id="results"></pre>
 <script>

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -13,7 +13,7 @@ short second line.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (198,-3) width=31 height=20)
             (rect (-3,17) width=115 height=5)
             (rect (198,17) width=31 height=5)

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -15,7 +15,7 @@ Line
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (region
+        (interaction
             (rect (-3,-3) width=36 height=85)
 )
         (borderRadius 0.00)])

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1584,6 +1584,18 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static getCALayerTree()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(() => {
+                return uiController.caLayerTreeAsText;
+            })()`, resolve);
+        });
+    }
+
     static dragFromPointToPoint(fromX, fromY, toX, toY, duration)
     {
         if (!this.isWebKit2() || !this.isIOSFamily()) {

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -105,22 +105,19 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         return std::nullopt;
 
     auto& mainFrameView = *regionRenderer.document().frame()->mainFrame().view();
-    auto layoutArea = mainFrameView.layoutSize().area();
+    auto layoutSize = mainFrameView.layoutSize();
+    // Adding some wiggle room, we use this to avoid extreme cases.
+    layoutSize.scale(1.3, 1.3);
+    auto layoutArea = layoutSize.area();
 
     auto checkedRegionArea = bounds.area<RecordOverflow>();
     if (checkedRegionArea.hasOverflowed())
-        return std::nullopt;
-
-    if (checkedRegionArea.value() > layoutArea / 2)
         return std::nullopt;
 
     auto element = dynamicDowncast<Element>(regionRenderer.node());
     if (!element) 
         element = regionRenderer.node()->parentElement();
     if (!element)
-        return std::nullopt;
-
-    if (!isNodeAriaVisible(element))
         return std::nullopt;
 
     if (auto* linkElement = element->enclosingLinkEventParentOrSelf())
@@ -139,11 +136,26 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         return std::nullopt;
 
     // FIXME: Consider also allowing elements that only receive touch events.
-    if (!renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick))
-        return std::nullopt;
+    bool hasListener = renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick);
+    bool hasPointer = cursorTypeForElement(*element) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*element);
+    if (!hasListener || !hasPointer) {
+        bool isOverlay = checkedRegionArea.value() <= layoutArea && renderer.style().specifiedZIndex() > 0;
+        if (isOverlay) {
+            Region boundsRegion;
+            boundsRegion.unite(bounds);
 
-    auto cursor = cursorTypeForElement(*element);
-    if (cursor != CursorType::Pointer && !shouldAllowNonPointerCursorForElement(*element))
+            return { {
+                element->identifier(),
+                boundsRegion,
+                0,
+                InteractionRegion::Type::Occlusion
+            } };
+        }
+
+        return std::nullopt;
+    }
+
+    if (checkedRegionArea.value() > layoutArea / 2)
         return std::nullopt;
 
     bool isInlineNonBlock = renderer.isInline() && !renderer.isReplacedOrInlineBlock();
@@ -170,13 +182,14 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     return { {
         element->identifier(),
         boundsRegion,
-        borderRadius
+        borderRadius,
+        InteractionRegion::Type::Interaction
     } };
 }
 
 TextStream& operator<<(TextStream& ts, const InteractionRegion& interactionRegion)
 {
-    ts.dumpProperty("region", interactionRegion.regionInLayerCoordinates);
+    ts.dumpProperty(interactionRegion.type == InteractionRegion::Type::Occlusion ? "occlusion" : "interaction", interactionRegion.regionInLayerCoordinates);
     ts.dumpProperty("borderRadius", interactionRegion.borderRadius);
 
     return ts;

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -45,9 +45,12 @@ class Page;
 class RenderObject;
 
 struct InteractionRegion {
+    enum class Type : bool { Interaction, Occlusion };
+
     ElementIdentifier elementIdentifier;
     Region regionInLayerCoordinates;
     float borderRadius { 0 };
+    Type type;
 
     WEBCORE_EXPORT ~InteractionRegion();
 
@@ -59,7 +62,8 @@ inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
 {
     return a.elementIdentifier == b.elementIdentifier
         && a.regionInLayerCoordinates == b.regionInLayerCoordinates
-        && a.borderRadius == b.borderRadius;
+        && a.borderRadius == b.borderRadius
+        && a.type == b.type;
 }
 
 WEBCORE_EXPORT std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject&, const Region&);
@@ -72,6 +76,7 @@ void InteractionRegion::encode(Encoder& encoder) const
     encoder << elementIdentifier;
     encoder << regionInLayerCoordinates;
     encoder << borderRadius;
+    encoder << type;
 }
 
 template<class Decoder>
@@ -92,10 +97,16 @@ std::optional<InteractionRegion> InteractionRegion::decode(Decoder& decoder)
     if (!borderRadius)
         return std::nullopt;
 
+    std::optional<Type> type;
+    decoder >> type;
+    if (!type)
+        return std::nullopt;
+
     return { {
         WTFMove(*elementIdentifier),
         WTFMove(*regionInLayerCoordinates),
-        WTFMove(*borderRadius)
+        WTFMove(*borderRadius),
+        WTFMove(*type)
     } };
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -47,6 +47,8 @@ struct WKAppPrivacyReportTestingData {
 
 @interface WKWebView (WKTesting)
 
+@property (nonatomic, readonly) NSString *_caLayerTreeAsText;
+
 - (void)_addEventAttributionWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destination sourceDescription:(NSString *)sourceDescription purchaser:(NSString *)purchaser reportEndpoint:(NSURL *)reportEndpoint optionalNonce:(nullable NSString *)nonce applicationBundleID:(NSString *)bundleID ephemeral:(BOOL)ephemeral WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_setPageScale:(CGFloat)scale withOrigin:(CGPoint)origin;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -69,6 +69,60 @@
 
 @implementation WKWebView (WKTesting)
 
+- (NSString *)_caLayerTreeAsText
+{
+    TextStream ts(TextStream::LineMode::MultipleLine);
+
+    {
+        TextStream::GroupScope scope(ts);
+        ts << "CALayer tree root ";
+        dumpCALayer(ts, self.layer, true);
+    }
+
+    return ts.release();
+}
+
+static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
+{
+    auto rectToString = [] (auto rect) {
+        return makeString("[x: ", rect.origin.x, " y: ", rect.origin.x, " width: ", rect.size.width, " height: ", rect.size.height, "]");
+    };
+
+    auto pointToString = [] (auto point) {
+        return makeString("[x: ", point.x, " y: ", point.x, "]");
+    };
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    if ([layer valueForKey:@"WKInteractionRegion"])
+        ts.dumpProperty("type", "interaction");
+    if ([layer valueForKey:@"WKInteractionRegionOcclusion"])
+        ts.dumpProperty("type", "occlusion");
+#endif
+
+    ts.dumpProperty("layer bounds", rectToString(layer.bounds));
+
+    if (layer.position.x || layer.position.y)
+        ts.dumpProperty("layer position", pointToString(layer.position));
+
+    if (layer.zPosition)
+        ts.dumpProperty("layer zPosition", makeString(layer.zPosition));
+
+    if (layer.anchorPoint.x != 0.5 || layer.anchorPoint.y != 0.5)
+        ts.dumpProperty("layer anchorPoint", pointToString(layer.anchorPoint));
+
+    if (layer.anchorPointZ)
+        ts.dumpProperty("layer anchorPointZ", makeString(layer.anchorPointZ));
+
+    if (traverse && layer.sublayers.count > 0) {
+        TextStream::GroupScope scope(ts);
+        ts << "sublayers";
+        for (CALayer *sublayer in layer.sublayers) {
+            TextStream::GroupScope scope(ts);
+            dumpCALayer(ts, sublayer, true);
+        }
+    }
+}
+
 - (void)_addEventAttributionWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destination sourceDescription:(NSString *)sourceDescription purchaser:(NSString *)purchaser reportEndpoint:(NSURL *)reportEndpoint optionalNonce:(NSString *)nonce applicationBundleID:(NSString *)bundleID ephemeral:(BOOL)ephemeral
 {
     WebCore::PrivateClickMeasurement measurement(

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -168,6 +168,12 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
     for (auto& newlyUnreachableLayerID : transaction.layerIDsWithNewlyUnreachableBackingStore())
         layerForID(newlyUnreachableLayerID).contents = nullptr;
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    // The Interaction Regions subtree is always on top.
+    [m_rootNode->interactionRegionsLayer() removeFromSuperlayer];
+    [m_rootNode->layer() addSublayer:m_rootNode->interactionRegionsLayer()];
+#endif
+
     return rootLayerChanged;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h
@@ -36,7 +36,7 @@ OBJC_CLASS NSMutableArray;
 namespace WebKit {
 
 void updateLayersForInteractionRegions(CALayer *, RemoteLayerTreeHost&, const RemoteLayerTreeTransaction::LayerProperties&);
-void appendInteractionRegionLayersForLayer(NSMutableArray *, CALayer *);
+void insertInteractionRegionLayersForLayer(NSMutableArray *, CALayer *);
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -51,6 +51,7 @@ namespace WebKit {
 using namespace WebCore;
 
 NSString *interactionRegionKey = @"WKInteractionRegion";
+NSString *interactionRegionOcclusionKey = @"WKInteractionRegionOcclusion";
 
 static std::optional<WebCore::InteractionRegion> interactionRegionForLayer(CALayer *layer)
 {
@@ -61,9 +62,22 @@ static std::optional<WebCore::InteractionRegion> interactionRegionForLayer(CALay
     return region.interactionRegion;
 }
 
-static bool isInteractionRegionLayer(CALayer *layer)
+static bool isInteractionLayer(CALayer *layer)
 {
     return !!interactionRegionForLayer(layer);
+}
+
+static bool isOcclusionLayer(CALayer *layer)
+{
+    id value = [layer valueForKey:interactionRegionOcclusionKey];
+    if (value)
+        return true;
+    return false;
+}
+
+static bool isAnyInteractionRegionLayer(CALayer *layer)
+{
+    return isOcclusionLayer(layer) || isInteractionLayer(layer);
 }
 
 static void setInteractionRegion(CALayer *layer, const WebCore::InteractionRegion& interactionRegion)
@@ -73,11 +87,19 @@ static void setInteractionRegion(CALayer *layer, const WebCore::InteractionRegio
     [layer setValue:region forKey:interactionRegionKey];
 }
 
-void appendInteractionRegionLayersForLayer(NSMutableArray *sublayers, CALayer *layer)
+static void setInteractionRegionOcclusion(CALayer *layer)
 {
+    [layer setValue:@(YES) forKey:interactionRegionOcclusionKey];
+}
+
+void insertInteractionRegionLayersForLayer(NSMutableArray *sublayers, CALayer *layer)
+{
+    NSUInteger insertionPoint = 0;
     for (CALayer *sublayer in layer.sublayers) {
-        if (isInteractionRegionLayer(sublayer))
-            [sublayers addObject:sublayer];
+        if (isAnyInteractionRegionLayer(sublayer)) {
+            [sublayers insertObject:sublayer atIndex:insertionPoint];
+            insertionPoint++;
+        }
     }
 }
 
@@ -85,51 +107,104 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
 {
     ASSERT(properties.changedProperties & LayerChange::EventRegionChanged);
 
-    HashMap<IntRect, CALayer *> interactionRegionLayers;
+    HashMap<IntRect, CALayer *> interactionLayers;
+    HashMap<IntRect, CALayer *> occlusionLayers;
+    CALayer *lastOcclusion = nil;
+
     for (CALayer *sublayer in layer.sublayers) {
-        if (!isInteractionRegionLayer(sublayer))
+        if (!isAnyInteractionRegionLayer(sublayer))
             continue;
+
         auto enclosingFrame = enclosingIntRect(sublayer.frame);
         if (enclosingFrame.isEmpty())
             continue;
-        auto result = interactionRegionLayers.add(enclosingFrame, sublayer);
+
+        auto result = isInteractionLayer(sublayer) ? interactionLayers.add(enclosingFrame, sublayer) : occlusionLayers.add(enclosingFrame, sublayer);
+        if (isOcclusionLayer(sublayer))
+            lastOcclusion = sublayer;
+
         ASSERT_UNUSED(result, result.isNewEntry);
     }
 
     bool applyBackgroundColorForDebugging = [[NSUserDefaults standardUserDefaults] boolForKey:@"WKInteractionRegionDebugFill"];
     float minimumBorderRadius = host.drawingArea().page().preferences().interactionRegionMinimumCornerRadius();
 
-    HashSet<IntRect> liveLayerBounds;
+    HashSet<IntRect> liveInteractionBounds;
+    HashSet<IntRect> liveOcclusionBounds;
     for (const WebCore::InteractionRegion& region : properties.eventRegion.interactionRegions()) {
         for (IntRect rect : region.regionInLayerCoordinates.rects()) {
-            if (!liveLayerBounds.add(rect).isNewEntry)
+            if (region.type == InteractionRegion::Type::Occlusion) {
+                if (!liveOcclusionBounds.add(rect).isNewEntry)
+                    continue;
+
+                auto layerIterator = occlusionLayers.find(rect);
+
+                RetainPtr<CALayer> interactionRegionLayer;
+                if (layerIterator != occlusionLayers.end()) {
+                    interactionRegionLayer = layerIterator->value;
+                    occlusionLayers.remove(layerIterator);
+                    continue;
+                }
+
+                interactionRegionLayer = adoptNS([[CALayer alloc] init]);
+                [interactionRegionLayer setFrame:rect];
+                [interactionRegionLayer setHitTestsAsOpaque:YES];
+                setInteractionRegionOcclusion(interactionRegionLayer.get());
+
+                if (applyBackgroundColorForDebugging) {
+                    [interactionRegionLayer setBackgroundColor:cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .1) }).get()];
+                    [interactionRegionLayer setName:@"Occlusion"];
+                }
+
+                if (!lastOcclusion)
+                    lastOcclusion = interactionRegionLayer.get();
+
+                // In a given layer, occlusions come first and the inter-occlusion order does not matter.
+                [layer insertSublayer:interactionRegionLayer.get() atIndex: 0];
+
+                continue;
+            }
+
+            if (!liveInteractionBounds.add(rect).isNewEntry)
                 continue;
 
-            auto layerIterator = interactionRegionLayers.find(rect);
+            auto layerIterator = interactionLayers.find(rect);
 
             RetainPtr<CALayer> interactionRegionLayer;
-            if (layerIterator != interactionRegionLayers.end()) {
+            if (layerIterator != interactionLayers.end()) {
                 interactionRegionLayer = layerIterator->value;
-                interactionRegionLayers.remove(layerIterator);
+                interactionLayers.remove(layerIterator);
             } else {
                 interactionRegionLayer = adoptNS([[CALayer alloc] init]);
                 [interactionRegionLayer setFrame:rect];
                 [interactionRegionLayer setHitTestsAsOpaque:YES];
 
-                if (applyBackgroundColorForDebugging)
-                    [interactionRegionLayer setBackgroundColor:cachedCGColor({ WebCore::SRGBA<float>(0, 1, 0, .3) }).get()];
+                if (applyBackgroundColorForDebugging) {
+                    [interactionRegionLayer setBackgroundColor:cachedCGColor({ WebCore::SRGBA<float>(0, 1, 0, .2) }).get()];
+                    [interactionRegionLayer setName:@"Interaction"];
+                }
 
-                setInteractionRegion(interactionRegionLayer.get(), region);
-                configureLayerForInteractionRegion(interactionRegionLayer.get(), makeString("WKInteractionRegion-"_s, String::number(region.elementIdentifier.toUInt64())));
-
-                [layer addSublayer:interactionRegionLayer.get()];
+                // In a given layer, interactions go after occlusions, sorted by area.
+                NSUInteger insertionPoint = lastOcclusion ? ([layer.sublayers indexOfObject:lastOcclusion] + 1) : 0;
+                auto area = CGFloat(rect.area());
+                auto layerAtIndex = insertionPoint < layer.sublayers.count ? [layer.sublayers objectAtIndex: insertionPoint] : nil;
+                while (layerAtIndex && !!interactionRegionForLayer(layerAtIndex) && layerAtIndex.frame.size.width * layerAtIndex.frame.size.height > area) {
+                    insertionPoint++;
+                    layerAtIndex = insertionPoint < layer.sublayers.count ? [layer.sublayers objectAtIndex: insertionPoint] : nil;
+                }
+                [layer insertSublayer:interactionRegionLayer.get() atIndex: insertionPoint];
             }
 
+            setInteractionRegion(interactionRegionLayer.get(), region);
+            configureLayerForInteractionRegion(interactionRegionLayer.get(), makeString("WKInteractionRegion-"_s, String::number(region.elementIdentifier.toUInt64())));
             [interactionRegionLayer setCornerRadius:std::max(region.borderRadius, minimumBorderRadius)];
         }
     }
 
-    for (CALayer *sublayer : interactionRegionLayers.values())
+    for (CALayer *sublayer : interactionLayers.values())
+        [sublayer removeFromSuperlayer];
+
+    for (CALayer *sublayer : occlusionLayers.values())
         [sublayer removeFromSuperlayer];
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -51,6 +51,9 @@ public:
     static std::unique_ptr<RemoteLayerTreeNode> createWithPlainLayer(WebCore::GraphicsLayer::PlatformLayerID);
 
     CALayer *layer() const { return m_layer.get(); }
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    CALayer *interactionRegionsLayer() const { return m_interactionRegionsLayer.get(); }
+#endif
 #if PLATFORM(IOS_FAMILY)
     UIView *uiView() const { return m_uiView.get(); }
 #endif
@@ -86,6 +89,9 @@ private:
     WebCore::GraphicsLayer::PlatformLayerID m_layerID;
 
     RetainPtr<CALayer> m_layer;
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    RetainPtr<CALayer> m_interactionRegionsLayer;
+#endif
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<UIView> m_uiView;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -75,6 +75,9 @@ void RemoteLayerTreeNode::detachFromParent()
         return;
     }
 #endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [interactionRegionsLayer() removeFromSuperlayer];
+#endif
     [layer() removeFromSuperlayer];
 }
 
@@ -86,6 +89,10 @@ void RemoteLayerTreeNode::setEventRegion(const WebCore::EventRegion& eventRegion
 void RemoteLayerTreeNode::initializeLayer()
 {
     [layer() setValue:[NSValue valueWithPointer:this] forKey:WKRemoteLayerTreeNodePropertyKey];
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    m_interactionRegionsLayer = adoptNS([[CALayer alloc] init]);
+    [m_interactionRegionsLayer setName:@"InteractionRegions Container"];
+#endif
 }
 
 WebCore::GraphicsLayer::PlatformLayerID RemoteLayerTreeNode::layerID(CALayer *layer)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -337,6 +337,7 @@ interface UIScriptController {
 
     readonly attribute DOMString scrollingTreeAsText;
     readonly attribute DOMString uiViewTreeAsText;
+    readonly attribute DOMString caLayerTreeAsText;
 
     boolean mayContainEditableElementsInRect(unsigned long x, unsigned long y, unsigned long width, unsigned long height);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -152,6 +152,7 @@ public:
 
     virtual JSRetainPtr<JSStringRef> scrollingTreeAsText() const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> uiViewTreeAsText() const { notImplemented(); return nullptr; }
+    virtual JSRetainPtr<JSStringRef> caLayerTreeAsText() const { notImplemented(); return nullptr; }
 
     // Touches
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -52,6 +52,7 @@ private:
     void setDefaultCalendarType(JSStringRef calendarIdentifier, JSStringRef localeIdentifier) override;
     JSRetainPtr<JSStringRef> lastUndoLabel() const override;
     JSRetainPtr<JSStringRef> firstRedoLabel() const override;
+    JSRetainPtr<JSStringRef> caLayerTreeAsText() const override;
     NSUndoManager *platformUndoManager() const override;
 
     JSRetainPtr<JSStringRef> scrollingTreeAsText() const override;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -173,6 +173,11 @@ JSRetainPtr<JSStringRef> UIScriptControllerCocoa::lastUndoLabel() const
     return adopt(JSStringCreateWithCFString((__bridge CFStringRef)platformUndoManager().undoActionName));
 }
 
+JSRetainPtr<JSStringRef> UIScriptControllerCocoa::caLayerTreeAsText() const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef)[webView() _caLayerTreeAsText]));
+}
+
 JSRetainPtr<JSStringRef> UIScriptControllerCocoa::firstRedoLabel() const
 {
     return adopt(JSStringCreateWithCFString((__bridge CFStringRef)platformUndoManager().redoActionName));


### PR DESCRIPTION
#### 0c8fb49c7a40115abe543963829eb8268b96d048
<pre>
Interaction regions should support occlusions
<a href="https://bugs.webkit.org/show_bug.cgi?id=250860">https://bugs.webkit.org/show_bug.cgi?id=250860</a>
&lt;rdar://103928196&gt;

Reviewed by Tim Horton.

Maintain a separate layer tree for Interaction Regions on top of the
content. This &quot;mirror layer tree&quot; includes layers for occlusions and now
comes with clear ordering rules.

* LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt:
* LayoutTests/interaction-region/click-handler-expected.txt:
* LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt:
* LayoutTests/interaction-region/event-region-overflow-expected.txt:
* LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt:
* LayoutTests/interaction-region/inline-link-dark-background-expected.txt:
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-in-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt:
* LayoutTests/interaction-region/input-type-file-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* LayoutTests/interaction-region/paused-video-regions-expected.txt:
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Update expectations with the new dump format.

* LayoutTests/interaction-region/layer-tree-expected.txt: Added.
* LayoutTests/interaction-region/layer-tree.html: Added.
Add test covering the final RemoteLayerTree structure.

* LayoutTests/interaction-region/overlay-expected.txt: Renamed from LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree-expected.txt.
* LayoutTests/interaction-region/overlay.html: Renamed from LayoutTests/interaction-region/inline-link-in-aria-hidden-subtree.html.
Remove the aria-hidden test.
Add test for the occlusions detection.

* LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt:
* LayoutTests/interaction-region/region-area-overflow-does-not-crash.html:
Update test to also include a big occlusion region.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.getCALayerTree):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::caLayerTreeAsText const):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::caLayerTreeAsText const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _caLayerTreeAsText]):
(dumpCALayer):
Introduce a new test helper to get the full remote layer hierarchy.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Remove the aria-hidden check. It was too strict and is not needed
anymore.
Generate regions for elements likely to occlude interactions.
(WebCore::operator&lt;&lt;):
Update the dump format to differentiate interactions and occlusions.

* Source/WebCore/page/InteractionRegion.h:
(WebCore::operator==):
(WebCore::InteractionRegion::encode const):
(WebCore::InteractionRegion::decode):
Add a `type` enum to the InteractionRegion struct to differentiate
interactions and occlusions.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyGeometryPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
Extract the geometry related properties application code to a new
method.
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
Only update geometry and event region properties for Interaction Regions
layers.
(WebKit::applyInteractionRegionsHierarchyUpdate):
(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
Apply all hierarchy updates to the Interaction Regions mirror layer tree.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
Keep the Interaction Regions mirror layer tree on top of the content after
each layer tree update.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::isInteractionLayer):
(WebKit::isOcclusionLayer):
(WebKit::isAnyInteractionRegionLayer):
(WebKit::isInteractionRegionLayer): Deleted.
(WebKit::setInteractionRegionOcclusion):
Update utility functions to differentiate interactions and occlusions.
(WebKit::insertInteractionRegionLayersForLayer):
(WebKit::appendInteractionRegionLayersForLayer): Deleted.
Insert the Interaction Regions back at the beginning of the sublayers array.
(WebKit::updateLayersForInteractionRegions):
Maintain the following order when updating Interaction Regions layers:
1. Occlusions always come first (in no particular order).
2. Interactions come next, ordered by area (biggest to smallest).
3. Other siblings come last, in the same order as the content layers they mirror.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::interactionRegionsLayer const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::detachFromParent):
(WebKit::RemoteLayerTreeNode::initializeLayer):
Add an `interactionRegionsLayer` property to the RemoteLayerTreeNode.

Canonical link: <a href="https://commits.webkit.org/259504@main">https://commits.webkit.org/259504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63f6dc94d981bf1d442ffa4648a9bcec208d31d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113798 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174022 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4525 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112756 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38928 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80598 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6958 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27366 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3942 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46926 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6550 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8869 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->