### PR TITLE
[ui-Side compositing] Support custom scrollbars

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -1542,24 +1542,24 @@ bool FrameView::styleHidesScrollbarWithOrientation(ScrollbarOrientation orientat
     return scrollbarStyle && scrollbarStyle->display() == DisplayType::None;
 }
 
-bool FrameView::horizontalScrollbarHiddenByStyle() const
+NativeScrollbarVisibility FrameView::horizontalNativeScrollbarVisibility() const
 {
     if (managesScrollbars()) {
         auto* scrollbar = horizontalScrollbar();
-        return scrollbar && scrollbar->isHiddenByStyle();
+        return Scrollbar::nativeScrollbarVisibility(scrollbar);
     }
 
-    return styleHidesScrollbarWithOrientation(ScrollbarOrientation::Horizontal);
+    return styleHidesScrollbarWithOrientation(ScrollbarOrientation::Horizontal) ? NativeScrollbarVisibility::HiddenByStyle : NativeScrollbarVisibility::Visible;
 }
 
-bool FrameView::verticalScrollbarHiddenByStyle() const
+NativeScrollbarVisibility FrameView::verticalNativeScrollbarVisibility() const
 {
     if (managesScrollbars()) {
         auto* scrollbar = verticalScrollbar();
-        return scrollbar && scrollbar->isHiddenByStyle();
+        return Scrollbar::nativeScrollbarVisibility(scrollbar);
     }
-    
-    return styleHidesScrollbarWithOrientation(ScrollbarOrientation::Vertical);
+
+    return styleHidesScrollbarWithOrientation(ScrollbarOrientation::Vertical) ? NativeScrollbarVisibility::HiddenByStyle : NativeScrollbarVisibility::Visible;
 }
 
 void FrameView::setCannotBlitToWindow()

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -829,8 +829,8 @@ private:
     bool canShowNonOverlayScrollbars() const final;
 
     bool styleHidesScrollbarWithOrientation(ScrollbarOrientation) const;
-    bool horizontalScrollbarHiddenByStyle() const final;
-    bool verticalScrollbarHiddenByStyle() const final;
+    NativeScrollbarVisibility horizontalNativeScrollbarVisibility() const final;
+    NativeScrollbarVisibility verticalNativeScrollbarVisibility() const final;
 
     // Override scrollbar notifications to update the AXObject cache.
     void didAddScrollbar(Scrollbar*, ScrollbarOrientation) final;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -906,8 +906,8 @@ void AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry(Scrolling
     scrollParameters.verticalOverscrollBehavior = scrollableArea.verticalOverscrollBehavior();
     scrollParameters.horizontalScrollbarMode = scrollableArea.horizontalScrollbarMode();
     scrollParameters.verticalScrollbarMode = scrollableArea.verticalScrollbarMode();
-    scrollParameters.horizontalScrollbarHiddenByStyle = scrollableArea.horizontalScrollbarHiddenByStyle();
-    scrollParameters.verticalScrollbarHiddenByStyle = scrollableArea.verticalScrollbarHiddenByStyle();
+    scrollParameters.horizontalNativeScrollbarVisibility = scrollableArea.horizontalNativeScrollbarVisibility();
+    scrollParameters.verticalNativeScrollbarVisibility = scrollableArea.verticalNativeScrollbarVisibility();
     scrollParameters.useDarkAppearanceForScrollbars = scrollableArea.useDarkAppearanceForScrollbars();
 
     scrollingNode->setScrollableAreaParameters(scrollParameters);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -100,11 +100,10 @@ TextStream& operator<<(TextStream& ts, ScrollableAreaParameters scrollableAreaPa
         ts.dumpProperty("allows horizontal scrolling", scrollableAreaParameters.allowsHorizontalScrolling);
     if (scrollableAreaParameters.allowsVerticalScrolling)
         ts.dumpProperty("allows vertical scrolling", scrollableAreaParameters.allowsVerticalScrolling);
-
-    if (scrollableAreaParameters.horizontalScrollbarHiddenByStyle)
-        ts.dumpProperty("horizontal scrollbar hidden by style", scrollableAreaParameters.horizontalScrollbarHiddenByStyle);
-    if (scrollableAreaParameters.verticalScrollbarHiddenByStyle)
-        ts.dumpProperty("vertical scrollbar hidden by style", scrollableAreaParameters.verticalScrollbarHiddenByStyle);
+    if (scrollableAreaParameters.horizontalNativeScrollbarVisibility == NativeScrollbarVisibility::HiddenByStyle)
+        ts.dumpProperty("horizontal scrollbar hidden by style", scrollableAreaParameters.horizontalNativeScrollbarVisibility);
+    if (scrollableAreaParameters.verticalNativeScrollbarVisibility == NativeScrollbarVisibility::HiddenByStyle)
+        ts.dumpProperty("vertical scrollbar hidden by style", scrollableAreaParameters.verticalNativeScrollbarVisibility);
 
     return ts;
 }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -84,8 +84,8 @@ struct ScrollableAreaParameters {
     bool allowsHorizontalScrolling { false };
     bool allowsVerticalScrolling { false };
 
-    bool horizontalScrollbarHiddenByStyle { false };
-    bool verticalScrollbarHiddenByStyle { false };
+    NativeScrollbarVisibility horizontalNativeScrollbarVisibility { NativeScrollbarVisibility::Visible };
+    NativeScrollbarVisibility verticalNativeScrollbarVisibility { NativeScrollbarVisibility::Visible };
 
     bool useDarkAppearanceForScrollbars { false };
 
@@ -99,8 +99,8 @@ struct ScrollableAreaParameters {
             && verticalOverscrollBehavior == other.verticalOverscrollBehavior
             && allowsHorizontalScrolling == other.allowsHorizontalScrolling
             && allowsVerticalScrolling == other.allowsVerticalScrolling
-            && horizontalScrollbarHiddenByStyle == other.horizontalScrollbarHiddenByStyle
-            && verticalScrollbarHiddenByStyle == other.verticalScrollbarHiddenByStyle
+            && horizontalNativeScrollbarVisibility == other.horizontalNativeScrollbarVisibility
+            && verticalNativeScrollbarVisibility == other.verticalNativeScrollbarVisibility
             && useDarkAppearanceForScrollbars == other.useDarkAppearanceForScrollbars;
     }
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -102,8 +102,8 @@ public:
     const FloatSize& scrollableAreaSize() const { return m_scrollableAreaSize; }
     const FloatSize& totalContentsSize() const { return m_totalContentsSize; }
 
-    bool horizontalScrollbarHiddenByStyle() const { return m_scrollableAreaParameters.horizontalScrollbarHiddenByStyle; }
-    bool verticalScrollbarHiddenByStyle() const { return m_scrollableAreaParameters.verticalScrollbarHiddenByStyle; }
+    NativeScrollbarVisibility horizontalNativeScrollbarVisibility() const { return m_scrollableAreaParameters.horizontalNativeScrollbarVisibility; }
+    NativeScrollbarVisibility verticalNativeScrollbarVisibility() const { return m_scrollableAreaParameters.verticalNativeScrollbarVisibility; }
     bool canHaveHorizontalScrollbar() const { return m_scrollableAreaParameters.horizontalScrollbarMode != ScrollbarMode::AlwaysOff; }
     bool canHaveVerticalScrollbar() const { return m_scrollableAreaParameters.verticalScrollbarMode != ScrollbarMode::AlwaysOff; }
     bool canHaveScrollbars() const { return m_scrollableAreaParameters.horizontalScrollbarMode != ScrollbarMode::AlwaysOff || m_scrollableAreaParameters.verticalScrollbarMode != ScrollbarMode::AlwaysOff; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -51,6 +51,10 @@ public:
 
     virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
 
+#if PLATFORM(COCOA)
+    virtual void getScrollbarLayersForStateNode(const ScrollingStateScrollingNode&, CALayer**, CALayer**) { }
+#endif
+
 protected:
     WEBCORE_EXPORT ScrollingTree& scrollingTree() const;
     WEBCORE_EXPORT FloatPoint lastCommittedScrollPosition() const;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -41,6 +41,7 @@ class IntPoint;
 class ScrollingStateScrollingNode;
 class ScrollingTreeScrollingNode;
 class ScrollingTree;
+class ScrollerPairMac;
 
 class ScrollingTreeScrollingNodeDelegateMac final : public ThreadedScrollingTreeScrollingNodeDelegate {
 public:
@@ -60,6 +61,7 @@ public:
 
 private:
     void updateFromStateNode(const ScrollingStateScrollingNode&) final;
+    void getScrollbarLayersForStateNode(const ScrollingStateScrollingNode& scrollingStateNode, CALayer **horizontalLayer, CALayer **verticalLayer) final;
 
     // ScrollingEffectsControllerClient.
     bool allowsHorizontalStretching(const PlatformWheelEvent&) const final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -66,6 +66,22 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
     ThreadedScrollingTreeScrollingNodeDelegate::updateFromStateNode(scrollingStateNode);
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::getScrollbarLayersForStateNode(const ScrollingStateScrollingNode& scrollingStateNode, CALayer **horizontalLayer, CALayer **verticalLayer)
+{
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer) && scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility == NativeScrollbarVisibility::Visible)
+        *verticalLayer = static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer());
+
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer) && scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility ==  NativeScrollbarVisibility::Visible)
+        *horizontalLayer = static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer());
+
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
+        if (scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
+            *verticalLayer = nullptr;
+        if (scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
+            *horizontalLayer = nullptr;
+    }
+}
+
 bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 {
     bool wasInMomentumPhase = m_inMomentumPhase;

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -40,6 +40,16 @@ TextStream& operator<<(TextStream& ts, ScrollType scrollType)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, NativeScrollbarVisibility scrollBarHidden)
+{
+    switch (scrollBarHidden) {
+    case NativeScrollbarVisibility::Visible: ts << 0; break;
+    case NativeScrollbarVisibility::HiddenByStyle: ts << 1; break;
+    case NativeScrollbarVisibility::ReplacedByCustomScrollbar: ts << 2; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, ScrollClamping clamping)
 {
     switch (clamping) {

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -172,6 +172,12 @@ enum class ScrollbarExpansionState : uint8_t {
     Expanded
 };
 
+enum class NativeScrollbarVisibility : uint8_t {
+    Visible,
+    HiddenByStyle,
+    ReplacedByCustomScrollbar
+};
+
 enum class ScrollEventAxis : uint8_t {
     Horizontal,
     Vertical
@@ -349,6 +355,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarMode);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollDirection);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollGranularity);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, NativeScrollbarVisibility);
 
 struct ScrollPositionChangeOptions {
     ScrollType type;

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -136,8 +136,8 @@ public:
     virtual ScrollbarMode verticalScrollbarMode() const { return ScrollbarMode::Auto; }
     bool canHaveScrollbars() const { return horizontalScrollbarMode() != ScrollbarMode::AlwaysOff || verticalScrollbarMode() != ScrollbarMode::AlwaysOff; }
 
-    virtual bool horizontalScrollbarHiddenByStyle() const { return false; }
-    virtual bool verticalScrollbarHiddenByStyle() const { return false; }
+    virtual NativeScrollbarVisibility horizontalNativeScrollbarVisibility() const { return NativeScrollbarVisibility::Visible; }
+    virtual NativeScrollbarVisibility verticalNativeScrollbarVisibility() const { return NativeScrollbarVisibility::Visible; }
     
     virtual OverscrollBehavior horizontalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
     virtual OverscrollBehavior verticalOverscrollBehavior() const { return OverscrollBehavior::Auto; }

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -478,4 +478,14 @@ bool Scrollbar::supportsUpdateOnSecondaryThread() const
 #endif
 }
 
+NativeScrollbarVisibility Scrollbar::nativeScrollbarVisibility(const Scrollbar* scrollbar)
+{
+    if (scrollbar && scrollbar->isHiddenByStyle())
+        return NativeScrollbarVisibility::HiddenByStyle;
+    if (scrollbar && scrollbar->isCustomScrollbar())
+        return NativeScrollbarVisibility::ReplacedByCustomScrollbar;
+    return NativeScrollbarVisibility::Visible;
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -131,6 +131,7 @@ public:
 #endif
 
     bool supportsUpdateOnSecondaryThread() const;
+    static NativeScrollbarVisibility nativeScrollbarVisibility(const Scrollbar*);
 
 protected:
     Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5290,8 +5290,8 @@ void LegacyWebKitScrollingLayerCoordinator::updateScrollingLayer(RenderLayer& la
     auto* scrollableArea = layer.scrollableArea();
     ASSERT(scrollableArea);
 
-    bool allowHorizontalScrollbar = !scrollableArea->horizontalScrollbarHiddenByStyle();
-    bool allowVerticalScrollbar = !scrollableArea->verticalScrollbarHiddenByStyle();
+    bool allowHorizontalScrollbar = scrollableArea->horizontalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle;
+    bool allowVerticalScrollbar = scrollableArea->verticalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle;
 
     m_chromeClient.addOrUpdateScrollingLayer(layer.renderer().element(), backing->scrollContainerLayer()->platformLayer(), backing->scrolledContentsLayer()->platformLayer(),
         scrollableArea->reachableTotalContentsSize(), allowHorizontalScrollbar, allowVerticalScrollbar);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -828,19 +828,16 @@ void RenderLayerScrollableArea::invalidateScrollCornerRect(const IntRect& rect)
         m_resizer->repaintRectangle(rect);
 }
 
-static bool scrollbarHiddenByStyle(Scrollbar* scrollbar)
+NativeScrollbarVisibility RenderLayerScrollableArea::horizontalNativeScrollbarVisibility() const
 {
-    return scrollbar && scrollbar->isHiddenByStyle();
+    auto scrollbar = horizontalScrollbar();
+    return Scrollbar::nativeScrollbarVisibility(scrollbar);
 }
 
-bool RenderLayerScrollableArea::horizontalScrollbarHiddenByStyle() const
+NativeScrollbarVisibility RenderLayerScrollableArea::verticalNativeScrollbarVisibility() const
 {
-    return scrollbarHiddenByStyle(horizontalScrollbar());
-}
-
-bool RenderLayerScrollableArea::verticalScrollbarHiddenByStyle() const
-{
-    return scrollbarHiddenByStyle(verticalScrollbar());
+    auto scrollbar = verticalScrollbar();
+    return Scrollbar::nativeScrollbarVisibility(scrollbar);
 }
 
 bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -138,8 +138,8 @@ public:
     // All methods in this section override ScrollableaArea methods (final).
     void availableContentSizeChanged(AvailableSizeChangeReason) final;
 
-    bool horizontalScrollbarHiddenByStyle() const final;
-    bool verticalScrollbarHiddenByStyle() const final;
+    NativeScrollbarVisibility horizontalNativeScrollbarVisibility() const final;
+    NativeScrollbarVisibility verticalNativeScrollbarVisibility() const final;
 
     bool canShowNonOverlayScrollbars() const final;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1822,6 +1822,13 @@ header: <WebCore/ScrollTypes.h>
     AlwaysOn
 };
 
+header: <WebCore/ScrollTypes.h>
+[CustomHeader] enum class WebCore::NativeScrollbarVisibility : uint8_t {
+    Visible,
+    HiddenByStyle,
+    ReplacedByCustomScrollbar
+};
+
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] struct WebCore::ScrollableAreaParameters {
     WebCore::ScrollElasticity horizontalScrollElasticity;
@@ -1832,8 +1839,8 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
     WebCore::OverscrollBehavior verticalOverscrollBehavior;
     bool allowsHorizontalScrolling;
     bool allowsVerticalScrolling;
-    bool horizontalScrollbarHiddenByStyle;
-    bool verticalScrollbarHiddenByStyle;
+    WebCore::NativeScrollbarVisibility horizontalNativeScrollbarVisibility;
+    WebCore::NativeScrollbarVisibility verticalNativeScrollbarVisibility;
     bool useDarkAppearanceForScrollbars;
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -300,8 +300,8 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         UIScrollView *scrollView = this->scrollView();
 
-        [scrollView setShowsHorizontalScrollIndicator:!scrollingNode().horizontalScrollbarHiddenByStyle()];
-        [scrollView setShowsVerticalScrollIndicator:!scrollingNode().verticalScrollbarHiddenByStyle()];
+        [scrollView setShowsHorizontalScrollIndicator:!(scrollingNode().horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::HiddenByStyle)];
+        [scrollView setShowsVerticalScrollIndicator:!(scrollingNode().verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::HiddenByStyle)];
         [scrollView setScrollEnabled:scrollingNode().canHaveScrollbars()];
 
         END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -53,14 +53,12 @@ void ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren(const S
 {
     ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(stateNode);
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
-
-    // FIXME: Push to ScrollingTreeScrollingNodeDelegateMac?
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
-        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
-        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
-
+    CALayer* horizontalLayer = nullptr;
+    CALayer* verticalLayer = nullptr;
+    m_delegate->getScrollbarLayersForStateNode(scrollingStateNode, &horizontalLayer, &verticalLayer);
+    m_scrollerPair->horizontalScroller().setHostLayer(horizontalLayer);
+    m_scrollerPair->verticalScroller().setHostLayer(verticalLayer);
+    
     m_scrollerPair->updateValues();
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -55,13 +55,11 @@ void ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren(cons
     ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(stateNode);
     const auto& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(stateNode);
 
-    // FIXME: Push to ScrollingTreeScrollingNodeDelegateMac?
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
-        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
-        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
-
+    CALayer* horizontalLayer = nullptr;
+    CALayer* verticalLayer = nullptr;
+    m_delegate->getScrollbarLayersForStateNode(scrollingStateNode, &horizontalLayer, &verticalLayer);
+    m_scrollerPair->horizontalScroller().setHostLayer(horizontalLayer);
+    m_scrollerPair->verticalScroller().setHostLayer(verticalLayer);
     m_scrollerPair->updateValues();
 }
 


### PR DESCRIPTION
#### b0db30ddd932ac3b92d3f3f814b7f9e22a7bf989
<pre>
[ui-Side compositing] Support custom scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=250926">https://bugs.webkit.org/show_bug.cgi?id=250926</a>
rdar://103890177

Reviewed by Simon Fraser.

Since custom scrollbars are currently handled correctly with UI-side compositing,
we just need to hide the native scrollbars. We do this by making ScrollbarHiddenByStyle
an enum which can now be hidden by custom scrollbars as well. When this gets plumbed to
the UIProcess side, check the ScrollableArea parameters to see if we want to hide the
native scrollbars or not.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::horizontalScrollbarHidden const):
(WebCore::FrameView::verticalScrollbarHidden const):
(WebCore::FrameView::horizontalScrollbarHiddenByStyle const): Deleted.
(WebCore::FrameView::verticalScrollbarHiddenByStyle const): Deleted.
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::ScrollableAreaParameters::operator== const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::updateScrollbarsFromStateNode):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateScrollbarsFromStateNode):
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::horizontalScrollbarHidden const):
(WebCore::ScrollableArea::verticalScrollbarHidden const):
(WebCore::ScrollableArea::horizontalScrollbarHiddenByStyle const): Deleted.
(WebCore::ScrollableArea::verticalScrollbarHiddenByStyle const): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::LegacyWebKitScrollingLayerCoordinator::updateScrollingLayer):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::horizontalScrollbarHidden const):
(WebCore::RenderLayerScrollableArea::verticalScrollbarHidden const):
(WebCore::RenderLayerScrollableArea::horizontalScrollbarHiddenByStyle const): Deleted.
(WebCore::RenderLayerScrollableArea::verticalScrollbarHiddenByStyle const): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren):

Canonical link: <a href="https://commits.webkit.org/259322@main">https://commits.webkit.org/259322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87dc29e9db9f95f1dd102d8f54dffd136fb82770

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104575 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113853 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174078 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4579 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112805 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38972 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108052 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80636 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27406 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92465 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4789 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3979 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30049 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103412 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46962 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101151 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8916 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25115 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3411 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->