### PR TITLE
Reduce calls to LayoutUnit and use default constructors for containers

### DIFF
--- a/Source/WebCore/platform/graphics/LayoutPoint.h
+++ b/Source/WebCore/platform/graphics/LayoutPoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Google Inc. All rights reserved.
+ * Copyright (c) 2012-2013, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class LayoutPoint {
 public:
-    LayoutPoint() : m_x(0), m_y(0) { }
+    LayoutPoint() { }
     template<typename T, typename U> LayoutPoint(T x, U y) : m_x(x), m_y(y) { }
     LayoutPoint(const IntPoint& point) : m_x(point.x()), m_y(point.y()) { }
     explicit LayoutPoint(const FloatPoint& size) : m_x(size.x()), m_y(size.y()) { }

--- a/Source/WebCore/platform/graphics/LayoutSize.h
+++ b/Source/WebCore/platform/graphics/LayoutSize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Google Inc. All rights reserved.
+ * Copyright (c) 2012-2013, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -49,7 +49,7 @@ enum AspectRatioFit {
 
 class LayoutSize {
 public:
-    LayoutSize() : m_width(0), m_height(0) { }
+    LayoutSize() { }
     LayoutSize(const IntSize& size) : m_width(size.width()), m_height(size.height()) { }
     template<typename T, typename U> LayoutSize(T width, U height) : m_width(width), m_height(height) { }
 
@@ -64,7 +64,7 @@ public:
     template<typename T> void setWidth(T width) { m_width = width; }
     template<typename T> void setHeight(T height) { m_height = height; }
 
-    bool isEmpty() const { return m_width <= 0 || m_height <= 0; }
+    bool isEmpty() const { return m_width.rawValue() <= 0 || m_height.rawValue() <= 0; }
     bool isZero() const { return !m_width && !m_height; }
 
     float aspectRatio() const { return static_cast<float>(m_width) / static_cast<float>(m_height); }


### PR DESCRIPTION
#### 42948cd0674a44230185146a56461d957488da8a
<pre>
Reduce calls to LayoutUnit and use default constructors for containers

Reduce calls to LayoutUnit and use default constructors for containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=250884">https://bugs.webkit.org/show_bug.cgi?id=250884</a>

Reviewed by Alan Baradlay.

Merge (except RenderBox.h) - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=158483 &amp;
<a href="https://src.chromium.org/viewvc/blink?view=rev&amp">https://src.chromium.org/viewvc/blink?view=rev&amp</a>;revision=158571

LayoutUnit() is fast; LayoutUnit(int) is slow because of bounds-checks.
Since the default constructor sets the m_value of the LayoutUnit to 0,
we can replace calls to LayoutUnit(0) with the default constructor.

The integer constructor of LayoutUnit is relatively quite expensive;
the default constructor is a far cheaper way to initialize a LayoutUnit
with the value of 0.

Implicit conversions from int to LayoutUnit mean that tests against 0
are also surprisingly expensive.

* Source/WebCore/platform/graphics/LayoutPoint.h: Modify &apos;LayoutPoint()&apos; to default constructor
* Source/WebCore/platform/graphics/LayoutSize.h:
(1) Modify &apos;LayoutPoint()&apos; to default constructor
(2) bool &apos;isEmpty&apos; to return values with &quot;rawValues()&quot;

Canonical link: <a href="https://commits.webkit.org/259177@main">https://commits.webkit.org/259177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/885c643b12071650abde9714b6be711265cdfffb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113409 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173699 "Failed to checkout and rebase branch from PR 8872") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4204 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112467 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38732 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6652 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27100 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3647 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6319 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8570 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->