### PR TITLE
HTMLConverter should put accessibilityLabels into its NSAttributedString results

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -96,6 +96,7 @@ typedef enum {
 
 @interface NSTextAttachment ()
 - (id)initWithFileWrapper:(NSFileWrapper *)fileWrapper;
+@property (strong) NSString *accessibilityLabel;
 @end
 
 @interface NSTextAlternatives : NSObject

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -237,6 +237,7 @@ static RetainPtr<NSFileWrapper> fileWrapperForElement(HTMLImageElement&);
 - (void)setIgnoresOrientation:(BOOL)flag;
 - (void)setBounds:(CGRect)bounds;
 - (BOOL)ignoresOrientation;
+@property (strong) NSString *accessibilityLabel;
 @end
 
 #endif
@@ -1316,6 +1317,12 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
     if (fileWrapper || usePlaceholder) {
         NSUInteger textLength = [_attrStr length];
         RetainPtr<NSTextAttachment> attachment = adoptNS([[PlatformNSTextAttachment alloc] initWithFileWrapper:fileWrapper.get()]);
+
+        if (auto& ariaLabel = element.getAttribute("aria-label"_s); !ariaLabel.isEmpty())
+            attachment.get().accessibilityLabel = ariaLabel;
+        if (auto& altText = element.getAttribute("alt"_s); !altText.isEmpty())
+            attachment.get().accessibilityLabel = altText;
+
 #if PLATFORM(IOS_FAMILY)
         float verticalAlign = 0.0;
         _caches->floatPropertyValueForNode(element, CSSPropertyVerticalAlign, verticalAlign);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -169,3 +169,37 @@ TEST(WKWebView, GetContentsWithOpticallySizedFontShouldReturnAttributedString)
 
     TestWebKitAPI::Util::run(&finished);
 }
+
+TEST(WKWebView, AttributedStringAccessibilityLabel)
+{
+    auto webView = adoptNS([TestWKWebView new]);
+
+    NSString *imagePath = [[NSBundle mainBundle] pathForResource:@"icon" ofType:@"png" inDirectory:@"TestWebKitAPI.resources"];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<html><body><b>Hello</b> <img src='file://%@' width='100' height='100' alt='alt text'> <img src='file://%@' width='100' height='100' alt='aria label text'></body></html>", imagePath, imagePath]];
+
+    __block bool finished = false;
+
+    [webView _getContentsAsAttributedStringWithCompletionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *documentAttributes, NSError *error) {
+        EXPECT_NOT_NULL(attributedString);
+        EXPECT_NOT_NULL(documentAttributes);
+        EXPECT_NULL(error);
+
+        __block bool foundImage1 { NO };
+        __block bool foundImage2 { NO };
+        [attributedString enumerateAttribute:NSAttachmentAttributeName inRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(id value, NSRange attributeRange, BOOL* stop) {
+            if ([value isKindOfClass:NSTextAttachment.class]) {
+                if ([[value accessibilityLabel] isEqualToString:@"alt text"])
+                    foundImage1 = YES;
+                if ([[value accessibilityLabel] isEqualToString:@"aria label text"])
+                    foundImage2 = YES;
+            }
+        }];
+
+        EXPECT_TRUE(foundImage1);
+        EXPECT_TRUE(foundImage2);
+
+        finished = true;
+    }];
+
+    TestWebKitAPI::Util::run(&finished);
+}


### PR DESCRIPTION
#### a37792319b43c53b0a231c49487c502245ec262d
<pre>
HTMLConverter should put accessibilityLabels into its NSAttributedString results
<a href="https://bugs.webkit.org/show_bug.cgi?id=250947">https://bugs.webkit.org/show_bug.cgi?id=250947</a>
rdar://103608678

Reviewed by Timothy Hatcher.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_addAttachmentForElement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/259179@main">https://commits.webkit.org/259179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f62623cd3b3a85858839d35d24917cb27570de4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113456 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173746 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4247 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112508 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38757 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80422 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27131 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6829 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6321 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8615 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->