### PR TITLE
[WPE][GTK] Remove most webkit_web_view_new_with_*() constructors

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -58,9 +58,9 @@ struct _WebKitUserContentManagerPrivate {
  * webkit_user_content_manager_add_style_sheet().
  *
  * To use a #WebKitUserContentManager, it must be created using
- * webkit_user_content_manager_new(), and then passed to
- * webkit_web_view_new_with_user_content_manager(). User style
- * sheets can be created with webkit_user_style_sheet_new().
+ * webkit_user_content_manager_new(), and then used to construct
+ * a #WebKitWebView. User style sheets can be created with
+ * webkit_user_style_sheet_new().
  *
  * User style sheets can be added and removed at any time, but
  * they will affect the web pages loaded afterwards.

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -396,22 +396,29 @@ WEBKIT_API GtkWidget *
 webkit_web_view_new                                  (void);
 
 WEBKIT_API GtkWidget *
+webkit_web_view_new_with_related_view                (WebKitWebView             *web_view);
+
+#if !ENABLE(2022_GLIB_API)
+WEBKIT_API GtkWidget *
 webkit_web_view_new_with_context                     (WebKitWebContext          *context);
 
 WEBKIT_API GtkWidget *
 webkit_web_view_new_with_settings                    (WebKitSettings            *settings);
 
 WEBKIT_API GtkWidget *
-webkit_web_view_new_with_related_view                (WebKitWebView             *web_view);
-
-WEBKIT_API GtkWidget *
 webkit_web_view_new_with_user_content_manager        (WebKitUserContentManager  *user_content_manager);
+#endif
 #endif
 
 #if PLATFORM(WPE)
 WEBKIT_API WebKitWebView *
 webkit_web_view_new                                  (WebKitWebViewBackend      *backend);
 
+WEBKIT_API WebKitWebView *
+webkit_web_view_new_with_related_view                (WebKitWebViewBackend      *backend,
+                                                      WebKitWebView             *web_view);
+
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitWebView *
 webkit_web_view_new_with_context                     (WebKitWebViewBackend      *backend,
                                                       WebKitWebContext          *context);
@@ -421,12 +428,9 @@ webkit_web_view_new_with_settings                    (WebKitWebViewBackend      
                                                       WebKitSettings            *settings);
 
 WEBKIT_API WebKitWebView *
-webkit_web_view_new_with_related_view                (WebKitWebViewBackend      *backend,
-                                                      WebKitWebView             *web_view);
-
-WEBKIT_API WebKitWebView *
 webkit_web_view_new_with_user_content_manager        (WebKitWebViewBackend      *backend,
                                                       WebKitUserContentManager  *user_content_manager);
+#endif
 
 WEBKIT_API WebKitWebViewBackend *
 webkit_web_view_get_backend                          (WebKitWebView             *web_view);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -333,6 +333,7 @@ GtkWidget* webkit_web_view_new()
     return webkit_web_view_new_with_context(webkit_web_context_get_default());
 }
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_context:
  * @context: the #WebKitWebContext to be used by the #WebKitWebView
@@ -355,6 +356,7 @@ GtkWidget* webkit_web_view_new_with_context(WebKitWebContext* context)
         "web-context", context,
         nullptr));
 }
+#endif
 
 /**
  * webkit_web_view_new_with_related_view: (constructor)
@@ -388,6 +390,7 @@ GtkWidget* webkit_web_view_new_with_related_view(WebKitWebView* webView)
         nullptr));
 }
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_settings:
  * @settings: a #WebKitSettings
@@ -426,6 +429,7 @@ GtkWidget* webkit_web_view_new_with_user_content_manager(WebKitUserContentManage
 
     return GTK_WIDGET(g_object_new(WEBKIT_TYPE_WEB_VIEW, "user-content-manager", userContentManager, nullptr));
 }
+#endif
 
 /**
  * webkit_web_view_set_background_color:

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -86,6 +86,7 @@ WebKitWebView* webkit_web_view_new(WebKitWebViewBackend* backend)
         nullptr));
 }
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_context:
  * @backend: (transfer full) (not nullable): wrapped WPE view backend which
@@ -113,6 +114,7 @@ WebKitWebView* webkit_web_view_new_with_context(WebKitWebViewBackend* backend, W
         "web-context", context,
         nullptr));
 }
+#endif
 
 /**
  * webkit_web_view_new_with_related_view: (constructor)
@@ -145,6 +147,7 @@ WebKitWebView* webkit_web_view_new_with_related_view(WebKitWebViewBackend* backe
         nullptr));
 }
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_view_new_with_settings:
  * @backend: (transfer full) (not nullable): wrapped WPE view backend which
@@ -196,6 +199,7 @@ WebKitWebView* webkit_web_view_new_with_user_content_manager(WebKitWebViewBacken
         "user-content-manager", userContentManager,
         nullptr));
 }
+#endif
 
 /**
  * webkit_web_view_set_background_color:

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -59,3 +59,10 @@ enabled. This property was previously disabled by default.
 [signal@WebKit.WebView::context-menu] and [signal@WebKit.WebView::show-option-menu]
 no longer have a [type@Gdk.Event] parameter. Adjust your signal handlers
 accordingly.
+
+## Changes to WebKitWebView construction
+
+`webkit_web_view_new_with_context()`, `webkit_web_view_new_with_settings()`, and
+`webkit_web_view_new_with_user_content_manager()` have all been removed. You
+may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] and
+[ctor@WebKit.WebView.new_with_related_view] both remain.

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -186,11 +186,12 @@ public:
 
     static WebKitWebView* createWebView(WebKitWebContext* context)
     {
-#if PLATFORM(GTK)
-        return WEBKIT_WEB_VIEW(webkit_web_view_new_with_context(context));
-#elif PLATFORM(WPE)
-        return webkit_web_view_new_with_context(createWebViewBackend(), context);
+        return WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+                                            "backend", createWebViewBackend(),
 #endif
+                                            "web-context", context,
+                                            nullptr));
     }
 
     static WebKitWebView* createWebView(WebKitWebView* relatedView)
@@ -204,20 +205,22 @@ public:
 
     static WebKitWebView* createWebView(WebKitUserContentManager* contentManager)
     {
-#if PLATFORM(GTK)
-        return WEBKIT_WEB_VIEW(webkit_web_view_new_with_user_content_manager(contentManager));
-#elif PLATFORM(WPE)
-        return webkit_web_view_new_with_user_content_manager(createWebViewBackend(), contentManager);
+        return WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+                                            "backend", createWebViewBackend(),
 #endif
+                                            "user-content-manager", contentManager,
+                                            nullptr));
     }
 
     static WebKitWebView* createWebView(WebKitSettings* settings)
     {
-#if PLATFORM(GTK)
-        return WEBKIT_WEB_VIEW(webkit_web_view_new_with_settings(settings));
-#elif PLATFORM(WPE)
-        return webkit_web_view_new_with_settings(createWebViewBackend(), settings);
+        return WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+                                            "backend", createWebViewBackend(),
 #endif
+                                            "settings", settings,
+                                            nullptr));
     }
 
     static void objectFinalized(Test* test, GObject* finalizedObject)


### PR DESCRIPTION
#### f2357aa3082326a6bad6e0d5a0198c159b5617bc
<pre>
[WPE][GTK] Remove most webkit_web_view_new_with_*() constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=250835">https://bugs.webkit.org/show_bug.cgi?id=250835</a>

Reviewed by Carlos Garcia Campos.

So many constructors is unwieldy, and they&apos;re only useful if you need to
create a WebKitWebView with exactly one of the many construct
properties, which is a pretty niche situation. So get rid of them. An
exception is webkit_web_view_new_with_related_view() because it inherits
the relevant properties from the related view.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md:
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::createWebView):

Canonical link: <a href="https://commits.webkit.org/259285@main">https://commits.webkit.org/259285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/574d45f02521a55430c7e161f20e30becf1c9e4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113731 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173956 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4447 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112699 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38884 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6888 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46861 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6402 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8809 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->