### PR TITLE
[GTK][WPE] Allow specific TLS certificate for a host should not be global to the network process

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -95,14 +95,6 @@ private:
     HashSet<String> m_certificates;
 };
 
-using AllowedCertificatesMap = HashMap<String, HostTLSCertificateSet, ASCIICaseInsensitiveHash>;
-
-static AllowedCertificatesMap& allowedCertificates()
-{
-    static NeverDestroyed<AllowedCertificatesMap> certificates;
-    return certificates;
-}
-
 SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)
     : m_sessionID(sessionID)
 {
@@ -344,8 +336,8 @@ std::optional<ResourceError> SoupNetworkSession::checkTLSErrors(const URL& reque
     if (m_ignoreTLSErrors || !tlsErrors)
         return std::nullopt;
 
-    auto it = allowedCertificates().find<ASCIICaseInsensitiveStringViewHashTranslator>(requestURL.host());
-    if (it != allowedCertificates().end() && it->value.contains(certificate))
+    auto it = m_allowedCertificates.find<ASCIICaseInsensitiveStringViewHashTranslator>(requestURL.host());
+    if (it != m_allowedCertificates.end() && it->value.contains(certificate))
         return std::nullopt;
 
     return ResourceError::tlsError(requestURL, tlsErrors, certificate);
@@ -353,7 +345,7 @@ std::optional<ResourceError> SoupNetworkSession::checkTLSErrors(const URL& reque
 
 void SoupNetworkSession::allowSpecificHTTPSCertificateForHost(const CertificateInfo& certificateInfo, const String& host)
 {
-    allowedCertificates().add(host, HostTLSCertificateSet()).iterator->value.add(certificateInfo.certificate().get());
+    m_allowedCertificates.add(host, HostTLSCertificateSet()).iterator->value.add(certificateInfo.certificate().get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.h
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.h
@@ -30,6 +30,7 @@
 #include <glib-object.h>
 #include <pal/SessionID.h>
 #include <wtf/Function.h>
+#include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/WTFString.h>
@@ -42,6 +43,7 @@ typedef struct _SoupSession SoupSession;
 namespace WebCore {
 
 class CertificateInfo;
+class HostTLSCertificateSet;
 class ResourceError;
 
 class SoupNetworkSession {
@@ -66,7 +68,7 @@ public:
 
     WEBCORE_EXPORT void setIgnoreTLSErrors(bool);
     std::optional<ResourceError> checkTLSErrors(const URL&, GTlsCertificate*, GTlsCertificateFlags);
-    static void allowSpecificHTTPSCertificateForHost(const CertificateInfo&, const String& host);
+    void allowSpecificHTTPSCertificateForHost(const CertificateInfo&, const String& host);
 
     void getHostNamesWithHSTSCache(HashSet<String>&);
     void deleteHSTSCacheForHostNames(const Vector<String>&);
@@ -79,6 +81,7 @@ private:
     PAL::SessionID m_sessionID;
     bool m_ignoreTLSErrors { false };
     SoupNetworkProxySettings m_proxySettings;
+    HashMap<String, HostTLSCertificateSet, ASCIICaseInsensitiveHash> m_allowedCertificates;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -461,7 +461,7 @@ private:
 
     void setCacheModel(CacheModel);
     void setCacheModelSynchronouslyForTesting(CacheModel, CompletionHandler<void()>&&);
-    void allowSpecificHTTPSCertificateForHost(const WebCore::CertificateInfo&, const String& host);
+    void allowSpecificHTTPSCertificateForHost(PAL::SessionID, const WebCore::CertificateInfo&, const String& host);
     void allowTLSCertificateChainForLocalPCMTesting(PAL::SessionID, const WebCore::CertificateInfo&);
     void setAllowsAnySSLCertificateForWebSocket(bool, CompletionHandler<void()>&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -67,7 +67,7 @@ messages -> NetworkProcess LegacyReceiver {
 
     FlushCookies(PAL::SessionID sessionID) -> ()
 
-    AllowSpecificHTTPSCertificateForHost(WebCore::CertificateInfo certificate, String host)
+    AllowSpecificHTTPSCertificateForHost(PAL::SessionID sessionID, WebCore::CertificateInfo certificate, String host)
     AllowTLSCertificateChainForLocalPCMTesting(PAL::SessionID sessionID, WebCore::CertificateInfo certificate)
 
     SetCacheModel(enum:uint8_t WebKit::CacheModel cacheModel)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -176,7 +176,7 @@ void NetworkProcess::deleteHSTSCacheForHostNames(PAL::SessionID sessionID, const
 #endif
 }
 
-void NetworkProcess::allowSpecificHTTPSCertificateForHost(const WebCore::CertificateInfo& certificateInfo, const String& host)
+void NetworkProcess::allowSpecificHTTPSCertificateForHost(PAL::SessionID, const WebCore::CertificateInfo& certificateInfo, const String& host)
 {
     // FIXME: Remove this once rdar://30655740 is fixed.
     [NSURLRequest setAllowsSpecificHTTPSCertificate:(NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(certificateInfo.trust().get()).get() forHost:host];

--- a/Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp
@@ -42,7 +42,7 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
 {
 }
 
-void NetworkProcess::allowSpecificHTTPSCertificateForHost(const CertificateInfo& certificateInfo, const String& host)
+void NetworkProcess::allowSpecificHTTPSCertificateForHost(PAL::SessionID, const CertificateInfo& certificateInfo, const String& host)
 {
     notImplemented();
 }

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -161,9 +161,10 @@ void NetworkProcess::setIgnoreTLSErrors(PAL::SessionID sessionID, bool ignoreTLS
         static_cast<NetworkSessionSoup&>(*session).setIgnoreTLSErrors(ignoreTLSErrors);
 }
 
-void NetworkProcess::allowSpecificHTTPSCertificateForHost(const CertificateInfo& certificateInfo, const String& host)
+void NetworkProcess::allowSpecificHTTPSCertificateForHost(PAL::SessionID sessionID, const CertificateInfo& certificateInfo, const String& host)
 {
-    SoupNetworkSession::allowSpecificHTTPSCertificateForHost(certificateInfo, host);
+    if (auto* session = networkSession(sessionID))
+        static_cast<NetworkSessionSoup&>(*session).allowSpecificHTTPSCertificateForHost(certificateInfo, host);
 }
 
 void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -145,6 +145,11 @@ void NetworkSessionSoup::setIgnoreTLSErrors(bool ignoreTLSErrors)
     m_networkSession->setIgnoreTLSErrors(ignoreTLSErrors);
 }
 
+void NetworkSessionSoup::allowSpecificHTTPSCertificateForHost(const CertificateInfo& certificateInfo, const String& host)
+{
+    m_networkSession->allowSpecificHTTPSCertificateForHost(certificateInfo, host);
+}
+
 void NetworkSessionSoup::setProxySettings(const SoupNetworkProxySettings& settings)
 {
     m_networkSession->setProxySettings(settings);

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
@@ -32,6 +32,7 @@
 typedef struct _SoupSession SoupSession;
 
 namespace WebCore {
+class CertificateInfo;
 class SoupNetworkSession;
 struct SoupNetworkProxySettings;
 }
@@ -60,6 +61,7 @@ public:
     bool persistentCredentialStorageEnabled() const { return m_persistentCredentialStorageEnabled; }
 
     void setIgnoreTLSErrors(bool);
+    void allowSpecificHTTPSCertificateForHost(const WebCore::CertificateInfo&, const String&);
     void setProxySettings(const WebCore::SoupNetworkProxySettings&);
 
 private:

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1499,7 +1499,7 @@ static String computeMediaKeyFile(const String& mediaKeyDirectory)
 
 void WebsiteDataStore::allowSpecificHTTPSCertificateForHost(const WebCore::CertificateInfo& certificate, const String& host)
 {
-    networkProcess().send(Messages::NetworkProcess::AllowSpecificHTTPSCertificateForHost(certificate, host), 0);
+    networkProcess().send(Messages::NetworkProcess::AllowSpecificHTTPSCertificateForHost(sessionID(), certificate, host), 0);
 }
 
 void WebsiteDataStore::allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo& certificate)


### PR DESCRIPTION
#### c02853156a9142fb5ed284ef33ab78f1466063d7
<pre>
[GTK][WPE] Allow specific TLS certificate for a host should not be global to the network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=250894">https://bugs.webkit.org/show_bug.cgi?id=250894</a>

Reviewed by Adrian Perez de Castro.

This is not a problem for current API, because it&apos;s web context API and
we always have one network process per context with a single session.
For the new API, we&apos;ll have a global network process with multiple sessions
that shouldn&apos;t share the allowed certificates.

* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::SoupNetworkSession::checkTLSErrors):
(WebCore::SoupNetworkSession::allowSpecificHTTPSCertificateForHost):
(WebCore::allowedCertificates): Deleted.
* Source/WebCore/platform/network/soup/SoupNetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::allowSpecificHTTPSCertificateForHost):
* Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp:
(WebKit::NetworkProcess::allowSpecificHTTPSCertificateForHost):
* Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp:
(WebKit::NetworkProcess::allowSpecificHTTPSCertificateForHost):
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp:
(WebKit::NetworkSessionSoup::allowSpecificHTTPSCertificateForHost):
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::allowSpecificHTTPSCertificateForHost):

Canonical link: <a href="https://commits.webkit.org/259202@main">https://commits.webkit.org/259202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9c56c0a6a3c874fa5b39f4fe4d95bbe3edb2971

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113258 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173565 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4053 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112340 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38619 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3533 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46529 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6341 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8432 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->