### PR TITLE
WKWebViews should correctly indicate whether passkeys are available

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -55,7 +55,7 @@ String BasicCredential::type() const
 void BasicCredential::isConditionalMediationAvailable(Document& document, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
     if (auto* page = document.page())
-        page->authenticatorCoordinator().isConditionalMediationAvailable(WTFMove(promise));
+        page->authenticatorCoordinator().isConditionalMediationAvailable(document, WTFMove(promise));
     else
         promise.reject(Exception { InvalidStateError });
 }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -289,7 +289,7 @@ void AuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable(con
 }
 
 
-void AuthenticatorCoordinator::isConditionalMediationAvailable(DOMPromiseDeferred<IDLBoolean>&& promise) const
+void AuthenticatorCoordinator::isConditionalMediationAvailable(const Document& document, DOMPromiseDeferred<IDLBoolean>&& promise) const
 {
     if (!m_client)  {
         promise.reject(Exception { UnknownError, "Unknown internal error."_s });
@@ -300,7 +300,7 @@ void AuthenticatorCoordinator::isConditionalMediationAvailable(DOMPromiseDeferre
         promise.resolve(result);
     };
     // Async operations are dispatched and handled in the messenger.
-    m_client->isConditionalMediationAvailable(WTFMove(completionHandler));
+    m_client->isConditionalMediationAvailable(document.securityOrigin(), WTFMove(completionHandler));
 }
 
 void AuthenticatorCoordinator::resetUserGestureRequirement()

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
@@ -64,7 +64,7 @@ public:
     void create(const Document&, const PublicKeyCredentialCreationOptions&, WebAuthn::Scope, RefPtr<AbortSignal>&&, CredentialPromise&&);
     void discoverFromExternalSource(const Document&, CredentialRequestOptions&&, const ScopeAndCrossOriginParent&, CredentialPromise&&);
     void isUserVerifyingPlatformAuthenticatorAvailable(const Document&, DOMPromiseDeferred<IDLBoolean>&&) const;
-    void isConditionalMediationAvailable(DOMPromiseDeferred<IDLBoolean>&&) const;
+    void isConditionalMediationAvailable(const Document&, DOMPromiseDeferred<IDLBoolean>&&) const;
 
     void resetUserGestureRequirement();
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h
@@ -62,7 +62,7 @@ public:
 
     virtual void makeCredential(const Frame&, const SecurityOrigin&, const Vector<uint8_t>&, const PublicKeyCredentialCreationOptions&, RequestCompletionHandler&&) = 0;
     virtual void getAssertion(const Frame&, const SecurityOrigin&, const Vector<uint8_t>&, const PublicKeyCredentialRequestOptions&, MediationRequirement, const ScopeAndCrossOriginParent&, RequestCompletionHandler&&) = 0;
-    virtual void isConditionalMediationAvailable(QueryCompletionHandler&&) = 0;
+    virtual void isConditionalMediationAvailable(const SecurityOrigin&, QueryCompletionHandler&&) = 0;
     virtual void isUserVerifyingPlatformAuthenticatorAvailable(const SecurityOrigin&, QueryCompletionHandler&&) = 0;
 
     virtual void resetUserGestureRequirement() { }

--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -30,6 +30,7 @@
 @interface ASCWebKitSPISupport : NSObject
 @property (class, nonatomic) BOOL shouldUseAlternateCredentialStore;
 + (BOOL)arePasskeysDisallowedForRelyingParty:(nonnull NSString *)relyingParty;
++ (BOOL)canCurrentProcessAccessPasskeysForRelyingParty:(nonnull NSString *)relyingParty;
 @end
 
 // FIXME: Most of the forward declarations below should be behind a non-Apple-internal SDK compile-time flag.

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -124,7 +124,7 @@ void WebAuthenticatorCoordinatorProxy::isUserVerifyingPlatformAuthenticatorAvail
     handler(LocalService::isAvailable());
 }
 
-void WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(QueryCompletionHandler&& handler)
+void WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(const SecurityOriginData&, QueryCompletionHandler&& handler)
 {
     handler(false);
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -74,7 +74,7 @@ private:
     void makeCredential(WebCore::FrameIdentifier, FrameInfoData&&, Vector<uint8_t>&& hash, WebCore::PublicKeyCredentialCreationOptions&&, bool processingUserGesture, RequestCompletionHandler&&);
     void getAssertion(WebCore::FrameIdentifier, FrameInfoData&&, Vector<uint8_t>&& hash, WebCore::PublicKeyCredentialRequestOptions&&, WebCore::CredentialRequestOptions::MediationRequirement, std::optional<WebCore::SecurityOriginData>, bool processingUserGesture, RequestCompletionHandler&&);
     void isUserVerifyingPlatformAuthenticatorAvailable(const WebCore::SecurityOriginData&, QueryCompletionHandler&&);
-    void isConditionalMediationAvailable(QueryCompletionHandler&&);
+    void isConditionalMediationAvailable(const WebCore::SecurityOriginData&, QueryCompletionHandler&&);
 
     void handleRequest(WebAuthenticationRequestData&&, RequestCompletionHandler&&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
@@ -28,7 +28,7 @@ messages -> WebAuthenticatorCoordinatorProxy NotRefCounted {
 
     MakeCredential(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, Vector<uint8_t> hash, struct WebCore::PublicKeyCredentialCreationOptions options, bool processingUserGesture) -> (struct WebCore::AuthenticatorResponseData data, enum:int WebCore::AuthenticatorAttachment attachment, struct WebCore::ExceptionData exception)
     GetAssertion(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, Vector<uint8_t> hash, struct WebCore::PublicKeyCredentialRequestOptions options, enum:uint8_t WebCore::CredentialRequestOptions::MediationRequirement mediation, std::optional<WebCore::SecurityOriginData> parentOrigin, bool processingUserGesture) -> (struct WebCore::AuthenticatorResponseData data, enum:int WebCore::AuthenticatorAttachment attachment, struct WebCore::ExceptionData exception)
-    isConditionalMediationAvailable() -> (bool result)
+    isConditionalMediationAvailable(struct WebCore::SecurityOriginData origin) -> (bool result)
     IsUserVerifyingPlatformAuthenticatorAvailable(struct WebCore::SecurityOriginData origin) -> (bool result)
 }
 

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
@@ -86,9 +86,9 @@ void WebAuthenticatorCoordinator::getAssertion(const Frame& frame, const Securit
     m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetAssertion(webFrame->frameID(), webFrame->info(), hash, options, mediation, scopeAndCrossOriginParent.second, isProcessingUserGesture), WTFMove(handler));
 }
 
-void WebAuthenticatorCoordinator::isConditionalMediationAvailable(QueryCompletionHandler&& handler)
+void WebAuthenticatorCoordinator::isConditionalMediationAvailable(const SecurityOrigin& origin, QueryCompletionHandler&& handler)
 {
-    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(), WTFMove(handler));
+    m_webPage.sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(origin.data()), WTFMove(handler));
 };
 
 void WebAuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable(const SecurityOrigin& origin, QueryCompletionHandler&& handler)

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
@@ -42,7 +42,7 @@ private:
     // WebCore::AuthenticatorCoordinatorClient
     void makeCredential(const WebCore::Frame&, const WebCore::SecurityOrigin&, const Vector<uint8_t>&, const WebCore::PublicKeyCredentialCreationOptions&, WebCore::RequestCompletionHandler&&) final;
     void getAssertion(const WebCore::Frame&, const WebCore::SecurityOrigin&, const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, WebCore::MediationRequirement, const std::pair<WebAuthn::Scope, std::optional<WebCore::SecurityOriginData>>&, WebCore::RequestCompletionHandler&&) final;
-    void isConditionalMediationAvailable(WebCore::QueryCompletionHandler&&) final;
+    void isConditionalMediationAvailable(const WebCore::SecurityOrigin&, WebCore::QueryCompletionHandler&&) final;
     void isUserVerifyingPlatformAuthenticatorAvailable(const WebCore::SecurityOrigin&, WebCore::QueryCompletionHandler&&) final;
     void resetUserGestureRequirement() final { m_requireUserGesture = false; }
 


### PR DESCRIPTION
#### 0cf1f113fe36d059f9b6f5f1daa5a08c3c332805
<pre>
WKWebViews should correctly indicate whether passkeys are available
<a href="https://bugs.webkit.org/show_bug.cgi?id=250912">https://bugs.webkit.org/show_bug.cgi?id=250912</a>
rdar://104194528

Reviewed by J Pascoe.

isConditionalMediationAvailable and isUserVerifyingPlatformAuthenticatorAvailable
now check if either the client is an entitled web browser or the relying party
is in the client&apos;s associated domains and return false if neither are true.

Existing checks are performed after this new check.

To accomplish this, Document from BasicCredential is now plumbed through to
AuthenticatorCoordinator and SecurityOriginData is then passed to
WebAuthenticatorCoordinatorProxy.

* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
(WebCore::BasicCredential::isConditionalMediationAvailable):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::isConditionalMediationAvailable const):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h:
* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in:
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp:
(WebKit::WebAuthenticatorCoordinator::isConditionalMediationAvailable):
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/259253@main">https://commits.webkit.org/259253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cfd12f0f161f76cee99d54daa1b2d1750dd7b2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113641 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173933 "Failed to checkout and rebase branch from PR 8891") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4420 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112678 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38874 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25926 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6992 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46841 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6378 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8786 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->