### PR TITLE
[GTK] Remove WebKitPrintCustomWidget from modern API

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -177,7 +177,6 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/webkit.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitColorChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPointerLockPermissionRequest.h.in
-    ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPrintOperation.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitWebInspector.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitWebViewBase.h.in

--- a/Source/WebKit/PlatformGTKDeprecated.cmake
+++ b/Source/WebKit/PlatformGTKDeprecated.cmake
@@ -9,6 +9,7 @@ file(MAKE_DIRECTORY ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2)
 list(APPEND WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMimeInfo.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
+    ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in
 )
 
 list(APPEND WebKitWebExtension_HEADER_TEMPLATES

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -207,7 +207,6 @@ UIProcess/API/gtk/WebKitEmojiChooser.cpp @no-unify
 UIProcess/API/gtk/WebKitInputMethodContextGtk.cpp @no-unify
 UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp @no-unify
 UIProcess/API/gtk/WebKitPopupMenu.cpp @no-unify
-UIProcess/API/gtk/WebKitPrintCustomWidget.cpp @no-unify
 UIProcess/API/gtk/WebKitPrintOperation.cpp @no-unify
 UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp @no-unify
 UIProcess/API/gtk/WebKitScriptDialogGtk.cpp @no-unify

--- a/Source/WebKit/SourcesGTKDeprecated.txt
+++ b/Source/WebKit/SourcesGTKDeprecated.txt
@@ -24,6 +24,8 @@
 UIProcess/API/glib/WebKitMimeInfo.cpp @no-unify
 UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 
+UIProcess/API/gtk/WebKitPrintCustomWidget.cpp @no-unify
+
 WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp @no-unify
 
 WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp @no-unify
@@ -140,4 +142,3 @@ WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMWheelEvent.cpp
 WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathExpression.cpp
 WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathNSResolver.cpp
 WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathResult.cpp
-

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
@@ -75,7 +75,9 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitColorChooserRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitMediaKeySystemPermissionRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitOptionMenu, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPointerLockPermissionRequest, g_object_unref)
+#if !ENABLE(2022_GLIB_API)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPrintCustomWidget, g_object_unref)
+#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPrintOperation, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebInspector, g_object_unref)
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.cpp
@@ -39,8 +39,19 @@
  * webkit_print_custom_widget_new() and returning it from there. You can later
  * use webkit_print_operation_run_dialog() to display the dialog.
  *
+ * Unfortunately, use of custom widgets is incompatible with modern
+ * containerized application frameworks like Flatpak. A print dialog
+ * constructed in the application process will not have access to host
+ * printers, so instead it must be constructed by a desktop portal service
+ * running on the host system. Because this print dialog runs in a separate
+ * process, it's not possible to attach a custom widget.
+ *
  * Since: 2.16
+ *
+ * Deprecated: 2.40
  */
+
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 enum {
     APPLY,
@@ -109,6 +120,8 @@ static void webkit_print_custom_widget_class_init(WebKitPrintCustomWidgetClass* 
      * The custom #GtkWidget that will be embedded in the dialog.
      *
      * Since: 2.16
+     *
+     * Deprecated: 2.40
      */
     g_object_class_install_property(
         objectClass,
@@ -125,6 +138,8 @@ static void webkit_print_custom_widget_class_init(WebKitPrintCustomWidgetClass* 
      * The title of the custom widget.
      *
      * Since: 2.16
+     *
+     * Deprecated: 2.40
      */
     g_object_class_install_property(
         objectClass,
@@ -146,6 +161,8 @@ static void webkit_print_custom_widget_class_init(WebKitPrintCustomWidgetClass* 
      * according to their values.
      *
      * Since: 2.16
+     *
+     * Deprecated: 2.40
      */
     signals[UPDATE] =
         g_signal_new(
@@ -167,6 +184,8 @@ static void webkit_print_custom_widget_class_init(WebKitPrintCustomWidgetClass* 
      * is not guaranteed to be valid at a later time.
      *
      * Since: 2.16
+     *
+     * Deprecated: 2.40
      */
     signals[APPLY] =
         g_signal_new(
@@ -194,6 +213,8 @@ static void webkit_print_custom_widget_class_init(WebKitPrintCustomWidgetClass* 
  * Returns: (transfer full): a new #WebKitPrintOperation.
  *
  * Since: 2.16
+ *
+ * Deprecated: 2.40
  */
 WebKitPrintCustomWidget* webkit_print_custom_widget_new(GtkWidget* widget, const char* title)
 {
@@ -218,6 +239,8 @@ WebKitPrintCustomWidget* webkit_print_custom_widget_new(GtkWidget* widget, const
  * Returns: (transfer none): a #GtkWidget.
  *
  * Since: 2.16
+ *
+ * Deprecated: 2.40
  */
 GtkWidget* webkit_print_custom_widget_get_widget(WebKitPrintCustomWidget* printCustomWidget)
 {
@@ -238,6 +261,8 @@ GtkWidget* webkit_print_custom_widget_get_widget(WebKitPrintCustomWidget* printC
  * Returns: Title of the @print_custom_widget.
  *
  * Since: 2.16
+ *
+ * Deprecated: 2.40
  */
 const gchar* webkit_print_custom_widget_get_title(WebKitPrintCustomWidget* printCustomWidget)
 {
@@ -256,3 +281,5 @@ void webkitPrintCustomWidgetEmitUpdateCustomWidgetSignal(WebKitPrintCustomWidget
 {
     g_signal_emit(printCustomWidget, signals[UPDATE], 0, pageSetup, printSettings);
 }
+
+ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in
@@ -64,17 +64,17 @@ struct _WebKitPrintCustomWidgetClass {
     void    (*_webkit_reserved3) (void);
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_print_custom_widget_get_type   (void);
 
-WEBKIT_API WebKitPrintCustomWidget *
+WEBKIT_DEPRECATED WebKitPrintCustomWidget *
 webkit_print_custom_widget_new        (GtkWidget               *widget,
                                        const char              *title);
 
-WEBKIT_API GtkWidget *
+WEBKIT_DEPRECATED GtkWidget *
 webkit_print_custom_widget_get_widget (WebKitPrintCustomWidget *print_custom_widget);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_print_custom_widget_get_title  (WebKitPrintCustomWidget *print_custom_widget);
 
 G_END_DECLS

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -66,7 +66,9 @@ static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
 enum {
     FINISHED,
     FAILED,
+#if !ENABLE(2022_GLIB_API)
     CREATE_CUSTOM_WIDGET,
+#endif
 
     LAST_SIGNAL
 };
@@ -140,6 +142,7 @@ static void webkitPrintOperationSetProperty(GObject* object, guint propId, const
     }
 }
 
+#if !ENABLE(2022_GLIB_API)
 static gboolean webkitPrintOperationAccumulatorObjectHandled(GSignalInvocationHint*, GValue* returnValue, const GValue* handlerReturn, gpointer)
 {
     void* object = g_value_get_object(handlerReturn);
@@ -148,6 +151,7 @@ static gboolean webkitPrintOperationAccumulatorObjectHandled(GSignalInvocationHi
 
     return !object;
 }
+#endif
 
 static void webkit_print_operation_class_init(WebKitPrintOperationClass* printOperationClass)
 {
@@ -227,6 +231,9 @@ static void webkit_print_operation_class_init(WebKitPrintOperationClass* printOp
             G_TYPE_NONE, 1,
             G_TYPE_ERROR | G_SIGNAL_TYPE_STATIC_SCOPE);
 
+#if !ENABLE(2022_GLIB_API)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+
     /**
      * WebKitPrintOperation::create-custom-widget:
      * @print_operation: the #WebKitPrintOperation on which the signal was emitted
@@ -239,6 +246,8 @@ static void webkit_print_operation_class_init(WebKitPrintOperationClass* printOp
      * Returns: (transfer full): A #WebKitPrintCustomWidget that will be embedded in the dialog.
      *
      * Since: 2.16
+     *
+     * Deprecated: 2.40
      */
     signals[CREATE_CUSTOM_WIDGET] =
         g_signal_new(
@@ -249,13 +258,18 @@ static void webkit_print_operation_class_init(WebKitPrintOperationClass* printOp
             webkitPrintOperationAccumulatorObjectHandled, 0,
             g_cclosure_marshal_generic,
             WEBKIT_TYPE_PRINT_CUSTOM_WIDGET, 0);
+
+    ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
 }
 
 #if HAVE(GTK_UNIX_PRINTING)
+#if !ENABLE(2022_GLIB_API)
 static void notifySelectedPrinterCallback(GtkPrintUnixDialog* dialog, GParamSpec*, WebKitPrintCustomWidget* printCustomWidget)
 {
     webkitPrintCustomWidgetEmitUpdateCustomWidgetSignal(printCustomWidget, gtk_print_unix_dialog_get_page_setup(dialog), gtk_print_unix_dialog_get_settings(dialog));
 }
+#endif
 
 static WebKitPrintOperationResponse webkitPrintOperationRunDialog(WebKitPrintOperation* printOperation, GtkWindow* parent)
 {
@@ -281,15 +295,19 @@ static WebKitPrintOperationResponse webkitPrintOperationRunDialog(WebKitPrintOpe
 
     gtk_print_unix_dialog_set_embed_page_setup(printDialog, TRUE);
 
+#if !ENABLE(2022_GLIB_API)
     GRefPtr<WebKitPrintCustomWidget> customWidget;
     g_signal_emit(printOperation, signals[CREATE_CUSTOM_WIDGET], 0, &customWidget.outPtr());
     if (customWidget) {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         const gchar* widgetTitle = webkit_print_custom_widget_get_title(customWidget.get());
         GtkWidget* widget = webkit_print_custom_widget_get_widget(customWidget.get());
+        ALLOW_DEPRECATED_DECLARATIONS_END
 
         g_signal_connect(printDialog, "notify::selected-printer", G_CALLBACK(notifySelectedPrinterCallback), customWidget.get());
         gtk_print_unix_dialog_add_custom_tab(printDialog, widget, gtk_label_new(widgetTitle));
     }
+#endif
 
     WebKitPrintOperationResponse returnValue = WEBKIT_PRINT_OPERATION_RESPONSE_CANCEL;
     if (gtk_dialog_run(GTK_DIALOG(printDialog)) == GTK_RESPONSE_OK) {
@@ -297,8 +315,10 @@ static WebKitPrintOperationResponse webkitPrintOperationRunDialog(WebKitPrintOpe
         priv->pageSetup = gtk_print_unix_dialog_get_page_setup(printDialog);
         priv->printer = gtk_print_unix_dialog_get_selected_printer(printDialog);
         returnValue = WEBKIT_PRINT_OPERATION_RESPONSE_PRINT;
+#if !ENABLE(2022_GLIB_API)
         if (customWidget)
             webkitPrintCustomWidgetEmitCustomWidgetApplySignal(customWidget.get());
+#endif
     }
 
     gtk_widget_destroy(GTK_WIDGET(printDialog));

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
@@ -289,6 +289,7 @@ static void testPrintOperationCloseAfterPrint(CloseAfterPrintTest* test, gconstp
     test->waitUntilPrintFinishedAndViewClosed();
 }
 
+#if !ENABLE(2022_GLIB_API)
 class PrintCustomWidgetTest: public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(PrintCustomWidgetTest);
@@ -307,7 +308,9 @@ public:
 
     static void updateCallback(WebKitPrintCustomWidget* customWidget, GtkPageSetup*, GtkPrintSettings*, PrintCustomWidgetTest* test)
     {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         g_assert_true(test->m_widget == webkit_print_custom_widget_get_widget(customWidget));
+        ALLOW_DEPRECATED_DECLARATIONS_END
 
         test->m_updateEmitted = true;
         // Would be nice to avoid the 1 second timeout here - but I didn't found
@@ -332,7 +335,9 @@ public:
         g_signal_connect(printCustomWidget, "apply", G_CALLBACK(applyCallback), test);
         g_signal_connect(printCustomWidget, "update", G_CALLBACK(updateCallback), test);
 
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         GtkWidget* widget = webkit_print_custom_widget_get_widget(printCustomWidget);
+        ALLOW_DEPRECATED_DECLARATIONS_END
         test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(widget));
         g_signal_connect(widget, "realize", G_CALLBACK(widgetRealizeCallback), test);
 
@@ -380,7 +385,9 @@ public:
     WebKitPrintCustomWidget* createPrintCustomWidget()
     {
         m_widget = gtk_label_new("Label");
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return webkit_print_custom_widget_new(m_widget, "Custom Widget");
+        ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     void startPrinting()
@@ -451,6 +458,7 @@ static void testPrintCustomWidget(PrintCustomWidgetTest* test, gconstpointer)
     g_assert_true(test->m_updateEmitted);
     g_assert_true(test->m_applyEmitted);
 }
+#endif // !ENABLE(2022_GLIB_API)
 #endif // HAVE_GTK_UNIX_PRINTING
 
 void beforeAll()
@@ -461,7 +469,9 @@ void beforeAll()
     PrintTest::add("WebKitPrintOperation", "print", testPrintOperationPrint);
     PrintTest::add("WebKitPrintOperation", "print-errors", testPrintOperationErrors);
     CloseAfterPrintTest::add("WebKitPrintOperation", "close-after-print", testPrintOperationCloseAfterPrint);
+#if !ENABLE(2022_GLIB_API)
     PrintCustomWidgetTest::add("WebKitPrintOperation", "custom-widget", testPrintCustomWidget);
+#endif
 #endif
 }
 


### PR DESCRIPTION
#### e3ebba80adf1cc861a986732fe154aa72731b2b1
<pre>
[GTK] Remove WebKitPrintCustomWidget from modern API
<a href="https://bugs.webkit.org/show_bug.cgi?id=244513">https://bugs.webkit.org/show_bug.cgi?id=244513</a>

Reviewed by Carlos Garcia Campos.

Attaching custom widgets to the print dialog just cannot work when the
print dialog is out of process, and we really need to move to an out of
process dialog to fix printing in Flatpak.

Now, it would be possible to keep this functionality for non-flatpak
apps and leave it broken in Flatpak, but I&apos;d much rather reduce user
experience divergence.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformGTKDeprecated.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesGTKDeprecated.txt:
* Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.cpp:
(webkit_print_custom_widget_class_init):
* Source/WebKit/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
(webkit_print_operation_class_init):
(webkitPrintOperationRunDialog):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp:
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/259286@main">https://commits.webkit.org/259286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a23cad2839ba6201b8eef34348982732f1f06dde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113371 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173661 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4168 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112432 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38698 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80356 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27072 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3616 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6403 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8535 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->