### PR TITLE
Update generate-gpup-webgl and its output after 258127@main, 258650@main

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -46,8 +46,8 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
-    SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
-    SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle) NotStreamEncodable
+    void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
+    void SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
 #if ENABLE(MEDIA_STREAM)
     void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
@@ -55,7 +55,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
     void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t> data) -> (IPC::ArrayReference<uint8_t> data) Synchronous
     void ReadnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
-    void ReadnPixels2(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, WebKit::SharedMemory::Handle handle) -> (bool hadError) Synchronous NotStreamEncodable
+    void ReadnPixels2(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, WebKit::SharedMemory::Handle handle) -> (bool success) Synchronous NotStreamEncodable
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)
     void MultiDrawArraysInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> firstsCountsAandInstanceCounts)
     void MultiDrawElementsANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> countsAndOffsets, uint32_t type)

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -108,8 +108,10 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void GetError() -> (uint32_t returnValue) Synchronous
     void PaintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
     void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
-#if ENABLE(VIDEO)
-    void CopyTextureFromVideoFrame(WebKit::RemoteVideoFrameReadReference videoFrame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous
+#if ENABLE(VIDEO) && PLATFORM(COCOA)
+    void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
+    void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
+    void SetSharedVideoFrameMemory(WebKit::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
 #if ENABLE(MEDIA_STREAM)
     void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous


### PR DESCRIPTION
#### 6b2e0c8a8c007a262c37aae9d479f6e9f51a3957
<pre>
Update generate-gpup-webgl and its output after 258127@main, 258650@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=250904">https://bugs.webkit.org/show_bug.cgi?id=250904</a>

Reviewed by Kimmo Kinnunen.

Adjusting after 258127@main, generate-gpup-webgl generator is defining the
ReadnPixels2 message as returning a success boolean value, and the output
messages.in file should reflect that.

Adjusting after 258650@main, changes to the messages.in file are applied back to
the generate-gpup-webgl generator, covering the changed build guard, existing
CopyTextureFromVideoFrame message and the new SetSharedVideoFrameSemaphore and
SetSharedVideoFrameMemory messages.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/259204@main">https://commits.webkit.org/259204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af6c3cf417d654b9c8f67ffebb011edc750b8383

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113288 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173593 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4085 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112365 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94032 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38642 "Found 3 new test failures: imported/w3c/web-platform-tests/websockets/constructor/001.html, imported/w3c/web-platform-tests/websockets/constructor/001.html?wpt_flags=h2, imported/w3c/web-platform-tests/websockets/constructor/001.html?wss (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80299 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27020 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6684 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3559 "Found 2 new test failures: fast/images/avif-as-image.html, fast/images/background-image-relative-url-changes-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46555 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6344 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8461 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->