### PR TITLE
overscroll-behavior: none doesn't prevent overscroll when page is too small to scroll

### DIFF
--- a/LayoutTests/fast/scrolling/ios/overscroll-behavior-non-scrollable-document-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/overscroll-behavior-non-scrollable-document-expected.txt
@@ -1,0 +1,9 @@
+Top
+PASS window.pageYOffset is 0
+PASS window.pageXOffset is 0
+PASS window.pageYOffset is 0
+PASS window.pageXOffset is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/overscroll-behavior-non-scrollable-document.html
+++ b/LayoutTests/fast/scrolling/ios/overscroll-behavior-non-scrollable-document.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ]-->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        html {
+            overscroll-behavior: none;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        async function doTest()
+        {
+            shouldBe('window.pageYOffset', '0');
+            shouldBe('window.pageXOffset', '0');
+            
+            await UIHelper.dragFromPointToPoint(150, 150, 200, 200, 0.1);
+            shouldBe('window.pageYOffset', '0');
+            shouldBe('window.pageXOffset', '0');
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    Top
+    <div class="content"></div>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html
+++ b/LayoutTests/fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html
@@ -47,7 +47,7 @@ function startTest() {
             var y = scroller.clientHeight / 2;
             var delta = getDeltas("right");
             return mouseWheelScrollAndWait(x, y, delta.X, delta.Y, delta.X, delta.Y).then(() => {
-                assert_equals(root.scrollLeft > 0, true, 'Propagate horizontal scroll');
+                assert_equals(root.scrollLeft == 0, true, 'Should not propagate horizontal scroll');
             });
         }, 'Unscrollable iframe horizontal scroll test with overscroll-behavior: none.');
 
@@ -57,7 +57,7 @@ function startTest() {
             var y = scroller.clientHeight / 2;
             var delta = getDeltas("down");
             return mouseWheelScrollAndWait(x, y, delta.X, delta.Y, delta.X, delta.Y).then(() => {
-                assert_equals(root.scrollTop > 0, true, 'Propagate vertical scroll');
+                assert_equals(root.scrollTop == 0, true, 'Should not propagate vertical scroll');
             });
         }, 'Unscrollable iframe vertical scroll test with overscroll-behavior: none.');
 }

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -6206,7 +6206,7 @@ OverscrollBehavior FrameView::horizontalOverscrollBehavior() const
 {
     auto* document = m_frame->document();
     auto scrollingObject = document && document->documentElement() ? document->documentElement()->renderer() : nullptr;
-    if (scrollingObject && renderView() && renderView()->canBeScrolledAndHasScrollableArea())
+    if (scrollingObject && renderView())
         return scrollingObject->style().overscrollBehaviorX();
     return OverscrollBehavior::Auto;
 }
@@ -6215,7 +6215,7 @@ OverscrollBehavior FrameView::verticalOverscrollBehavior()  const
 {
     auto* document = m_frame->document();
     auto scrollingObject = document && document->documentElement() ? document->documentElement()->renderer() : nullptr;
-    if (scrollingObject && renderView() && renderView()->canBeScrolledAndHasScrollableArea())
+    if (scrollingObject && renderView())
         return scrollingObject->style().overscrollBehaviorY();
     return OverscrollBehavior::Auto;
 }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -992,14 +992,14 @@ int RenderLayerScrollableArea::horizontalScrollbarHeight(OverlayScrollbarSizeRel
 
 OverscrollBehavior RenderLayerScrollableArea::horizontalOverscrollBehavior() const
 {
-    if (m_layer.renderBox() && m_layer.renderBox()->canBeScrolledAndHasScrollableArea())
+    if (m_layer.renderBox())
         return m_layer.renderer().style().overscrollBehaviorX();
     return OverscrollBehavior::Auto;
 }
 
 OverscrollBehavior RenderLayerScrollableArea::verticalOverscrollBehavior() const
 {
-    if (m_layer.renderBox() && m_layer.renderBox()->canBeScrolledAndHasScrollableArea())
+    if (m_layer.renderBox())
         return m_layer.renderer().style().overscrollBehaviorY();
     return OverscrollBehavior::Auto;
 }


### PR DESCRIPTION
#### 487c9dfe271c5adf23677f733fa2b812f005ce70
<pre>
overscroll-behavior: none doesn&apos;t prevent overscroll when page is too small to scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=244232">https://bugs.webkit.org/show_bug.cgi?id=244232</a>
rdar://99018981

Reviewed by Simon Fraser.

We should not disallow overscroll behavior on a non-scrollable document
since it should prevent rubberbanding if overscroll behavior ia none

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::horizontalOverscrollBehavior const):
(WebCore::FrameView::verticalOverscrollBehavior const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::horizontalOverscrollBehavior const):
(WebCore::RenderLayerScrollableArea::verticalOverscrollBehavior const):

Canonical link: <a href="https://commits.webkit.org/259227@main">https://commits.webkit.org/259227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2b174ae59de37ff3f06fb04c527a89e0ac6ba50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113458 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173747 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4248 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112510 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38760 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27132 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3687 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46685 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8616 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3362 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->