### PR TITLE
[macOS] media/audio-session-category.html is a flaky failure

### DIFF
--- a/LayoutTests/media/audio-session-category-expected.txt
+++ b/LayoutTests/media/audio-session-category-expected.txt
@@ -19,6 +19,7 @@ EXPECTED (internals.routeSharingPolicy() == 'Default') OK
 ** Check category when an unmuted element is playing.
 RUN(video.muted = false)
 EVENT(volumechange)
+
 EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
 EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
 

--- a/LayoutTests/media/audio-session-category.html
+++ b/LayoutTests/media/audio-session-category.html
@@ -20,7 +20,7 @@
 
             testExpected('internals.audioSessionCategory()', category);
         }
-        
+
         async function testAudioElement()
         {
             consoleWrite('<br><br>** &lt;audio> element test **');
@@ -41,7 +41,7 @@
             consoleWrite('<br>** Check category when an unmuted element is playing.');
             runWithKeyDown(() => { run('video.muted = false') });
             await waitFor(video, 'volumechange');
-            testExpected('internals.audioSessionCategory()', 'MediaPlayback');
+            await waitForCategory('MediaPlayback', 1, '');
             testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
 
             consoleWrite('<br>** Mute the element, check again after 500ms.');

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1731,8 +1731,6 @@ webkit.org/b/245727 [ Monterey ] imported/w3c/web-platform-tests/notifications/i
 
 webkit.org/b/248734 media/video-inaccurate-duration-ended.html [ Crash ]
 
-webkit.org/b/250784 media/audio-session-category.html [ Pass Failure ]
-
 #webkit.org/b/248537 Batch mark expectations for Ventura test failures
 [ Ventura+ ] webrtc/canvas-to-peer-connection-2d.html [ Pass Timeout ]
 [ Ventura+ ] webrtc/canvas-to-peer-connection.html [ Pass Failure Timeout ]


### PR DESCRIPTION
#### 8eeac5b475965a5a9751af411712676794998c60
<pre>
[macOS] media/audio-session-category.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=250784">https://bugs.webkit.org/show_bug.cgi?id=250784</a>
rdar://problem/104392470

Reviewed by Eric Carlson.

The test is failing on release bots, instead of checking synchronously an audio session category,
we now wait for MediaPlayback category.

* LayoutTests/media/audio-session-category-expected.txt:
* LayoutTests/media/audio-session-category.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259151@main">https://commits.webkit.org/259151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d31fb1eb206706f0c9c122eb831545998d65489

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173571 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4059 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112346 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38622 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80280 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26999 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3538 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46533 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6304 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8438 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->