### PR TITLE
Fix a broken test which calls Selection.setPosition(null)

### DIFF
--- a/LayoutTests/editing/execCommand/indent-images-3-expected.txt
+++ b/LayoutTests/editing/execCommand/indent-images-3-expected.txt
@@ -1,8 +1,11 @@
 This test indents insides a document with exactly two image elements.
-Indentation should fail because the root editable element is inline.
+Indentation should succeed even if the root editable element is inline.
 | <span>
 |   contenteditable=""
-|   <img>
-|   <img>
+|   <blockquote>
+|     style="margin: 0 0 0 40px; border: none; padding: 0px;"
+|     <img>
+|     <img>
+|     <#selection-caret>
 | "\n"
 | "\n"

--- a/LayoutTests/editing/execCommand/indent-images-3.html
+++ b/LayoutTests/editing/execCommand/indent-images-3.html
@@ -10,11 +10,11 @@ if (window.testRunner)
 while (script = document.querySelector('script'))
     script.parentNode.removeChild(script);
 
-getSelection().setPosition(document.getElementsByTagName('div')[0], 2);
+getSelection().setPosition(document.getElementsByTagName('span')[0], 2);
 document.execCommand('indent');
 
 Markup.description('This test indents insides a document with exactly two image elements.\n'
-+ 'Indentation should fail because the root editable element is inline.');
++ 'Indentation should succeed even if the root editable element is inline.');
 Markup.dump(document.body);
 
 </script>


### PR DESCRIPTION
#### a47eabf67b7048e05c86f5eff7316abe3419004f
<pre>
Fix a broken test which calls Selection.setPosition(null)

Fix a broken test which calls Selection.setPosition(null)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250572">https://bugs.webkit.org/show_bug.cgi?id=250572</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/26117c9b8cf6d285a554dc8fcaf0ce8a55bec626">https://chromium.googlesource.com/chromium/blink/+/26117c9b8cf6d285a554dc8fcaf0ce8a55bec626</a>

This test calls document.getElementsByTagName(&apos;div&apos;) but there are no div elements.
As a result, test calls Selection.setPosition(null) and it is clearly not intended.
This test uses a span element instead of div element which is targeted in the indent-images-2.html. Thus this patch rewrite &apos;div&apos; to &apos;span&apos;.

This test originally expects that execCommand(&apos;indent&apos;) should not indent contents inside inline block.
However fixed case, which works as intended, indents the contents.
This patch does only fix broken scripts.

* LayoutTests/editing/execCommand/indent-images-3.html: Fixed Test
* LayoutTests/editing/execCommand/indent-images-3-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/259232@main">https://commits.webkit.org/259232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ef7cc6f534b4abe7d1bad861d9854db92c8de10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113442 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173732 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4235 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96456 "Failed to checkout and rebase branch from PR 8927") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112497 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94152 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96456 "Failed to checkout and rebase branch from PR 8927") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25763 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96456 "Failed to checkout and rebase branch from PR 8927") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3676 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46676 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6363 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8603 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->