### PR TITLE
Web Inspector: Fonts Panel: ITAL variation axis slider has value of NaN

### DIFF
--- a/LayoutTests/inspector/model/font-styles-conversion-expected.txt
+++ b/LayoutTests/inspector/model/font-styles-conversion-expected.txt
@@ -1,0 +1,27 @@
+Tests for WI.FontStyles.Conversion
+
+
+== Running test suite: WI.FontStyles.Conversion
+-- Running test case: WI.FontStyles.Conversion.axisValueToFontPropertyValue
+PASS: Mapping "wdth" 100 to font-stretch: 100%
+PASS: Mapping "slnt" 0 to font-style: oblique 0deg
+PASS: Mapping "slnt" 14 to font-style: oblique 14deg
+PASS: Mapping "ital" 0 to font-style: normal
+PASS: Mapping "ital" 1 to font-style: italic
+PASS: Mapping "ital" 99 to font-style: italic
+PASS: Mapping "xxxx" 99 to xxxx: 99
+
+-- Running test case: WI.FontStyles.Conversion.fontPropertyValueToAxisValue
+PASS: Mapping font-stretch: 100% to "wdth" 100
+PASS: Mapping font-stretch: 99.9% to "wdth" 99.9
+PASS: Mapping font-style: normal to "slnt" 0
+PASS: Mapping font-style: italic to "slnt" 14
+PASS: Mapping font-style: oblique to "slnt" 14
+PASS: Mapping font-style: oblique -99.9deg to "slnt" -99.9
+PASS: Mapping font-style: oblique to "ital" 1
+PASS: Mapping font-style: italic to "ital" 1
+PASS: Mapping font-style: oblique 0deg to "ital" 0
+PASS: Mapping font-style: oblique 14deg to "ital" 1
+PASS: Mapping font-style: oblique 99.9deg to "ital" 1
+PASS: Mapping xxxx: 99.9 to "xxxx" 99.9
+

--- a/LayoutTests/inspector/model/font-styles-conversion.html
+++ b/LayoutTests/inspector/model/font-styles-conversion.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+
+function test()
+{
+    let suite = InspectorTest.createSyncSuite("WI.FontStyles.Conversion");
+
+    suite.addTestCase({
+        name: "WI.FontStyles.Conversion.axisValueToFontPropertyValue",
+        description: "Check that font variation axis values map to appropriate font CSS properties values.",
+        test() {
+            const tests = [
+                {
+                    "tag": "wdth",
+                    "property": "font-stretch",
+                    "value": 100,
+                    "expected": "100%",
+                },
+                {
+                    "tag": "slnt",
+                    "property": "font-style",
+                    "value": 0,
+                    "expected": "oblique 0deg",
+                },
+                {
+                    "tag": "slnt",
+                    "property": "font-style",
+                    "value": 14,
+                    "expected": "oblique 14deg",
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": 0,
+                    "expected": "normal",
+                },                
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": 1,
+                    "expected": "italic",
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": 99,
+                    "expected": "italic",
+                },
+                {
+                    "tag": "xxxx",
+                    "property": "xxxx",
+                    "value": 99,
+                    "expected": 99,
+                },
+            ];
+
+            for (let {tag, property, value, expected} of tests) {
+                InspectorTest.expectEqual(WI.FontStyles.axisValueToFontPropertyValue(tag, value), expected, `Mapping "${tag}" ${value} to ${property}: ${expected}`);
+            }
+        },
+    });
+
+    suite.addTestCase({
+        name: "WI.FontStyles.Conversion.fontPropertyValueToAxisValue",
+        description: "Check that font CSS property values map to appropriate font variation axis values.",
+        test() {
+            const tests = [
+                {
+                    "tag": "wdth",
+                    "property": "font-stretch",
+                    "value": "100%",
+                    "expected": 100,
+                },
+                {
+                    "tag": "wdth",
+                    "property": "font-stretch",
+                    "value": "99.9%",
+                    "expected": 99.9,
+                },
+                {
+                    "tag": "slnt",
+                    "property": "font-style",
+                    "value": "normal",
+                    "expected": 0,
+                },
+                {
+                    "tag": "slnt",
+                    "property": "font-style",
+                    "value": "italic",
+                    "expected": 14,
+                },
+                {
+                    "tag": "slnt",
+                    "property": "font-style",
+                    "value": "oblique",
+                    "expected": 14,
+                },
+                {
+                    "tag": "slnt",
+                    "property": "font-style",
+                    "value": "oblique -99.9deg",
+                    "expected": -99.9,
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": "oblique",
+                    "expected": 1,
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": "italic",
+                    "expected": 1,
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": "oblique 0deg",
+                    "expected": 0,
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": "oblique 14deg",
+                    "expected": 1,
+                },
+                {
+                    "tag": "ital",
+                    "property": "font-style",
+                    "value": "oblique 99.9deg",
+                    "expected": 1,
+                },
+                {
+                    "tag": "xxxx",
+                    "property": "xxxx",
+                    "value": 99.9,
+                    "expected": 99.9,
+                },
+            ];
+
+            for (let {tag, property, value, expected} of tests) {
+                InspectorTest.expectEqual(WI.FontStyles.fontPropertyValueToAxisValue(tag, value), expected, `Mapping ${property}: ${value} to "${tag}" ${expected}`);
+            }
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+</head>
+<body onload="runTest();">
+<p>Tests for WI.FontStyles.Conversion</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/FontStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/FontStyles.js
@@ -77,6 +77,8 @@ WI.FontStyles = class FontStyles
             return `${value}%`;
         case "slnt":
             return `oblique ${value}deg`;
+        case "ital":
+            return value >= 1 ? "italic" : "normal";
         default:
             return value;
         }
@@ -87,15 +89,25 @@ WI.FontStyles = class FontStyles
         switch (tag) {
         case "wdth":
             return parseFloat(value);
+        case "ital":
         case "slnt":
+            // See: https://w3c.github.io/csswg-drafts/css-fonts/#valdef-font-style-oblique-angle--90deg-90deg
+            const obliqueAngleDefaultValue = 14;
+
             if (value === "normal")
                 return 0;
 
-            if (value === "oblique")
-                return 14;
+            if (tag === "ital" && (value === "oblique" || value === "italic"))
+                return 1;
+
+            if (tag === "slnt" && (value === "oblique" || value === "italic"))
+                return obliqueAngleDefaultValue;
 
             let degrees = value.match(/oblique (?<degrees>-?\d+(\.\d+)?)deg/)?.groups?.degrees;
-            if (degrees)
+            if (degrees && tag === "ital")
+                return parseFloat(degrees) >= obliqueAngleDefaultValue ? 1 : 0; // The `ital` variation axis acts as an on/off toggle (0 = off, 1 = on).
+
+            if (degrees && tag === "slnt")
                 return parseFloat(degrees);
 
             console.assert(false, `Unexpected font property value associated with variation axis ${tag}`, value);

--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
@@ -48,7 +48,7 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
         this._inputRangeElement.min = minimumValue;
         this._inputRangeElement.max = maximumValue;
         this._inputRangeElement.value = value ?? defaultValue;
-        this._inputRangeElement.step = this._getAxisResolution(minimumValue, maximumValue);
+        this._inputRangeElement.step = this._getAxisResolution(minimumValue, maximumValue, tag);
 
         this._variationMinValueElement = this._variationRangeElement.appendChild(document.createElement("div"));
         this._variationMinValueElement.className = "variation-minvalue";
@@ -126,12 +126,16 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
         return value.toLocaleString(undefined, options);
     }
 
-    _getAxisResolution(min, max)
+    _getAxisResolution(min, max, tag)
     {
+        // The `ital` variation axis acts as an on/off toggle (0 = off, 1 = on).
+        if (tag === "ital" && min === 0 && max === 1)
+            return 1;
+
         let delta = max - min;
         if (delta <= 1)
             return 0.01;
-        
+
         if (delta <= 10)
             return 0.1;
 


### PR DESCRIPTION
#### c58b326609c90f5e3f07a21a6e2dce4dfd112904
<pre>
Web Inspector: Fonts Panel: ITAL variation axis slider has value of NaN
<a href="https://bugs.webkit.org/show_bug.cgi?id=250906">https://bugs.webkit.org/show_bug.cgi?id=250906</a>

Reviewed by Patrick Angle.

The value of the `font-style` CSS property maps to either
`ITAL` or `SLNT` font variation axes when available.

`font-style: normal` should equate to `ITAL: 0`.
This case wasn&apos;t handled for the `ITAL` axis.

* LayoutTests/inspector/model/font-styles-conversion-expected.txt: Added.
* LayoutTests/inspector/model/font-styles-conversion.html: Added.
* Source/WebInspectorUI/UserInterface/Models/FontStyles.js:
(WI.FontStyles.axisValueToFontPropertyValue):
(WI.FontStyles.fontPropertyValueToAxisValue):
* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js:
(WI.FontVariationDetailsSectionRow):
(WI.FontVariationDetailsSectionRow.prototype._getAxisResolution):

Canonical link: <a href="https://commits.webkit.org/259351@main">https://commits.webkit.org/259351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f4934a4eb84a3d8eac701f428245acdeadc8526

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113976 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4709 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112904 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110462 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108171 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80723 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7133 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92594 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7239 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30154 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103525 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13286 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101280 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6447 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9026 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->