### PR TITLE
Refactor Document.h to reduce build times

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -905,6 +905,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/Autofill.h
     html/CachedHTMLCollection.h
     html/CanvasBase.h
+    html/CanvasObserver.h
     html/CollectionTraversal.h
     html/CollectionType.h
     html/CustomElementFormValue.h

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -36,14 +36,17 @@
 
 namespace WebCore {
 
+enum class DOMAudioSessionType : uint8_t { Auto, Playback, Transient, TransientSolo, Ambient, PlayAndRecord };
+enum class DOMAudioSessionState : uint8_t { Inactive, Active, Interrupted };
+
 class DOMAudioSession final : public RefCounted<DOMAudioSession>, public ActiveDOMObject, public EventTarget, public AudioSession::InterruptionObserver {
     WTF_MAKE_ISO_ALLOCATED(DOMAudioSession);
 public:
     static Ref<DOMAudioSession> create(ScriptExecutionContext*);
     ~DOMAudioSession();
 
-    enum class Type : uint8_t { Auto, Playback, Transient, TransientSolo, Ambient, PlayAndRecord };
-    enum class State : uint8_t { Inactive, Active, Interrupted };
+    using Type = DOMAudioSessionType;
+    using State = DOMAudioSessionState;
 
     ExceptionOr<void> setType(Type);
     Type type() const;

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -27,6 +27,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "CanvasBase.h"
+#include "CanvasObserver.h"
 #include "MediaStreamTrack.h"
 #include "Timer.h"
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -27,7 +27,7 @@
 #include "WakeLock.h"
 
 #include "DOMWindow.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "EventLoop.h"
 #include "Exception.h"
 #include "FeaturePolicy.h"

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "EventNames.h"
 #include "JSWebXRReferenceSpace.h"
+#include "SecurityOrigin.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WebXRBoundedReferenceSpace.h"
 #include "WebXRFrame.h"

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(WEBXR)
 
-#include "CanvasBase.h"
+#include "CanvasObserver.h"
 #include "ExceptionOr.h"
 #include "FloatRect.h"
 #include "GraphicsTypesGL.h"

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -789,6 +789,12 @@ bool ScriptController::canExecuteScripts(ReasonForCallingCanExecuteScripts reaso
     return m_frame.loader().client().allowScript(m_frame.settings().isScriptEnabled());
 }
 
+void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigin> securityOrigin, ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL)
+{
+    bool didReplaceDocument = false;
+    executeJavaScriptURL(url, securityOrigin, shouldReplaceDocumentIfJavaScriptURL, didReplaceDocument);
+}
+
 void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigin> requesterSecurityOrigin, ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL, bool& didReplaceDocument)
 {
     ASSERT(url.protocolIsJavaScript());

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -109,11 +109,7 @@ public:
 
     // This asserts that URL argument is a JavaScript URL.
     void executeJavaScriptURL(const URL&, RefPtr<SecurityOrigin>, ShouldReplaceDocumentIfJavaScriptURL, bool& didReplaceDocument);
-    void executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigin> securityOrigin = nullptr, ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL = ReplaceDocumentIfJavaScriptURL)
-    {
-        bool didReplaceDocument = false;
-        executeJavaScriptURL(url, securityOrigin, shouldReplaceDocumentIfJavaScriptURL, didReplaceDocument);
-    }
+    void executeJavaScriptURL(const URL&, RefPtr<SecurityOrigin> = nullptr, ShouldReplaceDocumentIfJavaScriptURL = ReplaceDocumentIfJavaScriptURL);
 
     static void initializeMainThread();
 

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include "ClientOrigin.h"
 #include "Document.h"
+#include "FocusOptions.h"
 #include "FrameDestructionObserverInlines.h"
 #include "MediaProducer.h"
 #include "SecurityOrigin.h"
@@ -80,6 +82,8 @@ inline bool Document::hasMutationObserversOfType(MutationObserverOptionType type
     return m_mutationObserverTypes.containsAny(type);
 }
 
+inline ClientOrigin Document::clientOrigin() const { return { topOrigin().data(), securityOrigin().data() }; }
+
 inline bool Document::isSameOriginAsTopDocument() const { return securityOrigin().isSameOriginAs(topOrigin()); }
 
 inline bool Document::shouldMaskURLForBindings(const URL& urlToMask) const
@@ -116,5 +120,8 @@ inline WebCoreOpaqueRoot Node::opaqueRoot() const
         return WebCoreOpaqueRoot { &document() };
     return traverseToOpaqueRoot();
 }
+
+inline bool Document::wasLastFocusByClick() const { return m_latestFocusTrigger == FocusTrigger::Click; }
+
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -421,7 +421,7 @@ bool Element::shouldUseInputMethod()
 
 static bool isForceEvent(const PlatformMouseEvent& platformEvent)
 {
-    return platformEvent.type() == PlatformEvent::MouseForceChanged || platformEvent.type() == PlatformEvent::MouseForceDown || platformEvent.type() == PlatformEvent::MouseForceUp;
+    return platformEvent.type() == PlatformEvent::Type::MouseForceChanged || platformEvent.type() == PlatformEvent::Type::MouseForceDown || platformEvent.type() == PlatformEvent::Type::MouseForceUp;
 }
 
 static bool isCompatibilityMouseEvent(const MouseEvent& mouseEvent)
@@ -3526,7 +3526,7 @@ bool Element::dispatchMouseForceWillBegin()
     if (!frame)
         return false;
 
-    PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), NoButton, PlatformEvent::NoType, 1, { }, WallTime::now(), ForceAtClick, NoTap };
+    PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), NoButton, PlatformEvent::Type::NoType, 1, { }, WallTime::now(), ForceAtClick, NoTap };
     auto mouseForceWillBeginEvent = MouseEvent::create(eventNames().webkitmouseforcewillbeginEvent, document().windowProxy(), platformMouseEvent, 0, nullptr);
     mouseForceWillBeginEvent->setTarget(Ref { *this });
     dispatchEvent(mouseForceWillBeginEvent);

--- a/Source/WebCore/dom/FragmentScriptingPermission.h
+++ b/Source/WebCore/dom/FragmentScriptingPermission.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-enum class ParserContentPolicy {
+enum class ParserContentPolicy : uint8_t {
     AllowScriptingContent = 1 << 0,
     AllowPluginContent = 1 << 1,
     DoNotMarkAlreadyStarted = 1 << 2,

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -40,17 +40,17 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(KeyboardEvent);
 static inline const AtomString& eventTypeForKeyboardEventType(PlatformEvent::Type type)
 {
     switch (type) {
-        case PlatformEvent::KeyUp:
-            return eventNames().keyupEvent;
-        case PlatformEvent::RawKeyDown:
-            return eventNames().keydownEvent;
-        case PlatformEvent::Char:
-            return eventNames().keypressEvent;
-        case PlatformEvent::KeyDown:
-            // The caller should disambiguate the combined event into RawKeyDown or Char events.
-            break;
-        default:
-            break;
+    case PlatformEvent::Type::KeyUp:
+        return eventNames().keyupEvent;
+    case PlatformEvent::Type::RawKeyDown:
+        return eventNames().keydownEvent;
+    case PlatformEvent::Type::Char:
+        return eventNames().keypressEvent;
+    case PlatformEvent::Type::KeyDown:
+        // The caller should disambiguate the combined event into RawKeyDown or Char events.
+        break;
+    default:
+        break;
     }
     ASSERT_NOT_REACHED();
     return eventNames().keydownEvent;

--- a/Source/WebCore/dom/VisibilityState.h
+++ b/Source/WebCore/dom/VisibilityState.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-enum class VisibilityState {
+enum class VisibilityState : bool {
     Hidden,
     Visible
 };

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class AffineTransform;
 class CanvasBase;
+class CanvasObserver;
 class CanvasRenderingContext;
 class Element;
 class GraphicsClient;
@@ -45,17 +46,6 @@ class FloatRect;
 class ScriptExecutionContext;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
-
-class CanvasObserver : public CanMakeWeakPtr<CanvasObserver> {
-public:
-    virtual ~CanvasObserver() = default;
-
-    virtual bool isStyleCanvasImage() const { return false; }
-
-    virtual void canvasChanged(CanvasBase&, const std::optional<FloatRect>& changedRect) = 0;
-    virtual void canvasResized(CanvasBase&) = 0;
-    virtual void canvasDestroyed(CanvasBase&) = 0;
-};
 
 class CanvasDisplayBufferObserver : public CanMakeWeakPtr<CanvasDisplayBufferObserver> {
 public:

--- a/Source/WebCore/html/CanvasObserver.h
+++ b/Source/WebCore/html/CanvasObserver.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class CanvasBase;
+class FloatRect;
+
+class CanvasObserver : public CanMakeWeakPtr<CanvasObserver> {
+public:
+    virtual ~CanvasObserver() = default;
+
+    virtual bool isStyleCanvasImage() const { return false; }
+
+    virtual void canvasChanged(CanvasBase&, const std::optional<FloatRect>& changedRect) = 0;
+    virtual void canvasResized(CanvasBase&) = 0;
+    virtual void canvasDestroyed(CanvasBase&) = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -39,6 +39,8 @@ class GPU;
 
 namespace WebCore {
 
+enum class TextDirection : bool;
+
 class ChromeClient;
 class ColorChooser;
 class ColorChooserClient;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1650,7 +1650,7 @@ void ContextMenuController::showContextMenuAt(Frame& frame, const IntPoint& clic
     clearContextMenu();
     
     // Simulate a click in the middle of the accessibility object.
-    PlatformMouseEvent mouseEvent(clickPoint, clickPoint, RightButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), ForceAtClick, NoTap);
+    PlatformMouseEvent mouseEvent(clickPoint, clickPoint, RightButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), ForceAtClick, NoTap);
     frame.eventHandler().handleMousePressEvent(mouseEvent);
     bool handled = frame.eventHandler().sendContextMenuEvent(mouseEvent);
     if (handled)

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -581,7 +581,7 @@ bool InteractionRegionOverlay::mouseEvent(PageOverlay& overlay, const PlatformMo
         if (!rectForSettingAtIndex(i).contains(eventInContentsCoordinates))
             continue;
         cursorToSet = handCursor();
-        if (event.button() == LeftButton && event.type() == PlatformEvent::MousePressed) {
+        if (event.button() == LeftButton && event.type() == PlatformEvent::Type::MousePressed) {
             m_settings[i].value = !m_settings[i].value;
             m_page.forceRepaintAllFrames();
             return true;
@@ -594,7 +594,7 @@ bool InteractionRegionOverlay::mouseEvent(PageOverlay& overlay, const PlatformMo
     m_mouseLocationInContentCoordinates = eventInContentsCoordinates;
     overlay.setNeedsDisplay();
 
-    if (event.type() == PlatformEvent::MouseMoved && !event.buttons() && !valueForSetting("hover"_s))
+    if (event.type() == PlatformEvent::Type::MouseMoved && !event.buttons() && !valueForSetting("hover"_s))
         return true;
 
     return false;

--- a/Source/WebCore/page/DisabledAdaptations.h
+++ b/Source/WebCore/page/DisabledAdaptations.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 WEBCORE_EXPORT String watchAdaptationName();
 
-enum class DisabledAdaptations {
+enum class DisabledAdaptations : uint8_t {
     Watch = 1 << 0,
 };
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -129,7 +129,7 @@ bool isDraggableLink(const Element& element)
 static PlatformMouseEvent createMouseEvent(const DragData& dragData)
 {
     auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
-    return PlatformMouseEvent(dragData.clientPosition(), dragData.globalPosition(), LeftButton, PlatformEvent::MouseMoved, 0, modifiers, WallTime::now(), ForceAtClick, NoTap);
+    return PlatformMouseEvent(dragData.clientPosition(), dragData.globalPosition(), LeftButton, PlatformEvent::Type::MouseMoved, 0, modifiers, WallTime::now(), ForceAtClick, NoTap);
 }
 
 DragController::DragController(Page& page, std::unique_ptr<DragClient>&& client)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -250,16 +250,16 @@ public:
         m_force = forceDefaultValue;
 
         PlatformEvent::Type type = event.type();
-        ASSERT(type == PlatformEvent::MouseMoved || type == PlatformEvent::MousePressed || type == PlatformEvent::MouseReleased);
+        ASSERT(type == PlatformEvent::Type::MouseMoved || type == PlatformEvent::Type::MousePressed || type == PlatformEvent::Type::MouseReleased);
 
         switch (type) {
-        case PlatformEvent::MouseMoved:
+        case PlatformEvent::Type::MouseMoved:
             m_state = TouchMoved;
             break;
-        case PlatformEvent::MousePressed:
+        case PlatformEvent::Type::MousePressed:
             m_state = TouchPressed;
             break;
-        case PlatformEvent::MouseReleased:
+        case PlatformEvent::Type::MouseReleased:
             m_state = TouchReleased;
             break;
         default:
@@ -274,18 +274,18 @@ public:
     explicit SyntheticSingleTouchEvent(const PlatformMouseEvent& event)
     {
         switch (event.type()) {
-        case PlatformEvent::MouseMoved:
-            m_type = TouchMove;
+        case PlatformEvent::Type::MouseMoved:
+            m_type = Type::TouchMove;
             break;
-        case PlatformEvent::MousePressed:
-            m_type = TouchStart;
+        case PlatformEvent::Type::MousePressed:
+            m_type = Type::TouchStart;
             break;
-        case PlatformEvent::MouseReleased:
-            m_type = TouchEnd;
+        case PlatformEvent::Type::MouseReleased:
+            m_type = Type::TouchEnd;
             break;
         default:
             ASSERT_NOT_REACHED();
-            m_type = NoType;
+            m_type = Type::NoType;
             break;
         }
         m_timestamp = event.timestamp();
@@ -2232,9 +2232,9 @@ bool EventHandler::handleMouseForceEvent(const PlatformMouseEvent& event)
 #if ENABLE(POINTER_LOCK)
     if (m_frame.page()->pointerLockController().isLocked()) {
         m_frame.page()->pointerLockController().dispatchLockedMouseEvent(event, eventNames().webkitmouseforcechangedEvent);
-        if (event.type() == PlatformEvent::MouseForceDown)
+        if (event.type() == PlatformEvent::Type::MouseForceDown)
             m_frame.page()->pointerLockController().dispatchLockedMouseEvent(event, eventNames().webkitmouseforcedownEvent);
-        if (event.type() == PlatformEvent::MouseForceUp)
+        if (event.type() == PlatformEvent::Type::MouseForceUp)
             m_frame.page()->pointerLockController().dispatchLockedMouseEvent(event, eventNames().webkitmouseforceupEvent);
         return true;
     }
@@ -2250,9 +2250,9 @@ bool EventHandler::handleMouseForceEvent(const PlatformMouseEvent& event)
     auto mouseEvent = prepareMouseEvent(hitType, event);
 
     bool swallowedEvent = !dispatchMouseEvent(eventNames().webkitmouseforcechangedEvent, mouseEvent.targetNode(), 0, event, FireMouseOverOut::No);
-    if (event.type() == PlatformEvent::MouseForceDown)
+    if (event.type() == PlatformEvent::Type::MouseForceDown)
         swallowedEvent |= !dispatchMouseEvent(eventNames().webkitmouseforcedownEvent, mouseEvent.targetNode(), 0, event, FireMouseOverOut::No);
-    if (event.type() == PlatformEvent::MouseForceUp)
+    if (event.type() == PlatformEvent::Type::MouseForceUp)
         swallowedEvent |= !dispatchMouseEvent(eventNames().webkitmouseforceupEvent, mouseEvent.targetNode(), 0, event, FireMouseOverOut::No);
 
     return swallowedEvent;
@@ -2283,10 +2283,10 @@ bool EventHandler::handlePasteGlobalSelection(const PlatformMouseEvent& platform
     // clears the text box. So it's important this happens after the event
     // handlers have been fired.
 #if PLATFORM(GTK)
-    if (platformMouseEvent.type() != PlatformEvent::MousePressed)
+    if (platformMouseEvent.type() != PlatformEvent::Type::MousePressed)
         return false;
 #else
-    if (platformMouseEvent.type() != PlatformEvent::MouseReleased)
+    if (platformMouseEvent.type() != PlatformEvent::Type::MouseReleased)
         return false;
 #endif
 
@@ -3399,9 +3399,9 @@ bool EventHandler::sendContextMenuEventForKey()
     // This is required for web compatibility.
 
 #if OS(WINDOWS)
-    PlatformEvent::Type eventType = PlatformEvent::MouseReleased;
+    PlatformEvent::Type eventType = PlatformEvent::Type::MouseReleased;
 #else
-    PlatformEvent::Type eventType = PlatformEvent::MousePressed;
+    PlatformEvent::Type eventType = PlatformEvent::Type::MousePressed;
 #endif
     PlatformMouseEvent platformMouseEvent(position, globalPosition, RightButton, eventType, 1, { }, WallTime::now(), ForceAtClick, NoTap);
 
@@ -3489,7 +3489,7 @@ void EventHandler::fakeMouseMoveEventTimerFired()
         return;
 
     auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
-    PlatformMouseEvent fakeMouseMoveEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition, NoButton, PlatformEvent::MouseMoved, 0, modifiers, WallTime::now(), 0, NoTap);
+    PlatformMouseEvent fakeMouseMoveEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition, NoButton, PlatformEvent::Type::MouseMoved, 0, modifiers, WallTime::now(), 0, NoTap);
     mouseMoved(fakeMouseMoveEvent);
 }
 #endif // !ENABLE(IOS_TOUCH_EVENTS)
@@ -3569,7 +3569,7 @@ bool EventHandler::isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent& ke
     if (document->fullscreenManager().isFullscreenKeyboardInputAllowed())
         return true;
 
-    if (keyEvent.type() == PlatformKeyboardEvent::Char) {
+    if (keyEvent.type() == PlatformKeyboardEvent::Type::Char) {
         if (keyEvent.text().length() != 1)
             return false;
         UChar character = keyEvent.text()[0];
@@ -3626,12 +3626,12 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     LOG(Editing, "EventHandler %p keyEvent (text %s keyIdentifier %s)", this, initialKeyEvent.text().utf8().data(), initialKeyEvent.keyIdentifier().utf8().data());
 
 #if ENABLE(POINTER_LOCK)
-    if (initialKeyEvent.type() == PlatformEvent::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE && m_frame.page()->pointerLockController().element()) {
+    if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE && m_frame.page()->pointerLockController().element()) {
         m_frame.page()->pointerLockController().requestPointerUnlockAndForceCursorVisible();
     }
 #endif
 
-    if (initialKeyEvent.type() == PlatformEvent::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE) {
+    if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE) {
         if (auto* page = m_frame.page()) {
             if (auto* validationMessageClient = page->validationMessageClient())
                 validationMessageClient->hideAnyValidationMessage();
@@ -3640,7 +3640,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
 
 #if ENABLE(FULLSCREEN_API)
     if (m_frame.document()->fullscreenManager().isFullscreen()) {
-        if (initialKeyEvent.type() == PlatformEvent::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE) {
+        if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE) {
             m_frame.document()->fullscreenManager().cancelFullscreen();
             return true;
         }
@@ -3656,7 +3656,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
 #if ENABLE(PAN_SCROLLING)
     if (Ref(m_frame.mainFrame())->eventHandler().panScrollInProgress()) {
         // If a key is pressed while the panScroll is in progress then we want to stop
-        if (initialKeyEvent.type() == PlatformEvent::KeyDown || initialKeyEvent.type() == PlatformEvent::RawKeyDown)
+        if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown || initialKeyEvent.type() == PlatformEvent::Type::RawKeyDown)
             stopAutoscrollTimer();
 
         // If we were in panscroll mode, we swallow the key event
@@ -3686,18 +3686,18 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     // On Windows, WebKit explicitly calls handleAccessKey() instead of dispatching a keypress event for WM_SYSCHAR messages.
     // Other platforms currently match either Mac or Windows behavior, depending on whether they send combined KeyDown events.
     bool matchedAnAccessKey = false;
-    if (initialKeyEvent.type() == PlatformEvent::KeyDown)
+    if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown)
         matchedAnAccessKey = handleAccessKey(initialKeyEvent);
 
     // FIXME: it would be fair to let an input method handle KeyUp events before DOM dispatch.
-    if (initialKeyEvent.type() == PlatformEvent::KeyUp || initialKeyEvent.type() == PlatformEvent::Char)
+    if (initialKeyEvent.type() == PlatformEvent::Type::KeyUp || initialKeyEvent.type() == PlatformEvent::Type::Char)
         return !element->dispatchKeyEvent(initialKeyEvent);
 
     bool backwardCompatibilityMode = needsKeyboardEventDisambiguationQuirks();
 
     PlatformKeyboardEvent keyDownEvent = initialKeyEvent;    
-    if (keyDownEvent.type() != PlatformEvent::RawKeyDown)
-        keyDownEvent.disambiguateKeyDownEvent(PlatformEvent::RawKeyDown, backwardCompatibilityMode);
+    if (keyDownEvent.type() != PlatformEvent::Type::RawKeyDown)
+        keyDownEvent.disambiguateKeyDownEvent(PlatformEvent::Type::RawKeyDown, backwardCompatibilityMode);
     auto keydown = KeyboardEvent::create(keyDownEvent, &m_frame.windowProxy());
     if (matchedAnAccessKey)
         keydown->preventDefault();
@@ -3715,7 +3715,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     };
     setHasFocusVisibleIfNeeded(*element);
 
-    if (initialKeyEvent.type() == PlatformEvent::RawKeyDown) {
+    if (initialKeyEvent.type() == PlatformEvent::Type::RawKeyDown) {
         element->dispatchEvent(keydown);
         // If frame changed as a result of keydown dispatch, then return true to avoid sending a subsequent keypress message to the new frame.
         bool changedFocusedFrame = m_frame.page() && &m_frame != &m_frame.page()->focusController().focusedOrMainFrame();
@@ -3767,7 +3767,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     }
 
     PlatformKeyboardEvent keyPressEvent = initialKeyEvent;
-    keyPressEvent.disambiguateKeyDownEvent(PlatformEvent::Char, backwardCompatibilityMode);
+    keyPressEvent.disambiguateKeyDownEvent(PlatformEvent::Type::Char, backwardCompatibilityMode);
     if (keyPressEvent.text().isEmpty())
         return keydownResult;
     auto keypress = KeyboardEvent::create(keyPressEvent, &m_frame.windowProxy());
@@ -4102,7 +4102,7 @@ RefPtr<Element> EventHandler::draggedElement() const
 
 bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDragHysteresis checkDragHysteresis)
 {
-    if (event.event().button() != LeftButton || event.event().type() != PlatformEvent::MouseMoved) {
+    if (event.event().button() != LeftButton || event.event().type() != PlatformEvent::Type::MouseMoved) {
         // If we allowed the other side of the bridge to handle a drag
         // last time, then m_mousePressed might still be set. So we
         // clear it now to make sure the next move after a drag
@@ -4136,7 +4136,7 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
     // For drags starting in the selection, the user must wait between the mousedown and mousedrag,
     // or else we bail on the dragging stuff and allow selection to occur
     if (m_mouseDownMayStartDrag && m_dragMayStartSelectionInstead && dragState().type.contains(DragSourceAction::Selection) && event.event().timestamp() - m_mouseDownTimestamp < TextDragDelay) {
-        ASSERT(event.event().type() == PlatformEvent::MouseMoved);
+        ASSERT(event.event().type() == PlatformEvent::Type::MouseMoved);
         if (dragState().type.contains(DragSourceAction::Image)) {
             // ... unless the mouse is over an image, then we start dragging just the image
             dragState().type = DragSourceAction::Image;
@@ -4935,7 +4935,7 @@ bool EventHandler::dispatchSyntheticTouchEventIfEnabled(const PlatformMouseEvent
         return false;
 
     PlatformEvent::Type eventType = platformMouseEvent.type();
-    if (eventType != PlatformEvent::MouseMoved && eventType != PlatformEvent::MousePressed && eventType != PlatformEvent::MouseReleased)
+    if (eventType != PlatformEvent::Type::MouseMoved && eventType != PlatformEvent::Type::MousePressed && eventType != PlatformEvent::Type::MouseReleased)
         return false;
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent };
@@ -4944,7 +4944,7 @@ bool EventHandler::dispatchSyntheticTouchEventIfEnabled(const PlatformMouseEvent
         return false;
 
     // The order is important. This check should follow the subframe test: http://webkit.org/b/111292.
-    if (eventType == PlatformEvent::MouseMoved && !m_touchPressed)
+    if (eventType == PlatformEvent::Type::MouseMoved && !m_touchPressed)
         return true;
 
     SyntheticSingleTouchEvent touchEvent(platformMouseEvent);

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -82,21 +82,21 @@ bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& ev
         return false;
 
     switch (event.type()) {
-    case PlatformEvent::MousePressed: {
+    case PlatformEvent::Type::MousePressed: {
         m_overlay->setShouldIgnoreMouseEventsOutsideBounds(false);
         m_dragging = true;
         IntPoint location = m_overlay->frame().location();
         m_dragPoint = event.position() + IntPoint(-location.x(), -location.y());
         return true;
     }
-    case PlatformEvent::MouseReleased:
+    case PlatformEvent::Type::MouseReleased:
         if (m_dragging) {
             m_overlay->setShouldIgnoreMouseEventsOutsideBounds(true);
             m_dragging = false;
             return true;
         }
         break;
-    case PlatformEvent::MouseMoved:
+    case PlatformEvent::Type::MouseMoved:
         if (m_dragging) {
             IntRect newFrame = m_overlay->frame();
 

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -129,8 +129,8 @@ bool EventHandler::wheelEvent(WebEvent *event)
 
 bool EventHandler::dispatchSimulatedTouchEvent(IntPoint location)
 {
-    bool handled = handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::TouchStart, location));
-    handled |= handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::TouchEnd, location));
+    bool handled = handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::Type::TouchStart, location));
+    handled |= handleTouchEvent(PlatformEventFactory::createPlatformSimulatedTouchEvent(PlatformEvent::Type::TouchEnd, location));
     return handled;
 }
     
@@ -723,8 +723,8 @@ bool EventHandler::tryToBeginDragAtPoint(const IntPoint& clientPosition, const I
     IntPoint adjustedClientPosition = roundedIntPoint(adjustedClientPositionAsFloatPoint);
     IntPoint adjustedGlobalPosition = protectedFrame->view()->windowToContents(adjustedClientPosition);
 
-    PlatformMouseEvent syntheticMousePressEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), 0, NoTap);
-    PlatformMouseEvent syntheticMouseMoveEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
+    PlatformMouseEvent syntheticMousePressEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), 0, NoTap);
+    PlatformMouseEvent syntheticMouseMoveEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent };
     auto documentPoint = protectedFrame->view() ? protectedFrame->view()->windowToContents(syntheticMouseMoveEvent.position()) : syntheticMouseMoveEvent.position();

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -133,7 +133,7 @@ bool ImageOverlayController::platformHandleMouseEvent(const PlatformMouseEvent& 
         }
     }
 
-    if (event.type() == PlatformEvent::MousePressed && mouseIsOverActiveDataDetectorHighlightButton)
+    if (event.type() == PlatformEvent::Type::MousePressed && mouseIsOverActiveDataDetectorHighlightButton)
         return handleDataDetectorAction(*activeDataDetectorElement, mousePositionInContents);
 
     return false;

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -585,7 +585,7 @@ bool ServicesOverlayController::mouseEvent(PageOverlay&, const PlatformMouseEven
     }
 
     // If the mouse lifted while still over the highlight button that it went down on, then that is a click.
-    if (event.type() == PlatformEvent::MouseReleased) {
+    if (event.type() == PlatformEvent::Type::MouseReleased) {
         auto mouseDownHighlight = m_currentMouseDownOnButtonHighlight.copyRef();
         m_currentMouseDownOnButtonHighlight = nullptr;
 
@@ -600,7 +600,7 @@ bool ServicesOverlayController::mouseEvent(PageOverlay&, const PlatformMouseEven
     }
 
     // If the mouse moved outside of the button tracking a potential click, stop tracking the click.
-    if (event.type() == PlatformEvent::MouseMoved) {
+    if (event.type() == PlatformEvent::Type::MouseMoved) {
         if (m_currentMouseDownOnButtonHighlight && mouseIsOverActiveHighlightButton)
             return true;
 
@@ -609,7 +609,7 @@ bool ServicesOverlayController::mouseEvent(PageOverlay&, const PlatformMouseEven
     }
 
     // If the mouse went down over the active highlight's button, track this as a potential click.
-    if (event.type() == PlatformEvent::MousePressed) {
+    if (event.type() == PlatformEvent::Type::MousePressed) {
         if (m_activeHighlight && mouseIsOverActiveHighlightButton) {
             m_currentMouseDownOnButtonHighlight = m_activeHighlight;
             return true;

--- a/Source/WebCore/platform/EventTrackingRegions.h
+++ b/Source/WebCore/platform/EventTrackingRegions.h
@@ -41,25 +41,27 @@ enum class TrackingType : uint8_t {
     Synchronous = 2
 };
 
+enum class EventTrackingRegionsEventType : uint8_t {
+    Mousedown,
+    Mousemove,
+    Mouseup,
+    Mousewheel,
+    Pointerdown,
+    Pointerenter,
+    Pointerleave,
+    Pointermove,
+    Pointerout,
+    Pointerover,
+    Pointerup,
+    Touchend,
+    Touchforcechange,
+    Touchmove,
+    Touchstart,
+    Wheel,
+};
+
 struct EventTrackingRegions {
-    enum class EventType : uint8_t {
-        Mousedown,
-        Mousemove,
-        Mouseup,
-        Mousewheel,
-        Pointerdown,
-        Pointerenter,
-        Pointerleave,
-        Pointermove,
-        Pointerout,
-        Pointerover,
-        Pointerup,
-        Touchend,
-        Touchforcechange,
-        Touchmove,
-        Touchstart,
-        Wheel,
-    };
+    using EventType = EventTrackingRegionsEventType;
 
     WEBCORE_EXPORT static ASCIILiteral eventName(EventType);
     WEBCORE_EXPORT static const AtomString& eventNameAtomString(const EventNames&, EventType);

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -46,8 +46,8 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
     if (!platformEvent)
         return { };
 
-    // PlatformEvent::Char is a "keypress" event.
-    if (!(platformEvent->type() == PlatformEvent::RawKeyDown || platformEvent->type() == PlatformEvent::Char))
+    // PlatformEvent::Type::Char is a "keypress" event.
+    if (!(platformEvent->type() == PlatformEvent::Type::RawKeyDown || platformEvent->type() == PlatformEvent::Type::Char))
         return { };
 
     static constexpr std::pair<PackedASCIILiteral<uint64_t>, KeyboardScrollingKey> mappings[] = {

--- a/Source/WebCore/platform/PlatformEvent.h
+++ b/Source/WebCore/platform/PlatformEvent.h
@@ -36,58 +36,63 @@ enum class EventHandling : uint8_t {
     DefaultHandled      = 1 << 2,
 };
 
-class PlatformEvent {
-public:
-    enum Type : uint8_t {
-        NoType = 0,
+enum class PlatformEventType : uint8_t {
+    NoType = 0,
 
-        // PlatformKeyboardEvent
-        KeyDown,
-        KeyUp,
-        RawKeyDown,
-        Char,
+    // PlatformKeyboardEvent
+    KeyDown,
+    KeyUp,
+    RawKeyDown,
+    Char,
 
-        // PlatformMouseEvent
-        MouseMoved,
-        MousePressed,
-        MouseReleased,
-        MouseForceChanged,
-        MouseForceDown,
-        MouseForceUp,
-        MouseScroll,
+    // PlatformMouseEvent
+    MouseMoved,
+    MousePressed,
+    MouseReleased,
+    MouseForceChanged,
+    MouseForceDown,
+    MouseForceUp,
+    MouseScroll,
 
-        // PlatformWheelEvent
-        Wheel,
+    // PlatformWheelEvent
+    Wheel,
 
 #if ENABLE(TOUCH_EVENTS)
-        // PlatformTouchEvent
-        TouchStart,
-        TouchMove,
-        TouchEnd,
-        TouchCancel,
-        TouchForceChange,
+    // PlatformTouchEvent
+    TouchStart,
+    TouchMove,
+    TouchEnd,
+    TouchCancel,
+    TouchForceChange,
 #endif
 
 #if ENABLE(MAC_GESTURE_EVENTS)
-        // PlatformGestureEvent
-        GestureStart,
-        GestureChange,
-        GestureEnd,
+    // PlatformGestureEvent
+    GestureStart,
+    GestureChange,
+    GestureEnd,
 #endif
-    };
+};
 
-    enum class Modifier : uint8_t {
-        AltKey      = 1 << 0,
-        ControlKey  = 1 << 1,
-        MetaKey     = 1 << 2,
-        ShiftKey    = 1 << 3,
-        CapsLockKey = 1 << 4,
+enum class PlatformEventModifier : uint8_t {
+    AltKey      = 1 << 0,
+    ControlKey  = 1 << 1,
+    MetaKey     = 1 << 2,
+    ShiftKey    = 1 << 3,
+    CapsLockKey = 1 << 4,
 
-        // Never used in native platforms but added for initEvent
-        AltGraphKey = 1 << 5,
-    };
+    // Never used in native platforms but added for initEvent
+    AltGraphKey = 1 << 5,
+};
 
-    Type type() const { return static_cast<Type>(m_type); }
+
+class PlatformEvent {
+public:
+
+    using Type = PlatformEventType;
+    using Modifier = PlatformEventModifier;
+
+    Type type() const { return m_type; }
 
     bool shiftKey() const { return m_modifiers.contains(Modifier::ShiftKey); }
     bool controlKey() const { return m_modifiers.contains(Modifier::ControlKey); }
@@ -100,7 +105,7 @@ public:
 
 protected:
     PlatformEvent()
-        : m_type(NoType)
+        : m_type(Type::NoType)
     {
     }
 
@@ -135,7 +140,7 @@ protected:
     ~PlatformEvent() = default;
 
     WallTime m_timestamp;
-    unsigned m_type;
+    Type m_type;
     OptionSet<Modifier> m_modifiers;
 };
 

--- a/Source/WebCore/platform/PlatformKeyboardEvent.h
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
@@ -47,7 +47,7 @@ namespace WebCore {
         WTF_MAKE_FAST_ALLOCATED;
     public:
         PlatformKeyboardEvent()
-            : PlatformEvent(PlatformEvent::KeyDown)
+            : PlatformEvent(PlatformEvent::Type::KeyDown)
         {
         }
 

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -44,7 +44,7 @@ const double ForceAtForceClick = 2;
     class PlatformMouseEvent : public PlatformEvent {
     public:
         PlatformMouseEvent()
-            : PlatformEvent(PlatformEvent::MouseMoved)
+            : PlatformEvent(Type::MouseMoved)
         {
         }
 

--- a/Source/WebCore/platform/PlatformTouchEvent.h
+++ b/Source/WebCore/platform/PlatformTouchEvent.h
@@ -32,7 +32,7 @@ namespace WebCore {
 class PlatformTouchEvent : public PlatformEvent {
 public:
     PlatformTouchEvent()
-        : PlatformEvent(PlatformEvent::TouchStart)
+        : PlatformEvent(PlatformEvent::Type::TouchStart)
     {
     }
 

--- a/Source/WebCore/platform/PlatformWheelEvent.cpp
+++ b/Source/WebCore/platform/PlatformWheelEvent.cpp
@@ -59,13 +59,13 @@ PlatformWheelEvent PlatformWheelEvent::createFromGesture(const PlatformGestureEv
 
 #if ENABLE(KINETIC_SCROLLING)
     switch (platformGestureEvent.type()) {
-    case PlatformEvent::GestureStart:
+    case PlatformEvent::Type::GestureStart:
         platformWheelEvent.m_phase = PlatformWheelEventPhase::Began;
         break;
-    case PlatformEvent::GestureChange:
+    case PlatformEvent::Type::GestureChange:
         platformWheelEvent.m_phase = PlatformWheelEventPhase::Changed;
         break;
-    case PlatformEvent::GestureEnd:
+    case PlatformEvent::Type::GestureEnd:
         platformWheelEvent.m_phase = PlatformWheelEventPhase::Ended;
         break;
     default:

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -81,12 +81,12 @@ const float cScrollbarPixelsPerLine = 100.0f / 3.0f;
 class PlatformWheelEvent : public PlatformEvent {
 public:
     PlatformWheelEvent()
-        : PlatformEvent(PlatformEvent::Wheel)
+        : PlatformEvent(Type::Wheel)
     {
     }
 
     PlatformWheelEvent(IntPoint position, IntPoint globalPosition, float deltaX, float deltaY, float wheelTicksX, float wheelTicksY, PlatformWheelEventGranularity granularity, bool shiftKey, bool ctrlKey, bool altKey, bool metaKey)
-        : PlatformEvent(PlatformEvent::Wheel, shiftKey, ctrlKey, altKey, metaKey, { })
+        : PlatformEvent(Type::Wheel, shiftKey, ctrlKey, altKey, metaKey, { })
         , m_granularity(granularity)
         , m_position(position)
         , m_globalPosition(globalPosition)

--- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
@@ -1339,7 +1339,7 @@ void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardCom
     if (backwardCompatibilityMode || m_handledByInputMethod)
         return;
 
-    if (type == PlatformEvent::RawKeyDown) {
+    if (type == PlatformEvent::Type::RawKeyDown) {
         m_text = String();
         m_unmodifiedText = String();
     } else {

--- a/Source/WebCore/platform/ios/KeyEventIOS.mm
+++ b/Source/WebCore/platform/ios/KeyEventIOS.mm
@@ -296,13 +296,13 @@ static bool isFunctionKey(UChar charCode)
 void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardCompatibilityMode)
 {
     // Can only change type from KeyDown to RawKeyDown or Char, as we lack information for other conversions.
-    ASSERT(m_type == KeyDown);
-    ASSERT(type == RawKeyDown || type == Char);
+    ASSERT(m_type == Type::KeyDown);
+    ASSERT(type == Type::RawKeyDown || type == Type::Char);
     m_type = type;
     if (backwardCompatibilityMode)
         return;
 
-    if (type == PlatformEvent::RawKeyDown) {
+    if (type == PlatformEvent::Type::RawKeyDown) {
         m_text = String();
         m_unmodifiedText = String();
     } else {

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -72,14 +72,14 @@ static PlatformEvent::Type mouseEventType(WebEvent *event)
 {
     switch (event.type) {
     case WebEventMouseDown:
-        return PlatformEvent::MousePressed;
+        return PlatformEvent::Type::MousePressed;
     case WebEventMouseUp:
-        return PlatformEvent::MouseReleased;
+        return PlatformEvent::Type::MouseReleased;
     case WebEventMouseMoved:
-        return PlatformEvent::MouseMoved;
+        return PlatformEvent::Type::MouseMoved;
     default:
         ASSERT_NOT_REACHED();
-        return PlatformEvent::MousePressed;
+        return PlatformEvent::Type::MousePressed;
     }
 }
 
@@ -109,7 +109,7 @@ public:
     {
         ASSERT(event.type == WebEventScrollWheel);
 
-        m_type = PlatformEvent::Wheel;
+        m_type = PlatformEvent::Type::Wheel;
         m_timestamp = WallTime::now();
 
         m_position = pointForEvent(event);
@@ -488,7 +488,7 @@ public:
     {
         ASSERT(event.type == WebEventKeyDown || event.type == WebEventKeyUp);
 
-        m_type = (event.type == WebEventKeyUp ? PlatformEvent::KeyUp : PlatformEvent::KeyDown);
+        m_type = (event.type == WebEventKeyUp ? PlatformEvent::Type::KeyUp : PlatformEvent::Type::KeyDown);
         m_modifiers = modifiersForEvent(event);
         m_timestamp = WallTime::now();
 
@@ -560,27 +560,27 @@ static PlatformEvent::Type touchEventType(WebEvent *event)
 {
     switch (event.type) {
     case WebEventTouchBegin:
-        return PlatformEvent::TouchStart;
+        return PlatformEvent::Type::TouchStart;
     case WebEventTouchEnd:
-        return PlatformEvent::TouchEnd;
+        return PlatformEvent::Type::TouchEnd;
     case WebEventTouchCancel:
-        return PlatformEvent::TouchCancel;
+        return PlatformEvent::Type::TouchCancel;
     case WebEventTouchChange:
-        return PlatformEvent::TouchMove;
+        return PlatformEvent::Type::TouchMove;
     default:
         ASSERT_NOT_REACHED();
-        return PlatformEvent::TouchCancel;
+        return PlatformEvent::Type::TouchCancel;
     }
 }
     
 static PlatformTouchPoint::TouchPhaseType touchPhaseFromPlatformEventType(PlatformEvent::Type type)
 {
     switch (type) {
-    case PlatformEvent::TouchStart:
+    case PlatformEvent::Type::TouchStart:
         return PlatformTouchPoint::TouchPhaseBegan;
-    case PlatformEvent::TouchMove:
+    case PlatformEvent::Type::TouchMove:
         return PlatformTouchPoint::TouchPhaseMoved;
-    case PlatformEvent::TouchEnd:
+    case PlatformEvent::Type::TouchEnd:
         return PlatformTouchPoint::TouchPhaseEnded;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -56,7 +56,7 @@ ScrollAnimatorIOS::~ScrollAnimatorIOS()
 #if ENABLE(TOUCH_EVENTS)
 bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
 {
-    if (touchEvent.type() == PlatformEvent::TouchStart && touchEvent.touchCount() == 1) {
+    if (touchEvent.type() == PlatformEvent::Type::TouchStart && touchEvent.touchCount() == 1) {
         m_firstTouchPoint = touchEvent.touchLocationAtIndex(0);
         m_lastTouchPoint = m_firstTouchPoint;
         m_inTouchSequence = true;
@@ -70,7 +70,7 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
     if (!m_inTouchSequence)
         return false;
 
-    if (touchEvent.type() == PlatformEvent::TouchEnd || touchEvent.type() == PlatformEvent::TouchCancel) {
+    if (touchEvent.type() == PlatformEvent::Type::TouchEnd || touchEvent.type() == PlatformEvent::Type::TouchCancel) {
         m_inTouchSequence = false;
         m_scrollableAreaForTouchSequence = 0;
         if (m_startedScroll)

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -35,6 +35,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WorkQueue.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_COMMA_BEGIN

--- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
@@ -1331,7 +1331,7 @@ void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardsCo
     if (backwardsCompatibility || m_handledByInputMethod)
         return;
 
-    if (type == PlatformEvent::RawKeyDown) {
+    if (type == PlatformEvent::Type::RawKeyDown) {
         m_text = String();
         m_unmodifiedText = String();
     } else {

--- a/Source/WebCore/platform/mac/KeyEventMac.mm
+++ b/Source/WebCore/platform/mac/KeyEventMac.mm
@@ -235,13 +235,13 @@ int windowsKeyCodeForCharCode(unichar charCode)
 void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardCompatibilityMode)
 {
     // Can only change type from KeyDown to RawKeyDown or Char, as we lack information for other conversions.
-    ASSERT(m_type == KeyDown);
-    ASSERT(type == RawKeyDown || type == Char);
+    ASSERT(m_type == Type::KeyDown);
+    ASSERT(type == Type::RawKeyDown || type == Type::Char);
     m_type = type;
     if (backwardCompatibilityMode)
         return;
 
-    if (type == RawKeyDown) {
+    if (type == Type::RawKeyDown) {
         m_text = String();
         m_unmodifiedText = String();
     } else {

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -137,17 +137,17 @@ static PlatformEvent::Type mouseEventTypeForEvent(NSEvent* event)
     case NSEventTypeMouseMoved:
     case NSEventTypeOtherMouseDragged:
     case NSEventTypeRightMouseDragged:
-        return PlatformEvent::MouseMoved;
+        return PlatformEvent::Type::MouseMoved;
     case NSEventTypeLeftMouseDown:
     case NSEventTypeRightMouseDown:
     case NSEventTypeOtherMouseDown:
-        return PlatformEvent::MousePressed;
+        return PlatformEvent::Type::MousePressed;
     case NSEventTypeLeftMouseUp:
     case NSEventTypeRightMouseUp:
     case NSEventTypeOtherMouseUp:
-        return PlatformEvent::MouseReleased;
+        return PlatformEvent::Type::MouseReleased;
     default:
-        return PlatformEvent::MouseMoved;
+        return PlatformEvent::Type::MouseMoved;
     }
 }
 
@@ -712,11 +712,11 @@ public:
             // Since AppKit doesn't send mouse events for force down or force up, we have to use the current pressure
             // event and correspondingPressureEvent to detect if this is MouseForceDown, MouseForceUp, or just MouseForceChanged.
             if (correspondingPressureEvent.stage == 1 && event.stage == 2)
-                m_type = PlatformEvent::MouseForceDown;
+                m_type = PlatformEvent::Type::MouseForceDown;
             else if (correspondingPressureEvent.stage == 2 && event.stage == 1)
-                m_type = PlatformEvent::MouseForceUp;
+                m_type = PlatformEvent::Type::MouseForceUp;
             else
-                m_type = PlatformEvent::MouseForceChanged;
+                m_type = PlatformEvent::Type::MouseForceChanged;
         }
 
         m_modifiers = modifiersForEvent(event);
@@ -753,7 +753,7 @@ public:
     PlatformWheelEventBuilder(NSEvent *event, NSView *windowView)
     {
         // PlatformEvent
-        m_type = PlatformEvent::Wheel;
+        m_type = PlatformEvent::Type::Wheel;
         m_modifiers = modifiersForEvent(event);
         m_timestamp = eventTimeStampSince1970(event.timestamp);
 
@@ -792,7 +792,7 @@ public:
     PlatformKeyboardEventBuilder(NSEvent *event)
     {
         // PlatformEvent
-        m_type = isKeyUpEvent(event) ? PlatformEvent::KeyUp : PlatformEvent::KeyDown;
+        m_type = isKeyUpEvent(event) ? PlatformEvent::Type::KeyUp : PlatformEvent::Type::KeyDown;
         m_modifiers = modifiersForEvent(event);
         m_timestamp = eventTimeStampSince1970(event.timestamp);
 

--- a/Source/WebCore/platform/win/KeyEventWin.cpp
+++ b/Source/WebCore/platform/win/KeyEventWin.cpp
@@ -151,7 +151,7 @@ static String keyIdentifierForWindowsKeyCode(unsigned short keyCode)
 
 static bool isKeypadEvent(WPARAM code, LPARAM keyData, PlatformEvent::Type type)
 {
-    if (type != PlatformEvent::RawKeyDown && type != PlatformEvent::KeyUp)
+    if (type != PlatformEvent::Type::RawKeyDown && type != PlatformEvent::Type::KeyUp)
         return false;
 
     switch (code) {
@@ -230,12 +230,12 @@ static WindowsKeyNames& windowsKeyNames()
 
 PlatformKeyboardEvent::PlatformKeyboardEvent(HWND, WPARAM code, LPARAM keyData, Type type, bool systemKey)
     : PlatformEvent(type, GetKeyState(VK_SHIFT) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_CONTROL) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, false, WallTime::fromRawSeconds(::GetTickCount() * 0.001))
-    , m_text((type == PlatformEvent::Char) ? singleCharacterString(code) : String())
-    , m_unmodifiedText((type == PlatformEvent::Char) ? singleCharacterString(code) : String())
-    , m_key(type == PlatformEvent::Char ? windowsKeyNames().domKeyFromChar(code) : windowsKeyNames().domKeyFromParams(code, keyData))
+    , m_text((type == PlatformEvent::Type::Char) ? singleCharacterString(code) : String())
+    , m_unmodifiedText((type == PlatformEvent::Type::Char) ? singleCharacterString(code) : String())
+    , m_key(type == PlatformEvent::Type::Char ? windowsKeyNames().domKeyFromChar(code) : windowsKeyNames().domKeyFromParams(code, keyData))
     , m_code(windowsKeyNames().domCodeFromLParam(keyData))
-    , m_keyIdentifier((type == PlatformEvent::Char) ? String() : keyIdentifierForWindowsKeyCode(code))
-    , m_windowsVirtualKeyCode((type == RawKeyDown || type == KeyUp) ? windowsKeycodeWithLocation(code, keyData) : 0)
+    , m_keyIdentifier((type == PlatformEvent::Type::Char) ? String() : keyIdentifierForWindowsKeyCode(code))
+    , m_windowsVirtualKeyCode((type == Type::RawKeyDown || type == Type::KeyUp) ? windowsKeycodeWithLocation(code, keyData) : 0)
     , m_autoRepeat(HIWORD(keyData) & KF_REPEAT)
     , m_isKeypad(isKeypadEvent(code, keyData, type))
     , m_isSystemKey(systemKey)

--- a/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
+++ b/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
@@ -61,21 +61,21 @@ static PlatformEvent::Type messageToEventType(UINT message)
         case WM_LBUTTONDOWN:
         case WM_RBUTTONDOWN:
         case WM_MBUTTONDOWN:
-            return PlatformEvent::MousePressed;
+            return PlatformEvent::Type::MousePressed;
 
         case WM_LBUTTONUP:
         case WM_RBUTTONUP:
         case WM_MBUTTONUP:
-            return PlatformEvent::MouseReleased;
+            return PlatformEvent::Type::MouseReleased;
 
         case WM_MOUSELEAVE:
         case WM_MOUSEMOVE:
-            return PlatformEvent::MouseMoved;
+            return PlatformEvent::Type::MouseMoved;
 
         default:
             ASSERT_NOT_REACHED();
             //Move is relatively harmless
-            return PlatformEvent::MouseMoved;
+            return PlatformEvent::Type::MouseMoved;
     }
 }
 

--- a/Source/WebCore/platform/win/WheelEventWin.cpp
+++ b/Source/WebCore/platform/win/WheelEventWin.cpp
@@ -73,7 +73,7 @@ static int verticalScrollLines()
 }
 
 PlatformWheelEvent::PlatformWheelEvent(HWND hWnd, WPARAM wParam, LPARAM lParam, bool isMouseHWheel)
-    : PlatformEvent(PlatformEvent::Wheel, wParam & MK_SHIFT, wParam & MK_CONTROL, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, WallTime::fromRawSeconds(::GetTickCount() * 0.001))
+    : PlatformEvent(PlatformEvent::Type::Wheel, wParam & MK_SHIFT, wParam & MK_CONTROL, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, WallTime::fromRawSeconds(::GetTickCount() * 0.001))
     , m_position(positionForEvent(hWnd, lParam))
     , m_globalPosition(globalPositionForEvent(hWnd, lParam))
     , m_directionInvertedFromDevice(false)

--- a/Source/WebCore/rendering/style/StyleCanvasImage.h
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "CanvasBase.h"
+#include "CanvasObserver.h"
 #include "StyleGeneratedImage.h"
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.h
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+struct BlendingContext;
+
 class StyleCrossfadeImage final : public StyleGeneratedImage, private CachedImageClient {
 public:
     static Ref<StyleCrossfadeImage> create(RefPtr<StyleImage> from, RefPtr<StyleImage> to, double percentage, bool isPrefixed)

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -20,6 +20,7 @@
 #include "DOMParser.h"
 
 #include "DOMImplementation.h"
+#include "FragmentScriptingPermission.h"
 #include "SecurityOriginPolicy.h"
 #include "Settings.h"
 

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -60,27 +60,27 @@ public:
         // PlatformEvent
         switch (webEvent.type()) {
         case WebEventType::MouseDown:
-            m_type = WebCore::PlatformEvent::MousePressed;
+            m_type = WebCore::PlatformEvent::Type::MousePressed;
             m_force = WebCore::ForceAtClick;
             break;
         case WebEventType::MouseUp:
-            m_type = WebCore::PlatformEvent::MouseReleased;
+            m_type = WebCore::PlatformEvent::Type::MouseReleased;
             m_force = WebCore::ForceAtClick;
             break;
         case WebEventType::MouseMove:
-            m_type = WebCore::PlatformEvent::MouseMoved;
+            m_type = WebCore::PlatformEvent::Type::MouseMoved;
             m_force = webEvent.force();
             break;
         case WebEventType::MouseForceChanged:
-            m_type = WebCore::PlatformEvent::MouseForceChanged;
+            m_type = WebCore::PlatformEvent::Type::MouseForceChanged;
             m_force = webEvent.force();
             break;
         case WebEventType::MouseForceDown:
-            m_type = WebCore::PlatformEvent::MouseForceDown;
+            m_type = WebCore::PlatformEvent::Type::MouseForceDown;
             m_force = WebCore::ForceAtForceClick;
             break;
         case WebEventType::MouseForceUp:
-            m_type = WebCore::PlatformEvent::MouseForceUp;
+            m_type = WebCore::PlatformEvent::Type::MouseForceUp;
             m_force = WebCore::ForceAtForceClick;
             break;
         default:
@@ -146,7 +146,7 @@ public:
     WebKit2PlatformWheelEvent(const WebWheelEvent& webEvent)
     {
         // PlatformEvent
-        m_type = PlatformEvent::Wheel;
+        m_type = PlatformEvent::Type::Wheel;
 
         m_modifiers = platform(webEvent.modifiers());
 
@@ -190,16 +190,16 @@ public:
         // PlatformEvent
         switch (webEvent.type()) {
         case WebEventType::KeyDown:
-            m_type = WebCore::PlatformEvent::KeyDown;
+            m_type = WebCore::PlatformEvent::Type::KeyDown;
             break;
         case WebEventType::KeyUp:
-            m_type = WebCore::PlatformEvent::KeyUp;
+            m_type = WebCore::PlatformEvent::Type::KeyUp;
             break;
         case WebEventType::RawKeyDown:
-            m_type = WebCore::PlatformEvent::RawKeyDown;
+            m_type = WebCore::PlatformEvent::Type::RawKeyDown;
             break;
         case WebEventType::Char:
-            m_type = WebCore::PlatformEvent::Char;
+            m_type = WebCore::PlatformEvent::Type::Char;
             break;
         default:
             ASSERT_NOT_REACHED();
@@ -327,16 +327,16 @@ public:
         // PlatformEvent
         switch (webEvent.type()) {
         case WebEventType::TouchStart:
-            m_type = WebCore::PlatformEvent::TouchStart;
+            m_type = WebCore::PlatformEvent::Type::TouchStart;
             break;
         case WebEventType::TouchMove:
-            m_type = WebCore::PlatformEvent::TouchMove;
+            m_type = WebCore::PlatformEvent::Type::TouchMove;
             break;
         case WebEventType::TouchEnd:
-            m_type = WebCore::PlatformEvent::TouchEnd;
+            m_type = WebCore::PlatformEvent::Type::TouchEnd;
             break;
         case WebEventType::TouchCancel:
-            m_type = WebCore::PlatformEvent::TouchCancel;
+            m_type = WebCore::PlatformEvent::Type::TouchCancel;
             break;
         default:
             ASSERT_NOT_REACHED();
@@ -380,13 +380,13 @@ public:
     {
         switch (webEvent.type()) {
         case WebEventType::GestureStart:
-            m_type = WebCore::PlatformEvent::GestureStart;
+            m_type = WebCore::PlatformEvent::Type::GestureStart;
             break;
         case WebEventType::GestureChange:
-            m_type = WebCore::PlatformEvent::GestureChange;
+            m_type = WebCore::PlatformEvent::Type::GestureChange;
             break;
         case WebEventType::GestureEnd:
-            m_type = WebCore::PlatformEvent::GestureEnd;
+            m_type = WebCore::PlatformEvent::Type::GestureEnd;
             break;
         default:
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerPairMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerPairMac.mm
@@ -164,7 +164,7 @@ bool ScrollerPairMac::handleWheelEvent(const WebCore::PlatformWheelEvent& event)
 
 bool ScrollerPairMac::handleMouseEvent(const WebCore::PlatformMouseEvent& event)
 {
-    if (event.type() != WebCore::PlatformEvent::MouseMoved)
+    if (event.type() != WebCore::PlatformEvent::Type::MouseMoved)
         return false;
 
     m_lastKnownMousePosition = event.position();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
@@ -58,6 +58,7 @@
 #include <WebCore/FullscreenManager.h>
 #include <WebCore/JSExecState.h>
 #include <WebCore/SecurityOrigin.h>
+#include <WebCore/VisibilityState.h>
 #include <wtf/GetPtr.h>
 #include <wtf/RefPtr.h>
 

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/Blob.h>
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/Document.h>
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/ExceptionCode.h>
 #include <WebCore/Frame.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
@@ -98,7 +98,7 @@ void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
         // During RawKeyDown events if an editor command will insert text, defer
         // the insertion until the keypress event. We want keydown to bubble up
         // through the DOM first.
-        if (platformEvent->type() == PlatformEvent::RawKeyDown) {
+        if (platformEvent->type() == PlatformEvent::Type::RawKeyDown) {
             if (executePendingEditorCommands(*frame, pendingEditorCommands, false))
                 event.setDefaultHandled();
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -622,7 +622,7 @@ void FindController::didScrollAffectingFindIndicatorPosition()
 
 bool FindController::mouseEvent(PageOverlay&, const PlatformMouseEvent& mouseEvent)
 {
-    if (mouseEvent.type() == PlatformEvent::MousePressed)
+    if (mouseEvent.type() == PlatformEvent::Type::MousePressed)
         hideFindUI();
 
     return false;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2871,12 +2871,12 @@ WebContextMenu* WebPage::contextMenuAtPointInWindow(const IntPoint& point)
     corePage()->contextMenuController().clearContextMenu();
 
     // Simulate a mouse click to generate the correct menu.
-    PlatformMouseEvent mousePressEvent(point, point, RightButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
+    PlatformMouseEvent mousePressEvent(point, point, RightButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     corePage()->userInputBridge().handleMousePressEvent(mousePressEvent);
     Ref mainFrame = corePage()->mainFrame();
     bool handled = corePage()->userInputBridge().handleContextMenuEvent(mousePressEvent, mainFrame);
     auto* menu = handled ? &contextMenu() : nullptr;
-    PlatformMouseEvent mouseReleaseEvent(point, point, RightButton, PlatformEvent::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
+    PlatformMouseEvent mouseReleaseEvent(point, point, RightButton, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     corePage()->userInputBridge().handleMouseReleaseEvent(mouseReleaseEvent);
 
     return menu;
@@ -3105,7 +3105,7 @@ static bool handleMouseEvent(const WebMouseEvent& mouseEvent, WebPage* page)
     PlatformMouseEvent platformMouseEvent = platform(mouseEvent);
 
     switch (platformMouseEvent.type()) {
-        case PlatformEvent::MousePressed: {
+        case PlatformEvent::Type::MousePressed: {
 #if ENABLE(CONTEXT_MENUS)
             if (isContextClick(platformMouseEvent))
                 page->corePage()->contextMenuController().clearContextMenu();
@@ -3118,12 +3118,12 @@ static bool handleMouseEvent(const WebMouseEvent& mouseEvent, WebPage* page)
 #endif
             return handled;
         }
-        case PlatformEvent::MouseReleased:
+        case PlatformEvent::Type::MouseReleased:
             if (mouseEvent.gestureWasCancelled() == GestureWasCancelled::Yes)
                 frame.eventHandler().invalidateClick();
             return page->corePage()->userInputBridge().handleMouseReleaseEvent(platformMouseEvent);
 
-        case PlatformEvent::MouseMoved:
+        case PlatformEvent::Type::MouseMoved:
 #if PLATFORM(COCOA)
             // We need to do a full, normal hit test during this mouse event if the page is active or if a mouse
             // button is currently pressed. It is possible that neither of those things will be true since on
@@ -3135,9 +3135,9 @@ static bool handleMouseEvent(const WebMouseEvent& mouseEvent, WebPage* page)
 #endif
             return page->corePage()->userInputBridge().handleMouseMoveEvent(platformMouseEvent);
 
-        case PlatformEvent::MouseForceChanged:
-        case PlatformEvent::MouseForceDown:
-        case PlatformEvent::MouseForceUp:
+        case PlatformEvent::Type::MouseForceChanged:
+        case PlatformEvent::Type::MouseForceDown:
+        case PlatformEvent::Type::MouseForceUp:
             return page->corePage()->userInputBridge().handleMouseForceEvent(platformMouseEvent);
 
         default:
@@ -3580,7 +3580,7 @@ void WebPage::setInitialFocus(bool forward, bool isKeyboardEventValid, const Web
 
     if (isKeyboardEventValid && event.type() == WebEventType::KeyDown) {
         PlatformKeyboardEvent platformEvent(platform(event));
-        platformEvent.disambiguateKeyDownEvent(PlatformEvent::RawKeyDown);
+        platformEvent.disambiguateKeyDownEvent(PlatformEvent::Type::RawKeyDown);
         focusController->setInitialFocus(forward ? FocusDirection::Forward : FocusDirection::Backward, &KeyboardEvent::create(platformEvent, &frame->windowProxy()).get());
         completionHandler();
         return;
@@ -4776,7 +4776,7 @@ void WebPage::dragEnded(WebCore::IntPoint clientPosition, WebCore::IntPoint glob
     if (!view)
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
-    PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::NoTap);
+    PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::NoTap);
     m_page->mainFrame().eventHandler().dragSourceEndedAt(event, dragOperationMask);
 
     send(Messages::WebPageProxy::DidEndDragging());

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -551,7 +551,7 @@ bool WebPage::handleEditingKeyboardEvent(KeyboardEvent& event)
         return true;
 
     // FIXME: Interpret the event immediately upon receiving it in UI process, without sending to WebProcess first.
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::InterpretKeyEvent(editorState(ShouldPerformLayout::Yes), platformEvent->type() == PlatformKeyboardEvent::Char), m_identifier);
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::InterpretKeyEvent(editorState(ShouldPerformLayout::Yes), platformEvent->type() == PlatformKeyboardEvent::Type::Char), m_identifier);
     auto [eventWasHandled] = sendResult.takeReplyOr(false);
     return eventWasHandled;
 }
@@ -683,7 +683,7 @@ void WebPage::updateSelectionAppearance()
 static void dispatchSyntheticMouseMove(Frame& mainFrame, const WebCore::FloatPoint& location, OptionSet<WebEventModifier> modifiers, WebCore::PointerID pointerId = WebCore::mousePointerID)
 {
     IntPoint roundedAdjustedPoint = roundedIntPoint(location);
-    auto mouseEvent = PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, NoButton, PlatformEvent::MouseMoved, 0, platform(modifiers), WallTime::now(), WebCore::ForceAtClick, WebCore::OneFingerTap, pointerId);
+    auto mouseEvent = PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, NoButton, PlatformEvent::Type::MouseMoved, 0, platform(modifiers), WallTime::now(), WebCore::ForceAtClick, WebCore::OneFingerTap, pointerId);
     // FIXME: Pass caps lock state.
     mainFrame.eventHandler().dispatchSyntheticMouseMove(mouseEvent);
 }
@@ -698,27 +698,27 @@ void WebPage::generateSyntheticEditingCommand(SyntheticEditingCommandType comman
     
     switch (command) {
     case SyntheticEditingCommandType::Undo:
-        keyEvent = PlatformKeyboardEvent(PlatformEvent::KeyDown, "z"_s, "z"_s,
+        keyEvent = PlatformKeyboardEvent(PlatformEvent::Type::KeyDown, "z"_s, "z"_s,
         "z"_s, "KeyZ"_s,
         "U+005A"_s, 90, false, false, false, modifiers, WallTime::now());
         break;
     case SyntheticEditingCommandType::Redo:
-        keyEvent = PlatformKeyboardEvent(PlatformEvent::KeyDown, "y"_s, "y"_s,
+        keyEvent = PlatformKeyboardEvent(PlatformEvent::Type::KeyDown, "y"_s, "y"_s,
         "y"_s, "KeyY"_s,
         "U+0059"_s, 89, false, false, false, modifiers, WallTime::now());
         break;
     case SyntheticEditingCommandType::ToggleBoldface:
-        keyEvent = PlatformKeyboardEvent(PlatformEvent::KeyDown, "b"_s, "b"_s,
+        keyEvent = PlatformKeyboardEvent(PlatformEvent::Type::KeyDown, "b"_s, "b"_s,
         "b"_s, "KeyB"_s,
         "U+0042"_s, 66, false, false, false, modifiers, WallTime::now());
         break;
     case SyntheticEditingCommandType::ToggleItalic:
-        keyEvent = PlatformKeyboardEvent(PlatformEvent::KeyDown, "i"_s, "i"_s,
+        keyEvent = PlatformKeyboardEvent(PlatformEvent::Type::KeyDown, "i"_s, "i"_s,
         "i"_s, "KeyI"_s,
         "U+0049"_s, 73, false, false, false, modifiers, WallTime::now());
         break;
     case SyntheticEditingCommandType::ToggleUnderline:
-        keyEvent = PlatformKeyboardEvent(PlatformEvent::KeyDown, "u"_s, "u"_s,
+        keyEvent = PlatformKeyboardEvent(PlatformEvent::Type::KeyDown, "u"_s, "u"_s,
         "u"_s, "KeyU"_s,
         "U+0055"_s, 85, false, false, false, modifiers, WallTime::now());
         break;
@@ -846,7 +846,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     // FIXME: Pass caps lock state.
     auto platformModifiers = platform(modifiers);
 
-    bool handledPress = mainframe.eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::MousePressed, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId));
+    bool handledPress = mainframe.eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId));
     if (m_isClosed)
         return;
 
@@ -855,7 +855,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     else if (!handledPress)
         clearSelectionAfterTapIfNeeded();
 
-    bool handledRelease = mainframe.eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::MouseReleased, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId));
+    bool handledRelease = mainframe.eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId));
     if (m_isClosed)
         return;
 
@@ -867,7 +867,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
         // Dispatch mouseOut to dismiss tooltip content when tapping on the control bar buttons (cc, settings).
         if (document.quirks().needsYouTubeMouseOutQuirk()) {
             if (auto* frame = document.frame())
-                frame->eventHandler().dispatchSyntheticMouseOut(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::NoType, 0, platformModifiers, WallTime::now(), 0, WebCore::NoTap, pointerId));
+                frame->eventHandler().dispatchSyntheticMouseOut(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::NoType, 0, platformModifiers, WallTime::now(), 0, WebCore::NoTap, pointerId));
         }
     }
 
@@ -908,10 +908,10 @@ void WebPage::handleDoubleTapForDoubleClickAtPoint(const IntPoint& point, Option
 
     auto platformModifiers = platform(modifiers);
     auto roundedAdjustedPoint = roundedIntPoint(adjustedPoint);
-    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::MousePressed, 2, platformModifiers, WallTime::now(), 0, WebCore::OneFingerTap));
+    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 2, platformModifiers, WallTime::now(), 0, WebCore::OneFingerTap));
     if (m_isClosed)
         return;
-    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::MouseReleased, 2, platformModifiers, WallTime::now(), 0, WebCore::OneFingerTap));
+    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 2, platformModifiers, WallTime::now(), 0, WebCore::OneFingerTap));
 }
 
 void WebPage::requestFocusedElementInformation(CompletionHandler<void(const std::optional<FocusedElementInformation>&)>&& completionHandler)
@@ -937,7 +937,7 @@ void WebPage::requestAdditionalItemsForDragSession(const IntPoint& clientPositio
     // To augment the platform drag session with additional items, end the current drag session and begin a new drag session with the new drag item.
     // This process is opaque to the UI process, which still maintains the old drag item in its drag session. Similarly, this persistent drag session
     // is opaque to the web process, which only sees that the current drag has ended, and that a new one is beginning.
-    PlatformMouseEvent event(clientPosition, globalPosition, LeftButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
+    PlatformMouseEvent event(clientPosition, globalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
     m_page->dragController().dragEnded();
     m_page->mainFrame().eventHandler().dragSourceEndedAt(event, { }, MayExtendDragSession::Yes);
 
@@ -1215,7 +1215,7 @@ void WebPage::inspectorNodeSearchMovedToPosition(const FloatPoint& position)
     IntPoint adjustedPoint = roundedIntPoint(position);
     Frame& mainframe = m_page->mainFrame();
 
-    mainframe.eventHandler().mouseMoved(PlatformMouseEvent(adjustedPoint, adjustedPoint, NoButton, PlatformEvent::MouseMoved, 0, { }, { }, 0, WebCore::NoTap));
+    mainframe.eventHandler().mouseMoved(PlatformMouseEvent(adjustedPoint, adjustedPoint, NoButton, PlatformEvent::Type::MouseMoved, 0, { }, { }, 0, WebCore::NoTap));
     mainframe.document()->updateStyleIfNeeded();
 }
 
@@ -1723,16 +1723,16 @@ void WebPage::dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch tou
     auto& eventHandler = m_page->mainFrame().eventHandler();
     switch (touch) {
     case SelectionTouch::Started:
-        eventHandler.handleMousePressEvent({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, NoTap });
+        eventHandler.handleMousePressEvent({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, NoTap });
         break;
     case SelectionTouch::Moved:
-        eventHandler.dispatchSyntheticMouseMove({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, NoTap });
+        eventHandler.dispatchSyntheticMouseMove({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, NoTap });
         break;
     case SelectionTouch::Ended:
     case SelectionTouch::EndedMovingForward:
     case SelectionTouch::EndedMovingBackward:
     case SelectionTouch::EndedNotMoving:
-        eventHandler.handleMouseReleaseEvent({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, NoTap });
+        eventHandler.handleMouseReleaseEvent({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, NoTap });
         break;
     }
 }

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -278,7 +278,7 @@ bool WebPage::executeKeypressCommandsInternal(const Vector<WebCore::KeypressComm
                 bool commandExecutedByEditor = command.execute(event);
                 eventWasHandled |= commandExecutedByEditor;
                 if (!commandExecutedByEditor) {
-                    bool performedNonEditingBehavior = event->underlyingPlatformEvent()->type() == PlatformEvent::RawKeyDown && performNonEditingBehaviorForSelector(commands[i].commandName, event);
+                    bool performedNonEditingBehavior = event->underlyingPlatformEvent()->type() == PlatformEvent::Type::RawKeyDown && performNonEditingBehaviorForSelector(commands[i].commandName, event);
                     eventWasHandled |= performedNonEditingBehavior;
                 }
             } else {
@@ -303,7 +303,7 @@ bool WebPage::handleEditingKeyboardEvent(KeyboardEvent& event)
     ASSERT(!platformEvent->macEvent()); // Cannot have a native event in WebProcess.
 
     // Don't handle Esc while handling keydown event, we need to dispatch a keypress first.
-    if (platformEvent->type() != PlatformEvent::Char && platformEvent->windowsVirtualKeyCode() == VK_ESCAPE && commands.size() == 1 && commandNameForSelectorName(commands[0].commandName) == "cancelOperation"_s)
+    if (platformEvent->type() != PlatformEvent::Type::Char && platformEvent->windowsVirtualKeyCode() == VK_ESCAPE && commands.size() == 1 && commandNameForSelectorName(commands[0].commandName) == "cancelOperation"_s)
         return false;
 
     if (handleKeyEventByRelinquishingFocusToChrome(event))
@@ -322,7 +322,7 @@ bool WebPage::handleEditingKeyboardEvent(KeyboardEvent& event)
     }
     // If there are no text insertion commands, default keydown handler is the right time to execute the commands.
     // Keypress (Char event) handler is the latest opportunity to execute.
-    if (!haveTextInsertionCommands || platformEvent->type() == PlatformEvent::Char) {
+    if (!haveTextInsertionCommands || platformEvent->type() == PlatformEvent::Type::Char) {
         eventWasHandled = executeKeypressCommandsInternal(commands, &event);
         commands.clear();
     }

--- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
+++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
@@ -233,7 +233,7 @@ bool WebPage::handleEditingKeyboardEvent(WebCore::KeyboardEvent& event)
 
     auto command = frame->editor().command(String::fromLatin1(interpretKeyEvent(&event)));
 
-    if (keyEvent->type() == PlatformEvent::RawKeyDown) {
+    if (keyEvent->type() == PlatformEvent::Type::RawKeyDown) {
         // WebKit doesn't have enough information about mode to decide
         // how commands that just insert text if executed via Editor
         // should be treated, so we leave it upon WebCore to either

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -82,6 +82,7 @@
 #import <WebCore/Text.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/TreeWalker.h>
+#import <WebCore/VisibilityState.h>
 #import <WebCore/WebScriptObjectPrivate.h>
 #import <WebCore/XPathExpression.h>
 #import <WebCore/XPathNSResolver.h>

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -957,7 +957,7 @@ static NSURL *createUniqueWebDataURL();
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
     WebCore::PlatformMouseEvent event(WebCore::IntPoint(windowLoc), WebCore::IntPoint(WebCore::globalPoint(windowLoc, [view->platformWidget() window])),
-        WebCore::LeftButton, WebCore::PlatformEvent::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
+        WebCore::LeftButton, WebCore::PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     _private->coreFrame->eventHandler().dragSourceEndedAt(event, coreDragOperationMask(dragOperationMask));
 }
 #endif // ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -4527,7 +4527,7 @@ static RefPtr<WebCore::KeyboardEvent> currentKeyboardEvent(WebCore::Frame* coreF
     switch ([event type]) {
     case NSEventTypeKeyDown: {
         WebCore::PlatformKeyboardEvent platformEvent = WebCore::PlatformEventFactory::createPlatformKeyboardEvent(event);
-        platformEvent.disambiguateKeyDownEvent(WebCore::PlatformEvent::RawKeyDown);
+        platformEvent.disambiguateKeyDownEvent(WebCore::PlatformEvent::Type::RawKeyDown);
         return WebCore::KeyboardEvent::create(platformEvent, &coreFrame->windowProxy());
     }
     case NSEventTypeKeyUp:
@@ -6009,7 +6009,7 @@ static BOOL writingDirectionKeyBindingsEnabled()
         }
         // If there are no text insertion commands, default keydown handler is the right time to execute the commands.
         // Keypress (Char event) handler is the latest opportunity to execute.
-        if (!haveTextInsertionCommands || platformEvent->type() == WebCore::PlatformEvent::Char)
+        if (!haveTextInsertionCommands || platformEvent->type() == WebCore::PlatformEvent::Type::Char)
             [self _executeSavedKeypressCommands];
     }
     _private->interpretKeyEventsParameters = nullptr;
@@ -6051,7 +6051,7 @@ static BOOL writingDirectionKeyBindingsEnabled()
         if (!webView.isEditable && event.isTabKey)
             return NO;
 
-        bool isCharEvent = platformEvent->type() == WebCore::PlatformKeyboardEvent::Char;
+        bool isCharEvent = platformEvent->type() == WebCore::PlatformKeyboardEvent::Type::Char;
 
         if (!isCharEvent && [webView._UIKitDelegateForwarder handleKeyTextCommandForCurrentEvent])
             return YES;

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -950,7 +950,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
         break;
     case NSEventTypeKeyDown: {
         auto pe = WebCore::PlatformEventFactory::createPlatformKeyboardEvent(nsEvent);
-        pe.disambiguateKeyDownEvent(WebCore::PlatformEvent::RawKeyDown);
+        pe.disambiguateKeyDownEvent(WebCore::PlatformEvent::Type::RawKeyDown);
         event = WebCore::KeyboardEvent::create(pe, nullptr);
         break;
     }

--- a/Source/WebKitLegacy/win/WebDropSource.cpp
+++ b/Source/WebKitLegacy/win/WebDropSource.cpp
@@ -100,7 +100,7 @@ PlatformMouseEvent generateMouseEvent(WebView* webView, bool isDrag)
     if (SUCCEEDED(webView->viewWindow(&viewWindow)))
         ::ScreenToClient(viewWindow, reinterpret_cast<LPPOINT>(&localpt));
     return PlatformMouseEvent(IntPoint(localpt.x, localpt.y), IntPoint(pt.x, pt.y),
-        isDrag ? LeftButton : NoButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
+        isDrag ? LeftButton : NoButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
 }
 
 STDMETHODIMP WebDropSource::QueryContinueDrag(_In_ BOOL fEscapePressed, _In_ DWORD grfKeyState)

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -2004,7 +2004,7 @@ bool WebView::execCommand(WPARAM wParam, LPARAM /*lParam*/)
 
 bool WebView::keyUp(WPARAM virtualKeyCode, LPARAM keyData, bool systemKeyDown)
 {
-    PlatformKeyboardEvent keyEvent(m_viewWindow, virtualKeyCode, keyData, PlatformEvent::KeyUp, systemKeyDown);
+    PlatformKeyboardEvent keyEvent(m_viewWindow, virtualKeyCode, keyData, PlatformEvent::Type::KeyUp, systemKeyDown);
 
     Frame& frame = m_page->focusController().focusedOrMainFrame();
     m_currentCharacterCode = 0;
@@ -2147,7 +2147,7 @@ bool WebView::handleEditingKeyboardEvent(KeyboardEvent& event)
 
     auto command = frame->editor().command(String::fromLatin1(interpretKeyEvent(&event)));
 
-    if (keyEvent->type() == PlatformEvent::RawKeyDown) {
+    if (keyEvent->type() == PlatformEvent::Type::RawKeyDown) {
         // WebKit doesn't have enough information about mode to decide how commands that just insert text if executed via Editor should be treated,
         // so we leave it upon WebCore to either handle them immediately (e.g. Tab that changes focus) or let a keypress event be generated
         // (e.g. Tab that inserts a Tab character, or Enter).
@@ -2184,7 +2184,7 @@ bool WebView::keyDown(WPARAM virtualKeyCode, LPARAM keyData, bool systemKeyDown)
             pendingCharEvents.append(msg);
     }
 
-    PlatformKeyboardEvent keyEvent(m_viewWindow, virtualKeyCode, keyData, PlatformEvent::RawKeyDown, systemKeyDown);
+    PlatformKeyboardEvent keyEvent(m_viewWindow, virtualKeyCode, keyData, PlatformEvent::Type::RawKeyDown, systemKeyDown);
     bool handled = frame.eventHandler().keyEvent(keyEvent);
 
     // These events cannot be canceled, and we have no default handling for them.
@@ -2260,7 +2260,7 @@ bool WebView::keyPress(WPARAM charCode, LPARAM keyData, bool systemKeyDown)
 {
     Frame& frame = m_page->focusController().focusedOrMainFrame();
 
-    PlatformKeyboardEvent keyEvent(m_viewWindow, charCode, keyData, PlatformEvent::Char, systemKeyDown);
+    PlatformKeyboardEvent keyEvent(m_viewWindow, charCode, keyData, PlatformEvent::Type::Char, systemKeyDown);
     // IE does not dispatch keypress event for WM_SYSCHAR.
     if (systemKeyDown)
         return frame.eventHandler().handleAccessKey(keyEvent);


### PR DESCRIPTION
#### a4a0ae0d75768887423c88d42cb963ec2035960b
<pre>
Refactor Document.h to reduce build times
<a href="https://bugs.webkit.org/show_bug.cgi?id=250887">https://bugs.webkit.org/show_bug.cgi?id=250887</a>
rdar://104465840

Reviewed by Darin Adler.

Replace explicit header includes with forward declarations wherever possible.

For some headers,
this requires enumerations to be moved outside an owning class and into namespace scope so those
enumerations can be forward declared.

For CanvasBase.h, pull CanvasObserver.h into its own file with minimal header dependencies.

For ScriptController, eliminate the requirement for SecurityOrigin to be included by modifying
executeJavaScriptURL() to take an r-value reference to a RefPtr&lt;SecurityOrigin&gt;.

With these changes, the compile-time cost of including Document.h has been reduced by 75%.

* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/bindings/js/ScriptController.h:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement):
(WebCore::Document::hasListenerTypeForEventType const):
(WebCore::m_reportingScope): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::setFocusedElement): Deleted.
(WebCore::Document::wasLastFocusByClick const): Deleted.
(WebCore::Document::clientOrigin const): Deleted.
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::clientOrigin const):
(WebCore::Document::wasLastFocusByClick const):
* Source/WebCore/dom/Element.cpp:
(WebCore::isForceEvent):
(WebCore::Element::dispatchMouseForceWillBegin):
* Source/WebCore/dom/FragmentScriptingPermission.h:
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::eventTypeForKeyboardEventType):
* Source/WebCore/dom/VisibilityState.h:
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasObserver::isStyleCanvasImage const): Deleted.
* Source/WebCore/html/CanvasObserver.h: Copied from Source/WebCore/page/DisabledAdaptations.h.
(WebCore::CanvasObserver::isStyleCanvasImage const):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::showContextMenuAt):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::mouseEvent):
* Source/WebCore/page/DisabledAdaptations.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::createMouseEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::SyntheticTouchPoint::SyntheticTouchPoint):
(WebCore::SyntheticSingleTouchEvent::SyntheticSingleTouchEvent):
(WebCore::EventHandler::handleMouseForceEvent):
(WebCore::EventHandler::handlePasteGlobalSelection):
(WebCore::EventHandler::sendContextMenuEventForKey):
(WebCore::EventHandler::fakeMouseMoveEventTimerFired):
(WebCore::EventHandler::isKeyEventAllowedInFullScreen const):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::handleDrag):
(WebCore::EventHandler::dispatchSyntheticTouchEventIfEnabled):
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::dispatchSimulatedTouchEvent):
(WebCore::EventHandler::tryToBeginDragAtPoint):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::platformHandleMouseEvent):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::mouseEvent):
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::keyboardScrollingKeyForKeyboardEvent):
* Source/WebCore/platform/PlatformEvent.h:
(WebCore::PlatformEvent::type const):
(WebCore::PlatformEvent::PlatformEvent):
(): Deleted.
* Source/WebCore/platform/PlatformKeyboardEvent.h:
(WebCore::PlatformKeyboardEvent::PlatformKeyboardEvent):
* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
* Source/WebCore/platform/PlatformWheelEvent.cpp:
(WebCore::PlatformWheelEvent::createFromGesture):
* Source/WebCore/platform/PlatformWheelEvent.h:
(WebCore::PlatformWheelEvent::PlatformWheelEvent):
* Source/WebCore/platform/ios/KeyEventIOS.mm:
(WebCore::PlatformKeyboardEvent::disambiguateKeyDownEvent):
* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
(WebCore::mouseEventType):
(WebCore::PlatformWheelEventBuilder::PlatformWheelEventBuilder):
(WebCore::PlatformKeyboardEventBuilder::PlatformKeyboardEventBuilder):
(WebCore::touchEventType):
(WebCore::touchPhaseFromPlatformEventType):
* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:
(WebCore::ScrollAnimatorIOS::handleTouchEvent):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
* Source/WebCore/platform/mac/KeyEventMac.mm:
(WebCore::PlatformKeyboardEvent::disambiguateKeyDownEvent):
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::mouseEventTypeForEvent):
(WebCore::PlatformMouseEventBuilder::PlatformMouseEventBuilder):
(WebCore::PlatformWheelEventBuilder::PlatformWheelEventBuilder):
(WebCore::PlatformKeyboardEventBuilder::PlatformKeyboardEventBuilder):
* Source/WebCore/rendering/style/StyleCanvasImage.h:
* Source/WebCore/rendering/style/StyleCrossfadeImage.h:
* Source/WebCore/xml/DOMParser.cpp:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::platform):
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
(WebKit::WebKit2PlatformWheelEvent::WebKit2PlatformWheelEvent):
(WebKit::WebKit2PlatformKeyboardEvent::WebKit2PlatformKeyboardEvent):
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
(WebKit::WebKit2PlatformGestureEvent::WebKit2PlatformGestureEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerPairMac.mm:
(WebKit::ScrollerPairMac::handleMouseEvent):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::dispatchSyntheticMouseMove):
(WebKit::WebPage::generateSyntheticEditingCommand):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::requestAdditionalItemsForDragSession):
(WebKit::WebPage::inspectorNodeSearchMovedToPosition):
(WebKit::WebPage::dispatchSyntheticMouseEventsForSelectionGesture):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::executeKeypressCommandsInternal):
(WebKit::WebPage::handleEditingKeyboardEvent):
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _dragSourceEndedAt:operation:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(currentKeyboardEvent):
(-[WebHTMLView _interpretKeyEvent:savingCommands:]):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView PDFViewWillClickOnLink:withURL:]):

Canonical link: <a href="https://commits.webkit.org/259231@main">https://commits.webkit.org/259231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f7b55200318846710ffebfa20c3c028f0d2cfc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104352 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113568 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173861 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4350 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112608 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38828 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27227 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3780 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46785 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6365 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8716 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->