### PR TITLE
imported/w3c/web-platform-tests/mimesniff/mime-types/charset-parameter.window.html  is flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mimesniff/mime-types/resources/mime-charset.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/mimesniff/mime-types/resources/mime-charset.py
@@ -12,6 +12,7 @@ def main(request, response):
     output = b"HTTP/1.1 200 OK\r\n"
     output += b"Content-Length: " + isomorphic_encode(str(len(content))) + b"\r\n"
     output += b"Content-Type: " + request.GET.first(b"type") + b"\r\n"
+    output += b"Connection: close\r\n"
     output += b"\r\n"
     output += content
     response.writer.write(output)

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2322,8 +2322,6 @@ webkit.org/b/244297 [ Release arm64 ] svg/transforms/transformed-text-fill-gradi
 imported/w3c/web-platform-tests/clear-site-data/navigation-insecure.html [ Skip ]
 imported/w3c/web-platform-tests/clear-site-data/resource.html [ Skip ]
 
-webkit.org/b/244639 [ Release arm64 ] imported/w3c/web-platform-tests/mimesniff/mime-types/charset-parameter.window.html [ Pass Failure ]
-
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-databases-opaque-origin.html [ Pass Failure ]
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-deleteDatabase-opaque-origin.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1964,8 +1964,6 @@ webkit.org/b/219965 [ BigSur+ ] imported/w3c/web-platform-tests/fetch/content-ty
 
 webkit.org/b/217621 media/video-buffering-allowed.html [ Pass Timeout ]
 
-webkit.org/b/220332 [ BigSur+ ] imported/w3c/web-platform-tests/mimesniff/mime-types/charset-parameter.window.html [ Pass Failure ]
-
 # The system font does not handle all the various width values on older OSes.
 [ BigSur ] fast/text/system-font-width-4.html [ ImageOnlyFailure ]
 [ BigSur ] fast/text/system-font-width-6.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### baa5398261183ae8dc22b4629002a14fbb5f312e
<pre>
imported/w3c/web-platform-tests/mimesniff/mime-types/charset-parameter.window.html  is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=250917">https://bugs.webkit.org/show_bug.cgi?id=250917</a>
rdar://99409762

Reviewed by Tim Nguyen.

imported/w3c/web-platform-tests/mimesniff/mime-types/charset-parameter.window.html
is flaky on Cocoa ports due to loads intermittently failing with a
cfurlErrorNetworkConnectionLost error.

I shown the logs to the CFNetwork team and the error occurs when trying to reuse
connections. It seems the server doesn&apos;t support reusing connection and we reach
a retry limit in CFNetwork (rdar://100873042).

I believe the reason we&apos;re unable to reuse the connection is because the python
script uses `response.close_connection = True`. The recommendation from the
CFNetwork team is for the python script to also send the `Connection: close`
header so that CFNetwork doesn&apos;t attempt to reuse it.

I tried the suggested change and it seems to address the flakiness locally.

* LayoutTests/imported/w3c/web-platform-tests/mimesniff/mime-types/resources/mime-charset.py:
(main):

Canonical link: <a href="https://commits.webkit.org/259159@main">https://commits.webkit.org/259159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0daf1d7afcda60e4e511796e3dc2d0157273e40a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113324 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173626 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4121 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112393 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109886 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/10995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38664 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6573 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46578 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6309 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8492 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->