### PR TITLE
[ews-build.webkit.org] Convert BlockPullRequest to new-style

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1926,7 +1926,7 @@ class SetCommitQueueMinusFlagOnPatch(buildstep.BuildStep, BugzillaMixin):
 class BlockPullRequest(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
     name = 'block-pull-request'
 
-    def start(self):
+    def run(self):
         pr_number = self.getProperty('github.number', '')
         build_finish_summary = self.getProperty('build_finish_summary', None)
 
@@ -1942,10 +1942,9 @@ class BlockPullRequest(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
                 not self.add_label(pr_number, self.BLOCKED_LABEL, repository_url=repository_url),
             )):
                 rc = FAILURE
-        self.finished(rc)
         if build_finish_summary:
             self.build.buildFinished([build_finish_summary], FAILURE)
-        return None
+        return rc
 
     def getResultSummary(self):
         if self.results == SUCCESS:


### PR DESCRIPTION
#### 4e32b6b25e796964a73687879b9ac5e0a31daeff
<pre>
[ews-build.webkit.org] Convert BlockPullRequest to new-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=250877">https://bugs.webkit.org/show_bug.cgi?id=250877</a>
rdar://104453787

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(BlockPullRequest.run): Renamed from &apos;start&apos;, return step status.
(BlockPullRequest.start): Renamed &apos;run&apos;.

Canonical link: <a href="https://commits.webkit.org/259278@main">https://commits.webkit.org/259278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d53dc692ba064efac2b6e94687ce4f2e3a214c24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113658 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173948 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4438 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96714 "Failed to checkout and rebase branch from PR 8863") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112692 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94329 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96714 "Failed to checkout and rebase branch from PR 8863") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25940 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96714 "Failed to checkout and rebase branch from PR 8863") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6880 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27297 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3854 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103286 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46855 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8801 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3390 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->