### PR TITLE
Call CFArrayGetCount instead of deprecated SecTrustGetCertificateCount

### DIFF
--- a/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
@@ -41,10 +41,14 @@ bool certificatesMatch(SecTrustRef trust1, SecTrustRef trust2)
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
     auto chain1 = adoptCF(SecTrustCopyCertificateChain(trust1));
     auto chain2 = adoptCF(SecTrustCopyCertificateChain(trust2));
-#endif
 
+    CFIndex count1 = CFArrayGetCount(chain1.get());
+    CFIndex count2 = CFArrayGetCount(chain2.get());
+#else
     CFIndex count1 = SecTrustGetCertificateCount(trust1);
     CFIndex count2 = SecTrustGetCertificateCount(trust2);
+#endif
+
     if (count1 != count2)
         return false;
 

--- a/Source/WebCore/platform/network/cocoa/CertificateInfoCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CertificateInfoCocoa.mm
@@ -33,13 +33,15 @@ void CertificateInfo::dump() const
 {
 #if PLATFORM(COCOA)
     if (m_trust) {
-        CFIndex entries = SecTrustGetCertificateCount(trust().get());
 
-        NSLog(@"CertificateInfo SecTrust\n");
-        NSLog(@"  Entries: %ld\n", entries);
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
         auto chain = adoptCF(SecTrustCopyCertificateChain(trust().get()));
+        CFIndex entries = CFArrayGetCount(chain.get());
+#else
+        CFIndex entries = SecTrustGetCertificateCount(trust().get());
 #endif
+        NSLog(@"CertificateInfo SecTrust\n");
+        NSLog(@"  Entries: %ld\n", entries);
         for (CFIndex i = 0; i < entries; ++i) {
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
             RetainPtr<CFStringRef> summary = adoptCF(SecCertificateCopySubjectSummary(checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), i))));


### PR DESCRIPTION
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c967b9c08305c84ca43db881d098e2a1c73e2597

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114515 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174703 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5256 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97570 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111011 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7764 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47521 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9553 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->