### PR TITLE
AudioContext::suspend creates a remote audio destination

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -142,30 +142,32 @@ void RemoteAudioDestinationProxy::startRendering(CompletionHandler<void(bool)>&&
 {
     auto* connection = this->connection();
     if (!connection) {
-        RunLoop::current().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
+        RunLoop::current().dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+            protectedThis->setIsPlaying(false);
             completionHandler(false);
         });
         return;
     }
 
-    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StartAudioDestination(m_destinationID), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
-        setIsPlaying(isPlaying);
+    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StartAudioDestination(m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
+        protectedThis->setIsPlaying(isPlaying);
         completionHandler(isPlaying);
     });
 }
 
 void RemoteAudioDestinationProxy::stopRendering(CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* connection = this->connection();
+    auto* connection = existingConnection();
     if (!connection) {
-        RunLoop::current().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
-            completionHandler(false);
+        RunLoop::current().dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+            protectedThis->setIsPlaying(false);
+            completionHandler(true);
         });
         return;
     }
 
-    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StopAudioDestination(m_destinationID), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
-        setIsPlaying(isPlaying);
+    connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StopAudioDestination(m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
+        protectedThis->setIsPlaying(isPlaying);
         completionHandler(!isPlaying);
     });
 }


### PR DESCRIPTION
#### 3c729e10ad7a04cb531fbce23850242271c48222
<pre>
AudioContext::suspend creates a remote audio destination
<a href="https://bugs.webkit.org/show_bug.cgi?id=250890">https://bugs.webkit.org/show_bug.cgi?id=250890</a>
rdar://problem/104470320

Reviewed by Youenn Fablet.

Stopping RemoteAudioDestinationProxy that was not started would
establish a connection to GPUP RemoteAudioDestination. This is a slow
operation.

This would happen sometimes during load, where load commit would suspend
the AudioContext that the page created but did not start. AudioContext
starts in Suspended state, but suspending it would cause stop call
to the underlying destination.

To minimize the change at this time, fix the problem at
RemoteAudioDestinationProxy level. Later on, AudioContext can be
improved further.

* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::startRendering):
(WebKit::RemoteAudioDestinationProxy::stopRendering):

Canonical link: <a href="https://commits.webkit.org/259134@main">https://commits.webkit.org/259134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68c1451603ef69ea8ed232bb4837f639f762bbff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113252 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4047 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96275 "Reverted pull request changes (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112334 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109810 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/93999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38615 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80273 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26988 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3527 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46522 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6294 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8426 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->