### PR TITLE
[GTK] Remove webkit_web_context_get/set_process_model from modern API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -64,6 +64,7 @@ typedef enum {
     WEBKIT_CACHE_MODEL_DOCUMENT_BROWSER
 } WebKitCacheModel;
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * WebKitProcessModel:
  * @WEBKIT_PROCESS_MODEL_SHARED_SECONDARY_PROCESS: Deprecated 2.26.
@@ -80,11 +81,14 @@ typedef enum {
  * Enum values used for determining the #WebKitWebContext process model.
  *
  * Since: 2.4
+ *
+ * Deprecated: 2.40
  */
 typedef enum {
     WEBKIT_PROCESS_MODEL_SHARED_SECONDARY_PROCESS,
     WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES,
 } WebKitProcessModel;
+#endif
 
 /**
  * WebKitURISchemeRequestCallback:
@@ -289,12 +293,14 @@ webkit_web_context_allow_tls_certificate_for_host   (WebKitWebContext           
                                                      GTlsCertificate               *certificate,
                                                      const gchar                   *host);
 
-WEBKIT_API void
+#if !ENABLE(2022_GLIB_API)
+WEBKIT_DEPRECATED void
 webkit_web_context_set_process_model                (WebKitWebContext              *context,
                                                      WebKitProcessModel             process_model);
 
-WEBKIT_API WebKitProcessModel
+WEBKIT_DEPRECATED WebKitProcessModel
 webkit_web_context_get_process_model                (WebKitWebContext              *context);
+#endif
 
 WEBKIT_API void
 webkit_web_context_initialize_notification_permissions

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -257,10 +257,6 @@ int main(int argc, char *argv[])
         webkit_cookie_manager_set_persistent_storage(cookieManager, cookiesFile, storageType);
     }
 
-    const char* singleprocess = g_getenv("MINIBROWSER_SINGLEPROCESS");
-    webkit_web_context_set_process_model(webContext, (singleprocess && *singleprocess) ?
-        WEBKIT_PROCESS_MODEL_SHARED_SECONDARY_PROCESS : WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES);
-
     WebKitUserContentManager* userContentManager = nullptr;
     if (contentFilter) {
         GFile* contentFilterFile = g_file_new_for_commandline_arg(contentFilter);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp
@@ -35,7 +35,6 @@ public:
         , m_webViewBusNames(numViews)
         , m_webViews(numViews)
     {
-        webkit_web_context_set_process_model(m_webContext.get(), WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES);
     }
 
     void initializeWebExtensions() override
@@ -171,7 +170,6 @@ public:
         : m_mainLoop(g_main_loop_new(nullptr, TRUE))
         , m_initializeWebExtensionsSignalCount(0)
     {
-        webkit_web_context_set_process_model(m_webContext.get(), WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES);
         m_webView = WEBKIT_WEB_VIEW(Test::createWebView(m_webContext.get()));
 #if PLATFORM(GTK)
         g_object_ref_sink(m_webView);
@@ -252,9 +250,6 @@ static void testMultiprocessWebViewCreateReadyClose(UIClientMultiprocessTest* te
 
 void beforeAll()
 {
-    // Check that default setting is the one stated in the documentation
-    g_assert_cmpuint(webkit_web_context_get_process_model(webkit_web_context_get_default()), ==, WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES);
-
     MultiprocessTest::add("WebKitWebContext", "process-per-web-view", testProcessPerWebView);
     UIClientMultiprocessTest::add("WebKitWebView", "multiprocess-create-ready-close", testMultiprocessWebViewCreateReadyClose);
 }


### PR DESCRIPTION
#### 236cbd390f687a3b1b00c76c97b277cdf44bbf50
<pre>
[GTK] Remove webkit_web_context_get/set_process_model from modern API
<a href="https://bugs.webkit.org/show_bug.cgi?id=240868">https://bugs.webkit.org/show_bug.cgi?id=240868</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextConstructed):
(webkit_web_context_set_process_model):
(webkit_web_context_get_process_model):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Tools/MiniBrowser/wpe/main.cpp:
(main):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp:
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/259218@main">https://commits.webkit.org/259218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a50d19a0324ac21dab600682f5e71e0b22fa6468

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113597 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4375 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96607 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112637 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110147 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93084 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6820 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12976 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6357 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8744 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->