### PR TITLE
AudioBufferSourceNode.start with duration fails sometimes

### DIFF
--- a/LayoutTests/webaudio/audiobuffersource-start-when-in-past-expected.txt
+++ b/LayoutTests/webaudio/audiobuffersource-start-when-in-past-expected.txt
@@ -1,0 +1,11 @@
+Tests AudioBufferSourceNode starts immediately if the `when` value passed to start() is in the past.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS First half of the rendered data is identical to the source buffer
+PASS Second half of the rendered data is identical to the source buffer as well
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/audiobuffersource-start-when-in-past.html
+++ b/LayoutTests/webaudio/audiobuffersource-start-when-in-past.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="resources/audio-testing.js"></script>
+<script src="resources/audiobuffersource-testing-legacy.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests AudioBufferSourceNode starts immediately if the `when` value passed to start() is in the past.");
+jsTestIsAsync = true;
+
+const numberOfFrames = 256;
+const sourceBufferSize = numberOfFrames / 2;
+const sampleRate = 44100.;
+
+let context = new OfflineAudioContext(1, numberOfFrames, sampleRate);
+let source = null;
+
+function createSourceNode()
+{
+    if (source) {
+        source.disconnect();
+        source.stop();
+    }
+    source = context.createBufferSource();
+    source.buffer = createTestBuffer(context, numberOfFrames / 2);
+    source.loop = true;
+    source.connect(context.destination);
+    source.start(0, 0, sourceBufferSize / sampleRate);
+}
+
+function convertToRegularJSArray(data, offset, count)
+{
+    let array = new Array();
+    let outputIndex = 0;
+    for (let i = offset; i < offset + count; ++i)
+        array[outputIndex++] = data[i];
+    return array;
+}
+
+context.suspend(sourceBufferSize / sampleRate).then(() => {
+    createSourceNode();
+    context.resume();
+});
+createSourceNode();
+context.startRendering().then((renderBuffer) => {
+    let renderedData = renderBuffer.getChannelData(0);
+    let expectedData = source.buffer.getChannelData(0);
+    let success = true;
+    for (var i = 0; i < expectedData.length; ++i) {
+        if (expectedData[i] != renderedData[i]) {
+            var s = "First half: expected: " + convertToRegularJSArray(expectedData, 0, sourceBufferSize) + " actual: " + convertToRegularJSArray(renderedData, 0, sourceBufferSize);
+            testFailed(s);
+            success = false;
+            break;
+        }
+    }
+    if (success)
+        testPassed("First half of the rendered data is identical to the source buffer");
+    
+    success = true;
+    for (var i = 0; i < expectedData.length; ++i) {
+        if (expectedData[i] != renderedData[sourceBufferSize + i]) {
+            var s = "Second half: expected: " + convertToRegularJSArray(expectedData, 0, sourceBufferSize) + " actual: " + convertToRegularJSArray(renderedData, sourceBufferSize, sourceBufferSize);
+            testFailed(s);
+            success = false;
+            break;
+        }
+    }
+    if (success)
+        testPassed("Second half of the rendered data is identical to the source buffer as well");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -505,7 +505,10 @@ ExceptionOr<void> AudioBufferSourceNode::startPlaying(double when, double grainO
     m_grainOffset = grainOffset;
     m_grainDuration = grainDuration.value_or(0);
     m_wasGrainDurationGiven = !!grainDuration;
-    m_startTime = when;
+
+    // If 0 is passed in for |when| or if the value is less than currentTime, then the sound will start playing immediately.
+    // https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start-when-offset-duration-when
+    m_startTime = std::max(when, context().currentTime());
 
     adjustGrainParameters();
 


### PR DESCRIPTION
#### 703601b447f8e4b1b26265e13e5941f4916d3526
<pre>
AudioBufferSourceNode.start with duration fails sometimes
<a href="https://bugs.webkit.org/show_bug.cgi?id=248658">https://bugs.webkit.org/show_bug.cgi?id=248658</a>
rdar://103178030

Reviewed by Eric Carlson and Jer Noble.

Per the specification [1], if you call AudioBufferNode.start() with a `when`
value that is less than the AudioContext&apos;s currentTime, it should start
immediately.

Previously, we were missing this logic, causing the AudioBufferNode to not
start if the `when` value was in the past.

[1] <a href="https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start-when-offset-duration-when">https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start-when-offset-duration-when</a>

* LayoutTests/webaudio/audiobuffersource-start-when-in-past-expected.txt: Added.
* LayoutTests/webaudio/audiobuffersource-start-when-in-past.html: Added.
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::startPlaying):

Canonical link: <a href="https://commits.webkit.org/259234@main">https://commits.webkit.org/259234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00e1cab9a4f5b8bb7cc5bf84603abe2bb724768e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113344 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173642 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4142 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112409 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38679 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80337 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6730 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3597 "Found 1 new test failure: fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46599 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8511 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3365 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->