### PR TITLE
[git-webkit] Make the default for automatically rebasing pull requests be "No" during `git webkit setup`

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -295,7 +295,7 @@ class Setup(Command):
             log.info('Setting auto update on PR creation...')
             response = Terminal.choose(
                 'Would you like to automatically rebase your branch when creating or\nupdating a pull request?',
-                default='Yes', options=('Yes', 'No', 'Later'),
+                default='No', options=('Yes', 'No', 'Later'),
             )
             if response in ['Yes', 'No']:
                 if run(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -151,7 +151,7 @@ Set 'Tim Apple' as the git user name for this repository ([Yes]/No):
 Enter git user name for this repository: 
 Auto-color status, diff, and branch for this repository? ([Yes]/Skip): 
 Would you like to automatically rebase your branch when creating or
-updating a pull request? ([Yes]/No/Later): 
+updating a pull request? (Yes/[No]/Later): 
 Would you like to create new branches to retain history when you overwrite
 a pull request branch? ([when-user-owned]/disabled/always/never): 
 Pick a commit message editor for this repository:
@@ -176,7 +176,7 @@ Setting better Objective-C diffing behavior for this repository...
 Set better Objective-C diffing behavior for this repository!
 Using a rebase merge strategy for this repository
 Setting auto update on PR creation...
-Enabled auto update on PR creation
+Disabled auto update on PR creation
 Setting git editor for {repository}...
 Using the default git editor for this repository
 Saving GitHub credentials in system credential store...


### PR DESCRIPTION
#### bccfa03529c2333ade99a1d1a82d2398db776a93
<pre>
[git-webkit] Make the default for automatically rebasing pull requests be &quot;No&quot; during `git webkit setup`
<a href="https://bugs.webkit.org/show_bug.cgi?id=250888">https://bugs.webkit.org/show_bug.cgi?id=250888</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:

Canonical link: <a href="https://commits.webkit.org/259135@main">https://commits.webkit.org/259135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff5411c8f3b79868ce795245365d37d5ed570bbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104029 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113241 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173547 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4037 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112324 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38610 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107514 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80268 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26975 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3519 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/102897 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46509 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8414 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3333 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->