### PR TITLE
Fix misc compiler warnings, January 2023 edition

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -322,7 +322,7 @@ JSC_DEFINE_JIT_OPERATION(operationMaterializeObjectInOSR, JSCell*, (JSGlobalObje
                 if (property.location().kind() == ClosureVarPLoc)
                     numberOfClosureVarPloc++;
             }
-            ASSERT(numberOfClosureVarPloc == table->scopeSize());
+            ASSERT_UNUSED(numberOfClosureVarPloc, numberOfClosureVarPloc == table->scopeSize());
         }
 
         return result;

--- a/Source/ThirdParty/xdgmime/CMakeLists.txt
+++ b/Source/ThirdParty/xdgmime/CMakeLists.txt
@@ -21,7 +21,8 @@ add_definitions(-DXDG_PREFIX=_wk_xdg)
 add_library(xdgmime STATIC ${XDGMIME_SOURCES})
 
 if (COMPILER_IS_GCC_OR_CLANG)
-    WEBKIT_ADD_TARGET_C_FLAGS(xdgmime -Wno-cast-function-type
+    WEBKIT_ADD_TARGET_C_FLAGS(xdgmime -Wno-cast-align
+                                      -Wno-cast-function-type
                                       -Wno-sign-compare
                                       -Wno-unused-parameter)
 endif ()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.h
@@ -40,7 +40,7 @@ public:
     static Ref<ScrollingTreePositionedNodeNicosia> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreePositionedNodeNicosia();
 
-    Nicosia::CompositionLayer* layer() const { return m_layer.get(); }
+    Nicosia::CompositionLayer* layer() const override { return m_layer.get(); }
 
 private:
     ScrollingTreePositionedNodeNicosia(ScrollingTree&, ScrollingNodeID);

--- a/Source/WebCore/platform/audio/AudioUtilities.cpp
+++ b/Source/WebCore/platform/audio/AudioUtilities.cpp
@@ -69,7 +69,7 @@ size_t timeToSampleFrame(double time, double sampleRate, SampleFrameRounding rou
     }
 
     // Just return the largest possible size_t value if necessary.
-    if (frame >= std::numeric_limits<size_t>::max())
+    if (frame >= static_cast<double>(std::numeric_limits<size_t>::max()))
         return std::numeric_limits<size_t>::max();
 
     return static_cast<size_t>(frame);

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -71,7 +71,7 @@ private:
 
     // PlatformMediaResourceClient virtual methods.
     void responseReceived(PlatformMediaResource&, const ResourceResponse&, CompletionHandler<void(ShouldContinuePolicyCheck)>&&) override;
-    void redirectReceived(PlatformMediaResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
+    void redirectReceived(PlatformMediaResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
     void dataReceived(PlatformMediaResource&, const SharedBuffer&) override;
     void accessControlCheckFailed(PlatformMediaResource&, const ResourceError&) override;
     void loadFailed(PlatformMediaResource&, const ResourceError&) override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2719,7 +2719,7 @@ RefPtr<WebKit::ViewSnapshot> webkitWebViewBaseTakeViewSnapshot(WebKitWebViewBase
     if (!renderNode)
         return nullptr;
 
-    graphene_rect_t viewport = { 0, 0, static_cast<float>(size.width()), static_cast<float>(size.height()) };
+    graphene_rect_t viewport = { { 0, 0 }, { static_cast<float>(size.width()), static_cast<float>(size.height()) } };
     GdkTexture* texture = gsk_renderer_render_texture(renderer, renderNode.get(), &viewport);
 
     return ViewSnapshot::create(WTFMove(texture));

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -342,7 +342,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     FloatSize viewSize(m_webPageProxy.viewSize());
 
 #if USE(GTK4)
-    graphene_rect_t bounds = { 0, 0, viewSize.width(), viewSize.height() };
+    graphene_rect_t bounds = { { 0, 0 }, { viewSize.width(), viewSize.height() } };
 #endif
 
     if (auto* snapshot = targetItem->snapshot()) {
@@ -464,7 +464,7 @@ void ViewGestureController::snapshot(GtkSnapshot* snapshot, GskRenderNode* pageR
 
     gtk_snapshot_save(snapshot);
 
-    graphene_rect_t clip = { 0, 0, static_cast<float>(size.width()), static_cast<float>(size.height()) };
+    graphene_rect_t clip = { { 0, 0 }, { static_cast<float>(size.width()), static_cast<float>(size.height()) } };
     gtk_snapshot_push_clip(snapshot, &clip);
 
     graphene_point_t translation = { swipingLayerOffset, 0 };
@@ -496,10 +496,10 @@ void ViewGestureController::snapshot(GtkSnapshot* snapshot, GskRenderNode* pageR
     GdkRGBA border = { 0, 0, 0, swipeOverlayBorderOpacity };
     GdkRGBA outline = { 1, 1, 1, swipeOverlayOutlineOpacity };
 
-    graphene_rect_t dimmingRect = { 0, 0,  static_cast<float>(width), static_cast<float>(height) };
-    graphene_rect_t borderRect = { 0, 0, 1, static_cast<float>(height) };
-    graphene_rect_t outlineRect = { -1, 0, 1, static_cast<float>(height) };
-    graphene_rect_t shadowRect = { 0, 0, swipeOverlayShadowWidth, static_cast<float>(height) };
+    graphene_rect_t dimmingRect = { { 0, 0 }, { static_cast<float>(width), static_cast<float>(height) } };
+    graphene_rect_t borderRect = { { 0, 0 }, { 1, static_cast<float>(height) } };
+    graphene_rect_t outlineRect = { { -1, 0 }, { 1, static_cast<float>(height) } };
+    graphene_rect_t shadowRect = { { 0, 0 }, { swipeOverlayShadowWidth, static_cast<float>(height) } };
     graphene_point_t shadowStart = { 0, 0 };
     graphene_point_t shadowEnd = { swipeOverlayShadowWidth, 0 };
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -87,7 +87,7 @@ Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*
     auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
     auto jsContext = jscContextGetOrCreate(frame->priv->webFrame->jsContextForWorld(wkWorld));
     JSDOMWindow* globalObject = frame->priv->webFrame->coreFrame()->script().globalObject(wkWorld->coreWorld());
-    return elements.map([frame, &jsContext, globalObject](auto& element) -> GRefPtr<JSCValue> {
+    return elements.map([&jsContext, globalObject](auto& element) -> GRefPtr<JSCValue> {
         JSValueRef jsValue = nullptr;
         {
             JSC::JSLockHolder lock(globalObject);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -783,6 +783,7 @@ public:
         gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(toggleAction.get()), TRUE);
         webkit_context_menu_append(contextMenu, webkit_context_menu_item_new(toggleAction.get()));
         webkit_context_menu_append(contextMenu, webkit_context_menu_item_new_separator());
+        G_GNUC_END_IGNORE_DEPRECATIONS;
 #endif
         GRefPtr<GAction> gAction = adoptGRef(G_ACTION(g_simple_action_new("WebKitGTKCustomGAction", nullptr)));
         g_simple_action_set_enabled(G_SIMPLE_ACTION(gAction.get()), FALSE);
@@ -790,7 +791,6 @@ public:
         GRefPtr<GAction> toggleGAction = adoptGRef(G_ACTION(g_simple_action_new_stateful("WebKitGTKCustomToggleGAction", nullptr, g_variant_new_boolean(TRUE))));
         webkit_context_menu_append(contextMenu, webkit_context_menu_item_new_from_gaction(toggleGAction.get(), "Custom T_oggle GAction", nullptr));
         webkit_context_menu_append(contextMenu, webkit_context_menu_item_new_separator());
-        G_GNUC_END_IGNORE_DEPRECATIONS;
 
         // Add a submenu.
         GRefPtr<WebKitContextMenu> subMenu = adoptGRef(webkit_context_menu_new());


### PR DESCRIPTION
#### 0b614af9503260341492d216d5f9e6998b390e57
<pre>
Fix misc compiler warnings, January 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=250945">https://bugs.webkit.org/show_bug.cgi?id=250945</a>

Reviewed by Philippe Normand.

It&apos;s been a long time since my last round of warning fixes, since
warnings on EWS are fatal now, which is saving me a lot of effort. But
today I decided to try building with Clang instead of GCC, and it found
some problems that GCC misses.

* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_JIT_OPERATION):
* Source/ThirdParty/xdgmime/CMakeLists.txt:
* Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.h:
* Source/WebCore/platform/audio/AudioUtilities.cpp:
(WebCore::AudioUtilities::timeToSampleFrame):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseTakeViewSnapshot):
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::snapshot):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
(webkitFrameGetJSCValuesForElementsInWorld):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp:

Canonical link: <a href="https://commits.webkit.org/259183@main">https://commits.webkit.org/259183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c00ff338a4744f2c6c067c460cd43c5fce134d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113441 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173739 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4234 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112496 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38751 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80412 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94258 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27122 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92123 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4456 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3675 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29951 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46675 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/100807 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6326 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8602 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25016 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->