### PR TITLE
[JSC] Remove Wasm::PinnedRegisterInfo

### DIFF
--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -1066,14 +1066,14 @@ AssemblyHelpers::JumpList AssemblyHelpers::branchIfValue(VM& vm, JSValueRegs val
 void AssemblyHelpers::loadWasmContextInstance(GPRReg dst)
 {
     JIT_COMMENT(*this, "Load wasm context instance to ", dst);
-    move(Wasm::PinnedRegisterInfo::get().wasmContextInstancePointer, dst);
+    move(GPRInfo::wasmContextInstancePointer, dst);
     JIT_COMMENT(*this, "Load wasm instance done");
 }
 
 void AssemblyHelpers::storeWasmContextInstance(GPRReg src)
 {
     JIT_COMMENT(*this, "Store wasm context instance from", src);
-    move(src, Wasm::PinnedRegisterInfo::get().wasmContextInstancePointer);
+    move(src, GPRInfo::wasmContextInstancePointer);
     JIT_COMMENT(*this, "Store wasm context instance done");
 }
 

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -487,6 +487,9 @@ public:
 #if !OS(WINDOWS)
     static constexpr GPRReg wasmScratchGPR1 = X86Registers::r10;
 #endif
+    static constexpr GPRReg wasmContextInstancePointer = regCS0;
+    static constexpr GPRReg wasmBaseMemoryPointer = regCS3;
+    static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS4;
 
     // FIXME: I believe that all uses of this are dead in the sense that it just causes the scratch
     // register allocator to select a different register and potentially spill things. It would be better
@@ -586,6 +589,12 @@ public:
     static constexpr GPRReg nonPreservedNonReturnGPR = ARMRegisters::r5;
     static constexpr GPRReg nonPreservedNonArgumentGPR0 = ARMRegisters::r5;
     static constexpr GPRReg nonPreservedNonArgumentGPR1 = InvalidGPRReg;
+
+    static constexpr GPRReg wasmScratchGPR0 = regT5;
+    static constexpr GPRReg wasmScratchGPR1 = regT6;
+    static constexpr GPRReg wasmContextInstancePointer = regCS0;
+    static constexpr GPRReg wasmBaseMemoryPointer = InvalidGPRReg;
+    static constexpr GPRReg wasmBoundsCheckingSizeRegister = InvalidGPRReg;
 
     static GPRReg toRegister(unsigned index)
     {
@@ -688,6 +697,9 @@ public:
     static constexpr GPRReg wasmScratchGPR1 = ARM64Registers::x10;
     static constexpr GPRReg wasmScratchGPR2 = ARM64Registers::x11;
     static constexpr GPRReg wasmScratchGPR3 = ARM64Registers::x12;
+    static constexpr GPRReg wasmContextInstancePointer = regCS0;
+    static constexpr GPRReg wasmBaseMemoryPointer = regCS3;
+    static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS4;
 
     // GPRReg mapping is direct, the machine register numbers can
     // be used directly as indices into the GPR RegisterBank.
@@ -886,6 +898,9 @@ public:
 
     static constexpr GPRReg wasmScratchGPR0 = RISCV64Registers::x6; // regT9
     static constexpr GPRReg wasmScratchGPR1 = RISCV64Registers::x7; // regT10
+    static constexpr GPRReg wasmContextInstancePointer = regCS0;
+    static constexpr GPRReg wasmBaseMemoryPointer = regCS3;
+    static constexpr GPRReg wasmBoundsCheckingSizeRegister = regCS4;
 
     static constexpr GPRReg patchpointScratchRegister = RISCV64Registers::x30; // Should match dataTempRegister
 

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -421,6 +421,22 @@ RegisterSet RegisterSetBuilder::allScalarRegisters()
     return result;
 }
 
+#if ENABLE(WEBASSEMBLY)
+RegisterSet RegisterSetBuilder::wasmPinnedRegisters(MemoryMode memoryMode)
+{
+    RegisterSet result;
+    if constexpr (GPRInfo::wasmBaseMemoryPointer != InvalidGPRReg)
+        result.add(GPRInfo::wasmBaseMemoryPointer, IgnoreVectors);
+    if constexpr (GPRInfo::wasmContextInstancePointer != InvalidGPRReg)
+        result.add(GPRInfo::wasmContextInstancePointer, IgnoreVectors);
+    if constexpr (GPRInfo::wasmBoundsCheckingSizeRegister != InvalidGPRReg) {
+        if (memoryMode == MemoryMode::BoundsChecking)
+            result.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
+    }
+    return result;
+}
+#endif
+
 } // namespace JSC
 
 #endif // ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -30,6 +30,7 @@
 #include "FPRInfo.h"
 #include "GPRInfo.h"
 #include "MacroAssembler.h"
+#include "MemoryMode.h"
 #include "Reg.h"
 #include "Width.h"
 #include <wtf/Bitmap.h>
@@ -207,6 +208,9 @@ public:
     JS_EXPORT_PRIVATE static RegisterSet ftlCalleeSaveRegisters(); // Registers that might be saved and used by the FTL JIT.
     JS_EXPORT_PRIVATE static RegisterSet stubUnavailableRegisters(); // The union of callee saves and special registers.
     JS_EXPORT_PRIVATE static RegisterSet argumentGPRS();
+#if ENABLE(WEBASSEMBLY)
+    JS_EXPORT_PRIVATE static RegisterSet wasmPinnedRegisters(MemoryMode);
+#endif
     JS_EXPORT_PRIVATE static RegisterSetBuilder registersToSaveForJSCall(RegisterSetBuilder live);
     JS_EXPORT_PRIVATE static RegisterSetBuilder registersToSaveForCCall(RegisterSetBuilder live);
 };

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
@@ -938,15 +938,14 @@ Tmp AirIRGenerator32::emitCatchImpl(CatchKind kind, ControlType& data, unsigned 
     patch->resultConstraints.append(B3::ValueRep::reg(GPRInfo::returnValueGPR));
     patch->resultConstraints.append(B3::ValueRep::SomeRegister);
     patch->resultConstraints.append(B3::ValueRep::SomeRegister); // result Tag
-    GPRReg wasmContextInstanceGPR = m_wasmContextInstanceGPR;
-    patch->setGenerator([=] (CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+    patch->setGenerator([=](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
         AllowMacroScratchRegisterUsage allowScratch(jit);
         // Returning one EncodedJSValue on the stack
         constexpr int32_t resultSpace = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(static_cast<int32_t>(sizeof(EncodedJSValue)));
         jit.subPtr(CCallHelpers::TrustedImm32(resultSpace), MacroAssembler::stackPointerRegister);
         jit.move(params[3].gpr(), GPRInfo::argumentGPR0);
         jit.move(MacroAssembler::stackPointerRegister, GPRInfo::argumentGPR1);
-        jit.prepareWasmCallOperation(wasmContextInstanceGPR);
+        jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
         CCallHelpers::Call call = jit.call(OperationPtrTag);
         jit.addLinkTask([call] (LinkBuffer& linkBuffer) {
             linkBuffer.link<OperationPtrTag>(call, operationWasmRetrieveAndClearExceptionIfCatchable);

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
@@ -33,34 +33,6 @@
 
 namespace JSC { namespace Wasm {
 
-const PinnedRegisterInfo& PinnedRegisterInfo::get()
-{
-    static LazyNeverDestroyed<PinnedRegisterInfo> staticPinnedRegisterInfo;
-    static std::once_flag staticPinnedRegisterInfoFlag;
-    std::call_once(staticPinnedRegisterInfoFlag, [] () {
-#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
-        GPRReg baseMemoryPointer = GPRInfo::regCS3;
-        GPRReg boundsCheckingSizeRegister = GPRInfo::regCS4;
-#elif CPU(ARM)
-        // Not enough registers. regCS0 is the wasm instance, regCS1 is LLInt PB
-        GPRReg baseMemoryPointer = InvalidGPRReg;
-        GPRReg boundsCheckingSizeRegister = InvalidGPRReg;
-#endif
-        GPRReg wasmContextInstancePointer = GPRInfo::regCS0;
-
-        staticPinnedRegisterInfo.construct(boundsCheckingSizeRegister, baseMemoryPointer, wasmContextInstancePointer);
-    });
-
-    return staticPinnedRegisterInfo.get();
-}
-
-PinnedRegisterInfo::PinnedRegisterInfo(GPRReg boundsCheckingSizeRegister, GPRReg baseMemoryPointer, GPRReg wasmContextInstancePointer)
-    : boundsCheckingSizeRegister(boundsCheckingSizeRegister)
-    , baseMemoryPointer(baseMemoryPointer)
-    , wasmContextInstancePointer(wasmContextInstancePointer)
-{
-}
-
 MemoryInformation::MemoryInformation(PageCount initial, PageCount maximum, bool isShared, bool isImport)
     : m_initial(initial)
     , m_maximum(maximum)

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
@@ -43,29 +43,6 @@ struct PinnedSizeRegisterInfo {
     unsigned sizeOffset;
 };
 
-class PinnedRegisterInfo {
-public:
-    PinnedRegisterInfo(GPRReg, GPRReg, GPRReg);
-
-    static const PinnedRegisterInfo& get();
-
-    RegisterSetBuilder toSave(MemoryMode mode) const
-    {
-        RegisterSetBuilder result;
-        if (baseMemoryPointer != InvalidGPRReg)
-            result.add(baseMemoryPointer, IgnoreVectors);
-        if (wasmContextInstancePointer != InvalidGPRReg)
-            result.add(wasmContextInstancePointer, IgnoreVectors);
-        if (mode == MemoryMode::BoundsChecking && boundsCheckingSizeRegister != InvalidGPRReg)
-            result.add(boundsCheckingSizeRegister, IgnoreVectors);
-        return result;
-    }
-
-    GPRReg boundsCheckingSizeRegister;
-    GPRReg baseMemoryPointer;
-    GPRReg wasmContextInstancePointer;
-};
-
 class MemoryInformation {
 public:
     MemoryInformation()

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -274,7 +274,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe::Context&
     OSREntryData& osrEntryData = *context.arg<OSREntryData*>();
     uint32_t functionIndex = osrEntryData.functionIndex();
     uint32_t loopIndex = osrEntryData.loopIndex();
-    Instance* instance = context.gpr<Instance*>(Wasm::PinnedRegisterInfo::get().wasmContextInstancePointer);
+    Instance* instance = context.gpr<Instance*>(GPRInfo::wasmContextInstancePointer);
 
     auto returnWithoutOSREntry = [&] {
         context.gpr(GPRInfo::argumentGPR0) = 0;


### PR DESCRIPTION
#### 4dae653b23bef55b7cb3cd3b4f74cbd9e53208af
<pre>
[JSC] Remove Wasm::PinnedRegisterInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=250920">https://bugs.webkit.org/show_bug.cgi?id=250920</a>
rdar://104496000

Reviewed by Mark Lam.

This patch removes Wasm::PinnedRegisterInfo since we no longer have TLS version.
So, these register information can be defined at compile time. We should just define them in GPRInfo,
easy to read what is specified in each architecture.

* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadWasmContextInstance):
(JSC::AssemblyHelpers::storeWasmContextInstance):
* Source/JavaScriptCore/jit/GPRInfo.h:
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::wasmPinnedRegisters):
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::AirIRGeneratorBase):
(JSC::Wasm::ExpressionType&gt;::restoreWebAssemblyGlobalState):
(JSC::Wasm::ExpressionType&gt;::addCall):
(JSC::Wasm::ExpressionType&gt;::emitIndirectCall):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::B3IRGenerator):
(JSC::Wasm::B3IRGenerator::restoreWebAssemblyGlobalState):
(JSC::Wasm::B3IRGenerator::emitIndirectCall):
(JSC::Wasm::B3IRGenerator::addCall):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
(JSC::Wasm::wasmToWasm):
* Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp:
(JSC::Wasm::PinnedRegisterInfo::get): Deleted.
(JSC::Wasm::PinnedRegisterInfo::PinnedRegisterInfo): Deleted.
* Source/JavaScriptCore/wasm/WasmMemoryInformation.h:
(JSC::Wasm::PinnedRegisterInfo::toSave const): Deleted.
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::materializeImportJSCell):
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::calleeSaves const):
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):

Canonical link: <a href="https://commits.webkit.org/259161@main">https://commits.webkit.org/259161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3d215ef6305f2ef96e3bc29b39bfe269a44dd07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13251 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113369 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4166 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112430 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109929 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/92880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90745 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6751 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12760 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/99356 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8533 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/24996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3346 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->