### PR TITLE
Incorrect paint of 'translate' property animation

### DIFF
--- a/LayoutTests/fast/repaint/translate-animation-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/translate-animation-repaint-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that an element with a 'translate' animation does not leave its unanimated paint state on screen.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(rect 0 0 100 100)
+(rect 200 0 100 100)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/translate-animation-repaint.html
+++ b/LayoutTests/fast/repaint/translate-animation-repaint.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+body {
+    margin: 0;
+    background-color: green;
+}
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+
+#cover {
+    position: absolute;
+    left: 100px;
+    top: 0;
+    right: 0;
+    height: 100%;
+    background-color: green;
+}
+
+</style>
+</head>
+<body>
+
+<div id="target"></div>
+<div id="cover" class="green"></div>
+
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+const repaintRectsFromString = (str) => {
+    const lines = str.split("\n");
+    lines.shift();
+    lines.pop();
+    return lines.map(line => line.trim());
+}
+
+(async function main() {
+    await UIHelper.renderingUpdate();
+    const target = document.getElementById("target");
+
+    window.internals?.startTrackingRepaints();
+    window.testRunner?.displayAndTrackRepaints();
+
+    const animation = target.animate({ translate: ["200px", "200px"] }, { duration: 1, fill: "forwards" });
+    await animation.finished;
+
+    if (window.internals) {
+        const repaintRects = repaintRectsFromString(window.internals?.repaintRectsAsText());
+        window.internals?.stopTrackingRepaints();
+
+        description("This test verifies that an element with a 'translate' animation does not leave its unanimated paint state on screen.");
+
+        // We log the first two repains because they're the relevant ones and some
+        // platforms will report more than 2.
+        debug(repaintRects[0]);
+        debug(repaintRects[1]);
+    }
+
+    finishJSTest();
+})();
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -429,7 +429,7 @@ bool RenderElement::repaintBeforeStyleChange(StyleDifference diff, const RenderS
         if (is<RenderLayerModelObject>(*this)) {
             // If we don't have a layer yet, but we are going to get one because of transform or opacity, then we need to repaint the old position of the object.
             bool hasLayer = downcast<RenderLayerModelObject>(*this).hasLayer();
-            bool willHaveLayer = newStyle.hasTransform() || newStyle.hasOpacity() || newStyle.hasFilter() || newStyle.hasBackdropFilter();
+            bool willHaveLayer = newStyle.affectsTransform() || newStyle.hasOpacity() || newStyle.hasFilter() || newStyle.hasBackdropFilter();
             if (!hasLayer && willHaveLayer)
                 return RequiredRepaint::RendererOnly;
         }


### PR DESCRIPTION
#### f55528510521414e5395a931109a5b9fe970b197
<pre>
Incorrect paint of &apos;translate&apos; property animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247299">https://bugs.webkit.org/show_bug.cgi?id=247299</a>
rdar://102064448

Reviewed by Simon Fraser.

When style changes, ensure we don&apos;t just check for the &quot;transform&quot; property
being set on the new style but any of the properties that contribute to a
transform being applied to the renderer when considering whether this renderer
will end up on a layer.

* LayoutTests/fast/repaint/translate-animation-repaint-expected.txt: Added.
* LayoutTests/fast/repaint/translate-animation-repaint.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintBeforeStyleChange):

Canonical link: <a href="https://commits.webkit.org/259173@main">https://commits.webkit.org/259173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6844def00fbf318070ac11a0cb95838ae493175c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113420 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173711 "Failed to checkout and rebase branch from PR 8879") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4214 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112478 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38734 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6662 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6797 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3656 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46657 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8581 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3351 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->