### PR TITLE
Prevent overflow of width/height of layout overflow rectangle which can cause scroll bar to malfunction

### DIFF
--- a/Source/WebCore/rendering/RenderOverflow.h
+++ b/Source/WebCore/rendering/RenderOverflow.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -77,10 +78,13 @@ inline void RenderOverflow::addLayoutOverflow(const LayoutRect& rect)
 {
     LayoutUnit maxX = std::max(rect.maxX(), m_layoutOverflow.maxX());
     LayoutUnit maxY = std::max(rect.maxY(), m_layoutOverflow.maxY());
-    m_layoutOverflow.setX(std::min(rect.x(), m_layoutOverflow.x()));
-    m_layoutOverflow.setY(std::min(rect.y(), m_layoutOverflow.y()));
-    m_layoutOverflow.setWidth(maxX - m_layoutOverflow.x());
-    m_layoutOverflow.setHeight(maxY - m_layoutOverflow.y());
+    LayoutUnit minX = std::min(rect.x(), m_layoutOverflow.x());
+    LayoutUnit minY = std::min(rect.y(), m_layoutOverflow.y());
+    // In case the width/height is larger than LayoutUnit can represent, fix the right/bottom edge and shift the top/left ones
+    m_layoutOverflow.setWidth(maxX - minX);
+    m_layoutOverflow.setHeight(maxY - minY);
+    m_layoutOverflow.setX(maxX - m_layoutOverflow.width());
+    m_layoutOverflow.setY(maxY - m_layoutOverflow.height());
 }
 
 inline void RenderOverflow::addVisualOverflow(const LayoutRect& rect)


### PR DESCRIPTION
#### 5f8306750a54e227a29119f33f4a888c778d54a0
<pre>
Prevent overflow of width/height of layout overflow rectangle which can cause scroll bar to malfunction

Prevent overflow of width/height of layout overflow rectangle which can cause scroll bar to malfunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=250944">https://bugs.webkit.org/show_bug.cgi?id=250944</a>

Reviewed by Alan Baradlay.

This patch is to align WebKit behavior with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/d050f9be579d02e40c8924b4153376bc32ffba1a">https://chromium.googlesource.com/chromium/blink/+/d050f9be579d02e40c8924b4153376bc32ffba1a</a>

When a child element is positioned very far away the width/height of
layout overflow rectangle may overflow. The patch detects such cases in
RenderOverflow::addLayoutOverflow and shift the top/left edges of the
rectangle to avoid overflow.

NOTE - The test case was already added by 138972@main from same
commit but original patch was not added. The test case still does not show
scrollbar like other browsers.

* Source/WebCore/rendering/RenderOverflow.h:
(RenderOverflow:addLayoutOverflow): Update to account for overflow of width/height

Canonical link: <a href="https://commits.webkit.org/259178@main">https://commits.webkit.org/259178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cbac545060edfba0ce3849bc407b7343bbd22ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113426 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173717 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4220 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112484 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38743 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6803 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3662 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46664 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6320 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8587 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->