### PR TITLE
Implement margin-trim for floats in block containers that contain only block boxes.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6251,6 +6251,8 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/module.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.html [ Skip ]
 
+webkit.org/b/252183 imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html [ ImageOnlyFailure ]
+
 #Skipping text-spacing tests until the features get implemented.
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-computed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-invalid.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-deeply-nested-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-deeply-nested-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html style="outline: 5px solid red;">
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<title>margin-trim: block-container-float-block-end-deeply-nested</title>
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Deeply nested float with many offsets in between should trim block end margin up to content">
+</head>
+<body>
+<div style="border: 10px solid black; padding: 20px;">
+    <div style="height: 50px; background-color: green"></div>
+    <div style="border: 25px solid purple">
+        <div style="width: 50px; height: 50px; background-color: blue; float: right; margin-block-end: 200px;"></div>
+        <div style="width: 50px; height: 50px; background-color: red;"></div>
+    </div>
+    <div style="border: 30px solid gray;">
+        <div style="height: 50px; background-color: yellow;"></div>
+        <div style="border: 5px solid orange;">
+            <div style="height: 25px; background-color: green"></div>
+            <div style="border: 15px solid purple;">
+                <div style="background-color: pink; height: 10px;"></div>
+                <div style="height: 25px; background-color: red"></div>   
+                <div style="width: 50px; height: 50px; background-color: orange; float: right;"></div>
+                <div style="width: 50px; height: 25px; background-color: blue"></div> 
+            </div> 
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-deeply-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-deeply-nested.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html style="outline: 5px solid red;">
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-deeply-nested</title>
+<meta name="assert" content="Deeply nested float with many offsets in between should trim block end margin up to content">
+</head>
+<body>
+<div style="border: 10px solid black; padding: 20px;">
+    <div style="height: 50px; background-color: green"></div>
+    <div style="margin-trim: block; border: 25px solid purple">
+        <div style="width: 50px; height: 50px; background-color: blue; float: right; margin-block-end: 800px"></div>
+        <div style="width: 50px; height: 50px; background-color: red;"></div>
+    </div>
+    <div style="border: 30px solid gray;">
+        <div style="height: 50px; background-color: yellow;"></div>
+        <div style="border: 5px solid orange;">
+            <div style="height: 25px; background-color: green"></div>
+            <div style="margin-trim: block; border: 15px solid purple;">
+                <div style="background-color: pink; height: 10px;"></div>
+                <div style="height: 25px; background-color: red"></div>   
+                <div style="width: 50px; height: 50px; background-color: orange; float: right; margin-block-end: 300px"></div>
+                <div style="width: 50px; height: 25px; background-color: blue"></div> 
+            </div> 
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr</title>
+<meta name="assert" content="block-end of a float should have its margin trimmed up to the content in its BFC">
+<style>
+container {
+    display: flow-root;
+    inline-size: 100px;
+    background-color: green;
+    writing-mode: vertical-lr;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 40px;
+}
+.float {
+    float: left;
+    block-size: 10px;
+    background-color: green;
+    margin-block-end: 45px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item></item>
+<div style="border: 10px solid green; margin-trim: block;">
+<item class="float"></item>
+</div>
+<item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-end-up-to-content-block-layout-different-containers</title>
+<meta name="assert" content="block-end of a float should have its margin trimmed up to the content in its BFC">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    background-color: green;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 40px;
+}
+.float {
+    float: right;
+    height: 30px;
+    background-color: green;
+    margin-block-end: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item></item>
+<div style="border: 10px solid green; margin-trim: block;">
+<item class="float"></item>
+</div>
+<item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end of a float should have its margin trimmed up to the content in its BFC">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    margin-trim: block-end;
+    background-color: green;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-block-start: 50px;
+}
+.float {
+    float: right;
+    height: 30px;
+    margin-block-end: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="float"></item>
+<item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    border: 1px solid black;
+}
+item {
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    border: 1px solid black;
+    margin-trim: block-start;
+}
+item {
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    margin-block-start: 10px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-relative-positioned-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-relative-positioned-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Relative positioned float should have its margins trimmed normally">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-relative-positioned.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-relative-positioned.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-start-relative-positioned</title>
+<meta name="assert" content="Relative positioned float should have its margins trimmed normally">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.relative-float {
+    float: left;
+    position: relative;
+    top: 50px;
+    margin-block-start: 100px;
+}
+</style>
+</head>
+</html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="relative-float"></item>
+<item></item>
+</container>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-with-transforms-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-with-transforms-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<title>margin-trim: block-container-float-block-start-with-transforms</title>
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-with-transforms.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-with-transforms.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-block-start-with-transforms</title>
+<meta name="assert" content="Float with transforms should get its margins trimmed normally">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.rotated-float {
+    float: right;
+    transform: rotate(90deg);
+    margin-block-start: 100px;
+}
+</style>
+</head>
+</html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="rotated-float"></item>
+<item></item>
+<item style="width: 100px;"></item>
+</container>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-fit-content-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-fit-content-block-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-fit-content-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-fit-content-block-layout.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="trimmed margins for a float should not contribute to its block container's intrinsic sizing">
+<style>
+container {
+    display: block;
+    width: fit-content;
+    margin-trim: inline;
+    background-color: green;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 100px;
+}
+.float {
+    float: right;
+    margin-inline: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="float"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+.float {
+    float: right;
+    margin-inline-end: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="float"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge">
+<style>
+container {
+    display: block;
+    width: min-content;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+.float {
+    float: left;
+    margin-inline-start: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="float"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr</title>
+<meta name="assert" content="trimmed inline margins for first float should allow second float to sit at same top offset">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 100px;
+    block-size: 50px;
+    background-color: green;
+}
+.floating-item {
+  float: left;
+  inline-size: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container style="writing-mode: vertical-lr;">
+  <item></item>
+  <item class="floating-item" style="margin-inline-start: 50px;"></item>
+  <item class="floating-item"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout</title>
+<meta name="assert" content="trimmed inline margins for first float should allow second float to sit at same top offset">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.floating-item {
+  float: left;
+  width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+  <item></item>
+  <item class="floating-item" style="margin-inline-start: 50px;"></item>
+  <item class="floating-item"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+<style>
+container {
+    display: block;
+    width: min-content;
+    height: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.float {
+    float: left;
+    margin-inline: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="float"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout</title>
+<meta name="assert" content="trimmed inline margins for first float should allow second float to sit at same top offset">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.floating-item {
+  float: right;
+  width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+  <item></item>
+  <item class="floating-item" style="margin-inline-end: 50px;"></item>
+  <item class="floating-item"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-overflowing-float-margins-trimmed-at-final-position-block-layout</title>
+<meta name="assert" content="the third float should be able to sit right under the first float with its margins trimmed">
+<style>
+.container {
+    width: 100px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<div class="container">
+  <div style="width: 100px; height: 50px; background-color: green"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: blue;"></div>
+  <div style="width: 25px; height: 50px; float: right; height: 80px; background-color: red;"></div>
+  <div style="width: 100px; height: 50px;"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: purple;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-overflowing-float-margins-trimmed-at-final-position-block-layout</title>
+<meta name="assert" content="the third float should be able to sit right under the first float with its margins trimmed">
+<style>
+.container {
+    width: 100px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<div class="container">
+  <div style="width: 100px; height: 50px; background-color: green"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: blue; margin-inline-start: 20px;"></div>
+  <div style="width: 25px; height: 50px; float: right; height: 80px; background-color: red; margin-inline-end: 20px;"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: purple; margin-inline-start: 80px;"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -112,6 +112,17 @@ LayoutSize FloatingObject::translationOffsetToAncestor() const
     return locationOffsetOfBorderBox() - renderer().locationOffset();
 }
 
+#if ASSERT_ENABLED
+
+bool FloatingObject::isLowestPlacedFloatBottomInBlockFormattingContext() const
+{
+    if (auto bfcRoot = m_renderer->blockFormattingContextRoot())
+        return bfcRoot->lowestFloatLogicalBottom() == bfcRoot->logicalBottomForFloat(*this);
+    return false;
+}
+
+#endif
+
 #if ENABLE(TREE_DEBUGGING)
 
 TextStream& operator<<(TextStream& stream, const FloatingObject& object)

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -64,7 +64,7 @@ public:
     void setX(LayoutUnit x) { ASSERT(!isInPlacedTree()); m_frameRect.setX(x); }
     void setY(LayoutUnit y) { ASSERT(!isInPlacedTree()); m_frameRect.setY(y); }
     void setWidth(LayoutUnit width) { ASSERT(!isInPlacedTree()); m_frameRect.setWidth(width); }
-    void setHeight(LayoutUnit height) { ASSERT(!isInPlacedTree()); m_frameRect.setHeight(height); }
+    void setHeight(LayoutUnit height) { ASSERT(!isInPlacedTree() || isLowestPlacedFloatBottomInBlockFormattingContext()); m_frameRect.setHeight(height); }
 
     void setMarginOffset(LayoutSize offset) { ASSERT(!isInPlacedTree()); m_marginOffset = offset; }
 
@@ -91,6 +91,8 @@ public:
     LegacyRootInlineBox* originatingLine() const { return m_originatingLine.get(); }
     void clearOriginatingLine() { m_originatingLine = nullptr; }
     void setOriginatingLine(LegacyRootInlineBox& line) { m_originatingLine = line; }
+
+    bool isLowestPlacedFloatBottomInBlockFormattingContext() const;
 
     LayoutSize locationOffsetOfBorderBox() const
     {

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2349,8 +2349,17 @@ void RenderBlock::computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth
         // A margin basically has three types: fixed, percentage, and auto (variable).
         // Auto and percentage margins simply become 0 when computing min/max width.
         // Fixed margins can be added in as is.
-        Length startMarginLength = childStyle.marginStartUsing(&styleToUse);
-        Length endMarginLength = childStyle.marginEndUsing(&styleToUse);
+        Length startMarginLength;
+        Length endMarginLength;
+        if (auto blockBox = dynamicDowncast<RenderBlockFlow>(this)) {
+            // Floats inside a block level box may not use their margins in their
+            // intrinsic size contributions if margin-trim is set
+            startMarginLength = blockBox->shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineStart, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginStartUsing(&styleToUse) : Length { 0, LengthType::Fixed };
+            endMarginLength = blockBox->shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineEnd, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginEndUsing(&styleToUse) : Length { 0, LengthType::Fixed };
+        }   else {
+            startMarginLength = childStyle.marginStartUsing(&styleToUse);
+            endMarginLength = childStyle.marginEndUsing(&styleToUse);
+        }
         LayoutUnit margin;
         LayoutUnit marginStart;
         LayoutUnit marginEnd;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -235,9 +235,11 @@ public:
     enum ApplyLayoutDeltaMode { ApplyLayoutDelta, DoNotApplyLayoutDelta };
     LayoutUnit logicalWidthForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.width() : child.height(); }
     LayoutUnit logicalHeightForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.height() : child.width(); }
+    LayoutUnit logicalMarginBoxHeightForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.marginBoxRect().height() : child.marginBoxRect().width(); }
     LayoutSize logicalSizeForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.size() : child.size().transposedSize(); }
     LayoutUnit logicalTopForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.y() : child.x(); }
     LayoutUnit logicalLeftForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.x() : child.y(); }
+    LayoutUnit logicalMarginBoxTopForChild(const RenderBox& child) const { return logicalTopForChild(child) - marginBeforeForChild(child); }
     void setLogicalLeftForChild(RenderBox& child, LayoutUnit logicalLeft, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
     void setLogicalTopForChild(RenderBox& child, LayoutUnit logicalTop, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
     LayoutUnit marginBeforeForChild(const RenderBoxModelObject& child) const { return child.marginBefore(&style()); }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -534,6 +534,13 @@ void RenderBlockFlow::layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalH
             setChildrenInline(true);
         dirtyForLayoutFromPercentageHeightDescendants();
         layoutInFlowChildren(relayoutChildren, repaintLogicalTop, repaintLogicalBottom, maxFloatLogicalBottom);
+
+        // The containing block's of the floats within this BFC may specify margin-trim: block-end
+        // so we need to go through the floats that this BFC is aware of and check if any of
+        // the float's need their block-end margin trimmed
+        if (m_floatingObjects && establishesBlockFormattingContext())
+            trimFloatBlockEndMargins(blockFormattingContextInFlowBlockLevelContentHeight());
+
         // Expand our intrinsic height to encompass floats.
         LayoutUnit toAdd = borderAndPaddingAfter() + scrollbarLogicalHeight();
         if (lowestFloatLogicalBottom() > (logicalHeight() - toAdd) && createsNewFormattingContext())
@@ -1380,6 +1387,57 @@ bool RenderBlockFlow::shouldTrimChildMargin(MarginTrimType marginTrimType, const
     if (marginTrimType == MarginTrimType::BlockStart)
         return firstInFlowChildBox() == &child;
     return lastInFlowChildBox() == &child;
+}
+
+void RenderBlockFlow::trimFloatBlockEndMargins(LayoutUnit blockFormattingContextInFlowContentHeight)
+{
+    ASSERT(m_floatingObjects && establishesBlockFormattingContext());
+    auto computeFloatMarginAfterStartLocationInBlockFormattingContext = [&](const RenderBox& floatBox) {
+        // Start with the location of the float within its containing block. If this containing
+        // block is the BFC in which we are trimming, then we can use this as the starting location
+        // since this is the float's positin within the BFC. If not, add the containing block's location
+        // to the float's location. This new value should be the location of the float relative to this
+        // new containing block. Keep doing this until we find the containing block that establishes
+        // a BFC
+        auto bfcRoot = floatBox.blockFormattingContextRoot();
+        ASSERT(bfcRoot);
+
+        LayoutSize offsetInsideBlockFormattingContext;
+        const RenderElement* currentBox = &floatBox;
+        while (currentBox != bfcRoot) {
+            offsetInsideBlockFormattingContext += currentBox->offsetFromContainer(*currentBox->container(), LayoutPoint { });
+            currentBox = currentBox->container();
+        }
+        if (bfcRoot->isHorizontalWritingMode())
+            return LayoutUnit { offsetInsideBlockFormattingContext.height() + bfcRoot->logicalHeightForChild(floatBox) };
+        return LayoutUnit { offsetInsideBlockFormattingContext.width() + bfcRoot->logicalWidthForChild(floatBox) };
+    };
+    for (auto& floatingObject : m_floatingObjects->set()) {
+        auto& floatBox = floatingObject->renderer();
+        auto floatContainingBlock = floatBox.containingBlock();
+        if (!floatContainingBlock->style().marginTrim().contains(MarginTrimType::BlockEnd) || floatBox.marginAfter() <= 0)
+            continue;
+
+        // There are 3 different cases that need to be taken into consideration when trimming the
+        // block-end margin of a float:
+        // 1.) The float margin box extends past the deepest past of content (margin should be trimmed all the way)
+        // 2.) The end of the deepest piece of is in between the float's border box and marign box (marign should be trimmed up to the content)
+        // 3.) The deepest piece of content is below the float's margin box (no trimming occurs)
+        auto floatMarginAfterStartLocation = computeFloatMarginAfterStartLocationInBlockFormattingContext(floatBox);
+        auto floatMarginAfter = floatContainingBlock->marginAfterForChild(floatBox);
+        if (floatMarginAfterStartLocation >= blockFormattingContextInFlowContentHeight)
+            trimMarginForFloat(*floatingObject, MarginTrimType::BlockEnd, floatMarginAfter);
+        else if (blockFormattingContextInFlowContentHeight > floatMarginAfterStartLocation && (blockFormattingContextInFlowContentHeight < floatMarginAfterStartLocation + floatMarginAfter))
+            trimMarginForFloat(*floatingObject, MarginTrimType::BlockEnd, floatMarginAfterStartLocation + floatMarginAfter - blockFormattingContextInFlowContentHeight);
+    }
+}
+
+bool RenderBlockFlow::shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType marginSide, const RenderElement& child) const
+{
+    // For the purposes of computing a block container's intrinsic size, a float should not
+    // include its trimmed margins in its intrinsic size contributions
+    ASSERT((marginSide == MarginTrimType::InlineStart || marginSide == MarginTrimType::InlineEnd) && (child.containingBlock() == this));
+    return !child.isFloating() || !style().marginTrim().contains(marginSide);
 }
 
 LayoutUnit RenderBlockFlow::clearFloatsIfNeeded(RenderBox& child, MarginInfo& marginInfo, LayoutUnit oldTopPosMargin, LayoutUnit oldTopNegMargin, LayoutUnit yPos)
@@ -2432,7 +2490,7 @@ FloatingObject* RenderBlockFlow::insertFloatingObject(RenderBox& floatBox)
     // Create the special floatingObject entry & append it to the list
 
     std::unique_ptr<FloatingObject> floatingObject = FloatingObject::create(floatBox);
-    
+
     // Our location is irrelevant if we're unsplittable or no pagination is in effect. Just lay out the float.
     bool isChildRenderBlock = floatBox.isRenderBlock();
     if (isChildRenderBlock && !floatBox.needsLayout() && view().frameView().layoutContext().layoutState()->pageLogicalHeightChanged())
@@ -2535,6 +2593,33 @@ LayoutUnit RenderBlockFlow::logicalRightOffsetForPositioningFloat(LayoutUnit log
     return adjustLogicalRightOffsetForLine(offset, applyTextIndent);
 }
 
+void RenderBlockFlow::trimMarginForFloat(FloatingObject& floatingObject, MarginTrimType marginTrimType, LayoutUnit trimAmount)
+{
+    ASSERT(!floatingObject.isPlaced() || marginTrimType == MarginTrimType::BlockEnd);
+    switch (marginTrimType) {
+    case MarginTrimType::InlineStart: {
+        setLogicalWidthForFloat(floatingObject, logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginStart(&style()));
+        floatingObject.renderer().setMarginStart(0_lu, &style());
+        break; 
+    }
+    case MarginTrimType::InlineEnd: {
+        setLogicalWidthForFloat(floatingObject, logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginEnd(&style()));
+        floatingObject.renderer().setMarginEnd(0_lu, &style());
+        break;
+    }
+    case MarginTrimType::BlockStart: {
+        setLogicalHeightForFloat(floatingObject, logicalHeightForFloat(floatingObject) - floatingObject.renderer().marginBefore(&style()));
+        floatingObject.renderer().setMarginBefore(0_lu, &style());
+        break;
+    }
+    case MarginTrimType::BlockEnd: {
+        ASSERT(trimAmount <= floatingObject.renderer().marginAfter(&style()) && trimAmount);
+        setLogicalHeightForFloat(floatingObject, logicalHeightForFloat(floatingObject) - trimAmount);
+        break;
+    }
+    }
+}
+
 void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObject, LayoutUnit& logicalTopOffset)
 {
     auto& childBox = floatingObject.renderer();
@@ -2545,6 +2630,20 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
 
     LayoutUnit floatLogicalLeft;
 
+    auto containingBlockMarginTrim = style().marginTrim();
+    auto floatWidthWithoutMargin = [&](FloatingObject& floatingObject, MarginTrimType marginSide) {
+        auto& containingBlockStyle = style();
+        switch (marginSide) {
+        case MarginTrimType::InlineStart:
+            return logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginStart(&containingBlockStyle);
+        case MarginTrimType::InlineEnd:
+            return logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginEnd(&containingBlockStyle);
+        default: {
+            ASSERT_NOT_REACHED();
+            return logicalWidthForFloat(floatingObject);
+        }
+        }
+    };
     bool insideFragmentedFlow = enclosingFragmentedFlow();
     bool isInitialLetter = childBox.style().styleType() == PseudoId::FirstLetter && childBox.style().initialLetterDrop() > 0;
     
@@ -2558,11 +2657,21 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
         }
     }
 
+    // For trimming the margins of floats:
+    // It also affects floats for which the block container is a containing block by:
+    // Discarding the inline-start/inline-end margin of an inline-start/inline-end float (or equivalent) 
+    // whose outer edge on that side coincides with the inner edge of the container.
+    auto floatMarginAdjoinsContainerInnerEdge = [&](MarginTrimType marginTrimType, LayoutUnit floatLogicalPosition, LayoutUnit logicalOffset) {
+        return containingBlockMarginTrim.contains(marginTrimType) && floatLogicalPosition == logicalOffset;
+    };
     if (RenderStyle::usedFloat(childBox) == UsedFloat::Left) {
         LayoutUnit heightRemainingLeft = 1_lu;
         LayoutUnit heightRemainingRight = 1_lu;
         floatLogicalLeft = logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
-        while (logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight) - floatLogicalLeft < floatLogicalWidth) {
+        auto availableSpace = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight) - floatLogicalLeft;
+        while (availableSpace < floatLogicalWidth) {
+            if (floatMarginAdjoinsContainerInnerEdge(MarginTrimType::InlineStart, floatLogicalLeft, logicalLeftOffset) && availableSpace >= floatWidthWithoutMargin(floatingObject, MarginTrimType::InlineStart))
+                break;
             logicalTopOffset += std::min(heightRemainingLeft, heightRemainingRight);
             floatLogicalLeft = logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
             if (insideFragmentedFlow) {
@@ -2571,13 +2680,20 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
                 logicalLeftOffset = logicalLeftOffsetForContent(logicalTopOffset); // Constant part of left offset.
                 floatLogicalWidth = std::min(logicalWidthForFloat(floatingObject), logicalRightOffset - logicalLeftOffset);
             }
+            availableSpace = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight) - floatLogicalLeft;
         }
         floatLogicalLeft = std::max(logicalLeftOffset - borderAndPaddingLogicalLeft(), floatLogicalLeft);
+        
+        if (containingBlockMarginTrim.contains(MarginTrimType::InlineStart) && logicalLeftOffset == floatLogicalLeft)
+            trimMarginForFloat(floatingObject, MarginTrimType::InlineStart);
     } else {
         LayoutUnit heightRemainingLeft = 1_lu;
         LayoutUnit heightRemainingRight = 1_lu;
         floatLogicalLeft = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight);
-        while (floatLogicalLeft - logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft) < floatLogicalWidth) {
+        auto availableSpace = floatLogicalLeft - logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
+        while (availableSpace < floatLogicalWidth) {
+            if (floatMarginAdjoinsContainerInnerEdge(MarginTrimType::InlineEnd, floatLogicalLeft, logicalRightOffset) && (availableSpace >= floatWidthWithoutMargin(floatingObject, MarginTrimType::InlineEnd)))
+                break;
             logicalTopOffset += std::min(heightRemainingLeft, heightRemainingRight);
             floatLogicalLeft = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight);
             if (insideFragmentedFlow) {
@@ -2586,12 +2702,20 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
                 logicalLeftOffset = logicalLeftOffsetForContent(logicalTopOffset); // Constant part of left offset.
                 floatLogicalWidth = std::min(logicalWidthForFloat(floatingObject), logicalRightOffset - logicalLeftOffset);
             }
+            availableSpace = floatLogicalLeft - logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
         }
+        // We trim before we update floatLogicalLeft becaue it currently represents the logical
+        // right for the float. We would have to otherwise update floatLogicalLeft each time we
+        // trim a margin by adding the trimmed margin to its value
+        if (containingBlockMarginTrim.contains(MarginTrimType::InlineEnd) && logicalRightOffset == floatLogicalLeft)
+            trimMarginForFloat(floatingObject, MarginTrimType::InlineEnd);    
         // Use the original width of the float here, since the local variable
         // |floatLogicalWidth| was capped to the available line width. See
         // fast/block/float/clamped-right-float.html.
         floatLogicalLeft -= logicalWidthForFloat(floatingObject);
     }
+    if (style().marginTrim().contains(MarginTrimType::BlockStart) && logicalTopOffset == borderAndPaddingBefore())
+        trimMarginForFloat(floatingObject, MarginTrimType::BlockStart);
 
     LayoutUnit childLogicalLeftMargin = style().isLeftToRightDirection() ? marginStartForChild(childBox) : marginEndForChild(childBox);
     LayoutUnit childBeforeMargin = marginBeforeForChild(childBox);
@@ -4683,6 +4807,19 @@ bool RenderBlockFlow::tryComputePreferredWidthsUsingModernPath(LayoutUnit& minLo
         walker.current()->setPreferredLogicalWidthsDirty(false);
     return true;
 }
+
+LayoutUnit RenderBlockFlow::blockFormattingContextInFlowBlockLevelContentHeight() const
+{
+    ASSERT(establishesBlockFormattingContext());
+    // For block layout we should just be able to check the height of the last in flow box
+    auto lastChild = lastInFlowChildBox();
+    if (!lastChild)
+        return 0_lu;
+    // Child's margin box starting location + border box height + margin after size
+    return logicalMarginBoxTopForChild(*lastChild) + logicalMarginBoxHeightForChild(*lastChild);
+}
+
+
 
 }
 // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -226,6 +226,8 @@ public:
     LayoutUnit marginOffsetForSelfCollapsingBlock();
 
     bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const final;
+    void trimFloatBlockEndMargins(LayoutUnit blockFormattingContextInFlowContentHeight);
+    bool shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType, const RenderElement&) const;
 
     void layoutBlockChild(RenderBox& child, MarginInfo&, LayoutUnit& previousFloatLogicalBottom, LayoutUnit& maxFloatLogicalBottom);
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);
@@ -331,6 +333,7 @@ public:
         else
             floatingObject.setMarginOffset(LayoutSize(logicalBeforeMargin, logicalLeftMargin));
     }
+    void trimMarginForFloat(FloatingObject&, MarginTrimType, LayoutUnit trimAmount = 0);
 
     LayoutPoint flipFloatForWritingModeForChild(const FloatingObject&, const LayoutPoint&) const;
 
@@ -400,6 +403,7 @@ public:
 
     std::optional<LayoutUnit> lowestInitialLetterLogicalBottom() const;
 
+    LayoutUnit blockFormattingContextInFlowBlockLevelContentHeight() const;
 protected:
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4971,6 +4971,24 @@ bool RenderBox::establishesIndependentFormattingContext() const
     return isGridItem() || RenderElement::establishesIndependentFormattingContext();
 }
 
+bool RenderBox::establishesBlockFormattingContext() const
+{
+    const auto& boxStyle = style();
+    if (!boxStyle.isDisplayBlockLevel())
+        return false;
+    auto isBlockWithOverFlowOtherThanVisibleAndClip = [&]() {
+        auto boxOverflowX = effectiveOverflowX();
+        auto boxOverflowY = effectiveOverflowY();
+        return boxOverflowX != Overflow::Visible && boxOverflowX != Overflow::Clip
+            && boxOverflowY != Overflow::Visible && boxOverflowY != Overflow::Clip;
+    };
+    return dynamicDowncast<HTMLHtmlElement>(element()) || isFloatingOrOutOfFlowPositioned() 
+    || isInlineBlockOrInlineTable() || isTableCell() || isTableCaption() || isBlockWithOverFlowOtherThanVisibleAndClip()
+    || boxStyle.display() == DisplayType::FlowRoot || boxStyle.containsLayoutOrPaint()
+    || isFlexItemIncludingDeprecated() || isGridItem() || boxStyle.specifiesColumns()
+    || boxStyle.columnSpan() == ColumnSpan::All;
+}
+
 bool RenderBox::avoidsFloats() const
 {
     return isReplacedOrInlineBlock() || isLegend() || isFieldset() || createsNewFormattingContext();
@@ -5629,6 +5647,16 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
     auto height = style().containIntrinsicHeight();
     ASSERT(height.has_value());
     return std::optional<LayoutUnit> { height->value() };
+}
+
+const RenderBlockFlow* RenderBox::blockFormattingContextRoot() const
+{
+    // This method should probably not be called on the initial containing block
+    ASSERT(!is<HTMLHtmlElement>(element()));
+    auto blockContainer = containingBlock();
+    while (blockContainer && !blockContainer->establishesBlockFormattingContext())
+        blockContainer = blockContainer->containingBlock();
+    return dynamicDowncast<RenderBlockFlow>(blockContainer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -185,6 +185,7 @@ public:
     FloatRect repaintRectInLocalCoordinates() const override { return borderBoxRect(); }
     FloatRect objectBoundingBox() const override { return borderBoxRect(); }
 
+    const RenderBlockFlow* blockFormattingContextRoot() const;    
     // Note these functions are not equivalent of childrenOfType<RenderBox>
     RenderBox* parentBox() const;
     RenderBox* firstChildBox() const;
@@ -705,6 +706,7 @@ public:
     }
 
     bool establishesIndependentFormattingContext() const override;
+    bool establishesBlockFormattingContext() const;
 
 protected:
     RenderBox(Element&, RenderStyle&&, BaseTypeFlags);


### PR DESCRIPTION
#### f679766e27a17ddcbdd8a562f6f1581fab68d053
<pre>
Implement margin-trim for floats in block containers that contain only block boxes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249207">https://bugs.webkit.org/show_bug.cgi?id=249207</a>
rdar://103285803

Reviewed by Alan Baradlay.

Another patch will be added to provide support for block containers that
contain only inline level boxes.

There are 3 different pieces that we need to implement:

1.) Trimming the block start, inline start, and inline end margins
2.) Trimming the block-end margin, which is slightly different from
the others
3.) Making sure the trimmed margins do not contribute to the inrinsic
sizing of the container

When a candidate position for a float is determined in the float
positioning code, we can determine whether it is possible to trim its
margins. For each candidate position, we can determine whether any edges
of the margin box would touch the container and then trim that edge if
it is specified in margin-trim. This can be done for the inline-start,
inline-end, and block-start edges of the container.

Trimming the block-end margin is slightly different because it is not
in the context of the containing block like the other margins but of the
block formatting context. This means that we can only trim these margins
after its block formatting context is done with layout. In
RnderBlockFlow we can check to see if it establishes a block formatting
context and then proceed to trim the block-end margins of its floats
where needed. As we iterate over each float, we check to see if its block
end location is lower than the lowest piece of content in the BFC. If
so, we trim it up to the necesssary amount where it will not extend the
height of the BFC.

Finally, to make sure that the trimmed inline margins do not contribute
to the intrinsic sizing of its containing block, all we need to do
is check to see if the item is a float and if any of the inline margins
are specified to be trimmed. If so, we do not include those in its
contribution.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-deeply-nested-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-deeply-nested.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-relative-positioned-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-relative-positioned.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-with-transforms-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-with-transforms.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-fit-content-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-fit-content-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html: Added.
* Source/WebCore/rendering/FloatingObjects.cpp:
(WebCore::FloatingObject::isLowestPlacedFloatBottomInBlockFormattingContext const):
* Source/WebCore/rendering/FloatingObjects.h:
(WebCore::FloatingObject::setHeight):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeBlockPreferredLogicalWidths const):
* Source/WebCore/rendering/RenderBlock.h:
(WebCore::RenderBlock::logicalMarginBoxHeightForChild const):
(WebCore::RenderBlock::logicalMarginBoxTopForChild const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::trimFloatBlockEndMargins):
(WebCore::RenderBlockFlow::shouldChildInlineMarginContributeToContainerIntrinsicSize const):
(WebCore::RenderBlockFlow::insertFloatingObject):
(WebCore::RenderBlockFlow::trimMarginForFloat):
(WebCore::RenderBlockFlow::computeLogicalLocationForFloat):
(WebCore::RenderBlockFlow::blockFormattingContextInFlowBlockLevelContentHeight const):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::establishesBlockFormattingContext const):
(WebCore::RenderBox::blockFormattingContextRoot const):
* Source/WebCore/rendering/RenderBox.h:

Canonical link: <a href="https://commits.webkit.org/260318@main">https://commits.webkit.org/260318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdb75fc05ba8a6093913cec82d8b492d7caf6d4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8254 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100063 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41541 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28686 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9866 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6929 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7138 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12144 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->