### PR TITLE
[WebGPU] Align our compositing infrastructure with the spec and WebGPU.h

### DIFF
--- a/Source/WTF/wtf/cocoa/TollFreeBridging.h
+++ b/Source/WTF/wtf/cocoa/TollFreeBridging.h
@@ -28,6 +28,8 @@
 #ifdef __OBJC__
 #import <CoreFoundation/CoreFoundation.h>
 #import <Foundation/Foundation.h>
+#import <IOSurface/IOSurface.h>
+#import <IOSurface/IOSurfaceObjC.h>
 #endif
 
 namespace WTF {
@@ -56,6 +58,7 @@ WTF_DECLARE_TOLL_FREE_BRIDGING_TRAITS(CFSet, NSSet)
 WTF_DECLARE_TOLL_FREE_BRIDGING_TRAITS(CFString, NSString)
 WTF_DECLARE_TOLL_FREE_BRIDGING_TRAITS(CFTimeZone, NSTimeZone)
 WTF_DECLARE_TOLL_FREE_BRIDGING_TRAITS(CFURL, NSURL)
+WTF_DECLARE_TOLL_FREE_BRIDGING_TRAITS(IOSurface, IOSurface)
 
 template<> struct CFTollFreeBridgingTraits<CFBooleanRef> { using BridgedType = NSNumber *; };
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -32,6 +32,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/GPUCompilationInfo.h
     Modules/WebGPU/GPUCompilationMessage.h
     Modules/WebGPU/GPUCompilationMessageType.h
+    Modules/WebGPU/GPUCompositorIntegration.h
     Modules/WebGPU/GPUComputePassDescriptor.h
     Modules/WebGPU/GPUComputePassEncoder.h
     Modules/WebGPU/GPUComputePassTimestampLocation.h

--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -37,29 +37,37 @@
 
 namespace WebCore {
 
+class GPUCompositorIntegration;
+class GPUSurface;
+struct GPUSurfaceDescriptor;
+
 class GPU : public RefCounted<GPU> {
 public:
-    static Ref<GPU> create()
+    static Ref<GPU> create(Ref<PAL::WebGPU::GPU>&& backing)
     {
-        return adoptRef(*new GPU());
+        return adoptRef(*new GPU(WTFMove(backing)));
     }
+
+    ~GPU();
 
     using RequestAdapterPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<GPUAdapter>>>;
     void requestAdapter(const std::optional<GPURequestAdapterOptions>&, RequestAdapterPromise&&);
 
     GPUTextureFormat getPreferredCanvasFormat();
 
-    void setBacking(PAL::WebGPU::GPU&);
+    Ref<GPUSurface> createSurface(const GPUSurfaceDescriptor&);
+
+    Ref<GPUCompositorIntegration> createCompositorIntegration();
 
 private:
-    GPU() = default;
+    GPU(Ref<PAL::WebGPU::GPU>&&);
 
     struct PendingRequestAdapterArguments {
         std::optional<GPURequestAdapterOptions> options;
         RequestAdapterPromise promise;
     };
     Deque<PendingRequestAdapterArguments> m_pendingRequestAdapterArguments;
-    RefPtr<PAL::WebGPU::GPU> m_backing;
+    Ref<PAL::WebGPU::GPU> m_backing;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GPUCompositorIntegration.h"
+
+namespace WebCore {
+
+#if PLATFORM(COCOA)
+Vector<MachSendRight> GPUCompositorIntegration::getRenderBuffers() const
+{
+    return m_backing->getRenderBuffers();
+}
+#endif
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <pal/graphics/WebGPU/WebGPUCompositorIntegration.h>
+#include <wtf/MachSendRight.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class GPUCompositorIntegration : public RefCounted<GPUCompositorIntegration> {
+public:
+    static Ref<GPUCompositorIntegration> create(Ref<PAL::WebGPU::CompositorIntegration>&& backing)
+    {
+        return adoptRef(*new GPUCompositorIntegration(WTFMove(backing)));
+    }
+
+#if PLATFORM(COCOA)
+    Vector<MachSendRight> getRenderBuffers() const;
+#endif
+
+    PAL::WebGPU::CompositorIntegration& backing() { return m_backing; }
+    const PAL::WebGPU::CompositorIntegration& backing() const { return m_backing; }
+
+private:
+    GPUCompositorIntegration(Ref<PAL::WebGPU::CompositorIntegration>&& backing)
+        : m_backing(WTFMove(backing))
+    {
+    }
+
+    Ref<PAL::WebGPU::CompositorIntegration> m_backing;
+};
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -118,16 +118,6 @@ Ref<GPUTexture> GPUDevice::createTexture(const GPUTextureDescriptor& textureDesc
     return GPUTexture::create(m_backing->createTexture(textureDescriptor.convertToBacking()));
 }
 
-Ref<GPUTexture> GPUDevice::createSurfaceTexture(const GPUTextureDescriptor& textureDescriptor, const GPUSurface& surface)
-{
-    return GPUTexture::create(m_backing->createSurfaceTexture(textureDescriptor.convertToBacking(), surface.backing()));
-}
-
-Ref<GPUSurface> GPUDevice::createSurface(const GPUSurfaceDescriptor& surfaceDescriptor)
-{
-    return GPUSurface::create(m_backing->createSurface(surfaceDescriptor.convertToBacking()));
-}
-
 Ref<GPUSwapChain> GPUDevice::createSwapChain(const GPUSurface& surface, const GPUSwapChainDescriptor& swapChainDescriptor)
 {
     return GPUSwapChain::create(m_backing->createSwapChain(surface.backing(), swapChainDescriptor.convertToBacking()));

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -101,8 +101,6 @@ public:
 
     Ref<GPUBuffer> createBuffer(const GPUBufferDescriptor&);
     Ref<GPUTexture> createTexture(const GPUTextureDescriptor&);
-    Ref<GPUTexture> createSurfaceTexture(const GPUTextureDescriptor&, const GPUSurface&);
-    Ref<GPUSurface> createSurface(const GPUSurfaceDescriptor&);
     Ref<GPUSwapChain> createSwapChain(const GPUSurface&, const GPUSwapChainDescriptor&);
     Ref<GPUSampler> createSampler(const std::optional<GPUSamplerDescriptor>&);
     Ref<GPUExternalTexture> importExternalTexture(const GPUExternalTextureDescriptor&);

--- a/Source/WebCore/Modules/WebGPU/GPUSurface.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUSurface.cpp
@@ -44,8 +44,4 @@ void GPUSurface::setLabel(String&& label)
     m_backing->setLabel(WTFMove(label));
 }
 
-void GPUSurface::destroy()
-{
-}
-
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSurface.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSurface.h
@@ -43,8 +43,6 @@ public:
     String label() const;
     void setLabel(String&&);
 
-    void destroy();
-
     PAL::WebGPU::Surface& backing() { return m_backing; }
     const PAL::WebGPU::Surface& backing() const { return m_backing; }
 

--- a/Source/WebCore/Modules/WebGPU/GPUSurfaceDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSurfaceDescriptor.h
@@ -25,11 +25,8 @@
 
 #pragma once
 
-#include "GPUExtent3DDict.h"
-#include "GPUIntegralTypes.h"
+#include "GPUCompositorIntegration.h"
 #include "GPUObjectDescriptorBase.h"
-#include "GPUTextureFormat.h"
-#include "GPUTextureUsage.h"
 #include <pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h>
 
 namespace WebCore {
@@ -37,19 +34,14 @@ namespace WebCore {
 struct GPUSurfaceDescriptor : public GPUObjectDescriptorBase {
     PAL::WebGPU::SurfaceDescriptor convertToBacking() const
     {
+        ASSERT(compositorIntegration);
         return {
             { label },
-            WebCore::convertToBacking(size),
-            sampleCount,
-            WebCore::convertToBacking(format),
-            convertTextureUsageFlagsToBacking(usage)
+            compositorIntegration->backing(),
         };
     }
 
-    GPUExtent3D size;
-    GPUSize32 sampleCount { 1 };
-    GPUTextureFormat format { GPUTextureFormat::R8unorm };
-    GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
+    GPUCompositorIntegration* compositorIntegration { nullptr };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSwapChain.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChain.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "GPUTexture.h"
+#include "GPUTextureView.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUSwapChain.h>
 #include <wtf/Ref.h>
@@ -43,10 +45,9 @@ public:
     String label() const;
     void setLabel(String&&);
 
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
-#endif
-    void destroy();
+    GPUTexture& getCurrentTexture();
+    GPUTextureView& getCurrentTextureView();
+    void present();
 
     PAL::WebGPU::SwapChain& backing() { return m_backing; }
     const PAL::WebGPU::SwapChain& backing() const { return m_backing; }
@@ -56,8 +57,13 @@ private:
         : m_backing(WTFMove(backing))
     {
     }
+    
+    void clearCurrentTextureAndView();
+    void ensureCurrentTextureAndView();
 
     Ref<PAL::WebGPU::SwapChain> m_backing;
+    RefPtr<GPUTexture> m_currentTexture;
+    RefPtr<GPUTextureView> m_currentTextureView;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSwapChainDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChainDescriptor.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include "GPUCanvasCompositingAlphaMode.h"
 #include "GPUExtent3DDict.h"
 #include "GPUIntegralTypes.h"
 #include "GPUObjectDescriptorBase.h"
 #include "GPUTextureFormat.h"
 #include "GPUTextureUsage.h"
 #include <pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -39,17 +41,25 @@ struct GPUSwapChainDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            WebCore::convertToBacking(size),
-            sampleCount,
             WebCore::convertToBacking(format),
             convertTextureUsageFlagsToBacking(usage),
+            viewFormats.map([] (auto& viewFormat) {
+                return WebCore::convertToBacking(viewFormat);
+            }),
+            WebCore::convertToBacking(colorSpace),
+            WebCore::convertToBacking(compositingAlphaMode),
+            width,
+            height,
         };
     }
 
-    GPUExtent3D size;
-    GPUSize32 sampleCount { 1 };
     GPUTextureFormat format { GPUTextureFormat::R8unorm };
-    GPUTextureUsageFlags usage { 0 };
+    GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
+    Vector<GPUTextureFormat> viewFormats;
+    GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
+    GPUCanvasCompositingAlphaMode compositingAlphaMode { GPUCanvasCompositingAlphaMode::Opaque };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
 };
 
 }

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		1C5C57E92757318E003B540D /* TextEncodingRegistryMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5C57E82757318D003B540D /* TextEncodingRegistryMac.mm */; };
 		1C77C8C925D7972000635E0C /* CoreTextSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C77C8C725D7972000635E0C /* CoreTextSoftLink.cpp */; };
 		1C77C8CE25D7A4A300635E0C /* OTSVGTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C77C8CD25D7A4A300635E0C /* OTSVGTable.cpp */; };
+		1CAB34F5297AA26B0088D4D3 /* WebGPUCompositorIntegrationImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAB34F1297A9F0A0088D4D3 /* WebGPUCompositorIntegrationImpl.cpp */; };
+		1CAB34F6297AA2760088D4D3 /* WebGPUCompositorIntegrationImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAB34F2297A9F0A0088D4D3 /* WebGPUCompositorIntegrationImpl.h */; };
+		1CAB34F7297AA2C30088D4D3 /* WebGPUCompositorIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAB34EE297A9E280088D4D3 /* WebGPUCompositorIntegration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1CB709FC28034EDF00A3A637 /* WebGPUDeviceHolderImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CB709FA28034EDF00A3A637 /* WebGPUDeviceHolderImpl.cpp */; };
 		1CB709FD28034EDF00A3A637 /* WebGPUDeviceHolderImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CB709FB28034EDF00A3A637 /* WebGPUDeviceHolderImpl.h */; };
 		1CCA5EFF280FABB4008A6F78 /* WebGPUCreateImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CCA5EFD280FABB4008A6F78 /* WebGPUCreateImpl.cpp */; };
@@ -750,6 +753,9 @@
 		1C77C8C825D7972000635E0C /* CoreTextSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreTextSoftLink.h; sourceTree = "<group>"; };
 		1C77C8CB25D79B6C00635E0C /* OTSVGTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OTSVGTable.h; sourceTree = "<group>"; };
 		1C77C8CD25D7A4A300635E0C /* OTSVGTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = OTSVGTable.cpp; sourceTree = "<group>"; };
+		1CAB34EE297A9E280088D4D3 /* WebGPUCompositorIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUCompositorIntegration.h; sourceTree = "<group>"; };
+		1CAB34F1297A9F0A0088D4D3 /* WebGPUCompositorIntegrationImpl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUCompositorIntegrationImpl.cpp; sourceTree = "<group>"; };
+		1CAB34F2297A9F0A0088D4D3 /* WebGPUCompositorIntegrationImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUCompositorIntegrationImpl.h; sourceTree = "<group>"; };
 		1CB709FA28034EDF00A3A637 /* WebGPUDeviceHolderImpl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUDeviceHolderImpl.cpp; sourceTree = "<group>"; };
 		1CB709FB28034EDF00A3A637 /* WebGPUDeviceHolderImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUDeviceHolderImpl.h; sourceTree = "<group>"; };
 		1CC3ACE722BD7EB800F360F0 /* MetalSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MetalSPI.h; sourceTree = "<group>"; };
@@ -1338,6 +1344,8 @@
 				1C19E6A4273F4244004B17B0 /* WebGPUCommandBufferImpl.h */,
 				1C19E65A273F3FD2004B17B0 /* WebGPUCommandEncoderImpl.cpp */,
 				1C19E6AB273F4245004B17B0 /* WebGPUCommandEncoderImpl.h */,
+				1CAB34F1297A9F0A0088D4D3 /* WebGPUCompositorIntegrationImpl.cpp */,
+				1CAB34F2297A9F0A0088D4D3 /* WebGPUCompositorIntegrationImpl.h */,
 				1C19E65E273F3FE2004B17B0 /* WebGPUComputePassEncoderImpl.cpp */,
 				1C19E69E273F4243004B17B0 /* WebGPUComputePassEncoderImpl.h */,
 				1C19E662273F3FEE004B17B0 /* WebGPUComputePipelineImpl.cpp */,
@@ -1493,6 +1501,7 @@
 				1CC5E45927374947006F6FF4 /* WebGPUCompilationInfo.h */,
 				1CC5E47927374949006F6FF4 /* WebGPUCompilationMessage.h */,
 				1CC5E43627374946006F6FF4 /* WebGPUCompilationMessageType.h */,
+				1CAB34EE297A9E280088D4D3 /* WebGPUCompositorIntegration.h */,
 				1CC5E48C2737494A006F6FF4 /* WebGPUComputePassDescriptor.h */,
 				1CC5E43E27374946006F6FF4 /* WebGPUComputePassEncoder.h */,
 				1CC5E48227374949006F6FF4 /* WebGPUComputePassTimestampLocation.h */,
@@ -1991,6 +2000,8 @@
 				DD20DD5D27BC90D70093D175 /* WebGPUCompilationInfo.h in Headers */,
 				DD20DD5E27BC90D70093D175 /* WebGPUCompilationMessage.h in Headers */,
 				DD20DD5F27BC90D70093D175 /* WebGPUCompilationMessageType.h in Headers */,
+				1CAB34F7297AA2C30088D4D3 /* WebGPUCompositorIntegration.h in Headers */,
+				1CAB34F6297AA2760088D4D3 /* WebGPUCompositorIntegrationImpl.h in Headers */,
 				DD20DD6027BC90D70093D175 /* WebGPUComputePassDescriptor.h in Headers */,
 				DD20DD6127BC90D70093D175 /* WebGPUComputePassEncoder.h in Headers */,
 				DD20DD2E27BC90D60093D175 /* WebGPUComputePassEncoderImpl.h in Headers */,
@@ -2298,6 +2309,7 @@
 				1C19E654273F3FB1004B17B0 /* WebGPUBufferImpl.cpp in Sources */,
 				1C19E658273F3FC0004B17B0 /* WebGPUCommandBufferImpl.cpp in Sources */,
 				1C19E65C273F3FD2004B17B0 /* WebGPUCommandEncoderImpl.cpp in Sources */,
+				1CAB34F5297AA26B0088D4D3 /* WebGPUCompositorIntegrationImpl.cpp in Sources */,
 				1C19E660273F3FE2004B17B0 /* WebGPUComputePassEncoderImpl.cpp in Sources */,
 				1C19E664273F3FEE004B17B0 /* WebGPUComputePipelineImpl.cpp in Sources */,
 				1C19E6B5273F85AF004B17B0 /* WebGPUConvertToBackingContext.cpp in Sources */,

--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PAL_PUBLIC_HEADERS
     graphics/WebGPU/Impl/WebGPUBufferImpl.h
     graphics/WebGPU/Impl/WebGPUCommandBufferImpl.h
     graphics/WebGPU/Impl/WebGPUCommandEncoderImpl.h
+    graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
     graphics/WebGPU/Impl/WebGPUComputePassEncoderImpl.h
     graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h
     graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h
@@ -68,6 +69,7 @@ set(PAL_PUBLIC_HEADERS
     graphics/WebGPU/WebGPUCompilationInfo.h
     graphics/WebGPU/WebGPUCompilationMessage.h
     graphics/WebGPU/WebGPUCompilationMessageType.h
+    graphics/WebGPU/WebGPUCompositorIntegration.h
     graphics/WebGPU/WebGPUComputePassDescriptor.h
     graphics/WebGPU/WebGPUComputePassEncoder.h
     graphics/WebGPU/WebGPUComputePassTimestampLocation.h
@@ -206,6 +208,7 @@ set(PAL_SOURCES
     graphics/WebGPU/Impl/WebGPUBufferImpl.cpp
     graphics/WebGPU/Impl/WebGPUCommandBufferImpl.cpp
     graphics/WebGPU/Impl/WebGPUCommandEncoderImpl.cpp
+    graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
     graphics/WebGPU/Impl/WebGPUComputePassEncoderImpl.cpp
     graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
     graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBindGroupLayoutImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBindGroupLayoutImpl.cpp
@@ -33,10 +33,12 @@
 
 namespace PAL::WebGPU {
 
-BindGroupLayoutImpl::BindGroupLayoutImpl(WGPUBindGroupLayout bindGroupLayout, ConvertToBackingContext& convertToBackingContext)
+BindGroupLayoutImpl::BindGroupLayoutImpl(WGPUBindGroupLayout bindGroupLayout, ConvertToBackingContext& convertToBackingContext, Ownership ownership)
     : m_backing(bindGroupLayout)
     , m_convertToBackingContext(convertToBackingContext)
 {
+    if (ownership == Ownership::Wrap)
+        wgpuBindGroupLayoutRetain(bindGroupLayout);
 }
 
 BindGroupLayoutImpl::~BindGroupLayoutImpl()

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBindGroupLayoutImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBindGroupLayoutImpl.h
@@ -39,7 +39,11 @@ class BindGroupLayoutImpl final : public BindGroupLayout {
 public:
     static Ref<BindGroupLayoutImpl> create(WGPUBindGroupLayout bindGroupLayout, ConvertToBackingContext& convertToBackingContext)
     {
-        return adoptRef(*new BindGroupLayoutImpl(bindGroupLayout, convertToBackingContext));
+        return adoptRef(*new BindGroupLayoutImpl(bindGroupLayout, convertToBackingContext, Ownership::Adopt));
+    }
+    static Ref<BindGroupLayoutImpl> wrap(WGPUBindGroupLayout bindGroupLayout, ConvertToBackingContext& convertToBackingContext)
+    {
+        return adoptRef(*new BindGroupLayoutImpl(bindGroupLayout, convertToBackingContext, Ownership::Wrap));
     }
 
     virtual ~BindGroupLayoutImpl();
@@ -47,7 +51,11 @@ public:
 private:
     friend class DowncastConvertToBackingContext;
 
-    BindGroupLayoutImpl(WGPUBindGroupLayout, ConvertToBackingContext&);
+    enum class Ownership {
+        Adopt,
+        Wrap,
+    };
+    BindGroupLayoutImpl(WGPUBindGroupLayout, ConvertToBackingContext&, Ownership);
 
     BindGroupLayoutImpl(const BindGroupLayoutImpl&) = delete;
     BindGroupLayoutImpl(BindGroupLayoutImpl&&) = delete;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebGPUCompositorIntegrationImpl.h"
+
+#if HAVE(WEBGPU_IMPLEMENTATION)
+
+#include "WebGPUConvertToBackingContext.h"
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOSurface/IOSurface.h>
+#include <WebGPU/WebGPUExt.h>
+
+namespace PAL::WebGPU {
+
+CompositorIntegrationImpl::CompositorIntegrationImpl(ConvertToBackingContext& convertToBackingContext)
+    : m_convertToBackingContext(convertToBackingContext)
+{
+}
+
+CompositorIntegrationImpl::~CompositorIntegrationImpl() = default;
+
+#if PLATFORM(COCOA)
+Vector<MachSendRight> CompositorIntegrationImpl::getRenderBuffers()
+{
+    return m_renderBuffers.map([] (const auto& renderBuffer) {
+        return MachSendRight::adopt(IOSurfaceCreateMachPort(renderBuffer.get()));
+    });
+}
+
+static RetainPtr<CFNumberRef> toCFNumber(int x)
+{
+    return adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &x));
+}
+
+Vector<RetainPtr<IOSurfaceRef>> CompositorIntegrationImpl::recreateIOSurfaces(const WGPUSwapChainDescriptor& descriptor)
+{
+    m_renderBuffers.clear();
+
+    auto createIOSurface = [&]() -> RetainPtr<IOSurfaceRef> {
+        unsigned bytesPerElement = 4;
+        unsigned bytesPerPixel = 4;
+
+        size_t bytesPerRow = IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, descriptor.width * bytesPerPixel);
+        ASSERT(bytesPerRow);
+
+        size_t totalBytes = IOSurfaceAlignProperty(kIOSurfaceAllocSize, descriptor.height * bytesPerRow);
+        ASSERT(totalBytes);
+
+        unsigned pixelFormat = 'BGRA';
+
+        auto options = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 8, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        CFDictionaryAddValue(options.get(), kIOSurfaceWidth, toCFNumber(descriptor.width).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceHeight, toCFNumber(descriptor.height).get());
+        CFDictionaryAddValue(options.get(), kIOSurfacePixelFormat, toCFNumber(pixelFormat).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceBytesPerElement, toCFNumber(bytesPerElement).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceBytesPerRow, toCFNumber(bytesPerRow).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceAllocSize, toCFNumber(totalBytes).get());
+#if PLATFORM(IOS_FAMILY)
+        CFDictionaryAddValue(options.get(), kIOSurfaceCacheMode, toCFNumber(kIOMapWriteCombineCache).get());
+#endif
+        CFDictionaryAddValue(options.get(), kIOSurfaceElementHeight, toCFNumber(1).get());
+
+        return adoptCF(IOSurfaceCreate(options.get()));
+    };
+
+    m_renderBuffers.append(createIOSurface());
+    m_renderBuffers.append(createIOSurface());
+
+    return m_renderBuffers;
+}
+#endif
+
+} // namespace PAL::WebGPU
+
+#endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(WEBGPU_IMPLEMENTATION)
+
+#include "WebGPUCompositorIntegration.h"
+
+#include <WebGPU/WebGPU.h>
+
+#if PLATFORM(COCOA)
+#include <IOSurface/IOSurface.h>
+#include <wtf/MachSendRight.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+#endif
+
+namespace PAL::WebGPU {
+
+class ConvertToBackingContext;
+
+class CompositorIntegrationImpl final : public CompositorIntegration {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<CompositorIntegrationImpl> create(ConvertToBackingContext& convertToBackingContext)
+    {
+        return adoptRef(*new CompositorIntegrationImpl(convertToBackingContext));
+    }
+
+    virtual ~CompositorIntegrationImpl();
+
+#if PLATFORM(COCOA)
+    Vector<RetainPtr<IOSurfaceRef>> recreateIOSurfaces(const WGPUSwapChainDescriptor&);
+#endif
+
+private:
+    friend class DowncastConvertToBackingContext;
+
+    explicit CompositorIntegrationImpl(ConvertToBackingContext&);
+
+    CompositorIntegrationImpl(const CompositorIntegrationImpl&) = delete;
+    CompositorIntegrationImpl(CompositorIntegrationImpl&&) = delete;
+    CompositorIntegrationImpl& operator=(const CompositorIntegrationImpl&) = delete;
+    CompositorIntegrationImpl& operator=(CompositorIntegrationImpl&&) = delete;
+
+#if PLATFORM(COCOA)
+    Vector<MachSendRight> getRenderBuffers() override;
+
+    Vector<RetainPtr<IOSurfaceRef>> m_renderBuffers;
+#endif
+
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
+};
+
+} // namespace PAL::WebGPU
+
+#endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
@@ -47,7 +47,7 @@ ComputePipelineImpl::~ComputePipelineImpl()
 
 Ref<BindGroupLayout> ComputePipelineImpl::getBindGroupLayout(uint32_t index)
 {
-    return BindGroupLayoutImpl::create(wgpuComputePipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
+    return BindGroupLayoutImpl::wrap(wgpuComputePipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
 }
 
 void ComputePipelineImpl::setLabelInternal(const String& label)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h
@@ -54,6 +54,8 @@ class CommandBuffer;
 class CommandEncoder;
 enum class CompareFunction : uint8_t;
 enum class CompilationMessageType : uint8_t;
+class CompositorIntegration;
+class CompositorIntegrationImpl;
 enum class ComputePassTimestampLocation : uint8_t;
 class ComputePassEncoder;
 class ComputePipeline;
@@ -164,6 +166,7 @@ public:
     virtual WGPUSwapChain convertToBacking(const SwapChain&) = 0;
     virtual WGPUTexture convertToBacking(const Texture&) = 0;
     virtual WGPUTextureView convertToBacking(const TextureView&) = 0;
+    virtual CompositorIntegrationImpl& convertToBacking(CompositorIntegration&) = 0;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
@@ -65,8 +65,6 @@ private:
 
     Ref<Buffer> createBuffer(const BufferDescriptor&) final;
     Ref<Texture> createTexture(const TextureDescriptor&) final;
-    Ref<Texture> createSurfaceTexture(const TextureDescriptor&, const Surface&) final;
-    Ref<Surface> createSurface(const SurfaceDescriptor&) final;
     Ref<SwapChain> createSwapChain(const Surface&, const SwapChainDescriptor&) final;
     Ref<Sampler> createSampler(const SamplerDescriptor&) final;
     Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) final;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.cpp
@@ -34,6 +34,7 @@
 #include "WebGPUBufferImpl.h"
 #include "WebGPUCommandBufferImpl.h"
 #include "WebGPUCommandEncoderImpl.h"
+#include "WebGPUCompositorIntegrationImpl.h"
 #include "WebGPUComputePassEncoderImpl.h"
 #include "WebGPUComputePipelineImpl.h"
 #include "WebGPUDeviceImpl.h"
@@ -168,6 +169,11 @@ WGPUTexture DowncastConvertToBackingContext::convertToBacking(const Texture& tex
 WGPUTextureView DowncastConvertToBackingContext::convertToBacking(const TextureView& textureView)
 {
     return static_cast<const TextureViewImpl&>(textureView).backing();
+}
+
+CompositorIntegrationImpl& DowncastConvertToBackingContext::convertToBacking(CompositorIntegration& compositorIntegration)
+{
+    return static_cast<CompositorIntegrationImpl&>(compositorIntegration);
 }
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.h
@@ -64,6 +64,7 @@ public:
     WGPUSwapChain convertToBacking(const SwapChain&) final;
     WGPUTexture convertToBacking(const Texture&) final;
     WGPUTextureView convertToBacking(const TextureView&) final;
+    CompositorIntegrationImpl& convertToBacking(CompositorIntegration&) final;
 
 private:
     DowncastConvertToBackingContext()

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h
@@ -61,6 +61,10 @@ private:
 
     void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) final;
 
+    Ref<Surface> createSurface(const SurfaceDescriptor&) final;
+
+    Ref<CompositorIntegration> createCompositorIntegration() final;
+
     WGPUInstance m_backing { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp
@@ -47,7 +47,7 @@ RenderPipelineImpl::~RenderPipelineImpl()
 
 Ref<BindGroupLayout> RenderPipelineImpl::getBindGroupLayout(uint32_t index)
 {
-    return BindGroupLayoutImpl::create(wgpuRenderPipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
+    return BindGroupLayoutImpl::wrap(wgpuRenderPipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
 }
 
 void RenderPipelineImpl::setLabelInternal(const String& label)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
@@ -36,29 +36,19 @@
 
 namespace PAL::WebGPU {
 
-SurfaceImpl::SurfaceImpl(WGPUSurface surface)
+SurfaceImpl::SurfaceImpl(WGPUSurface surface, ConvertToBackingContext& convertToBackingContext)
     : m_backing(surface)
+    , m_convertToBackingContext(convertToBackingContext)
 {
 }
 
 SurfaceImpl::~SurfaceImpl()
 {
-    destroy();
-}
-
-void SurfaceImpl::destroy()
-{
     wgpuSurfaceRelease(m_backing);
 }
 
-void SurfaceImpl::setLabelInternal(const String& label)
+void SurfaceImpl::setLabelInternal(const String&)
 {
-    UNUSED_PARAM(label);
-}
-
-IOSurfaceRef SurfaceImpl::drawingBuffer() const
-{
-    return wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(m_backing);
 }
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
@@ -41,31 +41,29 @@ class ConvertToBackingContext;
 class SurfaceImpl final : public Surface {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<SurfaceImpl> create(WGPUSurface surface)
+    static Ref<SurfaceImpl> create(WGPUSurface surface, ConvertToBackingContext& convertToBackingContext)
     {
-        return adoptRef(*new SurfaceImpl(surface));
+        return adoptRef(*new SurfaceImpl(surface, convertToBackingContext));
     }
 
     virtual ~SurfaceImpl();
 
     WGPUSurface backing() const { return m_backing; }
-    IOSurfaceRef drawingBuffer() const;
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    SurfaceImpl(WGPUSurface);
+    SurfaceImpl(WGPUSurface, ConvertToBackingContext&);
 
     SurfaceImpl(const SurfaceImpl&) = delete;
     SurfaceImpl(SurfaceImpl&&) = delete;
     SurfaceImpl& operator=(const SurfaceImpl&) = delete;
     SurfaceImpl& operator=(SurfaceImpl&&) = delete;
 
-    void destroy() final;
-
     void setLabelInternal(const String&) final;
 
     WGPUSurface m_backing { nullptr };
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.cpp
@@ -36,12 +36,14 @@
 
 namespace PAL::WebGPU {
 
-TextureImpl::TextureImpl(WGPUTexture texture, TextureFormat format, TextureDimension dimension, ConvertToBackingContext& convertToBackingContext)
+TextureImpl::TextureImpl(WGPUTexture texture, TextureFormat format, TextureDimension dimension, ConvertToBackingContext& convertToBackingContext, Ownership ownership)
     : m_format(format)
     , m_dimension(dimension)
     , m_backing(texture)
     , m_convertToBackingContext(convertToBackingContext)
 {
+    if (ownership == Ownership::Wrap)
+        wgpuTextureRetain(texture);
 }
 
 TextureImpl::~TextureImpl()

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.h
@@ -42,7 +42,11 @@ class TextureImpl final : public Texture {
 public:
     static Ref<TextureImpl> create(WGPUTexture texture, TextureFormat format, TextureDimension dimension, ConvertToBackingContext& convertToBackingContext)
     {
-        return adoptRef(*new TextureImpl(texture, format, dimension, convertToBackingContext));
+        return adoptRef(*new TextureImpl(texture, format, dimension, convertToBackingContext, Ownership::Adopt));
+    }
+    static Ref<TextureImpl> wrap(WGPUTexture texture, TextureFormat format, TextureDimension dimension, ConvertToBackingContext& convertToBackingContext)
+    {
+        return adoptRef(*new TextureImpl(texture, format, dimension, convertToBackingContext, Ownership::Wrap));
     }
 
     virtual ~TextureImpl();
@@ -50,7 +54,11 @@ public:
 private:
     friend class DowncastConvertToBackingContext;
 
-    TextureImpl(WGPUTexture, TextureFormat, TextureDimension, ConvertToBackingContext&);
+    enum class Ownership {
+        Adopt,
+        Wrap,
+    };
+    TextureImpl(WGPUTexture, TextureFormat, TextureDimension, ConvertToBackingContext&, Ownership);
 
     TextureImpl(const TextureImpl&) = delete;
     TextureImpl(TextureImpl&&) = delete;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.cpp
@@ -33,10 +33,12 @@
 
 namespace PAL::WebGPU {
 
-TextureViewImpl::TextureViewImpl(WGPUTextureView textureView, ConvertToBackingContext& convertToBackingContext)
+TextureViewImpl::TextureViewImpl(WGPUTextureView textureView, ConvertToBackingContext& convertToBackingContext, Ownership ownership)
     : m_backing(textureView)
     , m_convertToBackingContext(convertToBackingContext)
 {
+    if (ownership == Ownership::Wrap)
+        wgpuTextureViewRetain(textureView);
 }
 
 TextureViewImpl::~TextureViewImpl()

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.h
@@ -39,7 +39,11 @@ class TextureViewImpl final : public TextureView {
 public:
     static Ref<TextureViewImpl> create(WGPUTextureView textureView, ConvertToBackingContext& convertToBackingContext)
     {
-        return adoptRef(*new TextureViewImpl(textureView, convertToBackingContext));
+        return adoptRef(*new TextureViewImpl(textureView, convertToBackingContext, Ownership::Adopt));
+    }
+    static Ref<TextureViewImpl> wrap(WGPUTextureView textureView, ConvertToBackingContext& convertToBackingContext)
+    {
+        return adoptRef(*new TextureViewImpl(textureView, convertToBackingContext, Ownership::Wrap));
     }
 
     virtual ~TextureViewImpl();
@@ -47,7 +51,11 @@ public:
 private:
     friend class DowncastConvertToBackingContext;
 
-    TextureViewImpl(WGPUTextureView, ConvertToBackingContext&);
+    enum class Ownership {
+        Adopt,
+        Wrap,
+    };
+    TextureViewImpl(WGPUTextureView, ConvertToBackingContext&, Ownership);
 
     TextureViewImpl(const TextureViewImpl&) = delete;
     TextureViewImpl(TextureViewImpl&&) = delete;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h
@@ -34,12 +34,19 @@
 namespace PAL::WebGPU {
 
 class Adapter;
+class CompositorIntegration;
+class Surface;
+struct SurfaceDescriptor;
 
 class GPU : public RefCounted<GPU> {
 public:
     virtual ~GPU() = default;
 
     virtual void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) = 0;
+
+    virtual Ref<Surface> createSurface(const SurfaceDescriptor&) = 0;
+
+    virtual Ref<CompositorIntegration> createCompositorIntegration() = 0;
 
 protected:
     GPU() = default;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/MachSendRight.h>
+#include <wtf/Vector.h>
+#endif
+
+namespace PAL::WebGPU {
+
+class CompositorIntegration : public RefCounted<CompositorIntegration> {
+public:
+    virtual ~CompositorIntegration() = default;
+
+#if PLATFORM(COCOA)
+    virtual Vector<MachSendRight> getRenderBuffers() = 0;
+#endif
+
+protected:
+    CompositorIntegration() = default;
+
+private:
+    CompositorIntegration(const CompositorIntegration&) = delete;
+    CompositorIntegration(CompositorIntegration&&) = delete;
+    CompositorIntegration& operator=(const CompositorIntegration&) = delete;
+    CompositorIntegration& operator=(CompositorIntegration&&) = delete;
+};
+
+} // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
@@ -101,8 +101,6 @@ public:
 
     virtual Ref<Buffer> createBuffer(const BufferDescriptor&) = 0;
     virtual Ref<Texture> createTexture(const TextureDescriptor&) = 0;
-    virtual Ref<Texture> createSurfaceTexture(const TextureDescriptor&, const Surface&) = 0;
-    virtual Ref<Surface> createSurface(const SurfaceDescriptor&) = 0;
     virtual Ref<SwapChain> createSwapChain(const Surface&, const SwapChainDescriptor&) = 0;
     virtual Ref<Sampler> createSampler(const SamplerDescriptor&) = 0;
     virtual Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) = 0;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurface.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurface.h
@@ -43,8 +43,6 @@ public:
         setLabelInternal(m_label);
     }
 
-    virtual void destroy() = 0;
-
 protected:
     Surface() = default;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h
@@ -25,18 +25,14 @@
 
 #pragma once
 
-#include "WebGPUExtent3D.h"
-#include "WebGPUIntegralTypes.h"
+#include "WebGPUCompositorIntegration.h"
 #include "WebGPUObjectDescriptorBase.h"
 #include "WebGPUTextureFormat.h"
 
 namespace PAL::WebGPU {
 
 struct SurfaceDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    Size32 sampleCount { 1 };
-    TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage;
+    CompositorIntegration& compositorIntegration;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h
@@ -34,6 +34,8 @@ namespace PAL::WebGPU {
 
 class Surface;
 struct SurfaceDescriptor;
+class Texture;
+class TextureView;
 
 class SwapChain : public RefCounted<SwapChain> {
 public:
@@ -47,11 +49,9 @@ public:
         setLabelInternal(m_label);
     }
 
-    virtual void destroy() = 0;
-
-#if PLATFORM(COCOA)
-    virtual void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;
-#endif
+    virtual Texture& getCurrentTexture() = 0;
+    virtual TextureView& getCurrentTextureView() = 0;
+    virtual void present() = 0;
 
 protected:
     SwapChain() = default;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h
@@ -25,19 +25,23 @@
 
 #pragma once
 
-#include "WebGPUExtent3D.h"
+#include "WebGPUCanvasCompositingAlphaMode.h"
 #include "WebGPUIntegralTypes.h"
 #include "WebGPUObjectDescriptorBase.h"
+#include "WebGPUPredefinedColorSpace.h"
 #include "WebGPUTextureFormat.h"
 #include "WebGPUTextureUsage.h"
 
 namespace PAL::WebGPU {
 
 struct SwapChainDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    Size32 sampleCount { 1 };
     TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage;
+    TextureUsageFlags usage { TextureUsage::RenderAttachment };
+    Vector<TextureFormat> viewFormats;
+    PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
+    CanvasCompositingAlphaMode compositingAlphaMode { CanvasCompositingAlphaMode::Opaque };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -30,6 +30,7 @@ Modules/WebGPU/GPUCommandBuffer.cpp
 Modules/WebGPU/GPUCommandEncoder.cpp
 Modules/WebGPU/GPUCompilationInfo.cpp
 Modules/WebGPU/GPUCompilationMessage.cpp
+Modules/WebGPU/GPUCompositorIntegration.cpp
 Modules/WebGPU/GPUComputePassEncoder.cpp
 Modules/WebGPU/GPUComputePipeline.cpp
 Modules/WebGPU/GPUDevice.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -194,6 +194,7 @@ editing/mac/TextAlternativeWithRange.mm @no-unify
 editing/mac/TextUndoInsertionMarkupMac.mm
 fileapi/FileCocoa.mm
 history/mac/HistoryItemMac.mm
+html/canvas/GPUCanvasContextCocoa.cpp
 html/shadow/YouTubeEmbedShadowElement.cpp
 inspector/mac/PageDebuggerMac.mm
 loader/archive/cf/LegacyWebArchive.cpp

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -44,6 +44,7 @@ namespace WebCore {
 class BlobCallback;
 class CanvasRenderingContext;
 class CanvasRenderingContext2D;
+class GPU;
 class GraphicsContext;
 class Image;
 class ImageBitmapRenderingContext;
@@ -97,8 +98,8 @@ public:
 
     static bool isWebGPUType(const String&);
 #if HAVE(WEBGPU_IMPLEMENTATION)
-    GPUCanvasContext* createContextWebGPU(const String&);
-    GPUCanvasContext* getContextWebGPU(const String&);
+    GPUCanvasContext* createContextWebGPU(const String&, GPU*);
+    GPUCanvasContext* getContextWebGPU(const String&, GPU*);
 #endif // HAVE(WEBGPU_IMPLEMENTATION)
 
     WEBCORE_EXPORT ExceptionOr<UncachedString> toDataURL(const String& mimeType, JSC::JSValue quality);

--- a/Source/WebCore/html/canvas/GPUCanvasContext.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.cpp
@@ -24,201 +24,22 @@
  */
 
 #include "config.h"
-
-#if HAVE(WEBGPU_IMPLEMENTATION)
-
 #include "GPUCanvasContext.h"
-
-#include "GPUAdapter.h"
-#include "GPUCanvasConfiguration.h"
-#include "GPUSurface.h"
-#include "GPUSurfaceDescriptor.h"
-#include "GPUSwapChain.h"
-#include "GPUSwapChainDescriptor.h"
-#include "GPUTextureDescriptor.h"
-#include "GraphicsLayerContentsDisplayDelegate.h"
-#include "RenderBox.h"
-#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
-static IntSize getCanvasSizeAsIntSize(const GPUCanvasContext::CanvasType& canvas)
-{
-    return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> IntSize {
-        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
-        return { static_cast<int>(scaleFactor * htmlCanvas->width()), static_cast<int>(scaleFactor * htmlCanvas->height()) };
-    }
-#if ENABLE(OFFSCREEN_CANVAS)
-    , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> IntSize {
-        return { static_cast<int>(offscreenCanvas->width()), static_cast<int>(offscreenCanvas->height()) };
-    }
-#endif
-    );
-}
-
-static bool platformSupportsWebGPUSurface()
-{
-#if PLATFORM(COCOA)
-    return true;
-#else
-    return false;
-#endif
-}
-
 WTF_MAKE_ISO_ALLOCATED_IMPL(GPUCanvasContext);
 
-std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase& canvas)
+#if !PLATFORM(COCOA)
+std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase&, GPU&)
 {
-    if (!platformSupportsWebGPUSurface())
-        return nullptr;
-
-    auto context = std::unique_ptr<GPUCanvasContext>(new GPUCanvasContext(canvas));
-    context->suspendIfNeeded();
-    return context;
+    return nullptr;
 }
+#endif
 
 GPUCanvasContext::GPUCanvasContext(CanvasBase& canvas)
     : GPUBasedCanvasRenderingContext(canvas)
-    , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create())
 {
-    ASSERT(platformSupportsWebGPUSurface());
 }
 
-void GPUCanvasContext::reshape(int width, int height)
-{
-    if (m_width == width && m_height == height)
-        return;
-
-    m_width = width;
-    m_height = height;
-    m_swapChain = nullptr;
-
-    createSwapChainIfNeeded();
-}
-
-GPUCanvasContext::CanvasType GPUCanvasContext::canvas()
-{
-    return htmlCanvas();
-}
-
-void GPUCanvasContext::configure(GPUCanvasConfiguration&& configuration)
-{
-    m_configuration = WTFMove(configuration);
-
-    auto canvasSize = getCanvasSizeAsIntSize(htmlCanvas());
-    reshape(canvasSize.width(), canvasSize.height());
-}
-
-void GPUCanvasContext::createSwapChainIfNeeded()
-{
-    if (m_swapChain || !m_configuration)
-        return;
-
-    GPUSurfaceDescriptor surfaceDescriptor = {
-        { "WebGPU Canvas surface"_s },
-        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
-        1 /* sampleCount */,
-        m_configuration->format,
-        m_configuration->usage
-    };
-
-    m_surface = m_configuration->device->createSurface(surfaceDescriptor);
-    ASSERT(m_surface);
-
-    GPUSwapChainDescriptor descriptor = {
-        { "WebGPU Canvas swap chain"_s },
-        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
-        1 /* sampleCount */,
-        m_configuration->format,
-        m_configuration->usage
-    };
-
-    m_swapChain = m_configuration->device->createSwapChain(*m_surface, descriptor);
-    ASSERT(m_swapChain);
-}
-
-RefPtr<GPUTexture> GPUCanvasContext::getCurrentTexture()
-{
-    if (!m_configuration)
-        return nullptr;
-
-    createSwapChainIfNeeded();
-
-    GPUTextureDescriptor descriptor = {
-        { "WebGPU Display texture"_s },
-        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
-        1 /* mipMapCount */,
-        1 /* sampleCount */,
-        GPUTextureDimension::_2d,
-        m_configuration->format,
-        m_configuration->usage,
-        m_configuration->viewFormats
-    };
-
-    markContextChangedAndNotifyCanvasObservers();
-    return m_configuration->device->createSurfaceTexture(descriptor, *m_surface);
-}
-
-PixelFormat GPUCanvasContext::pixelFormat() const
-{
-    return PixelFormat::BGRA8;
-}
-
-void GPUCanvasContext::unconfigure()
-{
-    m_configuration.reset();
-}
-
-DestinationColorSpace GPUCanvasContext::colorSpace() const
-{
-    return DestinationColorSpace::SRGB();
-}
-
-RefPtr<GraphicsLayerContentsDisplayDelegate> GPUCanvasContext::layerContentsDisplayDelegate()
-{
-    return m_layerContentsDisplayDelegate.ptr();
-}
-
-void GPUCanvasContext::prepareForDisplay()
-{
-#if PLATFORM(COCOA)
-    m_swapChain->prepareForDisplay([protectedThis = Ref { *this }] (auto sendRight) {
-        protectedThis->m_layerContentsDisplayDelegate->setDisplayBuffer(WTFMove(sendRight));
-        protectedThis->m_compositingResultsNeedsUpdating = false;
-    });
-#endif
-}
-
-void GPUCanvasContext::markContextChangedAndNotifyCanvasObservers()
-{
-    m_compositingResultsNeedsUpdating = true;
-
-    bool canvasIsDirty = false;
-
-    if (auto* canvas = htmlCanvas()) {
-        auto* renderBox = canvas->renderBox();
-        if (isAccelerated() && renderBox && renderBox->hasAcceleratedCompositing()) {
-            canvasIsDirty = true;
-            canvas->clearCopiedImage();
-            renderBox->contentChanged(CanvasChanged);
-        }
-    }
-
-    if (!canvasIsDirty) {
-        canvasIsDirty = true;
-        canvasBase().didDraw({ });
-    }
-
-    if (!isAccelerated())
-        return;
-
-    auto* canvas = htmlCanvas();
-    if (!canvas)
-        return;
-
-    canvas->notifyObserversCanvasChanged({ });
-}
-
-}
-
-#endif // HAVE(WEBGPU_IMPLEMENTATION)
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -25,75 +25,21 @@
 
 #pragma once
 
-#if HAVE(WEBGPU_IMPLEMENTATION)
-#include "GPUBasedCanvasRenderingContext.h"
-#include "GPUCanvasConfiguration.h"
-#include "GPUSurface.h"
-#include "GPUSwapChain.h"
-#include "GPUTexture.h"
-#include "GraphicsLayerContentsDisplayDelegate.h"
-#include "HTMLCanvasElement.h"
-#include "IOSurface.h"
-#include "OffscreenCanvas.h"
-#include "PlatformCALayer.h"
-#include <variant>
-#include <wtf/MachSendRight.h>
-#endif
 
+#include "GPUBasedCanvasRenderingContext.h"
+#include <variant>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
-#if HAVE(WEBGPU_IMPLEMENTATION)
 namespace WebCore {
 
-class DisplayBufferDisplayDelegate final : public GraphicsLayerContentsDisplayDelegate {
-public:
-    static Ref<DisplayBufferDisplayDelegate> create(bool isOpaque = true, float contentsScale = 1)
-    {
-        return adoptRef(*new DisplayBufferDisplayDelegate(isOpaque, contentsScale));
-    }
-    // GraphicsLayerContentsDisplayDelegate overrides.
-    void prepareToDelegateDisplay(PlatformCALayer& layer) final
-    {
-        layer.setOpaque(m_isOpaque);
-        layer.setContentsScale(m_contentsScale);
-    }
-    void display(PlatformCALayer& layer) final
-    {
-        if (m_displayBuffer)
-            layer.setContents(m_displayBuffer);
-        else
-            layer.clearContents();
-    }
-    GraphicsLayer::CompositingCoordinatesOrientation orientation() const final
-    {
-        return GraphicsLayer::CompositingCoordinatesOrientation::TopDown;
-    }
-    void setDisplayBuffer(WTF::MachSendRight&& displayBuffer)
-    {
-        if (!displayBuffer) {
-            m_displayBuffer = { };
-            return;
-        }
+class CanvasBase;
+class GPU;
+struct GPUCanvasConfiguration;
+class GPUTexture;
 
-        if (m_displayBuffer && displayBuffer.sendRight() == m_displayBuffer.sendRight())
-            return;
-
-        m_displayBuffer = displayBuffer.copySendRight();
-    }
-private:
-    DisplayBufferDisplayDelegate(bool isOpaque, float contentsScale)
-        : m_contentsScale(contentsScale)
-        , m_isOpaque(isOpaque)
-    {
-    }
-    WTF::MachSendRight m_displayBuffer;
-    const float m_contentsScale;
-    const bool m_isOpaque;
-};
-
-class GPUCanvasContext final : public GPUBasedCanvasRenderingContext {
+class GPUCanvasContext : public GPUBasedCanvasRenderingContext {
     WTF_MAKE_ISO_ALLOCATED(GPUCanvasContext);
 public:
 #if ENABLE(OFFSCREEN_CANVAS)
@@ -102,25 +48,12 @@ public:
     using CanvasType = std::variant<RefPtr<HTMLCanvasElement>>;
 #endif
 
-    static std::unique_ptr<GPUCanvasContext> create(CanvasBase&);
+    static std::unique_ptr<GPUCanvasContext> create(CanvasBase&, GPU&);
 
-    DestinationColorSpace colorSpace() const override;
-    bool compositingResultsNeedUpdating() const override { return m_compositingResultsNeedsUpdating; }
-    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
-    bool needsPreparationForDisplay() const override { return true; }
-    void prepareForDisplay() override;
-    PixelFormat pixelFormat() const override;
-    void reshape(int width, int height) override;
-
-    // FIXME: implement these to allow for painting
-    void prepareForDisplayWithPaint() override { }
-    void paintRenderingResultsToCanvas() override { }
-    // GPUCanvasContext methods:
-    CanvasType canvas();
-    void configure(GPUCanvasConfiguration&&);
-    RefPtr<GPUTexture> getCurrentTexture();
-
-    void unconfigure();
+    virtual CanvasType canvas() = 0;
+    virtual void configure(GPUCanvasConfiguration&&) = 0;
+    virtual void unconfigure() = 0;
+    virtual RefPtr<GPUTexture> getCurrentTexture() = 0;
 
     bool isWebGPU() const override { return true; }
     const char* activeDOMObjectName() const override
@@ -128,32 +61,10 @@ public:
         return "GPUCanvasElement";
     }
 
-private:
-    explicit GPUCanvasContext(CanvasBase&);
-
-    void markContextChangedAndNotifyCanvasObservers();
-    void createSwapChainIfNeeded();
-
-    std::optional<GPUCanvasConfiguration> m_configuration;
-    Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
-    RefPtr<GPUSwapChain> m_swapChain;
-    RefPtr<GPUSurface> m_surface;
-
-    int m_width { 0 };
-    int m_height { 0 };
-    bool m_compositingResultsNeedsUpdating { false };
+protected:
+    GPUCanvasContext(CanvasBase&);
 };
 
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_CANVASRENDERINGCONTEXT(WebCore::GPUCanvasContext, isWebGPU())
-
-#else
-namespace WebCore {
-
-class GPUCanvasContext : public RefCounted<GPUCanvasContext> {
-public:
-};
-
-}
-#endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -30,7 +30,8 @@
     ActiveDOMObject,
     EnabledBySetting=WebGPU,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
-    SecureContext
+    SecureContext,
+    SkipVTableValidation,
 ]
 interface GPUCanvasContext {
     readonly attribute (HTMLCanvasElement

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GPUCanvasContextCocoa.h"
+
+#include "GPUAdapter.h"
+#include "GPUCanvasConfiguration.h"
+#include "GPUCompositorIntegration.h"
+#include "GPUSurface.h"
+#include "GPUSurfaceDescriptor.h"
+#include "GPUSwapChain.h"
+#include "GPUSwapChainDescriptor.h"
+#include "GPUTextureDescriptor.h"
+#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "RenderBox.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(GPUCanvasContextCocoa);
+
+std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase& canvas, GPU& gpu)
+{
+    auto context = GPUCanvasContextCocoa::create(canvas, gpu);
+    context->suspendIfNeeded();
+    return context;
+}
+
+std::unique_ptr<GPUCanvasContextCocoa> GPUCanvasContextCocoa::create(CanvasBase& canvas, GPU& gpu)
+{
+    return std::unique_ptr<GPUCanvasContextCocoa>(new GPUCanvasContextCocoa(canvas, gpu));
+}
+
+static GPUSurfaceDescriptor surfaceDescriptor(GPUCompositorIntegration& compositorIntegration)
+{
+    return {
+        {
+            "WebGPU Canvas surface"_s,
+        },
+        &compositorIntegration,
+    };
+}
+
+static int getCanvasWidth(const GPUCanvasContext::CanvasType& canvas)
+{
+    return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> int {
+        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
+        return scaleFactor * htmlCanvas->width();
+    }
+#if ENABLE(OFFSCREEN_CANVAS)
+    , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> int {
+        return offscreenCanvas->width();
+    }
+#endif
+    );
+}
+
+static int getCanvasHeight(const GPUCanvasContext::CanvasType& canvas)
+{
+    return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> int {
+        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
+        return scaleFactor * htmlCanvas->height();
+    }
+#if ENABLE(OFFSCREEN_CANVAS)
+    , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> int {
+        return offscreenCanvas->height();
+    }
+#endif
+    );
+}
+
+GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, GPU& gpu)
+    : GPUCanvasContext(canvas)
+    , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create())
+    , m_compositorIntegration(gpu.createCompositorIntegration())
+    , m_surface(gpu.createSurface(surfaceDescriptor(m_compositorIntegration)))
+    , m_width(getCanvasWidth(htmlCanvas()))
+    , m_height(getCanvasHeight(htmlCanvas()))
+{
+}
+
+void GPUCanvasContextCocoa::reshape(int width, int height)
+{
+    if (m_width == width && m_height == height)
+        return;
+
+    m_width = width;
+    m_height = height;
+
+    auto configuration = WTFMove(m_configuration);
+    ASSERT(!isConfigured());
+    if (configuration) {
+        GPUCanvasConfiguration canvasConfiguration {
+            configuration->device.ptr(),
+            configuration->format,
+            configuration->usage,
+            configuration->viewFormats,
+            configuration->colorSpace,
+            configuration->compositingAlphaMode,
+        };
+        configure(WTFMove(canvasConfiguration));
+    }
+}
+
+auto GPUCanvasContextCocoa::canvas() -> CanvasType
+{
+    return htmlCanvas();
+}
+
+void GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& configuration)
+{
+    if (isConfigured())
+        return;
+
+    if (!m_width || !m_height)
+        return;
+
+    ASSERT(configuration.device);
+    if (!configuration.device)
+        return;
+
+    GPUSwapChainDescriptor descriptor = {
+        {
+            "WebGPU Canvas swap chain"_s,
+        },
+        configuration.format,
+        configuration.usage,
+        configuration.viewFormats,
+        configuration.colorSpace,
+        configuration.compositingAlphaMode,
+        static_cast<uint32_t>(m_width), // FIXME: Is it possible for these to be negative?
+        static_cast<uint32_t>(m_height),
+    };
+
+    auto swapChain = configuration.device->createSwapChain(m_surface, descriptor);
+
+    auto renderBuffers = m_compositorIntegration->getRenderBuffers();
+    ASSERT(!renderBuffers.isEmpty());
+
+    m_configuration = {
+        *configuration.device,
+        swapChain,
+        configuration.format,
+        configuration.usage,
+        configuration.viewFormats,
+        configuration.colorSpace,
+        configuration.compositingAlphaMode,
+        WTFMove(renderBuffers),
+        0,
+    };
+}
+
+void GPUCanvasContextCocoa::unconfigure()
+{
+    m_configuration = std::nullopt;
+    ASSERT(!isConfigured());
+}
+
+RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
+{
+    if (!isConfigured()) {
+        // FIXME: I think we're supposed to return an invalid texture here.
+        return nullptr;
+    }
+
+    markContextChangedAndNotifyCanvasObservers();
+    return &m_configuration->swapChain->getCurrentTexture();
+}
+
+PixelFormat GPUCanvasContextCocoa::pixelFormat() const
+{
+    return PixelFormat::BGRA8;
+}
+
+DestinationColorSpace GPUCanvasContextCocoa::colorSpace() const
+{
+    return DestinationColorSpace::SRGB();
+}
+
+RefPtr<GraphicsLayerContentsDisplayDelegate> GPUCanvasContextCocoa::layerContentsDisplayDelegate()
+{
+    return m_layerContentsDisplayDelegate.ptr();
+}
+
+void GPUCanvasContextCocoa::prepareForDisplay()
+{
+    if (!isConfigured())
+        return;
+
+    ASSERT(m_configuration->frameCount < m_configuration->renderBuffers.size());
+
+    m_configuration->swapChain->present();
+
+    // FIXME: Wait for the results to be fully drawn
+
+    m_layerContentsDisplayDelegate->setDisplayBuffer(m_configuration->renderBuffers[m_configuration->frameCount]);
+    m_compositingResultsNeedsUpdating = false;
+    m_configuration->frameCount = (m_configuration->frameCount + 1) % m_configuration->renderBuffers.size();
+}
+
+void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
+{
+    m_compositingResultsNeedsUpdating = true;
+
+    bool canvasIsDirty = false;
+
+    if (auto* canvas = htmlCanvas()) {
+        auto* renderBox = canvas->renderBox();
+        if (isAccelerated() && renderBox && renderBox->hasAcceleratedCompositing()) {
+            canvasIsDirty = true;
+            canvas->clearCopiedImage();
+            renderBox->contentChanged(CanvasChanged);
+        }
+    }
+
+    if (!canvasIsDirty) {
+        canvasIsDirty = true;
+        canvasBase().didDraw({ });
+    }
+
+    if (!isAccelerated())
+        return;
+
+    auto* canvas = htmlCanvas();
+    if (!canvas)
+        return;
+
+    canvas->notifyObserversCanvasChanged({ });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GPU.h"
+#include "GPUBasedCanvasRenderingContext.h"
+#include "GPUCanvasConfiguration.h"
+#include "GPUCanvasContext.h"
+#include "GPUSurface.h"
+#include "GPUSwapChain.h"
+#include "GPUTexture.h"
+#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "HTMLCanvasElement.h"
+#include "IOSurface.h"
+#include "OffscreenCanvas.h"
+#include "PlatformCALayer.h"
+#include <variant>
+#include <wtf/MachSendRight.h>
+
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class DisplayBufferDisplayDelegate final : public GraphicsLayerContentsDisplayDelegate {
+public:
+    static Ref<DisplayBufferDisplayDelegate> create(bool isOpaque = true, float contentsScale = 1)
+    {
+        return adoptRef(*new DisplayBufferDisplayDelegate(isOpaque, contentsScale));
+    }
+    // GraphicsLayerContentsDisplayDelegate overrides.
+    void prepareToDelegateDisplay(PlatformCALayer& layer) final
+    {
+        layer.setOpaque(m_isOpaque);
+        layer.setContentsScale(m_contentsScale);
+    }
+    void display(PlatformCALayer& layer) final
+    {
+        if (m_displayBuffer)
+            layer.setContents(m_displayBuffer);
+        else
+            layer.clearContents();
+    }
+    GraphicsLayer::CompositingCoordinatesOrientation orientation() const final
+    {
+        return GraphicsLayer::CompositingCoordinatesOrientation::TopDown;
+    }
+    void setDisplayBuffer(WTF::MachSendRight& displayBuffer)
+    {
+        if (!displayBuffer) {
+            m_displayBuffer = { };
+            return;
+        }
+
+        if (m_displayBuffer && displayBuffer.sendRight() == m_displayBuffer.sendRight())
+            return;
+
+        m_displayBuffer = displayBuffer.copySendRight();
+    }
+private:
+    DisplayBufferDisplayDelegate(bool isOpaque, float contentsScale)
+        : m_contentsScale(contentsScale)
+        , m_isOpaque(isOpaque)
+    {
+    }
+    WTF::MachSendRight m_displayBuffer;
+    const float m_contentsScale;
+    const bool m_isOpaque;
+};
+
+class GPUCanvasContextCocoa final : public GPUCanvasContext {
+    WTF_MAKE_ISO_ALLOCATED(GPUCanvasContextCocoa);
+public:
+#if ENABLE(OFFSCREEN_CANVAS)
+    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+#else
+    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>>;
+#endif
+
+    static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&, GPU&);
+
+    DestinationColorSpace colorSpace() const override;
+    bool compositingResultsNeedUpdating() const override { return m_compositingResultsNeedsUpdating; }
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
+    bool needsPreparationForDisplay() const override { return true; }
+    void prepareForDisplay() override;
+    PixelFormat pixelFormat() const override;
+    void reshape(int width, int height) override;
+
+    // FIXME: implement these to allow for painting
+    void prepareForDisplayWithPaint() override { }
+    void paintRenderingResultsToCanvas() override { }
+
+    // GPUCanvasContext methods:
+    CanvasType canvas() override;
+    void configure(GPUCanvasConfiguration&&) override;
+    void unconfigure() override;
+    RefPtr<GPUTexture> getCurrentTexture() override;
+
+private:
+    GPUCanvasContextCocoa(CanvasBase&, GPU&);
+
+    void markContextChangedAndNotifyCanvasObservers();
+
+    bool isConfigured() const
+    {
+        return static_cast<bool>(m_configuration);
+    }
+
+    struct Configuration {
+        Ref<GPUDevice> device;
+        Ref<GPUSwapChain> swapChain;
+        GPUTextureFormat format { GPUTextureFormat::R8unorm };
+        GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
+        Vector<GPUTextureFormat> viewFormats;
+        GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
+        GPUCanvasCompositingAlphaMode compositingAlphaMode { GPUCanvasCompositingAlphaMode::Opaque };
+        Vector<MachSendRight> renderBuffers;
+        unsigned frameCount { 0 };
+    };
+    std::optional<Configuration> m_configuration;
+
+    Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
+    Ref<GPUCompositorIntegration> m_compositorIntegration;
+    Ref<GPUSurface> m_surface;
+
+    int m_width { 0 };
+    int m_height { 0 };
+    bool m_compositingResultsNeedsUpdating { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -374,8 +374,7 @@ GPU* Navigator::gpu()
         if (!gpu)
             return nullptr;
 
-        m_gpuForWebGPU = GPU::create();
-        m_gpuForWebGPU->setBacking(*gpu);
+        m_gpuForWebGPU = GPU::create(*gpu);
     }
 
     return m_gpuForWebGPU.get();

--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -149,6 +149,11 @@ void Adapter::requestInvalidDevice(CompletionHandler<void(Ref<Device>&&)>&& call
 
 #pragma mark WGPU Stubs
 
+void wgpuAdapterRetain(WGPUAdapter adapter)
+{
+    WebGPU::fromAPI(adapter).ref();
+}
+
 void wgpuAdapterRelease(WGPUAdapter adapter)
 {
     WebGPU::fromAPI(adapter).deref();

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -150,6 +150,11 @@ void BindGroup::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuBindGroupRetain(WGPUBindGroup bindGroup)
+{
+    WebGPU::fromAPI(bindGroup).ref();
+}
+
 void wgpuBindGroupRelease(WGPUBindGroup bindGroup)
 {
     WebGPU::fromAPI(bindGroup).deref();

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -222,6 +222,11 @@ bool BindGroupLayout::bindingContainsStage(uint32_t bindingIndex, ShaderStage sh
 
 #pragma mark WGPU Stubs
 
+void wgpuBindGroupLayoutRetain(WGPUBindGroupLayout bindGroupLayout)
+{
+    WebGPU::fromAPI(bindGroupLayout).ref();
+}
+
 void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout)
 {
     WebGPU::fromAPI(bindGroupLayout).deref();

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -341,6 +341,11 @@ void Buffer::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuBufferRetain(WGPUBuffer buffer)
+{
+    WebGPU::fromAPI(buffer).ref();
+}
+
 void wgpuBufferRelease(WGPUBuffer buffer)
 {
     WebGPU::fromAPI(buffer).deref();

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -52,6 +52,11 @@ void CommandBuffer::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuCommandBufferRetain(WGPUCommandBuffer commandBuffer)
+{
+    WebGPU::fromAPI(commandBuffer).ref();
+}
+
 void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer)
 {
     WebGPU::fromAPI(commandBuffer).deref();

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -965,6 +965,11 @@ void CommandEncoder::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuCommandEncoderRetain(WGPUCommandEncoder commandEncoder)
+{
+    WebGPU::fromAPI(commandEncoder).ref();
+}
+
 void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder)
 {
     WebGPU::fromAPI(commandEncoder).deref();

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -141,6 +141,11 @@ void ComputePassEncoder::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuComputePassEncoderRetain(WGPUComputePassEncoder computePassEncoder)
+{
+    WebGPU::fromAPI(computePassEncoder).ref();
+}
+
 void wgpuComputePassEncoderRelease(WGPUComputePassEncoder computePassEncoder)
 {
     WebGPU::fromAPI(computePassEncoder).deref();

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -206,6 +206,11 @@ void ComputePipeline::setLabel(String&&)
 
 #pragma mark WGPU Stubs
 
+void wgpuComputePipelineRetain(WGPUComputePipeline computePipeline)
+{
+    WebGPU::fromAPI(computePipeline).ref();
+}
+
 void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline)
 {
     WebGPU::fromAPI(computePipeline).deref();

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -321,6 +321,11 @@ void Device::setLabel(String&&)
 
 #pragma mark WGPU Stubs
 
+void wgpuDeviceRetain(WGPUDevice device)
+{
+    WebGPU::fromAPI(device).ref();
+}
+
 void wgpuDeviceRelease(WGPUDevice device)
 {
     WebGPU::fromAPI(device).deref();

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -201,6 +201,11 @@ void Instance::requestAdapter(const WGPURequestAdapterOptions& options, Completi
 
 #pragma mark WGPU Stubs
 
+void wgpuInstanceRetain(WGPUInstance instance)
+{
+    WebGPU::fromAPI(instance).ref();
+}
+
 void wgpuInstanceRelease(WGPUInstance instance)
 {
     WebGPU::fromAPI(instance).deref();
@@ -215,6 +220,7 @@ WGPUProc wgpuGetProcAddress(WGPUDevice, const char* procName)
 {
     // FIXME(PERFORMANCE): Use gperf to make this faster.
     // FIXME: Generate this at build time
+    // FIXME: Retain and release methods are not listed here.
     if (!strcmp(procName, "wgpuAdapterEnumerateFeatures"))
         return reinterpret_cast<WGPUProc>(&wgpuAdapterEnumerateFeatures);
     if (!strcmp(procName, "wgpuAdapterGetLimits"))
@@ -323,10 +329,6 @@ WGPUProc wgpuGetProcAddress(WGPUDevice, const char* procName)
         return reinterpret_cast<WGPUProc>(&wgpuDeviceCreateShaderModule);
     if (!strcmp(procName, "wgpuDeviceCreateSwapChain"))
         return reinterpret_cast<WGPUProc>(&wgpuDeviceCreateSwapChain);
-    if (!strcmp(procName, "wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer"))
-        return reinterpret_cast<WGPUProc>(&wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer);
-    if (!strcmp(procName, "wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer"))
-        return reinterpret_cast<WGPUProc>(&wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer);
     if (!strcmp(procName, "wgpuDeviceCreateTexture"))
         return reinterpret_cast<WGPUProc>(&wgpuDeviceCreateTexture);
     if (!strcmp(procName, "wgpuDeviceDestroy"))
@@ -453,6 +455,8 @@ WGPUProc wgpuGetProcAddress(WGPUDevice, const char* procName)
         return reinterpret_cast<WGPUProc>(&wgpuShaderModuleSetLabel);
     if (!strcmp(procName, "wgpuSurfaceGetPreferredFormat"))
         return reinterpret_cast<WGPUProc>(&wgpuSurfaceGetPreferredFormat);
+    if (!strcmp(procName, "wgpuSwapChainGetCurrentTexture"))
+        return reinterpret_cast<WGPUProc>(&wgpuSwapChainGetCurrentTexture);
     if (!strcmp(procName, "wgpuSwapChainGetCurrentTextureView"))
         return reinterpret_cast<WGPUProc>(&wgpuSwapChainGetCurrentTextureView);
     if (!strcmp(procName, "wgpuSwapChainPresent"))

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -80,6 +80,11 @@ bool PipelineLayout::operator!=(const PipelineLayout& other) const
 
 #pragma mark WGPU Stubs
 
+void wgpuPipelineLayoutRetain(WGPUPipelineLayout pipelineLayout)
+{
+    WebGPU::fromAPI(pipelineLayout).ref();
+}
+
 void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout)
 {
     WebGPU::fromAPI(pipelineLayout).deref();

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -41,6 +41,7 @@ namespace WebGPU {
 
 class Adapter;
 class Device;
+class Texture;
 class TextureView;
 
 class PresentationContext : public WGPUSurfaceImpl, public WGPUSwapChainImpl, public RefCounted<PresentationContext> {
@@ -60,6 +61,7 @@ public:
 
     virtual void present();
     virtual TextureView* getCurrentTextureView(); // FIXME: This should return a TextureView&.
+    virtual Texture* getCurrentTexture(); // FIXME: This should return a Texture&.
 
     virtual bool isPresentationContextIOSurface() const { return false; }
     virtual bool isPresentationContextCoreAnimation() const { return false; }

--- a/Source/WebGPU/WebGPU/PresentationContext.mm
+++ b/Source/WebGPU/WebGPU/PresentationContext.mm
@@ -76,13 +76,28 @@ TextureView* PresentationContext::getCurrentTextureView()
     return nullptr;
 }
 
+Texture* PresentationContext::getCurrentTexture()
+{
+    return nullptr;
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs
 
+void wgpuSurfaceRetain(WGPUSurface surface)
+{
+    WebGPU::fromAPI(surface).ref();
+}
+
 void wgpuSurfaceRelease(WGPUSurface surface)
 {
     WebGPU::fromAPI(surface).deref();
+}
+
+void wgpuSwapChainRetain(WGPUSwapChain swapChain)
+{
+    WebGPU::fromAPI(swapChain).ref();
 }
 
 void wgpuSwapChainRelease(WGPUSwapChain swapChain)
@@ -98,6 +113,11 @@ WGPUTextureFormat wgpuSurfaceGetPreferredFormat(WGPUSurface surface, WGPUAdapter
 WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain)
 {
     return WebGPU::fromAPI(swapChain).getCurrentTextureView();
+}
+
+WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain)
+{
+    return WebGPU::fromAPI(swapChain).getCurrentTexture();
 }
 
 void wgpuSwapChainPresent(WGPUSwapChain swapChain)

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
@@ -34,6 +34,7 @@
 namespace WebGPU {
 
 class Device;
+class Texture;
 class TextureView;
 
 class PresentationContextCoreAnimation : public PresentationContext {
@@ -50,6 +51,7 @@ public:
 
     void present() override;
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
+    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
 
     bool isPresentationContextCoreAnimation() const override { return true; }
 
@@ -57,9 +59,10 @@ private:
     PresentationContextCoreAnimation(const WGPUSurfaceDescriptor&);
 
     struct Configuration {
-        Configuration(uint32_t width, uint32_t height, String&& label, WGPUTextureFormat format, Device& device)
+        Configuration(uint32_t width, uint32_t height, WGPUTextureUsageFlags usage, String&& label, WGPUTextureFormat format, Device& device)
             : width(width)
             , height(height)
+            , usage(usage)
             , label(WTFMove(label))
             , format(format)
             , device(device)
@@ -68,6 +71,7 @@ private:
 
         struct FrameState {
             id<CAMetalDrawable> currentDrawable;
+            RefPtr<Texture> currentTexture;
             RefPtr<TextureView> currentTextureView;
         };
 
@@ -76,6 +80,7 @@ private:
         std::optional<FrameState> currentFrameState;
         uint32_t width { 0 };
         uint32_t height { 0 };
+        WGPUTextureUsageFlags usage { WGPUTextureUsage_None };
         String label;
         WGPUTextureFormat format { WGPUTextureFormat_Undefined };
         Ref<Device> device;

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
@@ -28,6 +28,7 @@
 
 #import "APIConversions.h"
 #import "Texture.h"
+#import "TextureView.h"
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebGPU {
@@ -68,7 +69,7 @@ void PresentationContextCoreAnimation::configure(Device& device, const WGPUSwapC
         return;
     }
 
-    m_configuration = Configuration(descriptor.width, descriptor.height, fromAPI(descriptor.label), descriptor.format, device);
+    m_configuration = Configuration(descriptor.width, descriptor.height, descriptor.usage, fromAPI(descriptor.label), descriptor.format, device);
 
     m_layer.pixelFormat = Texture::pixelFormat(descriptor.format);
     if (descriptor.usage == WGPUTextureUsage_RenderAttachment)
@@ -82,7 +83,22 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
     auto label = this->label.utf8();
 
     id<CAMetalDrawable> currentDrawable = [layer nextDrawable];
-    id<MTLTexture> texture = currentDrawable.texture;
+    id<MTLTexture> backingTexture = currentDrawable.texture;
+
+    WGPUTextureDescriptor textureDescriptor {
+        nullptr,
+        label.data(),
+        usage,
+        WGPUTextureDimension_2D, {
+            width,
+            height,
+            1,
+        },
+        format,
+        1,
+        1,
+    };
+    auto texture = Texture::create(backingTexture, textureDescriptor, { format }, device);
 
     WGPUTextureViewDescriptor textureViewDescriptor {
         nullptr,
@@ -95,8 +111,8 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
         1,
         WGPUTextureAspect_All,
     };
-    auto textureView = TextureView::create(texture, textureViewDescriptor, { { width, height, 1 } }, device);
-    return { currentDrawable, textureView.ptr() };
+    auto textureView = TextureView::create(backingTexture, textureViewDescriptor, { { width, height, 1 } }, device);
+    return { currentDrawable, texture.ptr(), textureView.ptr() };
 }
 
 void PresentationContextCoreAnimation::present()
@@ -121,6 +137,17 @@ TextureView* PresentationContextCoreAnimation::getCurrentTextureView()
         m_configuration->currentFrameState = m_configuration->generateCurrentFrameState(m_layer);
 
     return m_configuration->currentFrameState->currentTextureView.get();
+}
+
+Texture* PresentationContextCoreAnimation::getCurrentTexture()
+{
+    if (!m_configuration)
+        return nullptr;
+
+    if (!m_configuration->currentFrameState)
+        m_configuration->currentFrameState = m_configuration->generateCurrentFrameState(m_layer);
+
+    return m_configuration->currentFrameState->currentTexture.get();
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -26,10 +26,13 @@
 #pragma once
 
 #import "PresentationContext.h"
+#import <Foundation/Foundation.h>
+#import <wtf/Vector.h>
 
 namespace WebGPU {
 
 class Device;
+class Texture;
 class TextureView;
 
 class PresentationContextIOSurface : public PresentationContext {
@@ -46,18 +49,17 @@ public:
 
     void present() override;
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
-
-    RetainPtr<IOSurfaceRef> displayBuffer() const { return m_displayBuffer; }
-    RetainPtr<IOSurfaceRef> drawingBuffer() const { return m_drawingBuffer; }
-    RetainPtr<IOSurfaceRef> nextDrawable();
+    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
 
     bool isPresentationContextIOSurface() const override { return true; }
 
 private:
     PresentationContextIOSurface(const WGPUSurfaceDescriptor&);
 
-    RetainPtr<IOSurfaceRef> m_displayBuffer;
-    RetainPtr<IOSurfaceRef> m_drawingBuffer;
+    CFArrayRef (^m_recreateIOSurfaces)(const WGPUSwapChainDescriptor*);
+    Vector<Ref<Texture>> m_renderBuffers;
+    Vector<Ref<TextureView>> m_renderBufferViews;
+    size_t m_currentIndex { 0 };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -122,6 +122,11 @@ Vector<MTLTimestamp> QuerySet::resolveTimestamps() const
 
 #pragma mark WGPU Stubs
 
+void wgpuQuerySetRetain(WGPUQuerySet querySet)
+{
+    WebGPU::fromAPI(querySet).ref();
+}
+
 void wgpuQuerySetRelease(WGPUQuerySet querySet)
 {
     WebGPU::fromAPI(querySet).deref();

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -466,6 +466,11 @@ void Queue::scheduleWork(Instance::WorkItem&& workItem)
 
 #pragma mark WGPU Stubs
 
+void wgpuQueueRetain(WGPUQueue queue)
+{
+    WebGPU::fromAPI(queue).ref();
+}
+
 void wgpuQueueRelease(WGPUQueue queue)
 {
     WebGPU::fromAPI(queue).deref();

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -53,6 +53,11 @@ void RenderBundle::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuRenderBundleRetain(WGPURenderBundle renderBundle)
+{
+    WebGPU::fromAPI(renderBundle).ref();
+}
+
 void wgpuRenderBundleRelease(WGPURenderBundle renderBundle)
 {
     WebGPU::fromAPI(renderBundle).deref();

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -278,6 +278,11 @@ void RenderBundleEncoder::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuRenderBundleEncoderRetain(WGPURenderBundleEncoder renderBundleEncoder)
+{
+    WebGPU::fromAPI(renderBundleEncoder).ref();
+}
+
 void wgpuRenderBundleEncoderRelease(WGPURenderBundleEncoder renderBundleEncoder)
 {
     WebGPU::fromAPI(renderBundleEncoder).deref();

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -243,6 +243,11 @@ void RenderPassEncoder::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuRenderPassEncoderRetain(WGPURenderPassEncoder renderPassEncoder)
+{
+    WebGPU::fromAPI(renderPassEncoder).ref();
+}
+
 void wgpuRenderPassEncoderRelease(WGPURenderPassEncoder renderPassEncoder)
 {
     WebGPU::fromAPI(renderPassEncoder).deref();

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -429,11 +429,10 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         }
     }
 
-    MTLDepthStencilDescriptor *depthStencilDescriptor = nil;
+    MTLDepthStencilDescriptor *depthStencilDescriptor = [MTLDepthStencilDescriptor new];
     if (auto depthStencil = descriptor.depthStencil) {
         mtlRenderPipelineDescriptor.depthAttachmentPixelFormat = Texture::pixelFormat(depthStencil->format);
 
-        depthStencilDescriptor = [MTLDepthStencilDescriptor new];
         depthStencilDescriptor.depthCompareFunction = convertToMTLCompare(depthStencil->depthCompare);
         depthStencilDescriptor.depthWriteEnabled = depthStencil->depthWriteEnabled;
         populateStencilOperation(depthStencilDescriptor.frontFaceStencil, depthStencil->stencilFront, depthStencil->stencilReadMask, depthStencil->stencilWriteMask);
@@ -617,6 +616,11 @@ bool RenderPipeline::validateDepthStencilState(bool depthReadOnly, bool stencilR
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs
+
+void wgpuRenderPipelineRetain(WGPURenderPipeline renderPipeline)
+{
+    WebGPU::fromAPI(renderPipeline).ref();
+}
 
 void wgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline)
 {

--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -186,6 +186,11 @@ void Sampler::setLabel(String&&)
 
 #pragma mark WGPU Stubs
 
+void wgpuSamplerRetain(WGPUSampler sampler)
+{
+    WebGPU::fromAPI(sampler).ref();
+}
+
 void wgpuSamplerRelease(WGPUSampler sampler)
 {
     WebGPU::fromAPI(sampler).deref();

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -332,6 +332,11 @@ const WGSL::Reflection::EntryPointInformation* ShaderModule::entryPointInformati
 
 #pragma mark WGPU Stubs
 
+void wgpuShaderModuleRetain(WGPUShaderModule shaderModule)
+{
+    WebGPU::fromAPI(shaderModule).ref();
+}
+
 void wgpuShaderModuleRelease(WGPUShaderModule shaderModule)
 {
     WebGPU::fromAPI(shaderModule).deref();

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -74,6 +74,7 @@ public:
     static bool isValidImageCopySource(WGPUTextureFormat, WGPUTextureAspect);
     static bool isValidImageCopyDestination(WGPUTextureFormat, WGPUTextureAspect);
     static bool validateLinearTextureData(const WGPUTextureDataLayout&, uint64_t, WGPUTextureFormat, WGPUExtent3D);
+    static MTLTextureUsage usage(WGPUTextureUsageFlags);
     static MTLPixelFormat pixelFormat(WGPUTextureFormat);
     static std::optional<MTLPixelFormat> depthOnlyAspectMetalFormat(WGPUTextureFormat);
     static std::optional<MTLPixelFormat> stencilOnlyAspectMetalFormat(WGPUTextureFormat);

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -55,6 +55,11 @@ void TextureView::setLabel(String&& label)
 
 #pragma mark WGPU Stubs
 
+void wgpuTextureViewRetain(WGPUTextureView textureView)
+{
+    WebGPU::fromAPI(textureView).ref();
+}
+
 void wgpuTextureViewRelease(WGPUTextureView textureView)
 {
     WebGPU::fromAPI(textureView).deref();

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -50,7 +50,6 @@ typedef enum WGPUSTypeExtended {
     WGPUSTypeExtended_TextureDescriptorViewFormats = 0x1D5BC57, // Random
     WGPUSTypeExtended_InstanceCocoaDescriptor = 0x151BBC00, // Random
     WGPUSTypeExtended_SurfaceDescriptorCocoaSurfaceBacking = 0x017E9710, // Random
-    WGPUSTypeExtended_TextureDescriptorCocoaSurfaceBacking = 0xCCE4ED61, // Random
     WGPUSTypeExtended_Force32 = 0x7FFFFFFF
 } WGPUSTypeExtended;
 
@@ -90,16 +89,34 @@ typedef struct WGPUTextureDescriptorViewFormats {
 
 typedef struct WGPUSurfaceDescriptorCocoaCustomSurface {
     WGPUChainedStruct chain;
-    uint32_t width;
-    uint32_t height;
+    CFArrayRef (^recreateIOSurfaces)(WGPUSwapChainDescriptor const *);
 } WGPUSurfaceDescriptorCocoaCustomSurface;
 
-typedef struct WGPUTextureDescriptorCocoaCustomSurface {
-    WGPUChainedStruct chain;
-    IOSurfaceRef surface;
-} WGPUTextureDescriptorCocoaCustomSurface;
-
 #if !defined(WGPU_SKIP_PROCS)
+
+typedef void (*WGPUProcAdapterRetain)(WGPUAdapter adapter);
+typedef void (*WGPUProcBindGroupLayoutRetain)(WGPUBindGroupLayout bindGroupLayout);
+typedef void (*WGPUProcBindGroupRetain)(WGPUBindGroup bindGroup);
+typedef void (*WGPUProcBufferRetain)(WGPUBuffer buffer);
+typedef void (*WGPUProcCommandBufferRetain)(WGPUCommandBuffer commandBuffer);
+typedef void (*WGPUProcCommandEncoderRetain)(WGPUCommandEncoder commandEncoder);
+typedef void (*WGPUProcComputePassEncoderRetain)(WGPUComputePassEncoder computePassEncoder);
+typedef void (*WGPUProcComputePipelineRetain)(WGPUComputePipeline computePipeline);
+typedef void (*WGPUProcDeviceRetain)(WGPUDevice device);
+typedef void (*WGPUProcInstanceRetain)(WGPUInstance instance);
+typedef void (*WGPUProcPipelineLayoutRetain)(WGPUPipelineLayout pipelineLayout);
+typedef void (*WGPUProcQuerySetRetain)(WGPUQuerySet querySet);
+typedef void (*WGPUProcQueueRetain)(WGPUQueue queue);
+typedef void (*WGPUProcRenderBundleEncoderRetain)(WGPURenderBundleEncoder renderBundleEncoder);
+typedef void (*WGPUProcRenderBundleRetain)(WGPURenderBundle renderBundle);
+typedef void (*WGPUProcRenderPassEncoderRetain)(WGPURenderPassEncoder renderPassEncoder);
+typedef void (*WGPUProcRenderPipelineRetain)(WGPURenderPipeline renderPipeline);
+typedef void (*WGPUProcSamplerRetain)(WGPUSampler sampler);
+typedef void (*WGPUProcShaderModuleRetain)(WGPUShaderModule shaderModule);
+typedef void (*WGPUProcSurfaceRetain)(WGPUSurface surface);
+typedef void (*WGPUProcSwapChainRetain)(WGPUSwapChain swapChain);
+typedef void (*WGPUProcTextureRetain)(WGPUTexture texture);
+typedef void (*WGPUProcTextureViewRetain)(WGPUTextureView textureView);
 
 typedef void (*WGPUProcAdapterRelease)(WGPUAdapter adapter);
 typedef void (*WGPUProcBindGroupLayoutRelease)(WGPUBindGroupLayout bindGroupLayout);
@@ -153,9 +170,35 @@ typedef void (*WGPUProcInstanceRequestAdapterWithBlock)(WGPUInstance instance, W
 typedef void (*WGPUProcQueueOnSubmittedWorkDoneWithBlock)(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneBlockCallback callback);
 typedef void (*WGPUProcShaderModuleGetCompilationInfoWithBlock)(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
 
+typedef void (*WGPUProcSwapChainGetCurrentTexture)(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
+
 #endif  // !defined(WGPU_SKIP_PROCS)
 
 #if !defined(WGPU_SKIP_DECLARATIONS)
+
+WGPU_EXPORT void wgpuAdapterRetain(WGPUAdapter adapter);
+WGPU_EXPORT void wgpuBindGroupLayoutRetain(WGPUBindGroupLayout bindGroupLayout);
+WGPU_EXPORT void wgpuBindGroupRetain(WGPUBindGroup bindGroup);
+WGPU_EXPORT void wgpuBufferRetain(WGPUBuffer buffer);
+WGPU_EXPORT void wgpuCommandBufferRetain(WGPUCommandBuffer commandBuffer);
+WGPU_EXPORT void wgpuCommandEncoderRetain(WGPUCommandEncoder commandEncoder);
+WGPU_EXPORT void wgpuComputePassEncoderRetain(WGPUComputePassEncoder computePassEncoder);
+WGPU_EXPORT void wgpuComputePipelineRetain(WGPUComputePipeline computePipeline);
+WGPU_EXPORT void wgpuDeviceRetain(WGPUDevice device);
+WGPU_EXPORT void wgpuInstanceRetain(WGPUInstance instance);
+WGPU_EXPORT void wgpuPipelineLayoutRetain(WGPUPipelineLayout pipelineLayout);
+WGPU_EXPORT void wgpuQuerySetRetain(WGPUQuerySet querySet);
+WGPU_EXPORT void wgpuQueueRetain(WGPUQueue queue);
+WGPU_EXPORT void wgpuRenderBundleEncoderRetain(WGPURenderBundleEncoder renderBundleEncoder);
+WGPU_EXPORT void wgpuRenderBundleRetain(WGPURenderBundle renderBundle);
+WGPU_EXPORT void wgpuRenderPassEncoderRetain(WGPURenderPassEncoder renderPassEncoder);
+WGPU_EXPORT void wgpuRenderPipelineRetain(WGPURenderPipeline renderPipeline);
+WGPU_EXPORT void wgpuSamplerRetain(WGPUSampler sampler);
+WGPU_EXPORT void wgpuShaderModuleRetain(WGPUShaderModule shaderModule);
+WGPU_EXPORT void wgpuSurfaceRetain(WGPUSurface surface);
+WGPU_EXPORT void wgpuSwapChainRetain(WGPUSwapChain swapChain);
+WGPU_EXPORT void wgpuTextureRetain(WGPUTexture texture);
+WGPU_EXPORT void wgpuTextureViewRetain(WGPUTextureView textureView);
 
 WGPU_EXPORT void wgpuAdapterRelease(WGPUAdapter adapter);
 WGPU_EXPORT void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout);
@@ -210,8 +253,7 @@ WGPU_EXPORT void wgpuInstanceRequestAdapterWithBlock(WGPUInstance instance, WGPU
 WGPU_EXPORT void wgpuQueueOnSubmittedWorkDoneWithBlock(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneBlockCallback callback);
 WGPU_EXPORT void wgpuShaderModuleGetCompilationInfoWithBlock(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
 
-WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(WGPUSurface);
-WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(WGPUSurface);
+WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);
 
 #endif  // !defined(WGPU_SKIP_DECLARATIONS)
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -145,6 +145,7 @@ set(WebKit_MESSAGES_IN_FILES
     GPUProcess/graphics/WebGPU/RemoteBuffer
     GPUProcess/graphics/WebGPU/RemoteCommandBuffer
     GPUProcess/graphics/WebGPU/RemoteCommandEncoder
+    GPUProcess/graphics/WebGPU/RemoteCompositorIntegration
     GPUProcess/graphics/WebGPU/RemoteComputePassEncoder
     GPUProcess/graphics/WebGPU/RemoteComputePipeline
     GPUProcess/graphics/WebGPU/RemoteDevice

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -46,6 +46,7 @@ $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
+$(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -182,6 +182,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandBufferMessageReceiver.c
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandBufferMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandEncoderMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandEncoderMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCompositorIntegrationMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCompositorIntegrationMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteComputePassEncoderMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteComputePassEncoderMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteComputePipelineMessageReceiver.cpp

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -271,6 +271,7 @@ MESSAGE_RECEIVERS = \
 	GPUProcess/graphics/WebGPU/RemoteBuffer \
 	GPUProcess/graphics/WebGPU/RemoteCommandBuffer \
 	GPUProcess/graphics/WebGPU/RemoteCommandEncoder \
+	GPUProcess/graphics/WebGPU/RemoteCompositorIntegration \
 	GPUProcess/graphics/WebGPU/RemoteComputePassEncoder \
 	GPUProcess/graphics/WebGPU/RemoteComputePipeline \
 	GPUProcess/graphics/WebGPU/RemoteDevice \

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteCompositorIntegration.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteCompositorIntegrationMessages.h"
+#include "StreamServerConnection.h"
+#include "WebGPUObjectHeap.h"
+#include <pal/graphics/WebGPU/WebGPUCompositorIntegration.h>
+
+namespace WebKit {
+
+RemoteCompositorIntegration::RemoteCompositorIntegration(PAL::WebGPU::CompositorIntegration& compositorIntegration, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
+    : m_backing(compositorIntegration)
+    , m_objectHeap(objectHeap)
+    , m_streamConnection(WTFMove(streamConnection))
+    , m_identifier(identifier)
+{
+    m_streamConnection->startReceivingMessages(*this, Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+}
+
+RemoteCompositorIntegration::~RemoteCompositorIntegration() = default;
+
+void RemoteCompositorIntegration::stopListeningForIPC()
+{
+    m_streamConnection->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+}
+
+#if PLATFORM(COCOA)
+void RemoteCompositorIntegration::getRenderBuffers(CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+{
+    callback(m_backing->getRenderBuffers());
+}
+#endif
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "StreamMessageReceiver.h"
+#include "WebGPUIdentifier.h"
+#include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
+#include <wtf/Ref.h>
+#include <wtf/text/WTFString.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/MachSendRight.h>
+#include <wtf/Vector.h>
+#endif
+
+namespace PAL::WebGPU {
+class CompositorIntegration;
+}
+
+namespace IPC {
+class StreamServerConnection;
+}
+
+namespace WebKit {
+
+namespace WebGPU {
+class ObjectHeap;
+}
+
+class RemoteCompositorIntegration final : public IPC::StreamMessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<RemoteCompositorIntegration> create(PAL::WebGPU::CompositorIntegration& compositorIntegration, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
+    {
+        return adoptRef(*new RemoteCompositorIntegration(compositorIntegration, objectHeap, WTFMove(streamConnection), identifier));
+    }
+
+    virtual ~RemoteCompositorIntegration();
+
+    void stopListeningForIPC();
+
+private:
+    friend class WebGPU::ObjectHeap;
+
+    RemoteCompositorIntegration(PAL::WebGPU::CompositorIntegration&, WebGPU::ObjectHeap&, Ref<IPC::StreamServerConnection>&&, WebGPUIdentifier);
+
+    RemoteCompositorIntegration(const RemoteCompositorIntegration&) = delete;
+    RemoteCompositorIntegration(RemoteCompositorIntegration&&) = delete;
+    RemoteCompositorIntegration& operator=(const RemoteCompositorIntegration&) = delete;
+    RemoteCompositorIntegration& operator=(RemoteCompositorIntegration&&) = delete;
+
+    PAL::WebGPU::CompositorIntegration& backing() { return m_backing; }
+
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+
+#if PLATFORM(COCOA)
+    void getRenderBuffers(CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+#endif
+
+    Ref<PAL::WebGPU::CompositorIntegration> m_backing;
+    WebGPU::ObjectHeap& m_objectHeap;
+    Ref<IPC::StreamServerConnection> m_streamConnection;
+    WebGPUIdentifier m_identifier;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -1,0 +1,32 @@
+/* Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(GPU_PROCESS)
+
+messages -> RemoteCompositorIntegration NotRefCounted Stream {
+#if PLATFORM(COCOA)
+void GetRenderBuffers() -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
+#endif
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -122,18 +122,6 @@ void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebG
     m_objectHeap.addObject(identifier, remoteBuffer);
 }
 
-void RemoteDevice::createSurface(const WebGPU::SurfaceDescriptor& descriptor, WebGPUIdentifier identifier)
-{
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
-
-    auto surface = m_backing->createSurface(*convertedDescriptor);
-    auto remoteSurface = RemoteSurface::create(surface, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteSurface);
-}
-
 void RemoteDevice::createSwapChain(WebGPUIdentifier surfaceIdentifier, const WebGPU::SwapChainDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
@@ -159,20 +147,6 @@ void RemoteDevice::createTexture(const WebGPU::TextureDescriptor& descriptor, We
         return;
 
     auto texture = m_backing->createTexture(*convertedDescriptor);
-    auto remoteTexture = RemoteTexture::create(texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteTexture);
-}
-
-void RemoteDevice::createSurfaceTexture(WebGPUIdentifier surfaceIdentifier, const WebGPU::TextureDescriptor& descriptor, WebGPUIdentifier identifier)
-{
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
-
-    auto surface = m_objectHeap.convertSurfaceFromBacking(surfaceIdentifier);
-    ASSERT(surface);
-    auto texture = m_backing->createSurfaceTexture(*convertedDescriptor, *surface);
     auto remoteTexture = RemoteTexture::create(texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteTexture);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -97,8 +97,6 @@ private:
 
     void createBuffer(const WebGPU::BufferDescriptor&, WebGPUIdentifier);
     void createTexture(const WebGPU::TextureDescriptor&, WebGPUIdentifier);
-    void createSurfaceTexture(WebGPUIdentifier, const WebGPU::TextureDescriptor&, WebGPUIdentifier);
-    void createSurface(const WebGPU::SurfaceDescriptor&, WebGPUIdentifier);
     void createSwapChain(WebGPUIdentifier, const WebGPU::SwapChainDescriptor&, WebGPUIdentifier);
     void createSampler(const WebGPU::SamplerDescriptor&, WebGPUIdentifier);
     void importExternalTexture(const WebGPU::ExternalTextureDescriptor&, WebGPUIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -27,8 +27,6 @@ messages -> RemoteDevice NotRefCounted Stream {
     void Destroy()
     void CreateBuffer(WebKit::WebGPU::BufferDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateTexture(WebKit::WebGPU::TextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
-    void CreateSurfaceTexture(WebKit::WebGPUIdentifier surfaceIdentifier, WebKit::WebGPU::TextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
-    void CreateSurface(WebKit::WebGPU::SurfaceDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateSwapChain(WebKit::WebGPUIdentifier surfaceIdentifier, WebKit::WebGPU::SwapChainDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateSampler(WebKit::WebGPU::SamplerDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void ImportExternalTexture(WebKit::WebGPU::ExternalTextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -136,6 +136,10 @@ private:
 
     void requestAdapter(const WebGPU::RequestAdapterOptions&, WebGPUIdentifier, CompletionHandler<void(std::optional<RequestAdapterResponse>&&)>&&);
 
+    void createSurface(const WebGPU::SurfaceDescriptor&, WebGPUIdentifier);
+
+    void createCompositorIntegration(WebGPUIdentifier);
+
     WeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     RefPtr<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -25,6 +25,8 @@
 
 messages -> RemoteGPU NotRefCounted Stream {
     void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPU::RequestAdapterResponse> response) Synchronous
+    void CreateSurface(WebKit::WebGPU::SurfaceDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
+    void CreateCompositorIntegration(WebKit::WebGPUIdentifier identifier)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp
@@ -52,11 +52,6 @@ void RemoteSurface::stopListeningForIPC()
     m_streamConnection->stopReceivingMessages(Messages::RemoteSurface::messageReceiverName(), m_identifier.toUInt64());
 }
 
-void RemoteSurface::destroy()
-{
-    m_backing->destroy();
-}
-
 void RemoteSurface::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.h
@@ -72,8 +72,6 @@ private:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void destroy();
-
     void setLabel(String&&);
 
     Ref<PAL::WebGPU::Surface> m_backing;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in
@@ -24,7 +24,6 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSurface NotRefCounted Stream {
-    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h
@@ -73,15 +73,11 @@ private:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void destroy();
+    void getCurrentTexture(WebGPUIdentifier);
+    void getCurrentTextureView(WebGPUIdentifier);
+    void present();
 
     void setLabel(String&&);
-
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
-#else
-    void prepareForDisplay(CompletionHandler<void()>&&);
-#endif
 
     Ref<PAL::WebGPU::SwapChain> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
@@ -24,16 +24,10 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSwapChain NotRefCounted Stream {
-    void Destroy()
+    void GetCurrentTexture(WebKit::WebGPUIdentifier identifier)
+    void GetCurrentTextureView(WebKit::WebGPUIdentifier identifier)
+    void Present()
     void SetLabel(String label)
-
-#if PLATFORM(COCOA)
-    void PrepareForDisplay() -> (MachSendRight displayBuffer) Synchronous NotStreamEncodableReply
-#endif
-#if !PLATFORM(COCOA)
-    void PrepareForDisplay() -> () Synchronous
-#endif
-
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp
@@ -34,6 +34,7 @@
 #include "RemoteBuffer.h"
 #include "RemoteCommandBuffer.h"
 #include "RemoteCommandEncoder.h"
+#include "RemoteCompositorIntegration.h"
 #include "RemoteComputePassEncoder.h"
 #include "RemoteComputePipeline.h"
 #include "RemoteDevice.h"
@@ -96,6 +97,12 @@ void ObjectHeap::addObject(WebGPUIdentifier identifier, RemoteCommandBuffer& com
 void ObjectHeap::addObject(WebGPUIdentifier identifier, RemoteCommandEncoder& commandEncoder)
 {
     auto result = m_objects.add(identifier, Object { IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder> { Ref { commandEncoder } } });
+    ASSERT_UNUSED(result, result.isNewEntry);
+}
+
+void ObjectHeap::addObject(WebGPUIdentifier identifier, RemoteCompositorIntegration& querySet)
+{
+    auto result = m_objects.add(identifier, Object { IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration> { Ref { querySet } } });
     ASSERT_UNUSED(result, result.isNewEntry);
 }
 
@@ -258,6 +265,14 @@ PAL::WebGPU::CommandEncoder* ObjectHeap::convertCommandEncoderFromBacking(WebGPU
     if (iterator == m_objects.end() || !std::holds_alternative<IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder>>(iterator->value))
         return nullptr;
     return &std::get<IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder>>(iterator->value)->backing();
+}
+
+PAL::WebGPU::CompositorIntegration* ObjectHeap::convertCompositorIntegrationFromBacking(WebGPUIdentifier identifier)
+{
+    auto iterator = m_objects.find(identifier);
+    if (iterator == m_objects.end() || !std::holds_alternative<IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration>>(iterator->value))
+        return nullptr;
+    return &std::get<IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration>>(iterator->value)->backing();
 }
 
 PAL::WebGPU::ComputePassEncoder* ObjectHeap::convertComputePassEncoderFromBacking(WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
@@ -42,6 +42,7 @@ class BindGroupLayout;
 class Buffer;
 class CommandBuffer;
 class CommandEncoder;
+class CompositorIntegration;
 class ComputePassEncoder;
 class ComputePipeline;
 class Device;
@@ -67,6 +68,7 @@ class RemoteBindGroupLayout;
 class RemoteBuffer;
 class RemoteCommandBuffer;
 class RemoteCommandEncoder;
+class RemoteCompositorIntegration;
 class RemoteComputePassEncoder;
 class RemoteComputePipeline;
 class RemoteDevice;
@@ -104,6 +106,7 @@ public:
     void addObject(WebGPUIdentifier, RemoteBuffer&);
     void addObject(WebGPUIdentifier, RemoteCommandBuffer&);
     void addObject(WebGPUIdentifier, RemoteCommandEncoder&);
+    void addObject(WebGPUIdentifier, RemoteCompositorIntegration&);
     void addObject(WebGPUIdentifier, RemoteComputePassEncoder&);
     void addObject(WebGPUIdentifier, RemoteComputePipeline&);
     void addObject(WebGPUIdentifier, RemoteDevice&);
@@ -132,6 +135,7 @@ public:
     PAL::WebGPU::Buffer* convertBufferFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::CommandBuffer* convertCommandBufferFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::CommandEncoder* convertCommandEncoderFromBacking(WebGPUIdentifier) final;
+    PAL::WebGPU::CompositorIntegration* convertCompositorIntegrationFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::ComputePassEncoder* convertComputePassEncoderFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::ComputePipeline* convertComputePipelineFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::Device* convertDeviceFromBacking(WebGPUIdentifier) final;
@@ -161,6 +165,7 @@ private:
         IPC::ScopedActiveMessageReceiveQueue<RemoteBuffer>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteCommandBuffer>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder>,
+        IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteComputePassEncoder>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteComputePipeline>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteDevice>,

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
@@ -67,6 +67,7 @@ struct CommandBufferDescriptor;
 class CommandEncoder;
 struct CommandEncoderDescriptor;
 class CompilationMessage;
+class CompositorIntegration;
 struct ComputePassDescriptor;
 class ComputePassEncoder;
 class ComputePipeline;
@@ -283,6 +284,7 @@ public:
     virtual PAL::WebGPU::Buffer* convertBufferFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::CommandBuffer* convertCommandBufferFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::CommandEncoder* convertCommandEncoderFromBacking(WebGPUIdentifier) = 0;
+    virtual PAL::WebGPU::CompositorIntegration* convertCompositorIntegrationFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::ComputePassEncoder* convertComputePassEncoderFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::ComputePipeline* convertComputePipelineFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::Device* convertDeviceFromBacking(WebGPUIdentifier) = 0;

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
@@ -66,6 +66,7 @@ struct CommandBufferDescriptor;
 class CommandEncoder;
 struct CommandEncoderDescriptor;
 class CompilationMessage;
+class CompositorIntegration;
 struct ComputePassDescriptor;
 class ComputePassEncoder;
 class ComputePipeline;
@@ -280,6 +281,7 @@ public:
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::Buffer&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandBuffer&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandEncoder&) = 0;
+    virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::CompositorIntegration&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePassEncoder&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePipeline&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::Device&) = 0;

--- a/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.cpp
@@ -40,11 +40,11 @@ std::optional<SurfaceDescriptor> ConvertToBackingContext::convertToBacking(const
     if (!base)
         return std::nullopt;
 
-    auto size = convertToBacking(surfaceDescriptor.size);
-    if (!size)
+    auto identifier = convertToBacking(surfaceDescriptor.compositorIntegration);
+    if (!identifier)
         return std::nullopt;
 
-    return { { WTFMove(*base), WTFMove(*size), surfaceDescriptor.sampleCount, surfaceDescriptor.format, surfaceDescriptor.usage } };
+    return { { WTFMove(*base), identifier } };
 }
 
 std::optional<PAL::WebGPU::SurfaceDescriptor> ConvertFromBackingContext::convertFromBacking(const SurfaceDescriptor& surfaceDescriptor)
@@ -53,11 +53,11 @@ std::optional<PAL::WebGPU::SurfaceDescriptor> ConvertFromBackingContext::convert
     if (!base)
         return std::nullopt;
 
-    auto size = convertFromBacking(surfaceDescriptor.size);
-    if (!size)
+    auto* compositorIntegration = convertCompositorIntegrationFromBacking(surfaceDescriptor.compositorIntegration);
+    if (!compositorIntegration)
         return std::nullopt;
 
-    return { { WTFMove(*base), WTFMove(*size), surfaceDescriptor.sampleCount, surfaceDescriptor.format, surfaceDescriptor.usage } };
+    return { { WTFMove(*base), *compositorIntegration } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.h
@@ -27,20 +27,13 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "WebGPUExtent3D.h"
+#include "WebGPUIdentifier.h"
 #include "WebGPUObjectDescriptorBase.h"
-#include <optional>
-#include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
-#include <pal/graphics/WebGPU/WebGPUTextureFormat.h>
-#include <pal/graphics/WebGPU/WebGPUTextureUsage.h>
 
 namespace WebKit::WebGPU {
 
 struct SurfaceDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    PAL::WebGPU::Size32 sampleCount { 1 };
-    PAL::WebGPU::TextureFormat format { PAL::WebGPU::TextureFormat::R8unorm };
-    PAL::WebGPU::TextureUsageFlags usage;
+    WebGPUIdentifier compositorIntegration;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.serialization.in
@@ -22,9 +22,6 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::SurfaceDescriptor : WebKit::WebGPU::ObjectDescriptorBase {
-    WebKit::WebGPU::Extent3D size;
-    PAL::WebGPU::Size32 sampleCount;
-    PAL::WebGPU::TextureFormat format;
-    PAL::WebGPU::TextureUsageFlags usage;
+    WebKit::WebGPUIdentifier compositorIntegration;
 };
 #endif

--- a/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.cpp
@@ -40,11 +40,7 @@ std::optional<SwapChainDescriptor> ConvertToBackingContext::convertToBacking(con
     if (!base)
         return std::nullopt;
 
-    auto size = convertToBacking(swapChainDescriptor.size);
-    if (!size)
-        return std::nullopt;
-
-    return { { WTFMove(*base), WTFMove(*size),  swapChainDescriptor.sampleCount, swapChainDescriptor.format, swapChainDescriptor.usage } };
+    return { { WTFMove(*base), swapChainDescriptor.format, swapChainDescriptor.usage, swapChainDescriptor.viewFormats, swapChainDescriptor.colorSpace, swapChainDescriptor.compositingAlphaMode, swapChainDescriptor.width, swapChainDescriptor.height } };
 }
 
 std::optional<PAL::WebGPU::SwapChainDescriptor> ConvertFromBackingContext::convertFromBacking(const SwapChainDescriptor& swapChainDescriptor)
@@ -53,11 +49,7 @@ std::optional<PAL::WebGPU::SwapChainDescriptor> ConvertFromBackingContext::conve
     if (!base)
         return std::nullopt;
 
-    auto size = convertFromBacking(swapChainDescriptor.size);
-    if (!size)
-        return std::nullopt;
-
-    return { { WTFMove(*base), WTFMove(*size), swapChainDescriptor.sampleCount, swapChainDescriptor.format, swapChainDescriptor.usage } };
+    return { { WTFMove(*base), swapChainDescriptor.format, swapChainDescriptor.usage, swapChainDescriptor.viewFormats, swapChainDescriptor.colorSpace, swapChainDescriptor.compositingAlphaMode, swapChainDescriptor.width, swapChainDescriptor.height } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.h
@@ -30,18 +30,22 @@
 #include "WebGPUExtent3D.h"
 #include "WebGPUObjectDescriptorBase.h"
 #include <optional>
-#include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
-#include <pal/graphics/WebGPU/WebGPUTextureDimension.h>
+#include <pal/graphics/WebGPU/WebGPUCanvasCompositingAlphaMode.h>
+#include <pal/graphics/WebGPU/WebGPUPredefinedColorSpace.h>
 #include <pal/graphics/WebGPU/WebGPUTextureFormat.h>
 #include <pal/graphics/WebGPU/WebGPUTextureUsage.h>
+#include <wtf/Vector.h>
 
 namespace WebKit::WebGPU {
 
 struct SwapChainDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    PAL::WebGPU::Size32 sampleCount { 1 };
     PAL::WebGPU::TextureFormat format { PAL::WebGPU::TextureFormat::R8unorm };
-    PAL::WebGPU::TextureUsageFlags usage;
+    PAL::WebGPU::TextureUsageFlags usage { PAL::WebGPU::TextureUsage::RenderAttachment };
+    Vector<PAL::WebGPU::TextureFormat> viewFormats;
+    PAL::WebGPU::PredefinedColorSpace colorSpace { PAL::WebGPU::PredefinedColorSpace::SRGB };
+    PAL::WebGPU::CanvasCompositingAlphaMode compositingAlphaMode { PAL::WebGPU::CanvasCompositingAlphaMode::Opaque };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.serialization.in
@@ -22,9 +22,12 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::SwapChainDescriptor : WebKit::WebGPU::ObjectDescriptorBase {
-    WebKit::WebGPU::Extent3D size;
-    PAL::WebGPU::Size32 sampleCount;
     PAL::WebGPU::TextureFormat format;
     PAL::WebGPU::TextureUsageFlags usage;
+    Vector<PAL::WebGPU::TextureFormat> viewFormats;
+    PAL::WebGPU::PredefinedColorSpace colorSpace;
+    PAL::WebGPU::CanvasCompositingAlphaMode compositingAlphaMode;
+    uint32_t width;
+    uint32_t height;
 };
 #endif

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -40,6 +40,7 @@ GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
 GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
 GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
 GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
 GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
 GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
 GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -687,6 +688,7 @@ WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -871,6 +873,7 @@ RemoteBindGroupLayoutMessageReceiver.cpp
 RemoteBufferMessageReceiver.cpp
 RemoteCommandBufferMessageReceiver.cpp
 RemoteCommandEncoderMessageReceiver.cpp
+RemoteCompositorIntegrationMessageReceiver.cpp
 RemoteComputePassEncoderMessageReceiver.cpp
 RemoteComputePipelineMessageReceiver.cpp
 RemoteDeviceMessageReceiver.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3851,6 +3851,11 @@
 		1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebInspectorUIProxyMac.mm; sourceTree = "<group>"; };
 		1CA8B943127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUIProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		1CA8B944127C882A00576C2B /* WebInspectorUIProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUIProxyMessages.h; sourceTree = "<group>"; };
+		1CAB34F8297AA3C20088D4D3 /* RemoteCompositorIntegration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCompositorIntegration.cpp; sourceTree = "<group>"; };
+		1CAB34F9297AA3C20088D4D3 /* RemoteCompositorIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteCompositorIntegration.h; sourceTree = "<group>"; };
+		1CAB34FA297AA4F10088D4D3 /* RemoteCompositorIntegration.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteCompositorIntegration.messages.in; sourceTree = "<group>"; };
+		1CAB34FB297AA8830088D4D3 /* RemoteCompositorIntegrationProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCompositorIntegrationProxy.cpp; sourceTree = "<group>"; };
+		1CAB34FC297AA8830088D4D3 /* RemoteCompositorIntegrationProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteCompositorIntegrationProxy.h; sourceTree = "<group>"; };
 		1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionURLSchemeHandler.h; sourceTree = "<group>"; };
 		1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionURLSchemeHandlerCocoa.mm; sourceTree = "<group>"; };
 		1CAECB5D27465AE300AB78D0 /* UnifiedSource109.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource109.cpp; sourceTree = "<group>"; };
@@ -9003,6 +9008,9 @@
 				1C98C05627446CB9002CCB78 /* RemoteCommandEncoder.cpp */,
 				1C98C05527446CB9002CCB78 /* RemoteCommandEncoder.h */,
 				1C98C0952744BD9B002CCB78 /* RemoteCommandEncoder.messages.in */,
+				1CAB34F8297AA3C20088D4D3 /* RemoteCompositorIntegration.cpp */,
+				1CAB34F9297AA3C20088D4D3 /* RemoteCompositorIntegration.h */,
+				1CAB34FA297AA4F10088D4D3 /* RemoteCompositorIntegration.messages.in */,
 				1C98C05827446CBA002CCB78 /* RemoteComputePassEncoder.cpp */,
 				1C98C05A27446CBA002CCB78 /* RemoteComputePassEncoder.h */,
 				1C98C0932744BD9B002CCB78 /* RemoteComputePassEncoder.messages.in */,
@@ -9093,6 +9101,8 @@
 				1CB7462C27436EE700F19874 /* RemoteCommandBufferProxy.h */,
 				1CB7462227436EE600F19874 /* RemoteCommandEncoderProxy.cpp */,
 				1CB7464027436EEA00F19874 /* RemoteCommandEncoderProxy.h */,
+				1CAB34FB297AA8830088D4D3 /* RemoteCompositorIntegrationProxy.cpp */,
+				1CAB34FC297AA8830088D4D3 /* RemoteCompositorIntegrationProxy.h */,
 				1CB7462327436EE600F19874 /* RemoteComputePassEncoderProxy.cpp */,
 				1CB7462627436EE600F19874 /* RemoteComputePassEncoderProxy.h */,
 				1CB7463F27436EEA00F19874 /* RemoteComputePipelineProxy.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteCompositorIntegrationProxy.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteCompositorIntegrationMessages.h"
+#include "RemoteGPUProxy.h"
+#include "WebGPUConvertToBackingContext.h"
+
+namespace WebKit::WebGPU {
+
+RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    : m_backing(identifier)
+    , m_convertToBackingContext(convertToBackingContext)
+    , m_parent(parent)
+{
+}
+
+RemoteCompositorIntegrationProxy::~RemoteCompositorIntegrationProxy() = default;
+
+#if PLATFORM(COCOA)
+Vector<MachSendRight> RemoteCompositorIntegrationProxy::getRenderBuffers()
+{
+    auto sendResult = sendSync(Messages::RemoteCompositorIntegration::GetRenderBuffers());
+    if (!sendResult)
+        return { };
+
+    auto [renderBuffers] = sendResult.takeReply();
+    return renderBuffers;
+}
+#endif
+
+} // namespace WebKit::WebGPU
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteGPUProxy.h"
+#include "WebGPUIdentifier.h"
+#include <pal/graphics/WebGPU/WebGPUCompositorIntegration.h>
+
+namespace WebKit::WebGPU {
+
+class ConvertToBackingContext;
+
+class RemoteCompositorIntegrationProxy final : public PAL::WebGPU::CompositorIntegration {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<RemoteCompositorIntegrationProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    {
+        return adoptRef(*new RemoteCompositorIntegrationProxy(parent, convertToBackingContext, identifier));
+    }
+
+    virtual ~RemoteCompositorIntegrationProxy();
+
+    RemoteGPUProxy& parent() { return m_parent; }
+    RemoteGPUProxy& root() { return m_parent; }
+
+private:
+    friend class DowncastConvertToBackingContext;
+
+    RemoteCompositorIntegrationProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+
+    RemoteCompositorIntegrationProxy(const RemoteCompositorIntegrationProxy&) = delete;
+    RemoteCompositorIntegrationProxy(RemoteCompositorIntegrationProxy&&) = delete;
+    RemoteCompositorIntegrationProxy& operator=(const RemoteCompositorIntegrationProxy&) = delete;
+    RemoteCompositorIntegrationProxy& operator=(RemoteCompositorIntegrationProxy&&) = delete;
+
+    WebGPUIdentifier backing() const { return m_backing; }
+    
+    static inline constexpr Seconds defaultSendTimeout = 30_s;
+    template<typename T>
+    WARN_UNUSED_RETURN bool send(T&& message)
+    {
+        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+    }
+    template<typename T>
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    {
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+    }
+
+#if PLATFORM(COCOA)
+    Vector<MachSendRight> getRenderBuffers() override;
+#endif
+
+    WebGPUIdentifier m_backing;
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
+    Ref<RemoteGPUProxy> m_parent;
+};
+
+} // namespace WebKit::WebGPU
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -87,21 +87,6 @@ Ref<PAL::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const PAL::WebGPU::Buff
     return RemoteBufferProxy::create(*this, m_convertToBackingContext, identifier);
 }
 
-Ref<PAL::WebGPU::Surface> RemoteDeviceProxy::createSurface(const PAL::WebGPU::SurfaceDescriptor& descriptor)
-{
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteSurfaceProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
-
-    auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = send(Messages::RemoteDevice::CreateSurface(*convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
-
-    return RemoteSurfaceProxy::create(*this, m_convertToBackingContext, identifier);
-}
-
 Ref<PAL::WebGPU::SwapChain> RemoteDeviceProxy::createSwapChain(const PAL::WebGPU::Surface& surface, const PAL::WebGPU::SwapChainDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
@@ -123,29 +108,14 @@ Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createTexture(const PAL::WebGPU::Te
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
     if (!convertedDescriptor) {
         // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateTexture(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureProxy::create(*this, m_convertToBackingContext, identifier);
-}
-
-Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createSurfaceTexture(const PAL::WebGPU::TextureDescriptor& descriptor, const PAL::WebGPU::Surface& surface)
-{
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
-
-    auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = send(Messages::RemoteDevice::CreateSurfaceTexture(m_convertToBackingContext->convertToBacking(surface), *convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
-
-    return RemoteTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 Ref<PAL::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const PAL::WebGPU::SamplerDescriptor& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -81,8 +81,6 @@ private:
 
     Ref<PAL::WebGPU::Buffer> createBuffer(const PAL::WebGPU::BufferDescriptor&) final;
     Ref<PAL::WebGPU::Texture> createTexture(const PAL::WebGPU::TextureDescriptor&) final;
-    Ref<PAL::WebGPU::Texture> createSurfaceTexture(const PAL::WebGPU::TextureDescriptor&, const PAL::WebGPU::Surface&) final;
-    Ref<PAL::WebGPU::Surface> createSurface(const PAL::WebGPU::SurfaceDescriptor&) final;
     Ref<PAL::WebGPU::SwapChain> createSwapChain(const PAL::WebGPU::Surface&, const PAL::WebGPU::SwapChainDescriptor&) final;
     Ref<PAL::WebGPU::Sampler> createSampler(const PAL::WebGPU::SamplerDescriptor&) final;
     Ref<PAL::WebGPU::ExternalTexture> importExternalTexture(const PAL::WebGPU::ExternalTextureDescriptor&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -31,15 +31,16 @@
 #include "GPUConnectionToWebProcessMessages.h"
 #include "GPUProcessConnection.h"
 #include "RemoteAdapterProxy.h"
+#include "RemoteCompositorIntegrationProxy.h"
 #include "RemoteGPU.h"
 #include "RemoteGPUMessages.h"
 #include "RemoteGPUProxyMessages.h"
+#include "RemoteSurfaceProxy.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <pal/graphics/WebGPU/WebGPUSupportedFeatures.h>
 #include <pal/graphics/WebGPU/WebGPUSupportedLimits.h>
 
 namespace WebKit {
-
 
 RemoteGPUProxy::RemoteGPUProxy(GPUProcessConnection& gpuProcessConnection, WebGPU::ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, RenderingBackendIdentifier renderingBackend)
     : m_backing(identifier)
@@ -147,6 +148,34 @@ void RemoteGPUProxy::requestAdapter(const PAL::WebGPU::RequestAdapterOptions& op
         response->limits.maxComputeWorkgroupsPerDimension
     );
     callback(WebGPU::RemoteAdapterProxy::create(WTFMove(response->name), WTFMove(resultSupportedFeatures), WTFMove(resultSupportedLimits), response->isFallbackAdapter, *this, m_convertToBackingContext, identifier));
+}
+
+Ref<PAL::WebGPU::Surface> RemoteGPUProxy::createSurface(const PAL::WebGPU::SurfaceDescriptor& descriptor)
+{
+    // FIXME: Should we be consulting m_lost?
+
+    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
+    if (!convertedDescriptor) {
+        // FIXME: Implement error handling.
+        return WebGPU::RemoteSurfaceProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+    }
+
+    auto identifier = WebGPUIdentifier::generate();
+    auto sendResult = send(Messages::RemoteGPU::CreateSurface(*convertedDescriptor, identifier));
+    UNUSED_VARIABLE(sendResult);
+
+    return WebGPU::RemoteSurfaceProxy::create(*this, m_convertToBackingContext, identifier);
+}
+
+Ref<PAL::WebGPU::CompositorIntegration> RemoteGPUProxy::createCompositorIntegration()
+{
+    // FIXME: Should we be consulting m_lost?
+
+    auto identifier = WebGPUIdentifier::generate();
+    auto sendResult = send(Messages::RemoteGPU::CreateCompositorIntegration(identifier));
+    UNUSED_VARIABLE(sendResult);
+
+    return WebGPU::RemoteCompositorIntegrationProxy::create(*this, m_convertToBackingContext, identifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -32,6 +32,7 @@
 #include "StreamClientConnection.h"
 #include "WebGPUIdentifier.h"
 #include <pal/graphics/WebGPU/WebGPU.h>
+#include <pal/graphics/WebGPU/WebGPUSurface.h>
 #include <wtf/Deque.h>
 
 namespace WebKit {
@@ -98,6 +99,10 @@ private:
     IPC::Connection& connection() const { return m_gpuProcessConnection->connection(); }
 
     void requestAdapter(const PAL::WebGPU::RequestAdapterOptions&, CompletionHandler<void(RefPtr<PAL::WebGPU::Adapter>&&)>&&) final;
+
+    Ref<PAL::WebGPU::Surface> createSurface(const PAL::WebGPU::SurfaceDescriptor&) final;
+
+    Ref<PAL::WebGPU::CompositorIntegration> createCompositorIntegration() final;
 
     void abandonGPUProcess();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp
@@ -33,7 +33,7 @@
 
 namespace WebKit::WebGPU {
 
-RemoteSurfaceProxy::RemoteSurfaceProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteSurfaceProxy::RemoteSurfaceProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
     , m_parent(parent)
@@ -42,12 +42,6 @@ RemoteSurfaceProxy::RemoteSurfaceProxy(RemoteDeviceProxy& parent, ConvertToBacki
 
 RemoteSurfaceProxy::~RemoteSurfaceProxy()
 {
-}
-
-void RemoteSurfaceProxy::destroy()
-{
-    auto sendResult = send(Messages::RemoteSurface::Destroy());
-    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteSurfaceProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "RemoteDeviceProxy.h"
+#include "RemoteGPUProxy.h"
 #include "WebGPUIdentifier.h"
 #include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
 #include <pal/graphics/WebGPU/WebGPUSurface.h>
@@ -39,20 +39,20 @@ class ConvertToBackingContext;
 class RemoteSurfaceProxy final : public PAL::WebGPU::Surface {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteSurfaceProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteSurfaceProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
         return adoptRef(*new RemoteSurfaceProxy(parent, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteSurfaceProxy();
 
-    RemoteDeviceProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& parent() { return m_parent; }
+    RemoteGPUProxy& root() { return m_parent; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteSurfaceProxy(RemoteDeviceProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteSurfaceProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteSurfaceProxy(const RemoteSurfaceProxy&) = delete;
     RemoteSurfaceProxy(RemoteSurfaceProxy&&) = delete;
@@ -73,13 +73,11 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
-    void destroy() final;
-
     void setLabelInternal(const String&) final;
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteDeviceProxy> m_parent;
+    Ref<RemoteGPUProxy> m_parent;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
@@ -35,6 +35,8 @@
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
+class RemoteTextureProxy;
+class RemoteTextureViewProxy;
 
 class RemoteSwapChainProxy final : public PAL::WebGPU::SwapChain {
     WTF_MAKE_FAST_ALLOCATED;
@@ -48,10 +50,6 @@ public:
 
     RemoteDeviceProxy& parent() { return m_parent; }
     RemoteGPUProxy& root() { return m_parent->root(); }
-
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
-#endif
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -77,13 +75,20 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
-    void destroy() final;
+    PAL::WebGPU::Texture& getCurrentTexture() final;
+    PAL::WebGPU::TextureView& getCurrentTextureView() final;
+    void present() final;
 
     void setLabelInternal(const String&) final;
+    
+    void clearCurrentTextureAndView();
+    void ensureCurrentTextureAndView();
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    RefPtr<RemoteTextureProxy> m_currentTexture;
+    RefPtr<RemoteTextureViewProxy> m_currentTextureView;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -35,10 +35,10 @@
 
 namespace WebKit::WebGPU {
 
-RemoteTextureProxy::RemoteTextureProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteTextureProxy::RemoteTextureProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 
@@ -53,7 +53,7 @@ Ref<PAL::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional
         convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
         if (!convertedDescriptor) {
             // FIXME: Implement error handling.
-            return RemoteTextureViewProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+            return RemoteTextureViewProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
         }
     }
 
@@ -61,7 +61,7 @@ Ref<PAL::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional
     auto sendResult = send(Messages::RemoteTexture::CreateView(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureViewProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureViewProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 void RemoteTextureProxy::destroy()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -42,20 +42,19 @@ class ConvertToBackingContext;
 class RemoteTextureProxy final : public PAL::WebGPU::Texture {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteTextureProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteTextureProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextureProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteTextureProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteTextureProxy();
 
-    RemoteDeviceProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteTextureProxy(RemoteDeviceProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteTextureProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteTextureProxy(const RemoteTextureProxy&) = delete;
     RemoteTextureProxy(RemoteTextureProxy&&) = delete;
@@ -84,7 +83,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteDeviceProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -33,10 +33,10 @@
 
 namespace WebKit::WebGPU {
 
-RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -38,20 +38,19 @@ class ConvertToBackingContext;
 class RemoteTextureViewProxy final : public PAL::WebGPU::TextureView {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteTextureViewProxy> create(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteTextureViewProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextureViewProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteTextureViewProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteTextureViewProxy();
 
-    RemoteTextureProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteTextureViewProxy(RemoteTextureProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteTextureViewProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteTextureViewProxy(const RemoteTextureViewProxy&) = delete;
     RemoteTextureViewProxy(RemoteTextureViewProxy&&) = delete;
@@ -76,7 +75,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteTextureProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
@@ -34,6 +34,7 @@
 #include "RemoteBufferProxy.h"
 #include "RemoteCommandBufferProxy.h"
 #include "RemoteCommandEncoderProxy.h"
+#include "RemoteCompositorIntegrationProxy.h"
 #include "RemoteComputePassEncoderProxy.h"
 #include "RemoteComputePipelineProxy.h"
 #include "RemoteDeviceProxy.h"
@@ -83,6 +84,11 @@ WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::We
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::WebGPU::CommandEncoder& commandEncoder)
 {
     return static_cast<const RemoteCommandEncoderProxy&>(commandEncoder).backing();
+}
+
+WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::WebGPU::CompositorIntegration& compositorIntegration)
+{
+    return static_cast<const RemoteCompositorIntegrationProxy&>(compositorIntegration).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::WebGPU::ComputePassEncoder& computePassEncoder)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
@@ -47,6 +47,7 @@ public:
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::Buffer&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandBuffer&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandEncoder&) final;
+    WebGPUIdentifier convertToBacking(const PAL::WebGPU::CompositorIntegration&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePassEncoder&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePipeline&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::Device&) final;


### PR DESCRIPTION
#### ac8f4008f465991806ce7c0323f9342a4aae7071
<pre>
[WebGPU] Align our compositing infrastructure with the spec and WebGPU.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=250949">https://bugs.webkit.org/show_bug.cgi?id=250949</a>
rdar://104516632

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/cocoa/TollFreeBridging.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::GPU):
(WebCore::GPU::requestAdapter):
(WebCore::GPU::createSurface):
(WebCore::GPU::createCompositorIntegration):
(WebCore::GPU::setBacking): Deleted.
* Source/WebCore/Modules/WebGPU/GPU.h:
(WebCore::GPU::create):
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp: Copied from Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp.
(WebCore::GPUCompositorIntegration::getRenderBuffers const):
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h: Copied from Source/WebCore/Modules/WebGPU/GPUSwapChain.h.
(WebCore::GPUCompositorIntegration::create):
(WebCore::GPUCompositorIntegration::backing):
(WebCore::GPUCompositorIntegration::backing const):
(WebCore::GPUCompositorIntegration::GPUCompositorIntegration):
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::createSurfaceTexture): Deleted.
(WebCore::GPUDevice::createSurface): Deleted.
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/WebGPU/GPUSurface.cpp:
(WebCore::GPUSurface::destroy): Deleted.
* Source/WebCore/Modules/WebGPU/GPUSurface.h:
* Source/WebCore/Modules/WebGPU/GPUSurfaceDescriptor.h:
(WebCore::GPUSurfaceDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp:
(WebCore::GPUSwapChain::clearCurrentTextureAndView):
(WebCore::GPUSwapChain::ensureCurrentTextureAndView):
(WebCore::GPUSwapChain::getCurrentTexture):
(WebCore::GPUSwapChain::getCurrentTextureView):
(WebCore::GPUSwapChain::present):
(WebCore::GPUSwapChain::prepareForDisplay): Deleted.
(WebCore::GPUSwapChain::destroy): Deleted.
* Source/WebCore/Modules/WebGPU/GPUSwapChain.h:
* Source/WebCore/Modules/WebGPU/GPUSwapChainDescriptor.h:
(WebCore::GPUSwapChainDescriptor::convertToBacking const):
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/CMakeLists.txt:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBindGroupLayoutImpl.cpp:
(PAL::WebGPU::BindGroupLayoutImpl::BindGroupLayoutImpl):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBindGroupLayoutImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp: Added.
(PAL::WebGPU::CompositorIntegrationImpl::CompositorIntegrationImpl):
(PAL::WebGPU::CompositorIntegrationImpl::getRenderBuffers):
(PAL::WebGPU::toCFNumber):
(PAL::WebGPU::CompositorIntegrationImpl::recreateIOSurfaces):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h: Copied from Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.h.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp:
(PAL::WebGPU::ComputePipelineImpl::getBindGroupLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createSwapChain):
(PAL::WebGPU::DeviceImpl::createSurfaceTexture): Deleted.
(PAL::WebGPU::convertToWidthHeight): Deleted.
(PAL::WebGPU::DeviceImpl::createSurface): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.cpp:
(PAL::WebGPU::DowncastConvertToBackingContext::convertToBacking):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp:
(PAL::WebGPU::GPUImpl::createSurface):
(PAL::WebGPU::GPUImpl::createCompositorIntegration):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp:
(PAL::WebGPU::RenderPipelineImpl::getBindGroupLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp:
(PAL::WebGPU::SurfaceImpl::SurfaceImpl):
(PAL::WebGPU::SurfaceImpl::~SurfaceImpl):
(PAL::WebGPU::SurfaceImpl::setLabelInternal):
(PAL::WebGPU::SurfaceImpl::destroy): Deleted.
(PAL::WebGPU::SurfaceImpl::drawingBuffer const): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp:
(PAL::WebGPU::SwapChainImpl::SwapChainImpl):
(PAL::WebGPU::SwapChainImpl::clearCurrentTextureAndView):
(PAL::WebGPU::SwapChainImpl::ensureCurrentTextureAndView):
(PAL::WebGPU::SwapChainImpl::getCurrentTexture):
(PAL::WebGPU::SwapChainImpl::getCurrentTextureView):
(PAL::WebGPU::SwapChainImpl::present):
(PAL::WebGPU::SwapChainImpl::setLabelInternal):
(PAL::WebGPU::SwapChainImpl::destroy): Deleted.
(PAL::WebGPU::SwapChainImpl::prepareForDisplay): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.cpp:
(PAL::WebGPU::TextureImpl::TextureImpl):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.cpp:
(PAL::WebGPU::TextureViewImpl::TextureViewImpl):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureViewImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h: Copied from Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h.
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurface.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h:
(): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::getContextWebGPU):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/canvas/GPUCanvasContext.cpp:
(WebCore::GPUCanvasContext::create):
(WebCore::GPUCanvasContext::GPUCanvasContext):
(WebCore::getCanvasSizeAsIntSize): Deleted.
(WebCore::platformSupportsWebGPUSurface): Deleted.
(WebCore::GPUCanvasContext::reshape): Deleted.
(WebCore::GPUCanvasContext::canvas): Deleted.
(WebCore::GPUCanvasContext::configure): Deleted.
(WebCore::GPUCanvasContext::createSwapChainIfNeeded): Deleted.
(WebCore::GPUCanvasContext::getCurrentTexture): Deleted.
(WebCore::GPUCanvasContext::pixelFormat const): Deleted.
(WebCore::GPUCanvasContext::unconfigure): Deleted.
(WebCore::GPUCanvasContext::colorSpace const): Deleted.
(WebCore::GPUCanvasContext::layerContentsDisplayDelegate): Deleted.
(WebCore::GPUCanvasContext::prepareForDisplay): Deleted.
(WebCore::GPUCanvasContext::markContextChangedAndNotifyCanvasObservers): Deleted.
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp: Added.
(WebCore::GPUCanvasContext::create):
(WebCore::GPUCanvasContextCocoa::create):
(WebCore::surfaceDescriptor):
(WebCore::getCanvasWidth):
(WebCore::getCanvasHeight):
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
(WebCore::GPUCanvasContextCocoa::reshape):
(WebCore::GPUCanvasContextCocoa::canvas):
(WebCore::GPUCanvasContextCocoa::configure):
(WebCore::GPUCanvasContextCocoa::unconfigure):
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
(WebCore::GPUCanvasContextCocoa::pixelFormat const):
(WebCore::GPUCanvasContextCocoa::colorSpace const):
(WebCore::GPUCanvasContextCocoa::layerContentsDisplayDelegate):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h: Copied from Source/WebCore/html/canvas/GPUCanvasContext.h.
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::gpu):
* Source/WebGPU/WebGPU/Adapter.mm:
(wgpuAdapterRetain):
* Source/WebGPU/WebGPU/BindGroup.mm:
(wgpuBindGroupRetain):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(wgpuBindGroupLayoutRetain):
* Source/WebGPU/WebGPU/Buffer.mm:
(wgpuBufferRetain):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(wgpuCommandBufferRetain):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(wgpuCommandEncoderRetain):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(wgpuComputePassEncoderRetain):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(wgpuComputePipelineRetain):
* Source/WebGPU/WebGPU/Device.mm:
(wgpuDeviceRetain):
* Source/WebGPU/WebGPU/Instance.mm:
(wgpuInstanceRetain):
(wgpuGetProcAddress):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(wgpuPipelineLayoutRetain):
* Source/WebGPU/WebGPU/PresentationContext.h:
* Source/WebGPU/WebGPU/PresentationContext.mm:
(WebGPU::PresentationContext::getCurrentTexture):
(wgpuSurfaceRetain):
(wgpuSwapChainRetain):
(wgpuSwapChainGetCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h:
(WebGPU::PresentationContextCoreAnimation::Configuration::Configuration):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm:
(WebGPU::PresentationContextCoreAnimation::configure):
(WebGPU::PresentationContextCoreAnimation::Configuration::generateCurrentFrameState):
(WebGPU::PresentationContextCoreAnimation::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
(WebGPU::PresentationContextIOSurface::displayBuffer const): Deleted.
(WebGPU::PresentationContextIOSurface::drawingBuffer const): Deleted.
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::PresentationContextIOSurface):
(WebGPU::PresentationContextIOSurface::configure):
(WebGPU::PresentationContextIOSurface::present):
(WebGPU::PresentationContextIOSurface::getCurrentTexture):
(WebGPU::PresentationContextIOSurface::getCurrentTextureView):
(WebGPU::optionsFor32BitSurface): Deleted.
(WebGPU::createIOSurface): Deleted.
(WebGPU::createSurfaceFromDescriptor): Deleted.
(WebGPU::PresentationContextIOSurface::nextDrawable): Deleted.
(wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer): Deleted.
(wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer): Deleted.
* Source/WebGPU/WebGPU/QuerySet.mm:
(wgpuQuerySetRetain):
* Source/WebGPU/WebGPU/Queue.mm:
(wgpuQueueRetain):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(wgpuRenderBundleRetain):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(wgpuRenderBundleEncoderRetain):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(wgpuRenderPassEncoderRetain):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(wgpuRenderPipelineRetain):
* Source/WebGPU/WebGPU/Sampler.mm:
(wgpuSamplerRetain):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(wgpuShaderModuleRetain):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::usage):
(WebGPU::storageMode):
(WebGPU::Device::createTexture):
(wgpuTextureRetain):
(WebGPU::Device::validateCreateIOSurfaceBackedTexture): Deleted.
(WebGPU::usage): Deleted.
* Source/WebGPU/WebGPU/TextureView.mm:
(wgpuTextureViewRetain):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp: Copied from Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp.
(WebKit::RemoteCompositorIntegration::RemoteCompositorIntegration):
(WebKit::RemoteCompositorIntegration::stopListeningForIPC):
(WebKit::RemoteCompositorIntegration::getRenderBuffers):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h: Copied from Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in: Copied from Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::createSurface): Deleted.
(WebKit::RemoteDevice::createSurfaceTexture): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createSurface):
(WebKit::RemoteGPU::createCompositorIntegration):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp:
(WebKit::RemoteSurface::destroy): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp:
(WebKit::RemoteSwapChain::getCurrentTexture):
(WebKit::RemoteSwapChain::getCurrentTextureView):
(WebKit::RemoteSwapChain::present):
(WebKit::RemoteSwapChain::setLabel):
(WebKit::RemoteSwapChain::destroy): Deleted.
(WebKit::RemoteSwapChain::prepareForDisplay): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp:
(WebKit::WebGPU::ObjectHeap::addObject):
(WebKit::WebGPU::ObjectHeap::convertCompositorIntegrationFromBacking):
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h:
* Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h:
* Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h:
* Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.h:
(): Deleted.
* Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.h:
* Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp: Copied from Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp.
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy):
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::getRenderBuffers):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h: Copied from Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createSurface): Deleted.
(WebKit::WebGPU::RemoteDeviceProxy::createSurfaceTexture): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::createSurface):
(WebKit::RemoteGPUProxy::createCompositorIntegration):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp:
(WebKit::WebGPU::RemoteSurfaceProxy::RemoteSurfaceProxy):
(WebKit::WebGPU::RemoteSurfaceProxy::destroy): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp:
(WebKit::WebGPU::RemoteSwapChainProxy::clearCurrentTextureAndView):
(WebKit::WebGPU::RemoteSwapChainProxy::ensureCurrentTextureAndView):
(WebKit::WebGPU::RemoteSwapChainProxy::getCurrentTexture):
(WebKit::WebGPU::RemoteSwapChainProxy::getCurrentTextureView):
(WebKit::WebGPU::RemoteSwapChainProxy::present):
(WebKit::WebGPU::RemoteSwapChainProxy::setLabelInternal):
(WebKit::WebGPU::RemoteSwapChainProxy::destroy): Deleted.
(WebKit::WebGPU::RemoteSwapChainProxy::prepareForDisplay): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::RemoteTextureProxy):
(WebKit::WebGPU::RemoteTextureProxy::createView):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
(WebKit::WebGPU::RemoteTextureViewProxy::RemoteTextureViewProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp:
(WebKit::WebGPU::DowncastConvertToBackingContext::convertToBacking):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac8f4008f465991806ce7c0323f9342a4aae7071

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104234 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13324 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37147 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113445 "Hash ac8f4008 for PR 8931 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173735 "Hash ac8f4008 for PR 8931 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108168 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14401 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4238 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96459 "Hash ac8f4008 for PR 8931 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112500 "Hash ac8f4008 for PR 8931 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110003 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/14401 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94153 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96459 "Hash ac8f4008 for PR 8931 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/14401 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25764 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96459 "Hash ac8f4008 for PR 8931 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94262 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6685 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27124 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4460 "Built successfully and passed tests") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6821 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3678 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29952 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12835 "Hash ac8f4008 for PR 8931 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46677 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/100811 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8606 "Hash ac8f4008 for PR 8931 does not build (failure)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25017 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->