### PR TITLE
Web Inspector: `extensionHostWebView` and `webView` for _WKRemoteWebInspectorViewController be nil, but is not marked as nullable

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtensionHost.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtensionHost.h
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract The web view that is used to host extension tabs created via _WKInspectorExtension.
  * @discussion Browsing contexts for extension tabs are loaded in subframes of this web view.
  */
-@property (nonatomic, readonly) WKWebView *extensionHostWebView;
+@property (nonatomic, nullable, readonly) WKWebView *extensionHostWebView;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.h
@@ -42,8 +42,8 @@ WK_CLASS_AVAILABLE(macos(10.12.3))
 
 @property (nonatomic, weak) id <_WKRemoteWebInspectorViewControllerDelegate> delegate;
 
-@property (nonatomic, readonly, retain) NSWindow *window;
-@property (nonatomic, readonly, retain) WKWebView *webView;
+@property (nonatomic, nullable, readonly, retain) NSWindow *window;
+@property (nonatomic, nullable, readonly, retain) WKWebView *webView;
 @property (nonatomic, readonly, copy) _WKInspectorConfiguration *configuration WK_API_AVAILABLE(macos(12.0));
 
 - (instancetype)initWithConfiguration:(_WKInspectorConfiguration *)configuration WK_API_AVAILABLE(macos(12.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -44,7 +44,6 @@
 #import <wtf/BlockPtr.h>
 #endif
 
-NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKRemoteWebInspectorViewController ()
 - (void)sendMessageToBackend:(NSString *)message;
@@ -157,7 +156,7 @@ private:
 
 // MARK: _WKRemoteWebInspectorViewControllerPrivate methods
 
-- (void)_setDiagnosticLoggingDelegate:(id<_WKDiagnosticLoggingDelegate> _Nullable)delegate
+- (void)_setDiagnosticLoggingDelegate:(id<_WKDiagnosticLoggingDelegate>)delegate
 {
     self.webView._diagnosticLoggingDelegate = delegate;
     m_remoteInspectorProxy->setDiagnosticLoggingAvailable(!!delegate);
@@ -170,7 +169,7 @@ private:
     return self.webView;
 }
 
-- (void)registerExtensionWithID:(NSString *)extensionID extensionBundleIdentifier:(NSString *)extensionBundleIdentifier displayName:(NSString *)displayName completionHandler:(void(^)(NSError *, _WKInspectorExtension * _Nullable))completionHandler
+- (void)registerExtensionWithID:(NSString *)extensionID extensionBundleIdentifier:(NSString *)extensionBundleIdentifier displayName:(NSString *)displayName completionHandler:(void(^)(NSError *, _WKInspectorExtension *))completionHandler
 {
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // If this method is called prior to creating a frontend with -loadForDebuggable:backendCommandsURL:, it will not succeed.
@@ -223,7 +222,7 @@ private:
     m_remoteInspectorProxy->showResources();
 }
 
-- (void)showExtensionTabWithIdentifier:(NSString *)extensionTabIdentifier completionHandler:(void(^)(NSError * _Nullable))completionHandler
+- (void)showExtensionTabWithIdentifier:(NSString *)extensionTabIdentifier completionHandler:(void(^)(NSError *))completionHandler
 {
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
@@ -243,7 +242,7 @@ private:
 #endif
 }
 
-- (void)navigateExtensionTabWithIdentifier:(NSString *)extensionTabIdentifier toURL:(NSURL *)url completionHandler:(void(^)(NSError * _Nullable))completionHandler
+- (void)navigateExtensionTabWithIdentifier:(NSString *)extensionTabIdentifier toURL:(NSURL *)url completionHandler:(void(^)(NSError *))completionHandler
 {
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // It is an error to call this method prior to creating a frontend (i.e., with -connect or -show).
@@ -264,7 +263,5 @@ private:
 }
 
 @end
-
-NS_ASSUME_NONNULL_END
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 6ca671233e2e274c939d425fab3318c712a79a5b
<pre>
Web Inspector: `extensionHostWebView` and `webView` for _WKRemoteWebInspectorViewController be nil, but is not marked as nullable
<a href="https://bugs.webkit.org/show_bug.cgi?id=250874">https://bugs.webkit.org/show_bug.cgi?id=250874</a>
rdar://92478255

Reviewed by Brian Weinstein.

The web view for an inspector may be nil if we have already torn down the window, as can the inspector.

* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtensionHost.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.h:
- Add `_Nullable` annotations.

* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm:
(-[_WKRemoteWebInspectorViewController _setDiagnosticLoggingDelegate:]):
(-[_WKRemoteWebInspectorViewController registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKRemoteWebInspectorViewController showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKRemoteWebInspectorViewController navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
- Remove nullability annotations from implementation file to match other files where we only annotate headers. Otherwise
we&apos;d have to mark the return types as nullable here as well.

Canonical link: <a href="https://commits.webkit.org/259258@main">https://commits.webkit.org/259258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b14167016fb6bb911e1d201ae22aa63b76f0b07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113644 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4423 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112681 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38876 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80545 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6866 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27286 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6995 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46844 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6383 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8789 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->