### PR TITLE
Disconnected <fieldset> elements sometimes incorrectly match :valid / :invalid selectors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected-expected.txt
@@ -1,0 +1,4 @@
+
+PASS <input> element becomes invalid inside disconnected <fieldset>
+PASS <select> element becomes valid inside disconnected <fieldset>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:valid, :invalid) on disconnected fieldset element</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<fieldset id=fieldset1>
+  <input id=input1>
+</fieldset>
+
+<fieldset id=fieldset2>
+  <select id=select1 required multiple>
+    <option>foo
+  </select>
+</fieldset>
+
+<script>
+test(() => {
+  const fieldset = document.querySelector("#fieldset1");
+  const input = document.querySelector("#input1");
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+
+  fieldset.remove();
+  input.setCustomValidity("foo");
+
+  assert_false(fieldset.matches(":valid"));
+  assert_true(fieldset.matches(":invalid"));
+
+  input.setCustomValidity("");
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+}, "<input> element becomes invalid inside disconnected <fieldset>");
+
+test(() => {
+  const fieldset = document.querySelector("#fieldset2");
+  const select = document.querySelector("#select1");
+
+  assert_false(fieldset.matches(":valid"));
+  assert_true(fieldset.matches(":invalid"));
+
+  fieldset.remove();
+  select.required = false;
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+
+  select.required = true;
+  select.firstElementChild.selected = true;
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+}, "<select> element becomes valid inside disconnected <fieldset>");
+</script>

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -262,13 +262,11 @@ void ValidatedFormListedElement::updateValidity()
 
         if (willValidate) {
             if (!newIsValid) {
-                if (element.isConnected())
-                    addInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
+                addInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
                 if (auto* form = this->form())
                     form->addInvalidFormControl(element);
             } else {
-                if (element.isConnected())
-                    removeInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
+                removeInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
                 if (auto* form = this->form())
                     form->removeInvalidFormControlIfNeeded(element);
             }


### PR DESCRIPTION
#### 7c77ae89409598c580a9d814b12d21a6cf71a31c
<pre>
Disconnected &lt;fieldset&gt; elements sometimes incorrectly match :valid / :invalid selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=250936">https://bugs.webkit.org/show_bug.cgi?id=250936</a>

Reviewed by Ryosuke Niwa.

This change removes isConnected() checks from updateValidity() so that form controls in disconnected
subtrees update validity status of their &lt;fieldset&gt; ancestors, like they do for form owners,
aligning WebKit with the spec [1], Blink, and Gecko.

[1] <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid">https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid</a> (no connected-ness check)

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html: Added.
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateValidity):

Canonical link: <a href="https://commits.webkit.org/259422@main">https://commits.webkit.org/259422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f5f7844977130991559ed62d4baeb4ced5b2329

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113402 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173692 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4197 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96418 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112460 "Hash 8f5f7844 for PR 8919 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38719 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6645 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3640 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6501 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8563 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->