### PR TITLE
Fix crash due to overflow when calculating area

### DIFF
--- a/LayoutTests/fast/text/text-selection-direction-overflow-crash-expected.txt
+++ b/LayoutTests/fast/text/text-selection-direction-overflow-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash.

--- a/LayoutTests/fast/text/text-selection-direction-overflow-crash.html
+++ b/LayoutTests/fast/text/text-selection-direction-overflow-crash.html
@@ -1,0 +1,15 @@
+<style>
+.classA { rotate: 60deg; min-height: 38%; font-size: 1px; display: inline-flex; -webkit-transform: translate(0px, 0px) scale(83); clip-path: polygon(0px 0px, 1px 0px); scale: 0.29403306255747363 32 7; -webkit-transform-origin: top left; }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+function testCase() {
+    try { textElement.selectionDirection = String.fromCodePoint(738995, 91741); } catch(e) { }
+}
+</script>
+<body onload=testCase()>
+<button id="buttonElement" class="classA"></button>
+<textarea id="textElement">Foo</textarea>
+<p>PASS if no crash.</p>
+</body>

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -792,7 +792,7 @@ Vector<FloatRect> WebPage::getEvasionRectsAroundSelection(const Vector<WebCore::
             continue;
 
         auto bounds = frameView->contentsToRootView(renderer->absoluteBoundingBoxRect());
-        auto area = bounds.area();
+        auto area = bounds.area<RecordOverflow>();
         if (area.hasOverflowed() || area > contextMenuAreaLimit)
             continue;
 


### PR DESCRIPTION
#### 637ee2cbc292f7e56a688f0fac932cab9a61dba1
<pre>
Fix crash due to overflow when calculating area
<a href="https://bugs.webkit.org/show_bug.cgi?id=250918">https://bugs.webkit.org/show_bug.cgi?id=250918</a>
rdar://104479890

Reviewed by David Kilzer.

The code in getEvasionRectsAroundSelection already has the logic to deal
with overflows, so we shoudn&apos;t crash in that case, and let the code
proceed to do the right thing.

* LayoutTests/fast/text/text-selection-direction-overflow-crash-expected.txt: Added.
* LayoutTests/fast/text/text-selection-direction-overflow-crash.html: Added.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getEvasionRectsAroundSelection const):

Canonical link: <a href="https://commits.webkit.org/259254@main">https://commits.webkit.org/259254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/278a3649fa2fe25548938c8a2584561b784404a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113337 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173637 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4135 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112404 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38674 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80331 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6586 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27051 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3594 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46589 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6381 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8504 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->