### PR TITLE
[@property] syntax "<color> | <color>+" does not match "yellow blue"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -59,6 +59,32 @@ PASS syntax:'<color>', initialValue:'lightgoldenrodyellow' is valid
 PASS syntax:'<image>', initialValue:'url(a)' is valid
 PASS syntax:'<image>', initialValue:'linear-gradient(yellow, blue)' is valid
 PASS syntax:'<url>', initialValue:'url(a)' is valid
+PASS syntax:'<color>+', initialValue:'yellow blue' is valid
+PASS syntax:'<color>+ | <color>', initialValue:'yellow blue' is valid
+PASS syntax:'<color> | <color>+', initialValue:'yellow blue' is valid
+PASS syntax:'<color># | <color>', initialValue:'yellow, blue' is valid
+PASS syntax:'<color> | <color>#', initialValue:'yellow, blue' is valid
+PASS syntax:'<color># | <color>+', initialValue:'yellow blue' is valid
+PASS syntax:'<color>+ | <color>#', initialValue:'yellow, blue' is valid
+PASS syntax:'<color>+ | yellow', initialValue:'yellow blue' is valid
+PASS syntax:'yellow', initialValue:'yellow' is valid
+PASS syntax:'yellow | <color>+', initialValue:'yellow blue' is valid
+PASS syntax:'<color># | yellow', initialValue:'yellow, blue' is valid
+PASS syntax:'yellow | <color>#', initialValue:'yellow, blue' is valid
+PASS syntax:'<transform-list> | <transform-function> ', initialValue:'scale(2) rotate(90deg)' is valid
+PASS syntax:'<transform-function> | <transform-list>', initialValue:'scale(2) rotate(90deg)' is valid
+PASS syntax:'<transform-list> | <transform-function>+ ', initialValue:'scale(2) rotate(90deg)' is valid
+PASS syntax:'<transform-function>+ | <transform-list>', initialValue:'scale(2) rotate(90deg)' is valid
+PASS syntax:'<transform-list> | <transform-function># ', initialValue:'scale(2) rotate(90deg)' is valid
+PASS syntax:'<transform-function># | <transform-list>', initialValue:'scale(2) rotate(90deg)' is valid
+PASS syntax:'<transform-list> | <transform-function># ', initialValue:'scale(2), rotate(90deg)' is valid
+PASS syntax:'<transform-function># | <transform-list>', initialValue:'scale(2), rotate(90deg)' is valid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1' is valid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1 1' is valid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1%' is valid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1% 1%' is valid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1px' is valid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1px 1px' is valid
 PASS syntax:'banana', initialValue:'banana' is valid
 PASS syntax:'bAnAnA', initialValue:'bAnAnA' is valid
 PASS syntax:'ba-na-nya', initialValue:'ba-na-nya' is valid
@@ -109,6 +135,12 @@ PASS syntax:'foo § bar', initialValue:'foo § bar' is invalid
 PASS syntax:'foo \1F914 bar', initialValue:'foo \1F914 bar' is invalid
 PASS syntax:'<length> <number>', initialValue:'0px 0' is invalid
 PASS syntax:'<length> <length> <length>', initialValue:'0px 0px 0px' is invalid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1 1%' is invalid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1% 1' is invalid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1px 1' is invalid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1 1px' is invalid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1px 1%' is invalid
+PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1% 1px' is invalid
 PASS syntax:'initial', initialValue:'initial' is invalid
 PASS syntax:'inherit', initialValue:'inherit' is invalid
 PASS syntax:'unset', initialValue:'unset' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html
@@ -88,6 +88,33 @@ assert_valid("<image>", "url(a)");
 assert_valid("<image>", "linear-gradient(yellow, blue)");
 assert_valid("<url>", "url(a)");
 
+assert_valid("<color>+", "yellow blue");
+assert_valid("<color>+ | <color>", "yellow blue");
+assert_valid("<color> | <color>+", "yellow blue");
+assert_valid("<color># | <color>", "yellow, blue");
+assert_valid("<color> | <color>#", "yellow, blue");
+assert_valid("<color># | <color>+", "yellow blue");
+assert_valid("<color>+ | <color>#", "yellow, blue");
+assert_valid("<color>+ | yellow", "yellow blue");
+assert_valid("yellow", "yellow");
+assert_valid("yellow | <color>+", "yellow blue");
+assert_valid("<color># | yellow", "yellow, blue");
+assert_valid("yellow | <color>#", "yellow, blue");
+assert_valid("<transform-list> | <transform-function> ", "scale(2) rotate(90deg)");
+assert_valid("<transform-function> | <transform-list>", "scale(2) rotate(90deg)");
+assert_valid("<transform-list> | <transform-function>+ ", "scale(2) rotate(90deg)");
+assert_valid("<transform-function>+ | <transform-list>", "scale(2) rotate(90deg)");
+assert_valid("<transform-list> | <transform-function># ", "scale(2) rotate(90deg)");
+assert_valid("<transform-function># | <transform-list>", "scale(2) rotate(90deg)");
+assert_valid("<transform-list> | <transform-function># ", "scale(2), rotate(90deg)");
+assert_valid("<transform-function># | <transform-list>", "scale(2), rotate(90deg)");
+assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1");
+assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1 1");
+assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1%");
+assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1% 1%");
+assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1px");
+assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1px 1px");
+
 assert_valid("banana", "banana");
 assert_valid("bAnAnA", "bAnAnA");
 assert_valid("ba-na-nya", "ba-na-nya");
@@ -141,6 +168,13 @@ assert_invalid("foo § bar", "foo § bar");
 assert_invalid("foo \\1F914 bar", "foo \\1F914 bar");
 assert_invalid("<length> <number>", "0px 0");
 assert_invalid("<length> <length> <length>", "0px 0px 0px");
+
+assert_invalid("<integer>+ | <percentage>+ | <length>+ ", "1 1%");
+assert_invalid("<integer>+ | <percentage>+ | <length>+ ", "1% 1");
+assert_invalid("<integer>+ | <percentage>+ | <length>+ ", "1px 1");
+assert_invalid("<integer>+ | <percentage>+ | <length>+ ", "1 1px");
+assert_invalid("<integer>+ | <percentage>+ | <length>+ ", "1px 1%");
+assert_invalid("<integer>+ | <percentage>+ | <length>+ ", "1% 1px");
 
 assert_invalid("initial", "initial");
 assert_invalid("inherit", "inherit");

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -359,7 +359,6 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
             if (auto value = consumeCustomIdent(range)) {
                 if (component.ident.isNull() || value->stringValue() == component.ident)
                     return value;
-                range = rangeCopy;
             }
             return nullptr;
         case CSSCustomPropertySyntax::Type::Percentage:
@@ -416,10 +415,10 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
 
     for (auto& component : syntax.definition) {
         if (auto value = consumeComponent(m_range, component)) {
-            if (!m_range.atEnd())
-                break;
-            return { value, component.type };
+            if (m_range.atEnd())
+                return { value, component.type };
         }
+        m_range = rangeCopy;
     }
     return { nullptr, CSSCustomPropertySyntax::Type::Unknown };
 }


### PR DESCRIPTION
#### 2f1e72c1151bf0d90f09e8a0ad6795256c9035c0
<pre>
[@property] syntax &quot;&lt;color&gt; | &lt;color&gt;+&quot; does not match &quot;yellow blue&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=250898">https://bugs.webkit.org/show_bug.cgi?id=250898</a>
&lt;rdar://problem/104475106&gt;

Reviewed by Sam Weinig.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html:

Add more tests for lists and |.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):

Always restore the state and continue when tokens don&apos;t match the syntax, or aren&apos;t consumed fully.

Canonical link: <a href="https://commits.webkit.org/259166@main">https://commits.webkit.org/259166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91739abb60a0b1058ac2733bc1ff87611f2ee4a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113391 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173681 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4186 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112450 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109950 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94109 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25721 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6635 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6770 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6315 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8553 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->