### PR TITLE
SharedWorkerGlobalScope.close() does not then allow the SharedWorker to be replaced

### DIFF
--- a/LayoutTests/http/wpt/shared-workers/relaunch-after-close-expected.txt
+++ b/LayoutTests/http/wpt/shared-workers/relaunch-after-close-expected.txt
@@ -1,0 +1,31 @@
+CONSOLE MESSAGE: PAGE 2:     Attempting to boot the shared worker
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'connected'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker connected
+CONSOLE MESSAGE: PAGE 2:     Telling the SharedWorker to shutdown
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'shutdown'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker successfully shutdown
+CONSOLE MESSAGE: PAGE 2:     Attempting to boot the shared worker
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'connected'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker connected
+CONSOLE MESSAGE: PAGE 2:     Telling the SharedWorker to shutdown
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'shutdown'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker successfully shutdown
+CONSOLE MESSAGE: PAGE 2:     Attempting to boot the shared worker
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'connected'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker connected
+CONSOLE MESSAGE: PAGE 2:     Telling the SharedWorker to shutdown
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'shutdown'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker successfully shutdown
+CONSOLE MESSAGE: PAGE 2:     Attempting to boot the shared worker
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'connected'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker connected
+CONSOLE MESSAGE: PAGE 2:     Telling the SharedWorker to shutdown
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'shutdown'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker successfully shutdown
+CONSOLE MESSAGE: PAGE 2:     Attempting to boot the shared worker
+CONSOLE MESSAGE: PAGE 2:     Received message from worker: 'connected'
+CONSOLE MESSAGE: PAGE 2:     SharedWorker connected
+CONSOLE MESSAGE: PAGE 2: PASS: Successfully shutdown and reconstructed the SharedWorker many times
+
+PASS Shared worker should be able to relaunch after calling SharedWorkerGlobalScope.close()
+

--- a/LayoutTests/http/wpt/shared-workers/relaunch-after-close.html
+++ b/LayoutTests/http/wpt/shared-workers/relaunch-after-close.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/relaunch-after-close-window.js"></script>
+</head>
+<body>
+<script>
+
+promise_test(async (t) => {
+    const worker = new SharedWorker('resources/relaunch-after-close-sharedworker.js');
+
+    await beginTestForPage1();
+    w = open("resources/relaunch-after-close-page2.html");
+
+    return new Promise((resolve, reject) => {
+        window.addEventListener("result", (e) => {
+            assert_equals(e.data, "PASS: Successfully shutdown and reconstructed the SharedWorker many times");
+            resolve();
+        });
+    });
+}, "Shared worker should be able to relaunch after calling SharedWorkerGlobalScope.close()");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-page2.html
+++ b/LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-page2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="relaunch-after-close-window.js"></script>
+</head>
+<body>
+<script>
+onload = () => {
+    beginTestForPage2();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-sharedworker.js
+++ b/LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-sharedworker.js
@@ -1,0 +1,56 @@
+const connections = new Set()
+
+self.onconnect = e => {
+  const port = e.ports[0]
+  const ref = new WeakRef(port)
+
+  port.onmessage = e => {
+    if (e.data === 'shutdown') {
+      shutdown()
+    }
+  }
+
+  connections.add(ref)
+  port.postMessage('connected')
+}
+
+function shutdown() {
+  broadcast('shutdown')
+
+  try {
+    for (const ref of connections) {
+      const port = ref.deref()
+
+      if (port) {
+        try {
+          port.onmessage = null
+          port.close()
+        } catch { }
+      }
+    }
+  } finally {
+    self.close()
+  }
+}
+
+function broadcast(msg) {
+  for (const ref of connections) {
+    sendMessageToPortRef(ref, msg)
+  }
+}
+
+function sendMessageToPortRef(ref, msg) {
+  const port = ref.deref()
+  let failed = false
+
+  try {
+    port?.postMessage(msg)
+  } catch {
+    failed = true
+  }
+
+  if (!port || failed) {
+    connections.delete(ref)
+  }
+}
+

--- a/LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-window.js
+++ b/LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-window.js
@@ -1,0 +1,132 @@
+let sharedWorker
+let count = 0
+const messageLogger = e => { log(`    Received message from worker: '${e.data}'`) }
+
+function testComplete(result) {
+  opener.dispatchEvent(new MessageEvent("result", { data: result }))
+}
+
+// TESTS
+async function beginTestForPage1() {
+  if (!await initSharedWorker('resources/relaunch-after-close-sharedworker.js')) { return }
+
+  // Prepare for when Page 2 will shutdown the SharedWorker
+  const shutdownListener = e => {
+    if (e.data === 'shutdown') {
+      sharedWorker.port.removeEventListener('message', shutdownListener)
+      disonnectFromSharedWorker()
+    }
+  }
+
+  sharedWorker.port.addEventListener('message', shutdownListener)
+}
+
+async function beginTestForPage2() {
+  if (!await initSharedWorker('relaunch-after-close-sharedworker.js')) { return }
+
+  while (count < 5) {
+    if (!await tellSharedWorkerToShutdown()) { return }
+    // NOTE: 1000 is arbitrary
+    await wait(500)
+    if (!await initSharedWorker('relaunch-after-close-sharedworker.js')) { return }
+  }
+
+  log('PASS: Successfully shutdown and reconstructed the SharedWorker many times')
+  testComplete("PASS: Successfully shutdown and reconstructed the SharedWorker many times")
+}
+
+// UTILITY FUNCTIONS
+async function initSharedWorker(workerURL) {
+  count += 1
+  log('    Attempting to boot the shared worker')
+
+  const def = deferredWithTimeout(3000)
+
+  sharedWorker = new SharedWorker(workerURL)
+
+  const connectedListener = e => {
+    if (e.data === 'connected') {
+      def.resolve()
+    }
+  }
+
+  sharedWorker.port.addEventListener('message', messageLogger)
+  sharedWorker.port.addEventListener('message', connectedListener)
+  sharedWorker.port.start()
+
+  try {
+    await def.promise
+    log('    SharedWorker connected')
+    return true
+  } catch {
+    log('FAIL: SharedWorker failed to connect')
+    if (window.opener)
+        testComplete("FAIL: SharedWorker failed to connect")
+    return false
+  } finally {
+    sharedWorker.port.removeEventListener('message', connectedListener)
+  }
+}
+
+function disonnectFromSharedWorker() {
+  sharedWorker.port.removeEventListener('message', messageLogger)
+  sharedWorker.port.close()
+  sharedWorker = null
+}
+
+async function tellSharedWorkerToShutdown() {
+  if (!sharedWorker) { return }
+
+  log('    Telling the SharedWorker to shutdown')
+
+  const def = deferredWithTimeout(3000)
+
+  const shutdownListener = e => {
+    if (e.data === 'shutdown') {
+      def.resolve()
+    }
+  }
+
+  sharedWorker.port.addEventListener('message', shutdownListener)
+  sharedWorker.port.postMessage('shutdown')
+
+  try {
+    await def.promise
+    log('    SharedWorker successfully shutdown')
+    return true
+  } catch {
+    log('FAIL: SharedWorker timed out during shutdown')
+    if (window.opener)
+      testComplete("FAIL: SharedWorker timed out during shutdown")
+    return false
+  } finally {
+    sharedWorker.port.removeEventListener('message', shutdownListener)
+    disonnectFromSharedWorker()
+  }
+}
+
+function log(msg) {
+  if (opener)
+    opener.console.log("PAGE 2: " + msg);
+}
+
+function deferredWithTimeout(amount) {
+  let resolve, reject
+
+  const promise = new Promise((re, rej) => {
+    resolve = re
+    reject = rej
+    setTimeout(() => rej(new Error('timeout')), amount)
+  })
+
+  return {
+    resolve,
+    reject,
+    promise
+  }
+}
+
+async function wait(amount) {
+  return await deferredWithTimeout(amount).promise.catch(() => {})
+}
+

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
@@ -50,13 +50,14 @@ public:
         virtual ~Connection() { }
         virtual void establishConnection(CompletionHandler<void()>&&) = 0;
         virtual void postExceptionToWorkerObject(SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) = 0;
+        virtual void sharedWorkerTerminated(SharedWorkerIdentifier) = 0;
         bool isClosed() const { return m_isClosed; }
 
     protected:
         void setAsClosed() { m_isClosed = true; }
 
         // IPC message handlers.
-        WEBCORE_EXPORT void postConnectEvent(SharedWorkerIdentifier, TransferredMessagePort&&, String&& sourceOrigin);
+        WEBCORE_EXPORT void postConnectEvent(SharedWorkerIdentifier, TransferredMessagePort&&, String&& sourceOrigin, CompletionHandler<void(bool)>&&);
         WEBCORE_EXPORT void terminateSharedWorker(SharedWorkerIdentifier);
         WEBCORE_EXPORT void suspendSharedWorker(SharedWorkerIdentifier);
         WEBCORE_EXPORT void resumeSharedWorker(SharedWorkerIdentifier);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -67,6 +67,7 @@ public:
     void suspendForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
     void resumeForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
     void postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
+    void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier);
 
     void terminateContextConnectionWhenPossible(const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);
     void addContextConnection(WebSharedWorkerServerToContextConnection&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -61,7 +61,7 @@ public:
     void terminateWhenPossible() { m_shouldTerminateWhenPossible = true; }
 
     void launchSharedWorker(WebSharedWorker&);
-    void postConnectEvent(const WebSharedWorker&, const WebCore::TransferredMessagePort&);
+    void postConnectEvent(const WebSharedWorker&, const WebCore::TransferredMessagePort&, CompletionHandler<void(bool)>&&);
     void terminateSharedWorker(const WebSharedWorker&);
 
     void suspendSharedWorker(WebCore::SharedWorkerIdentifier);
@@ -80,6 +80,7 @@ private:
 
     // IPC messages.
     void postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
+    void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier);
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
@@ -22,4 +22,5 @@
 
 messages -> WebSharedWorkerServerToContextConnection NotRefCounted {
     PostExceptionToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL)
+    SharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
 }

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -139,4 +139,10 @@ void WebSharedWorkerContextManagerConnection::close()
     WebProcess::singleton().enableTermination();
 }
 
+void WebSharedWorkerContextManagerConnection::sharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
+{
+    RELEASE_LOG(SharedWorker, "WebSharedWorkerContextManagerConnection::sharedWorkerTerminated: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
+    m_connectionToNetworkProcess->send(Messages::WebSharedWorkerServerToContextConnection::SharedWorkerTerminated { sharedWorkerIdentifier }, 0);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
@@ -54,6 +54,7 @@ public:
 
     void establishConnection(CompletionHandler<void()>&&) final;
     void postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) final;
+    void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier) final;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
@@ -22,7 +22,7 @@
 
 messages -> WebSharedWorkerContextManagerConnection NotRefCounted {
     LaunchSharedWorker(struct WebCore::ClientOrigin origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, struct WebCore::WorkerOptions workerOptions, struct WebCore::WorkerFetchResult workerFetchResult, struct WebCore::WorkerInitializationData workerInitializationData)
-    PostConnectEvent(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::TransferredMessagePort port, String sourceOrigin)
+    PostConnectEvent(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::TransferredMessagePort port, String sourceOrigin) -> (bool success)
     TerminateSharedWorker(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
     UpdatePreferencesStore(struct WebKit::WebPreferencesStore store)
     SetUserAgent(String userAgent)


### PR DESCRIPTION
#### 76527da41c8016eef5fc6f722377cd71f4d7ce47
<pre>
SharedWorkerGlobalScope.close() does not then allow the SharedWorker to be replaced
<a href="https://bugs.webkit.org/show_bug.cgi?id=250839">https://bugs.webkit.org/show_bug.cgi?id=250839</a>
rdar://problem/104481929

Reviewed by Youenn Fablet.

Shared workers are usually terminated once all their clients go away and the
NetworkProcess is in charge of this.

However, the shared worker can also choose to terminate itself by calling
`self.close()`. In this case, we were failing to notify the network process
that the shared worker had terminated. As a result, when a shared worker
connection request would come in later on, the network process would still
direct it towards the existing (now terminated) shared worker.

To address this issue, we now IPC back from the shared worker process to the
network process when a shared worker gets terminated. This allows the network
process state to remain up-to-date and to make more accurate decisions.

However, doing only this would still be flaky since there can be a race between
the NetworkProcess receiving the IPC about a shared worker being terminated
and a new connection request received by the NetworkProcess. To address this,
I now added a CompletionHandler to the PostConnectEvent IPC from the
NetworkProcess to the SharedWorker process, indicating if we managed to connect
this SharedWorker object to the existing SharedWorker context. In case of
failure, we clean the state in the NetworkProcess and re-attempt the connection,
which will relaunch a SharedWorker.

* LayoutTests/http/wpt/shared-workers/relaunch-after-close-expected.txt: Added.
* LayoutTests/http/wpt/shared-workers/relaunch-after-close.html: Added.
* LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-page2.html: Added.
* LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-sharedworker.js: Added.
(shutdown):
(broadcast):
(sendMessageToPortRef):
* LayoutTests/http/wpt/shared-workers/resources/relaunch-after-close-window.js: Added.
(testComplete):
(async beginTestForPage1):
(async beginTestForPage2):
(async initSharedWorker):
(disonnectFromSharedWorker):
(async tellSharedWorkerToShutdown):
(log):
(deferredWithTimeout):
(async wait):
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp:
(WebCore::SharedWorkerContextManager::stopSharedWorker):
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::sharedWorkerTerminated):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::sharedWorkerTerminated):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::sharedWorkerTerminated):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h:

Canonical link: <a href="https://commits.webkit.org/259228@main">https://commits.webkit.org/259228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb4debf8e0f5680b42d3a4eb390a1e752aa5c2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113602 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173896 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4380 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112642 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110152 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94291 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25902 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6825 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6955 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6361 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8749 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->