### PR TITLE
Use WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<> more in WebCore

### DIFF
--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,11 +29,12 @@
 #include "PositionedGlyphs.h"
 #include "RenderingResourceIdentifier.h"
 #include <wtf/HashSet.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
-class DecomposedGlyphs : public ThreadSafeRefCounted<DecomposedGlyphs, WTF::DestructionThread::Main>, public CanMakeWeakPtr<DecomposedGlyphs> {
+class DecomposedGlyphs final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DecomposedGlyphs, WTF::DestructionThread::Main> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     class Observer {

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,9 +76,9 @@ bool ImageSource::ensureDecoderAvailable(FragmentedSharedBuffer* data)
     if (!isDecoderAvailable())
         return false;
 
-    m_decoder->setEncodedDataStatusChangeCallback([weakThis = WeakPtr { *this }] (auto status) {
-        if (weakThis)
-            weakThis->encodedDataStatusChanged(status);
+    m_decoder->setEncodedDataStatusChangeCallback([weakThis = ThreadSafeWeakPtr { *this }] (auto status) {
+        if (RefPtr strongThis = weakThis.get())
+            strongThis->encodedDataStatusChanged(status);
     });
 
     if (auto expectedContentSize = expectedContentLength())

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SynchronizedFixedQueue.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/TextStream.h>
 
@@ -41,7 +41,8 @@ class GraphicsContext;
 class ImageDecoder;
 class FragmentedSharedBuffer;
 
-class ImageSource : public ThreadSafeRefCounted<ImageSource>, public CanMakeWeakPtr<ImageSource> {
+class ImageSource final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageSource> {
     friend class BitmapImage;
 public:
     ~ImageSource();

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc.  All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  * Copyright (C) 2012 Company 100 Inc.
  *
@@ -34,11 +34,12 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
-class NativeImage : public ThreadSafeRefCounted<NativeImage>, public CanMakeWeakPtr<NativeImage> {
+class NativeImage final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NativeImage> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     class Observer {

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,8 +40,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
-#include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS AVPlayerViewController;
 OBJC_CLASS UIViewController;
@@ -64,8 +63,7 @@ class VideoFullscreenChangeObserver;
 class VideoFullscreenInterfaceAVKit final
     : public VideoFullscreenModelClient
     , public PlaybackSessionModelClient
-    , public ThreadSafeRefCounted<VideoFullscreenInterfaceAVKit, WTF::DestructionThread::MainRunLoop>
-    , public CanMakeWeakPtr<VideoFullscreenInterfaceAVKit> {
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenInterfaceAVKit, WTF::DestructionThread::MainRunLoop> {
 public:
     WEBCORE_EXPORT static Ref<VideoFullscreenInterfaceAVKit> create(PlaybackSessionInterfaceAVKit&);
     virtual ~VideoFullscreenInterfaceAVKit();

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,9 +25,8 @@
 
 #pragma once
 
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URLHash.h>
-#include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSURLRequest;
 OBJC_CLASS WebCoreNSURLSessionDataTask;
@@ -38,7 +37,8 @@ struct ParsedRequestRange;
 class PlatformMediaResource;
 class ResourceResponse;
 
-class RangeResponseGenerator : public ThreadSafeRefCounted<RangeResponseGenerator, WTF::DestructionThread::Main>, public CanMakeWeakPtr<RangeResponseGenerator> {
+class RangeResponseGenerator final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RangeResponseGenerator, WTF::DestructionThread::Main> {
 public:
     static Ref<RangeResponseGenerator> create() { return adoptRef(*new RangeResponseGenerator); }
     ~RangeResponseGenerator();

--- a/Source/WebCore/storage/StorageQuotaManager.h
+++ b/Source/WebCore/storage/StorageQuotaManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,12 +28,13 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WorkQueue.h>
 
 namespace WebCore {
 
-class StorageQuotaManager : public ThreadSafeRefCounted<StorageQuotaManager>, public CanMakeWeakPtr<StorageQuotaManager> {
+class StorageQuotaManager final
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<StorageQuotaManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using UsageGetter = Function<uint64_t()>;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -168,7 +168,7 @@ void RemoteResourceCacheProxy::releaseNativeImage(RenderingResourceIdentifier re
 void RemoteResourceCacheProxy::clearNativeImageMap()
 {
     for (auto& nativeImage : m_nativeImages.values())
-        nativeImage->removeObserver(*this);
+        nativeImage.get()->removeObserver(*this);
     m_nativeImages.clear();
 }
 
@@ -204,7 +204,7 @@ void RemoteResourceCacheProxy::clearImageBufferBackends()
 void RemoteResourceCacheProxy::clearDecomposedGlyphsMap()
 {
     for (auto& decomposedGlyphs : m_decomposedGlyphs.values())
-        decomposedGlyphs->removeObserver(*this);
+        decomposedGlyphs.get()->removeObserver(*this);
     m_decomposedGlyphs.clear();
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -69,9 +69,9 @@ public:
 
 private:
     using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<RemoteImageBufferProxy>>;
-    using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::NativeImage>>;
+    using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::NativeImage>>;
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
-    using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::DecomposedGlyphs>>;
+    using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::DecomposedGlyphs>>;
     
     void releaseNativeImage(WebCore::RenderingResourceIdentifier) override;
     void releaseDecomposedGlyphs(WebCore::RenderingResourceIdentifier) override;


### PR DESCRIPTION
#### 8f33f11f2a7f6cf72197a8651b6a9cf17136154c
<pre>
Use WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt; more in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=250929">https://bugs.webkit.org/show_bug.cgi?id=250929</a>
&lt;rdar://problem/104436726&gt;

Reviewed by Chris Dumez.

Classes that inherit from both WTF::ThreadSafeRefCounted&lt;&gt; and
WTF::CanMakeWeakPtr&lt;&gt; should use
WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt; instead.

Most of the changes below are:
- to replace WeakPtr&lt;&gt; with ThreadSafeWeakPtr&lt;&gt; in instance
  variables and data structures,
- to change raw pointers returned from WeakPtr&lt;&gt;.get() to
  RefPtr&lt;&gt; types, and
- to use a local RefPtr&lt;&gt; to an object instead of checking the
  pointer value in the ThreadSafeWeakPtr&lt;&gt; object directly.

Since a lock is taken each time the value stored in the
ThreadSafeWeakPtr&lt;&gt; is returned, there is an effort to minimize
the number of times that happens within a given method by
creating a local RefPtr&lt;&gt; variable on the stack.

* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::ensureDecoderAvailable):
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(-[WebAVPlayerViewControllerDelegate fullscreenInterface]):
(-[WebAVPlayerViewControllerDelegate setFullscreenInterface:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerWillStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerDidStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:failedToStartPictureInPictureWithError:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerWillStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerDidStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:shouldExitFullScreenWithReason:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerWillStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerDidStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureController:failedToStartPictureInPictureWithError:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerWillStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerDidStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:]):
(-[WebAVPlayerViewController initWithFullscreenInterface:]):
(-[WebAVPlayerViewController enterFullScreenAnimated:completionHandler:]):
- On watchOS, if _fullscreenInterface is nullptr, attempt to
  call completionHandler if set.  Previously this would crash.
(-[WebAVPlayerViewController MY_NO_RETURN]):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h:
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived):
* Source/WebCore/storage/StorageQuotaManager.h:

* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::clearNativeImageMap):
(WebKit::RemoteResourceCacheProxy::clearDecomposedGlyphsMap):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/260107@main">https://commits.webkit.org/260107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f9950160535ef5326cb1c1e740f6e46ac0187fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7301 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99229 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40886 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27953 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/82637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9208 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29304 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6307 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6988 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11347 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->