### PR TITLE
style-checker: Disallow raw pointers and references for member variables

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1020,6 +1020,44 @@ class CppStyleTest(CppStyleTestBase):
                 , llaa_(laa_) { }''',
             '')
 
+    def test_runtime_raw_pointer(self):
+        self.assert_lint(
+            'void* m_member;',
+            'Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]')
+        self.assert_lint(
+            'void& m_member',
+                'Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]')
+        self.assert_lint(
+            'const Document& m_member { nullptr };',
+            'Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]')
+        self.assert_lint(
+            'Document* m_member { nullptr };',
+            'Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]')
+        self.assert_lint(
+            'HashMap<String, SomeType*> m_member;',
+            'Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]')
+        self.assert_lint(
+            'HashMap<Element*, OtherType> m_member;',
+            'Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]')
+        self.assert_lint(
+            'HashMap<String, String> m_member;',
+            '')
+        self.assert_lint(
+            'HashSet<String> m_member;',
+            '')
+        self.assert_lint(
+            'return (*m_string)[m_offset];',
+            '')
+        self.assert_lint(
+            'const LChar* characters8 = m_string->characters8();',
+            '')
+
     def test_runtime_rtti(self):
         statement = 'int* x = dynamic_cast<int*>(&foo);'
         error_message = (
@@ -1926,18 +1964,24 @@ class CppStyleTest(CppStyleTestBase):
     def test_retainptr_pointer(self):
         self.assert_lint(
             '''RetainPtr<CFRunLoopRef*> m_cfRunLoop;''',
+            ['Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]',
             'RetainPtr<> should never contain a type with \'*\'. Correct: RetainPtr<NSString>, RetainPtr<CFStringRef>.'
-            '  [runtime/retainptr] [5]')
+            '  [runtime/retainptr] [5]'])
         self.assert_lint('RetainPtr<CFRunLoopRef> m_cfRunLoop;', '')
         self.assert_lint(
             '''RetainPtr<NSRunLoop*> m_nsRunLoop;''',
+            ['Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]',
             'RetainPtr<> should never contain a type with \'*\'. Correct: RetainPtr<NSString>, RetainPtr<CFStringRef>.'
-            '  [runtime/retainptr] [5]')
+            '  [runtime/retainptr] [5]'])
         self.assert_lint('RetainPtr<NSRunLoop> m_nsRunLoop;', '')
         self.assert_lint(
             '''RetainPtr<NSMutableArray<NSDictionary *> *> m_editorStateHistory;''',
+            ['Member variable should be one of smart pointer types (Ref, RefPtr, CheckedRef, CheckedPtr, WeakPtr, or ThreadSafeWeakPtr).'
+            '  [runtime/raw_pointer] [1]',
             'RetainPtr<> should never contain a type with \'*\'. Correct: RetainPtr<NSString>, RetainPtr<CFStringRef>.'
-            '  [runtime/retainptr] [5]')
+            '  [runtime/retainptr] [5]'])
         self.assert_lint(
             '''RetainPtr<NSDictionary<NSString *, NSArray<NSString *>> *> dictionary;''',
             'RetainPtr<> should never contain a type with \'*\'. Correct: RetainPtr<NSString>, RetainPtr<CFStringRef>.'


### PR DESCRIPTION
#### 95c808624173fc6463e7005e70510d05a18f6400
<pre>
style-checker: Disallow raw pointers and references for member variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=250924">https://bugs.webkit.org/show_bug.cgi?id=250924</a>

Reviewed by NOBODY (OOPS!).

Detect &amp; warn the use of raw pointers and references in data members.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_member_raw_pointer):
(check_braces):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95c808624173fc6463e7005e70510d05a18f6400

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104150 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113360 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173652 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4158 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112421 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38688 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107636 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80346 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6607 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3608 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46611 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8524 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->