### PR TITLE
[GStreamer] Harness: Support for "sometimes" source pads

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -48,6 +48,8 @@ public:
         GRefPtr<GstBuffer> pullBuffer();
         GRefPtr<GstEvent> pullEvent();
 
+        bool sendEvent(GstEvent*);
+
         const GRefPtr<GstPad>& pad() const { return m_pad; }
         const GRefPtr<GstCaps>& outputCaps();
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -228,7 +228,12 @@ if (ENABLE_WEBCORE)
         ${TESTWEBKITAPI_DIR}
     )
 
+    set(TestWebCore_DEFINITIONS
+      WEBKIT_SRC_DIR="${CMAKE_SOURCE_DIR}"
+    )
+
     WEBKIT_EXECUTABLE_DECLARE(TestWebCore)
+    target_compile_definitions(TestWebCore PUBLIC TestWebCore_DEFINITIONS)
 endif ()
 
 # TestWebKitLegacy definitions

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -31,6 +31,7 @@
 #include "Test.h"
 #include <WebCore/GStreamerCommon.h>
 #include <WebCore/GStreamerElementHarness.h>
+#include <wtf/FileSystem.h>
 
 using namespace WebCore;
 
@@ -225,6 +226,188 @@ TEST_F(GStreamerTest, harnessFlush)
     // Flushed harness is empty.
     ASSERT_NULL(stream->pullBuffer());
     ASSERT_NULL(stream->pullEvent());
+}
+
+TEST_F(GStreamerTest, harnessParseMP4)
+{
+    GRefPtr<GstElement> element = gst_element_factory_make("parsebin", nullptr);
+    struct BufferTracker {
+        uint64_t totalAudioBuffers { 0 };
+        uint64_t totalVideoBuffers { 0 };
+    } bufferTracker;
+    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&bufferTracker](auto& stream, const auto&) mutable {
+        auto gstStream = adoptGRef(gst_pad_get_stream(stream.pad().get()));
+        auto streamType = gst_stream_get_stream_type(gstStream.get());
+        if (streamType == GST_STREAM_TYPE_AUDIO)
+            bufferTracker.totalAudioBuffers++;
+        else if (streamType == GST_STREAM_TYPE_VIDEO)
+            bufferTracker.totalVideoBuffers++;
+        else {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+    });
+
+    // Feed the contents of a MP4 file to the harnessed parsebin.
+    GUniquePtr<char> filePath(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "WebKit", "test.mp4", nullptr));
+    auto handle = FileSystem::openFile(makeString(filePath.get()), FileSystem::FileOpenMode::Read);
+
+    size_t totalRead = 0;
+    auto size = FileSystem::fileSize(handle).value_or(0);
+    auto caps = adoptGRef(gst_caps_new_empty_simple("video/quicktime"));
+    while (totalRead < size) {
+        size_t bytesToRead = 1024;
+        if (totalRead + bytesToRead > size)
+            bytesToRead = size - totalRead;
+
+        auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, bytesToRead, nullptr));
+        {
+            GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
+            FileSystem::readFromFile(handle, mappedBuffer.data(), bytesToRead);
+        }
+        auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+        EXPECT_TRUE(harness->pushSample(sample.get()));
+
+        totalRead += bytesToRead;
+    }
+
+    // The entire file was processed by parsebin, the output streams should have been created. Check
+    // the first events on each.
+    EXPECT_EQ(harness->outputStreams().size(), 2);
+    for (auto& stream : harness->outputStreams()) {
+        auto event = stream->pullEvent();
+        ASSERT_NOT_NULL(event.get());
+        EXPECT_STREQ(GST_EVENT_TYPE_NAME(event.get()), "stream-start");
+
+        event = stream->pullEvent();
+        ASSERT_NOT_NULL(event.get());
+        EXPECT_STREQ(GST_EVENT_TYPE_NAME(event.get()), "caps");
+        GstCaps* eventCaps;
+        gst_event_parse_caps(event.get(), &eventCaps);
+        ASSERT_TRUE(gst_caps_is_equal(stream->outputCaps().get(), eventCaps));
+
+        event = stream->pullEvent();
+        ASSERT_NOT_NULL(event.get());
+        EXPECT_STREQ(GST_EVENT_TYPE_NAME(event.get()), "stream-collection");
+        GstStreamCollection* collection;
+        gst_event_parse_stream_collection(event.get(), &collection);
+        ASSERT_EQ(gst_stream_collection_get_size(collection), 2);
+    }
+
+    // We haven't pulled any buffer yet, so our buffer tracker should report empty metrics.
+    ASSERT_EQ(bufferTracker.totalAudioBuffers, 0);
+    ASSERT_EQ(bufferTracker.totalVideoBuffers, 0);
+
+    // Flush all internal queues, the harness should trigger our buffer tracker now.
+    harness->flush();
+    ASSERT_EQ(bufferTracker.totalAudioBuffers, 260);
+    ASSERT_EQ(bufferTracker.totalVideoBuffers, 182);
+}
+
+TEST_F(GStreamerTest, harnessDecodeMP4Video)
+{
+    // Process an MP4 file, expecting non-video streams will be discarded.
+    GRefPtr<GstElement> element = gst_element_factory_make("decodebin3", nullptr);
+    struct BufferTracker {
+        uint64_t totalVideoBuffers { 0 };
+    } bufferTracker;
+    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&bufferTracker](auto& stream, const auto&) mutable {
+        auto gstStream = adoptGRef(gst_pad_get_stream(stream.pad().get()));
+        auto streamType = gst_stream_get_stream_type(gstStream.get());
+        if (streamType == GST_STREAM_TYPE_VIDEO)
+            bufferTracker.totalVideoBuffers++;
+        else {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+    });
+
+    auto caps = adoptGRef(gst_caps_new_empty_simple("video/quicktime"));
+    harness->start(WTFMove(caps));
+
+    // Feed the contents of a MP4 file to the harnessed decodebin3, until it is able to figure out
+    // the stream topology.
+    GUniquePtr<char> filePath(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "WebKit", "test.mp4", nullptr));
+    auto handle = FileSystem::openFile(makeString(filePath.get()), FileSystem::FileOpenMode::Read);
+
+    size_t totalRead = 0;
+    auto size = FileSystem::fileSize(handle).value_or(0);
+    GstStreamCollection* collection = nullptr;
+    RefPtr<GStreamerElementHarness::Stream> harnessedStream;
+    while (totalRead < size) {
+        size_t bytesToRead = 512;
+        if (totalRead + bytesToRead > size)
+            bytesToRead = size - totalRead;
+
+        auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, bytesToRead, nullptr));
+        {
+            GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
+            FileSystem::readFromFile(handle, mappedBuffer.data(), bytesToRead);
+        }
+        EXPECT_TRUE(harness->pushBuffer(buffer.leakRef()));
+        totalRead += bytesToRead;
+
+        // Process events, if a stream collection is received, interrupt the buffer feed.
+        for (auto& stream : harness->outputStreams()) {
+            while (auto event = stream->pullEvent()) {
+                if (GST_EVENT_TYPE(event.get()) == GST_EVENT_STREAM_COLLECTION) {
+                    gst_event_parse_stream_collection(event.get(), &collection);
+                    harnessedStream = stream;
+                    break;
+                }
+            }
+            if (collection)
+                break;
+        }
+
+        if (collection)
+            break;
+    }
+
+    // Process the stream collection, discard all non-video streams.
+    unsigned collectionSize = gst_stream_collection_get_size(collection);
+    GList* streams = nullptr;
+    for (unsigned i = 0; i < collectionSize; i++) {
+        auto* stream = gst_stream_collection_get_stream(collection, i);
+        auto streamType = gst_stream_get_stream_type(stream);
+        if (streamType == GST_STREAM_TYPE_VIDEO) {
+            streams = g_list_append(streams, const_cast<char*>(gst_stream_get_stream_id(stream)));
+            break;
+        }
+    }
+
+    // Instruct decodebin3 to reconfigure according to the streams we selected.
+    if (streams) {
+        harnessedStream->sendEvent(gst_event_new_select_streams(streams));
+        g_list_free(streams);
+    }
+
+    // Feed the remaining bytes of the MP4 file to decodebin3.
+    while (totalRead < size) {
+        size_t bytesToRead = 512;
+        if (totalRead + bytesToRead > size)
+            bytesToRead = size - totalRead;
+
+        auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, bytesToRead, nullptr));
+        {
+            GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
+            FileSystem::readFromFile(handle, mappedBuffer.data(), bytesToRead);
+        }
+        EXPECT_TRUE(harness->pushBuffer(buffer.leakRef()));
+
+        totalRead += bytesToRead;
+    }
+
+    // The entire file was processed by decodebin3, the output streams should have been created. We
+    // should only have one output stream at this point.
+    EXPECT_EQ(harness->outputStreams().size(), 1);
+
+    // We haven't pulled any buffer yet, so our buffer tracker should report empty metrics.
+    ASSERT_EQ(bufferTracker.totalVideoBuffers, 0);
+
+    // Flush all internal queues, the harness should trigger our buffer tracker now.
+    harness->flush();
+    ASSERT_GT(bufferTracker.totalVideoBuffers, 100);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b74a229b2b2fc662e3a25031c0d1a9d071f35f44
<pre>
[GStreamer] Harness: Support for &quot;sometimes&quot; source pads
<a href="https://bugs.webkit.org/show_bug.cgi?id=250932">https://bugs.webkit.org/show_bug.cgi?id=250932</a>

Reviewed by Xabier Rodriguez-Calvar.

The harness can now work on GStreamer auto-plugger elements such as parsebin and decodebin. This
will be useful for the ImageDecoder rewrite and also potentially for the MSE &quot;AppendPipeline&quot;.

* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::GStreamerElementHarness::pushBuffer):
(WebCore::GStreamerElementHarness::Stream::sendEvent):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/259209@main">https://commits.webkit.org/259209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7926e8207f77446daf692911e7ef7112237aab2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113396 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173687 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4191 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112454 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38713 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27090 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3634 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8557 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->