### PR TITLE
Scroll through content hidden with clip-path does not propagate below

### DIFF
--- a/LayoutTests/fast/scrolling/mac/event-region-clip-path-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/event-region-clip-path-expected.txt
@@ -1,0 +1,328 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 897.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 897.00)
+      (contentsOpaque 1)
+      (children 5
+        (GraphicsLayer
+          (position 28.00 33.00)
+          (bounds 202.00 402.00)
+          (drawsContent 1)
+          (mask layer)
+            (GraphicsLayer
+              (bounds 202.00 402.00)
+            )
+          (event region
+            (rect (0,0) width=202 height=202)
+          )
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 185.00 385.00)
+              (event region
+                (rect (0,0) width=185 height=385)
+              )
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 185.00 770.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=770)
+                  )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 200.00 400.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 385.00)
+                  (bounds 185.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=15)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 0.00)
+                  (bounds 15.00 385.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=385)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 385.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=15)
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 270.00 33.00)
+          (bounds 202.00 402.00)
+          (drawsContent 1)
+          (mask layer)
+            (GraphicsLayer
+              (bounds 202.00 402.00)
+            )
+          (event region
+            (rect (40,10) width=160 height=160)
+          )
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 185.00 385.00)
+              (event region
+                (rect (0,0) width=185 height=385)
+              )
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 185.00 770.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=770)
+                  )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 200.00 400.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 385.00)
+                  (bounds 185.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=15)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 0.00)
+                  (bounds 15.00 385.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=385)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 385.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=15)
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 512.00 33.00)
+          (bounds 202.00 402.00)
+          (drawsContent 1)
+          (mask layer)
+            (GraphicsLayer
+              (bounds 202.00 402.00)
+            )
+          (event region
+            (rect (0,10) width=202 height=160)
+          )
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 185.00 385.00)
+              (event region
+                (rect (0,0) width=185 height=385)
+              )
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 185.00 770.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=770)
+                  )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 200.00 400.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 385.00)
+                  (bounds 185.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=15)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 0.00)
+                  (bounds 15.00 385.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=385)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 385.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=15)
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 28.00 475.00)
+          (bounds 202.00 402.00)
+          (drawsContent 1)
+          (mask layer)
+            (GraphicsLayer
+              (bounds 202.00 402.00)
+            )
+          (event region
+            (rect (0,20) width=182 height=181)
+          )
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 185.00 385.00)
+              (event region
+                (rect (0,0) width=185 height=385)
+              )
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 185.00 770.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=770)
+                  )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 200.00 400.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 385.00)
+                  (bounds 185.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=15)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 0.00)
+                  (bounds 15.00 385.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=385)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 385.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=15)
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 270.00 475.00)
+          (bounds 202.00 402.00)
+          (drawsContent 1)
+          (mask layer)
+            (GraphicsLayer
+              (bounds 202.00 402.00)
+            )
+          (event region
+            (rect (80,40) width=80 height=80)
+          )
+          (children 2
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 185.00 385.00)
+              (event region
+                (rect (0,0) width=185 height=385)
+              )
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 185.00 770.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=770)
+                  )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 200.00 400.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 385.00)
+                  (bounds 185.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=185 height=15)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 0.00)
+                  (bounds 15.00 385.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=385)
+                  )
+                )
+                (GraphicsLayer
+                  (position 185.00 385.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
+                  (event region
+                    (rect (0,0) width=15 height=15)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/fast/scrolling/mac/event-region-clip-path.html
+++ b/LayoutTests/fast/scrolling/mac/event-region-clip-path.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .box {
+            float: left;
+            margin: 20px;
+            width: 200px;
+            height: 400px;
+            overflow: scroll;
+            border: 1px solid black;
+            background-color: silver;
+        }
+        
+        .content {
+            height: 200%;
+        }
+        
+        .composited {
+            transform: translateZ(0);
+        }
+        
+    </style>
+<script>
+    window.onload = function () {
+        if (!window.internals)
+            return;
+
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const results = document.getElementById('results');
+        results.innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION);
+    }
+</script>
+</head>
+<body>
+    <div class="composited box" style="clip-path: inset(0 0 200px 0);"><div class="content"></div></div>
+    <div class="composited box" style="clip-path: circle(80px at 120px 90px);"><div class="content"></div></div>
+    <div class="composited box" style="clip-path: ellipse(120px 80px at 120px 90px);"><div class="content"></div></div>
+    <div class="composited box" style="clip-path: polygon(nonzero, 10% 5%, 80% 15%, 90% 50%, 0% 50%);"><div class="content"></div></div>
+    <div class="composited box" style="clip-path: path(evenodd, 'M100,40l20,0 0,60 20,0 0,-20 -60,0 0,-20 80,0 0,60 -60,0 0,-80z')"><div class="content"></div></div>
+<pre id="results"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -29,9 +29,11 @@
 #include "ElementAncestorIterator.h"
 #include "HTMLFormControlElement.h"
 #include "Logging.h"
+#include "Path.h"
 #include "RenderBox.h"
 #include "RenderStyle.h"
 #include "SimpleRange.h"
+#include "WindRule.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -66,6 +68,13 @@ void EventRegionContext::pushClip(const IntRect& clipRect)
         m_clipStack.append(transformedClip);
     else
         m_clipStack.append(intersection(m_clipStack.last(), transformedClip));
+}
+
+void EventRegionContext::pushClip(const Path& path, WindRule)
+{
+    // FIXME: Approximate paths better.
+    auto pathBounds = enclosingIntRect(path.boundingRect());
+    pushClip(pathBounds);
 }
 
 void EventRegionContext::popClip()

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -38,8 +38,10 @@
 namespace WebCore {
 
 class EventRegion;
+class Path;
 class RenderObject;
 class RenderStyle;
+enum class WindRule : uint8_t;
 
 class EventRegionContext {
 public:
@@ -49,6 +51,7 @@ public:
     void popTransform();
 
     void pushClip(const IntRect&);
+    void pushClip(const Path&, WindRule);
     void popClip();
 
     void unite(const Region&, RenderObject&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
@@ -90,6 +93,14 @@ public:
         ASSERT(!m_pushedClip);
         if (m_context)
             m_context->pushClip(clipRect);
+        m_pushedClip = true;
+    }
+
+    void pushClip(const Path& path, WindRule windRule)
+    {
+        ASSERT(!m_pushedClip);
+        if (m_context)
+            m_context->pushClip(path, windRule);
         m_pushedClip = true;
     }
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1074,7 +1074,7 @@ private:
 
     std::pair<Path, WindRule> computeClipPath(const LayoutSize& offsetFromRoot, const LayoutRect& rootRelativeBoundsForNonBoxes) const;
 
-    void setupClipPath(GraphicsContext&, GraphicsContextStateSaver&, const LayerPaintingInfo&, const LayoutSize& offsetFromRoot);
+    void setupClipPath(GraphicsContext&, GraphicsContextStateSaver&, EventRegionContextStateSaver&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayoutSize& offsetFromRoot);
 
     void ensureLayerFilters();
     void clearLayerFilters();


### PR DESCRIPTION
#### 96deabf28dd062279a8949990fa8f42b215714d7
<pre>
Scroll through content hidden with clip-path does not propagate below
<a href="https://bugs.webkit.org/show_bug.cgi?id=233084">https://bugs.webkit.org/show_bug.cgi?id=233084</a>
rdar://85634077

Reviewed by Antti Koivisto.

Failing to take clip-path into account for event region building results
in async scrolling failing to find the right target in some configurations.

This is an initial fix which uses the clip path bounding-box to clip
the event region, for non-reference clip-paths. RenderLayer::setupClipPath()
is enhanced to apply the event-region clip, passing a EventRegionContextStateSaver
to correctly pop the clip.

EventRegion and EventRegionContextStateSaver gain `pushClip(const Path&amp;, WindRule)`,
which for now just use the bounding box of the path. Rasterizing the path into
a Region is complex code which will have to be done later.

* LayoutTests/fast/scrolling/mac/event-region-clip-path-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/event-region-clip-path.html: Added.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::pushClip):
* Source/WebCore/rendering/EventRegion.h:
(WebCore::EventRegionContextStateSaver::pushClip):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupClipPath):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::collectEventRegionForFragments):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/259368@main">https://commits.webkit.org/259368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/885dbd82eea929ce3ed49b2d085140af06a62a32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113326 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173628 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4123 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112395 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38669 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80326 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6575 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27047 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3588 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46585 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6455 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8494 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->