### PR TITLE
[WebGPU] Implement resource deallocation

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
@@ -49,7 +49,11 @@ SurfaceImpl::~SurfaceImpl()
 
 void SurfaceImpl::destroy()
 {
+    if (!m_backing)
+        return;
+
     wgpuSurfaceRelease(m_backing);
+    m_backing = nullptr;
 }
 
 void SurfaceImpl::setLabelInternal(const String&)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
@@ -45,12 +45,16 @@ SwapChainImpl::SwapChainImpl(WGPUSurface surface, WGPUSwapChain swapChain, Conve
 
 SwapChainImpl::~SwapChainImpl()
 {
-    wgpuSwapChainRelease(m_backing);
+    destroy();
 }
 
 void SwapChainImpl::destroy()
 {
+    if (!m_backing)
+        return;
+
     wgpuSwapChainRelease(m_backing);
+    m_backing = nullptr;
 }
 
 void SwapChainImpl::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -585,7 +585,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
     auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
     m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
 
-    return bindGroupLayout.ptr();
+    return WebGPU::releaseToAPI(WTFMove(bindGroupLayout));
 #else
     UNUSED_PARAM(groupIndex);
     return nullptr;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -50,7 +50,15 @@ RemoteAdapter::RemoteAdapter(PAL::WebGPU::Adapter& adapter, WebGPU::ObjectHeap& 
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteAdapter::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteAdapter::~RemoteAdapter() = default;
+RemoteAdapter::~RemoteAdapter()
+{
+    destroy();
+}
+
+void RemoteAdapter::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteAdapter::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -76,6 +76,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void requestDevice(const WebGPU::DeviceDescriptor&, WebGPUIdentifier, WebGPUIdentifier queueIdentifier, CompletionHandler<void(WebGPU::SupportedFeatures&&, WebGPU::SupportedLimits&&)>&&);
+    void destroy();
 
     Ref<PAL::WebGPU::Adapter> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteAdapter NotRefCounted Stream {
+    void Destroy()
     void RequestDevice(WebKit::WebGPU::DeviceDescriptor deviceDescriptor, WebKit::WebGPUIdentifier identifier, WebKit::WebGPUIdentifier queueIdentifier) -> (WebKit::WebGPU::SupportedFeatures supportedFeatures, WebKit::WebGPU::SupportedLimits supportedLimits) Synchronous
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -44,7 +44,15 @@ RemoteBindGroup::RemoteBindGroup(PAL::WebGPU::BindGroup& bindGroup, WebGPU::Obje
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteBindGroup::~RemoteBindGroup() = default;
+RemoteBindGroup::~RemoteBindGroup()
+{
+    destroy();
+}
+
+void RemoteBindGroup::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteBindGroup::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::BindGroup> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteBindGroup NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -44,7 +44,15 @@ RemoteBindGroupLayout::RemoteBindGroupLayout(PAL::WebGPU::BindGroupLayout& bindG
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteBindGroupLayout::~RemoteBindGroupLayout() = default;
+RemoteBindGroupLayout::~RemoteBindGroupLayout()
+{
+    destroy();
+}
+
+void RemoteBindGroupLayout::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteBindGroupLayout::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::BindGroupLayout> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteBindGroupLayout NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -43,7 +43,10 @@ RemoteBuffer::RemoteBuffer(PAL::WebGPU::Buffer& buffer, WebGPU::ObjectHeap& obje
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteBuffer::~RemoteBuffer() = default;
+RemoteBuffer::~RemoteBuffer()
+{
+    destroy();
+}
 
 void RemoteBuffer::stopListeningForIPC()
 {
@@ -96,7 +99,8 @@ void RemoteBuffer::unmap(Vector<uint8_t>&& data)
 
 void RemoteBuffer::destroy()
 {
-    m_backing->destroy();
+    if (m_objectHeap.removeObject(m_identifier))
+        m_backing->destroy();
 }
 
 void RemoteBuffer::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
@@ -44,7 +44,15 @@ RemoteCommandBuffer::RemoteCommandBuffer(PAL::WebGPU::CommandBuffer& commandBuff
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteCommandBuffer::~RemoteCommandBuffer() = default;
+RemoteCommandBuffer::~RemoteCommandBuffer()
+{
+    destroy();
+}
+
+void RemoteCommandBuffer::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteCommandBuffer::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::CommandBuffer> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteCommandBuffer NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -48,7 +48,15 @@ RemoteCommandEncoder::RemoteCommandEncoder(PAL::WebGPU::CommandEncoder& commandE
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteCommandEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteCommandEncoder::~RemoteCommandEncoder() = default;
+RemoteCommandEncoder::~RemoteCommandEncoder()
+{
+    destroy();
+}
+
+void RemoteCommandEncoder::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteCommandEncoder::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -125,6 +125,7 @@ private:
     void finish(const WebGPU::CommandBufferDescriptor&, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::CommandEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
@@ -31,6 +31,7 @@ messages -> RemoteCommandEncoder NotRefCounted Stream {
     void CopyTextureToBuffer(WebKit::WebGPU::ImageCopyTexture source, WebKit::WebGPU::ImageCopyBuffer destination, WebKit::WebGPU::Extent3D copySize)
     void CopyTextureToTexture(WebKit::WebGPU::ImageCopyTexture source, WebKit::WebGPU::ImageCopyTexture destination, WebKit::WebGPU::Extent3D copySize)
     void ClearBuffer(WebKit::WebGPUIdentifier buffer, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+    void Destroy()
     void PushDebugGroup(String groupLabel)
     void PopDebugGroup()
     void InsertDebugMarker(String markerLabel)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -44,7 +44,15 @@ RemoteComputePassEncoder::RemoteComputePassEncoder(PAL::WebGPU::ComputePassEncod
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteComputePassEncoder::~RemoteComputePassEncoder() = default;
+RemoteComputePassEncoder::~RemoteComputePassEncoder()
+{
+    destroy();
+}
+
+void RemoteComputePassEncoder::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteComputePassEncoder::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -87,6 +87,7 @@ private:
     void insertDebugMarker(String&& markerLabel);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::ComputePassEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteComputePassEncoder NotRefCounted Stream {
+    void Destroy()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void Dispatch(PAL::WebGPU::Size32 workgroupCountX, PAL::WebGPU::Size32 workgroupCountY, PAL::WebGPU::Size32 workgroupCountZ)
     void DispatchIndirect(WebKit::WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -46,7 +46,15 @@ RemoteComputePipeline::RemoteComputePipeline(PAL::WebGPU::ComputePipeline& compu
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteComputePipeline::~RemoteComputePipeline() = default;
+RemoteComputePipeline::~RemoteComputePipeline()
+{
+    destroy();
+}
+
+void RemoteComputePipeline::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteComputePipeline::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -75,6 +75,7 @@ private:
     void getBindGroupLayout(uint32_t index, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::ComputePipeline> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteComputePipeline NotRefCounted Stream {
+    void Destroy()
     void GetBindGroupLayout(uint32_t index, WebKit::WebGPUIdentifier identifier)
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -93,7 +93,10 @@ RemoteDevice::RemoteDevice(PAL::WebGPU::Device& device, WebGPU::ObjectHeap& obje
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteDevice::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteDevice::~RemoteDevice() = default;
+RemoteDevice::~RemoteDevice()
+{
+    destroy();
+}
 
 void RemoteDevice::stopListeningForIPC()
 {
@@ -107,7 +110,8 @@ RemoteQueue& RemoteDevice::queue()
 
 void RemoteDevice::destroy()
 {
-    m_backing->destroy();
+    if (m_objectHeap.removeObject(m_identifier))
+        m_backing->destroy();
 }
 
 void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
@@ -44,7 +44,15 @@ RemoteExternalTexture::RemoteExternalTexture(PAL::WebGPU::ExternalTexture& exter
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteExternalTexture::~RemoteExternalTexture() = default;
+RemoteExternalTexture::~RemoteExternalTexture()
+{
+    destroy();
+}
+
+void RemoteExternalTexture::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteExternalTexture::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::ExternalTexture> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteExternalTexture NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -77,6 +77,13 @@ void RemoteGPU::stopListeningForIPC(Ref<RemoteGPU>&& refFromConnection)
     });
 }
 
+void RemoteGPU::destroy()
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        stopListeningForIPC(Ref { *this });
+    });
+}
+
 void RemoteGPU::workQueueInitialize()
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -125,6 +125,7 @@ private:
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
     void workQueueInitialize();
     void workQueueUninitialize();
+    void destroy();
 
     template<typename T>
     bool send(T&& message) const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -25,6 +25,7 @@
 
 messages -> RemoteGPU NotRefCounted Stream {
     void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPU::RequestAdapterResponse> response) Synchronous
+    void Destroy()
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
@@ -44,7 +44,15 @@ RemotePipelineLayout::RemotePipelineLayout(PAL::WebGPU::PipelineLayout& pipeline
     m_streamConnection->startReceivingMessages(*this, Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemotePipelineLayout::~RemotePipelineLayout() = default;
+RemotePipelineLayout::~RemotePipelineLayout()
+{
+    destroy();
+}
+
+void RemotePipelineLayout::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemotePipelineLayout::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::PipelineLayout> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemotePipelineLayout NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -44,7 +44,10 @@ RemoteQuerySet::RemoteQuerySet(PAL::WebGPU::QuerySet& querySet, WebGPU::ObjectHe
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteQuerySet::~RemoteQuerySet() = default;
+RemoteQuerySet::~RemoteQuerySet()
+{
+    destroy();
+}
 
 void RemoteQuerySet::stopListeningForIPC()
 {
@@ -53,7 +56,8 @@ void RemoteQuerySet::stopListeningForIPC()
 
 void RemoteQuerySet::destroy()
 {
-    m_backing->destroy();
+    if (m_objectHeap.removeObject(m_identifier))
+        m_backing->destroy();
 }
 
 void RemoteQuerySet::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -44,7 +44,15 @@ RemoteQueue::RemoteQueue(PAL::WebGPU::Queue& queue, WebGPU::ObjectHeap& objectHe
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteQueue::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteQueue::~RemoteQueue() = default;
+RemoteQueue::~RemoteQueue()
+{
+    destroy();
+}
+
+void RemoteQueue::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteQueue::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -102,6 +102,7 @@ private:
         const WebGPU::Extent3D& copySize);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::Queue> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteQueue NotRefCounted Stream {
+    void Destroy()
     void Submit(Vector<WebKit::WebGPUIdentifier> commandBuffers)
     void OnSubmittedWorkDone() -> () Synchronous NotStreamEncodableReply
     void WriteBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::Size64 bufferOffset, Vector<uint8_t> data)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -44,7 +44,15 @@ RemoteRenderBundle::RemoteRenderBundle(PAL::WebGPU::RenderBundle& renderBundle, 
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteRenderBundle::~RemoteRenderBundle() = default;
+RemoteRenderBundle::~RemoteRenderBundle()
+{
+    destroy();
+}
+
+void RemoteRenderBundle::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteRenderBundle::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::RenderBundle> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderBundle NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -46,7 +46,15 @@ RemoteRenderBundleEncoder::RemoteRenderBundleEncoder(PAL::WebGPU::RenderBundleEn
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderBundleEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteRenderBundleEncoder::~RemoteRenderBundleEncoder() = default;
+RemoteRenderBundleEncoder::~RemoteRenderBundleEncoder()
+{
+    destroy();
+}
+
+void RemoteRenderBundleEncoder::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteRenderBundleEncoder::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -100,6 +100,7 @@ private:
     void finish(const WebGPU::RenderBundleDescriptor&, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::RenderBundleEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderBundleEncoder NotRefCounted Stream {
+    void Destroy()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
     void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -44,7 +44,15 @@ RemoteRenderPassEncoder::RemoteRenderPassEncoder(PAL::WebGPU::RenderPassEncoder&
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderPassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteRenderPassEncoder::~RemoteRenderPassEncoder() = default;
+RemoteRenderPassEncoder::~RemoteRenderPassEncoder()
+{
+    destroy();
+}
+
+void RemoteRenderPassEncoder::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteRenderPassEncoder::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -114,6 +114,7 @@ private:
     void end();
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::RenderPassEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderPassEncoder NotRefCounted Stream {
+    void Destroy()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
     void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -46,7 +46,15 @@ RemoteRenderPipeline::RemoteRenderPipeline(PAL::WebGPU::RenderPipeline& renderPi
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteRenderPipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteRenderPipeline::~RemoteRenderPipeline() = default;
+RemoteRenderPipeline::~RemoteRenderPipeline()
+{
+    destroy();
+}
+
+void RemoteRenderPipeline::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteRenderPipeline::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -75,6 +75,7 @@ private:
     void getBindGroupLayout(uint32_t index, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::RenderPipeline> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderPipeline NotRefCounted Stream {
+    void Destroy()
     void GetBindGroupLayout(uint32_t index, WebKit::WebGPUIdentifier identifier);
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
@@ -44,7 +44,15 @@ RemoteSampler::RemoteSampler(PAL::WebGPU::Sampler& sampler, WebGPU::ObjectHeap& 
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteSampler::~RemoteSampler() = default;
+RemoteSampler::~RemoteSampler()
+{
+    destroy();
+}
+
+void RemoteSampler::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteSampler::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::Sampler> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSampler NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -46,7 +46,15 @@ RemoteShaderModule::RemoteShaderModule(PAL::WebGPU::ShaderModule& shaderModule, 
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteShaderModule::~RemoteShaderModule() = default;
+RemoteShaderModule::~RemoteShaderModule()
+{
+    destroy();
+}
+
+void RemoteShaderModule::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteShaderModule::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -78,6 +78,7 @@ private:
     void compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&&);
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::ShaderModule> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
@@ -25,6 +25,7 @@
 
 messages -> RemoteShaderModule NotRefCounted Stream {
     void CompilationInfo() -> (Vector<WebKit::WebGPU::CompilationMessage> messages) Synchronous
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp
@@ -45,7 +45,10 @@ RemoteSurface::RemoteSurface(PAL::WebGPU::Surface& surface, WebGPU::ObjectHeap& 
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteSurface::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteSurface::~RemoteSurface() = default;
+RemoteSurface::~RemoteSurface()
+{
+    destroy();
+}
 
 void RemoteSurface::stopListeningForIPC()
 {
@@ -54,7 +57,8 @@ void RemoteSurface::stopListeningForIPC()
 
 void RemoteSurface::destroy()
 {
-    m_backing->destroy();
+    if (m_objectHeap.removeObject(m_identifier))
+        m_backing->destroy();
 }
 
 void RemoteSurface::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp
@@ -48,7 +48,10 @@ RemoteSwapChain::RemoteSwapChain(PAL::WebGPU::SwapChain& swapChain, WebGPU::Obje
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteSwapChain::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteSwapChain::~RemoteSwapChain() = default;
+RemoteSwapChain::~RemoteSwapChain()
+{
+    destroy();
+}
 
 void RemoteSwapChain::stopListeningForIPC()
 {
@@ -57,7 +60,8 @@ void RemoteSwapChain::stopListeningForIPC()
 
 void RemoteSwapChain::destroy()
 {
-    m_backing->destroy();
+    if (m_objectHeap.removeObject(m_identifier))
+        m_backing->destroy();
 }
 
 void RemoteSwapChain::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -48,7 +48,10 @@ RemoteTexture::RemoteTexture(PAL::WebGPU::Texture& texture, WebGPU::ObjectHeap& 
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteTexture::~RemoteTexture() = default;
+RemoteTexture::~RemoteTexture()
+{
+    destroy();
+}
 
 void RemoteTexture::stopListeningForIPC()
 {
@@ -73,7 +76,8 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
 
 void RemoteTexture::destroy()
 {
-    m_backing->destroy();
+    if (m_objectHeap.removeObject(m_identifier))
+        m_backing->destroy();
 }
 
 void RemoteTexture::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
@@ -44,7 +44,15 @@ RemoteTextureView::RemoteTextureView(PAL::WebGPU::TextureView& textureView, WebG
     m_streamConnection->startReceivingMessages(*this, Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteTextureView::~RemoteTextureView() = default;
+RemoteTextureView::~RemoteTextureView()
+{
+    destroy();
+}
+
+void RemoteTextureView::destroy()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
 
 void RemoteTextureView::stopListeningForIPC()
 {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destroy();
 
     Ref<PAL::WebGPU::TextureView> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteTextureView NotRefCounted Stream {
+    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
@@ -122,7 +122,7 @@ public:
     void addObject(WebGPUIdentifier, RemoteTexture&);
     void addObject(WebGPUIdentifier, RemoteTextureView&);
 
-    void removeObject(WebGPUIdentifier);
+    bool removeObject(WebGPUIdentifier);
 
     void clear();
 
@@ -180,6 +180,11 @@ private:
         IPC::ScopedActiveMessageReceiveQueue<RemoteTextureView>
     >;
     HashMap<WebGPUIdentifier, Object> m_objects;
+
+#if PLATFORM(COCOA)
+    void printObjectHeap();
+    const char* typeOfObject(const ObjectHeap::Object&);
+#endif
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -44,6 +44,8 @@ RemoteAdapterProxy::RemoteAdapterProxy(String&& name, PAL::WebGPU::SupportedFeat
 
 RemoteAdapterProxy::~RemoteAdapterProxy()
 {
+    auto sendResult = send(Messages::RemoteAdapter::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteAdapterProxy::requestDevice(const PAL::WebGPU::DeviceDescriptor& descriptor, CompletionHandler<void(Ref<PAL::WebGPU::Device>&&)>&& callback)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -69,11 +69,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
@@ -42,6 +42,8 @@ RemoteBindGroupLayoutProxy::RemoteBindGroupLayoutProxy(RemoteDeviceProxy& parent
 
 RemoteBindGroupLayoutProxy::~RemoteBindGroupLayoutProxy()
 {
+    auto sendResult = send(Messages::RemoteBindGroupLayout::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteBindGroupLayoutProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
@@ -42,6 +42,8 @@ RemoteBindGroupProxy::RemoteBindGroupProxy(RemoteDeviceProxy& parent, ConvertToB
 
 RemoteBindGroupProxy::~RemoteBindGroupProxy()
 {
+    auto sendResult = send(Messages::RemoteBindGroup::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteBindGroupProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -42,6 +42,7 @@ RemoteBufferProxy::RemoteBufferProxy(RemoteDeviceProxy& parent, ConvertToBacking
 
 RemoteBufferProxy::~RemoteBufferProxy()
 {
+    destroy();
 }
 
 void RemoteBufferProxy::mapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size, CompletionHandler<void()>&& callback)
@@ -96,6 +97,7 @@ void RemoteBufferProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteBuffer::Destroy());
     UNUSED_VARIABLE(sendResult);
+    m_destroyed = true;
 }
 
 void RemoteBufferProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -65,11 +65,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid() || m_destroyed)
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
@@ -88,6 +92,7 @@ private:
     Ref<RemoteDeviceProxy> m_parent;
     std::optional<Vector<uint8_t>> m_data;
     PAL::WebGPU::MapModeFlags m_mapModeFlags;
+    bool m_destroyed { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
@@ -42,6 +42,8 @@ RemoteCommandBufferProxy::RemoteCommandBufferProxy(RemoteDeviceProxy& parent, Co
 
 RemoteCommandBufferProxy::~RemoteCommandBufferProxy()
 {
+    auto sendResult = send(Messages::RemoteCommandBuffer::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteCommandBufferProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -45,6 +45,8 @@ RemoteCommandEncoderProxy::RemoteCommandEncoderProxy(RemoteDeviceProxy& parent, 
 
 RemoteCommandEncoderProxy::~RemoteCommandEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteCommandEncoder::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRenderPass(const PAL::WebGPU::RenderPassDescriptor& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -42,6 +42,8 @@ RemoteComputePassEncoderProxy::RemoteComputePassEncoderProxy(RemoteCommandEncode
 
 RemoteComputePassEncoderProxy::~RemoteComputePassEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteComputePassEncoder::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteComputePassEncoderProxy::setPipeline(const PAL::WebGPU::ComputePipeline& computePipeline)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -43,6 +43,8 @@ RemoteComputePipelineProxy::RemoteComputePipelineProxy(RemoteDeviceProxy& parent
 
 RemoteComputePipelineProxy::~RemoteComputePipelineProxy()
 {
+    auto sendResult = send(Messages::RemoteComputePipeline::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteComputePipelineProxy::getBindGroupLayout(uint32_t index)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -61,6 +61,7 @@ RemoteDeviceProxy::RemoteDeviceProxy(Ref<PAL::WebGPU::SupportedFeatures>&& featu
 
 RemoteDeviceProxy::~RemoteDeviceProxy()
 {
+    destroy();
 }
 
 PAL::WebGPU::Queue& RemoteDeviceProxy::queue()
@@ -70,6 +71,9 @@ PAL::WebGPU::Queue& RemoteDeviceProxy::queue()
 
 void RemoteDeviceProxy::destroy()
 {
+    auto sendResult = send(Messages::RemoteDevice::Destroy());
+    UNUSED_VARIABLE(sendResult);
+    m_destroyed = true;
 }
 
 Ref<PAL::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const PAL::WebGPU::BufferDescriptor& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -67,11 +67,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid() || m_destroyed)
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid() && !m_destroyed);
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
@@ -116,6 +120,7 @@ private:
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteAdapterProxy> m_parent;
     Ref<RemoteQueueProxy> m_queue;
+    bool m_destroyed { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
@@ -42,6 +42,8 @@ RemoteExternalTextureProxy::RemoteExternalTextureProxy(RemoteDeviceProxy& parent
 
 RemoteExternalTextureProxy::~RemoteExternalTextureProxy()
 {
+    auto sendResult = send(Messages::RemoteExternalTexture::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteExternalTextureProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -57,7 +57,12 @@ RemoteGPUProxy::RemoteGPUProxy(GPUProcessConnection& gpuProcessConnection, WebGP
     waitUntilInitialized();
 }
 
-RemoteGPUProxy::~RemoteGPUProxy() = default;
+RemoteGPUProxy::~RemoteGPUProxy()
+{
+    auto sendResult = send(Messages::RemoteGPU::Destroy());
+    UNUSED_VARIABLE(sendResult);
+    abandonGPUProcess();
+}
 
 void RemoteGPUProxy::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -58,6 +58,7 @@ public:
     RemoteGPUProxy& root() { return *this; }
 
     IPC::StreamClientConnection& streamClientConnection() { return *m_streamConnection; }
+    bool isValid() const { return m_gpuProcessConnection; }
 
 private:
     friend class WebGPU::DowncastConvertToBackingContext;
@@ -88,11 +89,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
     IPC::Connection& connection() const { return m_gpuProcessConnection->connection(); }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
@@ -42,6 +42,8 @@ RemotePipelineLayoutProxy::RemotePipelineLayoutProxy(RemoteDeviceProxy& parent, 
 
 RemotePipelineLayoutProxy::~RemotePipelineLayoutProxy()
 {
+    auto sendResult = send(Messages::RemotePipelineLayout::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemotePipelineLayoutProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
@@ -42,12 +42,14 @@ RemoteQuerySetProxy::RemoteQuerySetProxy(RemoteDeviceProxy& parent, ConvertToBac
 
 RemoteQuerySetProxy::~RemoteQuerySetProxy()
 {
+    destroy();
 }
 
 void RemoteQuerySetProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteQuerySet::Destroy());
     UNUSED_VARIABLE(sendResult);
+    m_destroyed = true;
 }
 
 void RemoteQuerySetProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid() || m_destroyed)
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid() && !m_destroyed);
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
@@ -79,6 +83,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    bool m_destroyed { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -42,6 +42,8 @@ RemoteQueueProxy::RemoteQueueProxy(RemoteDeviceProxy& parent, ConvertToBackingCo
 
 RemoteQueueProxy::~RemoteQueueProxy()
 {
+    auto sendResult = send(Messages::RemoteQueue::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteQueueProxy::submit(Vector<std::reference_wrapper<PAL::WebGPU::CommandBuffer>>&& commandBuffers)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -65,11 +65,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -43,6 +43,8 @@ RemoteRenderBundleEncoderProxy::RemoteRenderBundleEncoderProxy(RemoteDeviceProxy
 
 RemoteRenderBundleEncoderProxy::~RemoteRenderBundleEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderBundleEncoder::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteRenderBundleEncoderProxy::setPipeline(const PAL::WebGPU::RenderPipeline& renderPipeline)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
@@ -42,6 +42,8 @@ RemoteRenderBundleProxy::RemoteRenderBundleProxy(RemoteDeviceProxy& parent, Conv
 
 RemoteRenderBundleProxy::~RemoteRenderBundleProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderBundle::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteRenderBundleProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -42,6 +42,8 @@ RemoteRenderPassEncoderProxy::RemoteRenderPassEncoderProxy(RemoteCommandEncoderP
 
 RemoteRenderPassEncoderProxy::~RemoteRenderPassEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderPassEncoder::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteRenderPassEncoderProxy::setPipeline(const PAL::WebGPU::RenderPipeline& renderPipeline)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -43,6 +43,8 @@ RemoteRenderPipelineProxy::RemoteRenderPipelineProxy(RemoteDeviceProxy& parent, 
 
 RemoteRenderPipelineProxy::~RemoteRenderPipelineProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderPipeline::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteRenderPipelineProxy::getBindGroupLayout(uint32_t index)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
@@ -42,6 +42,8 @@ RemoteSamplerProxy::RemoteSamplerProxy(RemoteDeviceProxy& parent, ConvertToBacki
 
 RemoteSamplerProxy::~RemoteSamplerProxy()
 {
+    auto sendResult = send(Messages::RemoteSampler::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteSamplerProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -44,6 +44,8 @@ RemoteShaderModuleProxy::RemoteShaderModuleProxy(RemoteDeviceProxy& parent, Conv
 
 RemoteShaderModuleProxy::~RemoteShaderModuleProxy()
 {
+    auto sendResult = send(Messages::RemoteShaderModule::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteShaderModuleProxy::compilationInfo(CompletionHandler<void(Ref<PAL::WebGPU::CompilationInfo>&&)>&& callback)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp
@@ -42,12 +42,14 @@ RemoteSurfaceProxy::RemoteSurfaceProxy(RemoteDeviceProxy& parent, ConvertToBacki
 
 RemoteSurfaceProxy::~RemoteSurfaceProxy()
 {
+    destroy();
 }
 
 void RemoteSurfaceProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteSurface::Destroy());
     UNUSED_VARIABLE(sendResult);
+    m_destroyed = true;
 }
 
 void RemoteSurfaceProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h
@@ -65,11 +65,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid() || m_destroyed)
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid() && !m_destroyed);
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
@@ -80,6 +84,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    bool m_destroyed { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp
@@ -45,12 +45,14 @@ RemoteSwapChainProxy::RemoteSwapChainProxy(RemoteDeviceProxy& parent, ConvertToB
 
 RemoteSwapChainProxy::~RemoteSwapChainProxy()
 {
+    destroy();
 }
 
 void RemoteSwapChainProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteSwapChain::Destroy());
     UNUSED_VARIABLE(sendResult);
+    m_destroyed = true;
 }
 
 void RemoteSwapChainProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
@@ -69,11 +69,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid() || m_destroyed)
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid() && !m_destroyed);
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
@@ -84,6 +88,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    bool m_destroyed { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -44,6 +44,7 @@ RemoteTextureProxy::RemoteTextureProxy(RemoteDeviceProxy& parent, ConvertToBacki
 
 RemoteTextureProxy::~RemoteTextureProxy()
 {
+    destroy();
 }
 
 Ref<PAL::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional<PAL::WebGPU::TextureViewDescriptor>& descriptor)
@@ -68,6 +69,7 @@ void RemoteTextureProxy::destroy()
 {
     auto sendResult = send(Messages::RemoteTexture::Destroy());
     UNUSED_VARIABLE(sendResult);
+    m_destroyed = true;
 }
 
 void RemoteTextureProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -68,11 +68,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid() || m_destroyed)
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid() && !m_destroyed);
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
@@ -85,6 +89,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    bool m_destroyed { false };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -42,6 +42,8 @@ RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, Conve
 
 RemoteTextureViewProxy::~RemoteTextureViewProxy()
 {
+    auto sendResult = send(Messages::RemoteTextureView::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteTextureViewProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -64,11 +64,15 @@ private:
     template<typename T>
     WARN_UNUSED_RETURN bool send(T&& message)
     {
+        if (!root().isValid())
+            return false;
+
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }
     template<typename T>
     WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
+        ASSERT(root().isValid());
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 


### PR DESCRIPTION
#### 16f668371d1ab49a5cb205a706b8ca9e370d18f4
<pre>
[WebGPU] Implement resource deallocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=250865">https://bugs.webkit.org/show_bug.cgi?id=250865</a>
&lt;radar://103963935&gt;

Reviewed by NOBODY (OOPS!).

Resources were not getting removed from the GPUProcess
when they were no longer needed in the WebKit process.

Fix this by adding messages the WebKit process can send to
the GPU process to remove resources.

Also add a notification facility to show the number of
active objects in the WebGPUObjectHeap.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp:
(PAL::WebGPU::SurfaceImpl::destroy):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp:
(PAL::WebGPU::SwapChainImpl::~SwapChainImpl):
(PAL::WebGPU::SwapChainImpl::destroy):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::~RemoteAdapter):
(WebKit::RemoteAdapter::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp:
(WebKit::RemoteBindGroup::~RemoteBindGroup):
(WebKit::RemoteBindGroup::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp:
(WebKit::RemoteBindGroupLayout::~RemoteBindGroupLayout):
(WebKit::RemoteBindGroupLayout::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::~RemoteBuffer):
(WebKit::RemoteBuffer::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp:
(WebKit::RemoteCommandBuffer::~RemoteCommandBuffer):
(WebKit::RemoteCommandBuffer::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::~RemoteCommandEncoder):
(WebKit::RemoteCommandEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::~RemoteComputePassEncoder):
(WebKit::RemoteComputePassEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::~RemoteComputePipeline):
(WebKit::RemoteComputePipeline::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::~RemoteDevice):
(WebKit::RemoteDevice::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp:
(WebKit::RemoteExternalTexture::~RemoteExternalTexture):
(WebKit::RemoteExternalTexture::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp:
(WebKit::RemotePipelineLayout::~RemotePipelineLayout):
(WebKit::RemotePipelineLayout::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp:
(WebKit::RemoteQuerySet::~RemoteQuerySet):
(WebKit::RemoteQuerySet::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::~RemoteQueue):
(WebKit::RemoteQueue::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp:
(WebKit::RemoteRenderBundle::~RemoteRenderBundle):
(WebKit::RemoteRenderBundle::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::~RemoteRenderBundleEncoder):
(WebKit::RemoteRenderBundleEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::~RemoteRenderPassEncoder):
(WebKit::RemoteRenderPassEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::~RemoteRenderPipeline):
(WebKit::RemoteRenderPipeline::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp:
(WebKit::RemoteSampler::~RemoteSampler):
(WebKit::RemoteSampler::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp:
(WebKit::RemoteShaderModule::~RemoteShaderModule):
(WebKit::RemoteShaderModule::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp:
(WebKit::RemoteSurface::~RemoteSurface):
(WebKit::RemoteSurface::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp:
(WebKit::RemoteSwapChain::~RemoteSwapChain):
(WebKit::RemoteSwapChain::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::~RemoteTexture):
(WebKit::RemoteTexture::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp:
(WebKit::RemoteTextureView::~RemoteTextureView):
(WebKit::RemoteTextureView::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp:
(WebKit::WebGPU::ObjectHeap::typeOfObject):
(WebKit::WebGPU::ObjectHeap::printObjectHeap):
(WebKit::WebGPU::ObjectHeap::ObjectHeap):
(WebKit::WebGPU::ObjectHeap::removeObject):
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::~RemoteAdapterProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp:
(WebKit::WebGPU::RemoteBindGroupLayoutProxy::~RemoteBindGroupLayoutProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp:
(WebKit::WebGPU::RemoteBindGroupProxy::~RemoteBindGroupProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::~RemoteBufferProxy):
(WebKit::WebGPU::RemoteBufferProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp:
(WebKit::WebGPU::RemoteCommandBufferProxy::~RemoteCommandBufferProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::~RemoteCommandEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteComputePassEncoderProxy::~RemoteComputePassEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
(WebKit::WebGPU::RemoteComputePipelineProxy::~RemoteComputePipelineProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::~RemoteDeviceProxy):
(WebKit::WebGPU::RemoteDeviceProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp:
(WebKit::WebGPU::RemoteExternalTextureProxy::~RemoteExternalTextureProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::~RemoteGPUProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp:
(WebKit::WebGPU::RemotePipelineLayoutProxy::~RemotePipelineLayoutProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp:
(WebKit::WebGPU::RemoteQuerySetProxy::~RemoteQuerySetProxy):
(WebKit::WebGPU::RemoteQuerySetProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::~RemoteQueueProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::~RemoteRenderBundleEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleProxy::~RemoteRenderBundleProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::~RemoteRenderPassEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
(WebKit::WebGPU::RemoteRenderPipelineProxy::~RemoteRenderPipelineProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp:
(WebKit::WebGPU::RemoteSamplerProxy::~RemoteSamplerProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
(WebKit::WebGPU::RemoteShaderModuleProxy::~RemoteShaderModuleProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp:
(WebKit::WebGPU::RemoteSurfaceProxy::~RemoteSurfaceProxy):
(WebKit::WebGPU::RemoteSurfaceProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp:
(WebKit::WebGPU::RemoteSwapChainProxy::~RemoteSwapChainProxy):
(WebKit::WebGPU::RemoteSwapChainProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::~RemoteTextureProxy):
(WebKit::WebGPU::RemoteTextureProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
(WebKit::WebGPU::RemoteTextureViewProxy::~RemoteTextureViewProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16f668371d1ab49a5cb205a706b8ca9e370d18f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113909 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174124 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4639 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96964 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112849 "Hash 16f66837 for PR 8856 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39009 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108106 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80673 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94593 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27446 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92526 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4834 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7173 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4021 "Found 2 new test failures: fast/images/avif-heif-container-as-image.html, fast/images/avif-image-document.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30097 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103463 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47002 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101212 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8962 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25164 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->