### PR TITLE
[WebGPU] Add CompositorIntegration object

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GPUCompositorIntegration.h"
+
+namespace WebCore {
+
+#if PLATFORM(COCOA)
+Vector<MachSendRight> GPUCompositorIntegration::getRenderBuffers() const
+{
+    return m_backing->getRenderBuffers();
+}
+#endif
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <pal/graphics/WebGPU/WebGPUCompositorIntegration.h>
+#include <wtf/MachSendRight.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class GPUCompositorIntegration : public RefCounted<GPUCompositorIntegration> {
+public:
+    static Ref<GPUCompositorIntegration> create(Ref<PAL::WebGPU::CompositorIntegration>&& backing)
+    {
+        return adoptRef(*new GPUCompositorIntegration(WTFMove(backing)));
+    }
+
+#if PLATFORM(COCOA)
+    Vector<MachSendRight> getRenderBuffers() const;
+#endif
+
+    PAL::WebGPU::CompositorIntegration& backing() { return m_backing; }
+    const PAL::WebGPU::CompositorIntegration& backing() const { return m_backing; }
+
+private:
+    GPUCompositorIntegration(Ref<PAL::WebGPU::CompositorIntegration>&& backing)
+        : m_backing(WTFMove(backing))
+    {
+    }
+
+    Ref<PAL::WebGPU::CompositorIntegration> m_backing;
+};
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 struct GPUPresentationConfiguration;
+class GPUTexture;
 
 class GPUPresentationContext : public RefCounted<GPUPresentationContext> {
 public:

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		1C50DADF29837158005FA0A7 /* WebGPUPresentationContextImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C50DADD29837158005FA0A7 /* WebGPUPresentationContextImpl.cpp */; };
 		1C50DAE029837158005FA0A7 /* WebGPUPresentationContextImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C50DADE29837158005FA0A7 /* WebGPUPresentationContextImpl.h */; };
 		1C50DAE4298387A5005FA0A7 /* WebGPUPresentationContextDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C50DAE3298387A5005FA0A7 /* WebGPUPresentationContextDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C4F5A18297CB48B005BBEE9 /* WebGPUCompositorIntegrationImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C4F5A17297CB46D005BBEE9 /* WebGPUCompositorIntegrationImpl.cpp */; };
+		1C4F5A19297CB48E005BBEE9 /* WebGPUCompositorIntegrationImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4F5A16297CB46C005BBEE9 /* WebGPUCompositorIntegrationImpl.h */; };
+		1C4F5A1B297CB4CA005BBEE9 /* WebGPUCompositorIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4F5A1A297CB4BD005BBEE9 /* WebGPUCompositorIntegration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C5C57C927571531003B540D /* TextCodecICU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C5C57BD27571524003B540D /* TextCodecICU.cpp */; };
 		1C5C57CA27571531003B540D /* TextCodecUserDefined.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C5C57B72757151E003B540D /* TextCodecUserDefined.cpp */; };
 		1C5C57CB27571531003B540D /* TextCodecUTF16.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C5C57BE27571525003B540D /* TextCodecUTF16.cpp */; };
@@ -697,6 +700,9 @@
 		1C36C52D2743011A006DA4C1 /* WebGPUDowncastConvertToBackingContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUDowncastConvertToBackingContext.h; sourceTree = "<group>"; };
 		1C4876D61F8D7F4E00CCEEBD /* Logging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
 		1C4876D71F8D7F4E00CCEEBD /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
+		1C4F5A16297CB46C005BBEE9 /* WebGPUCompositorIntegrationImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUCompositorIntegrationImpl.h; sourceTree = "<group>"; };
+		1C4F5A17297CB46D005BBEE9 /* WebGPUCompositorIntegrationImpl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUCompositorIntegrationImpl.cpp; sourceTree = "<group>"; };
+		1C4F5A1A297CB4BD005BBEE9 /* WebGPUCompositorIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUCompositorIntegration.h; sourceTree = "<group>"; };
 		1C4FAE9628FC83DC00FFE212 /* libavif.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libavif.xcodeproj; path = libavif/libavif.xcodeproj; sourceTree = "<group>"; };
 		1C50DAD329836B16005FA0A7 /* WebGPUPresentationContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUPresentationContext.h; sourceTree = "<group>"; };
 		1C50DAD72983700C005FA0A7 /* WebGPUPresentationConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUPresentationConfiguration.h; sourceTree = "<group>"; };
@@ -1326,6 +1332,8 @@
 				1C19E6A4273F4244004B17B0 /* WebGPUCommandBufferImpl.h */,
 				1C19E65A273F3FD2004B17B0 /* WebGPUCommandEncoderImpl.cpp */,
 				1C19E6AB273F4245004B17B0 /* WebGPUCommandEncoderImpl.h */,
+				1C4F5A17297CB46D005BBEE9 /* WebGPUCompositorIntegrationImpl.cpp */,
+				1C4F5A16297CB46C005BBEE9 /* WebGPUCompositorIntegrationImpl.h */,
 				1C19E65E273F3FE2004B17B0 /* WebGPUComputePassEncoderImpl.cpp */,
 				1C19E69E273F4243004B17B0 /* WebGPUComputePassEncoderImpl.h */,
 				1C19E662273F3FEE004B17B0 /* WebGPUComputePipelineImpl.cpp */,
@@ -1479,6 +1487,7 @@
 				1CC5E45927374947006F6FF4 /* WebGPUCompilationInfo.h */,
 				1CC5E47927374949006F6FF4 /* WebGPUCompilationMessage.h */,
 				1CC5E43627374946006F6FF4 /* WebGPUCompilationMessageType.h */,
+				1C4F5A1A297CB4BD005BBEE9 /* WebGPUCompositorIntegration.h */,
 				1CC5E48C2737494A006F6FF4 /* WebGPUComputePassDescriptor.h */,
 				1CC5E43E27374946006F6FF4 /* WebGPUComputePassEncoder.h */,
 				1CC5E48227374949006F6FF4 /* WebGPUComputePassTimestampLocation.h */,
@@ -1974,6 +1983,8 @@
 				DD20DD5D27BC90D70093D175 /* WebGPUCompilationInfo.h in Headers */,
 				DD20DD5E27BC90D70093D175 /* WebGPUCompilationMessage.h in Headers */,
 				DD20DD5F27BC90D70093D175 /* WebGPUCompilationMessageType.h in Headers */,
+				1C4F5A1B297CB4CA005BBEE9 /* WebGPUCompositorIntegration.h in Headers */,
+				1C4F5A19297CB48E005BBEE9 /* WebGPUCompositorIntegrationImpl.h in Headers */,
 				DD20DD6027BC90D70093D175 /* WebGPUComputePassDescriptor.h in Headers */,
 				DD20DD6127BC90D70093D175 /* WebGPUComputePassEncoder.h in Headers */,
 				DD20DD2E27BC90D60093D175 /* WebGPUComputePassEncoderImpl.h in Headers */,
@@ -2279,6 +2290,7 @@
 				1C19E654273F3FB1004B17B0 /* WebGPUBufferImpl.cpp in Sources */,
 				1C19E658273F3FC0004B17B0 /* WebGPUCommandBufferImpl.cpp in Sources */,
 				1C19E65C273F3FD2004B17B0 /* WebGPUCommandEncoderImpl.cpp in Sources */,
+				1C4F5A18297CB48B005BBEE9 /* WebGPUCompositorIntegrationImpl.cpp in Sources */,
 				1C19E660273F3FE2004B17B0 /* WebGPUComputePassEncoderImpl.cpp in Sources */,
 				1C19E664273F3FEE004B17B0 /* WebGPUComputePipelineImpl.cpp in Sources */,
 				1C19E6B5273F85AF004B17B0 /* WebGPUConvertToBackingContext.cpp in Sources */,

--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PAL_PUBLIC_HEADERS
     graphics/WebGPU/Impl/WebGPUBufferImpl.h
     graphics/WebGPU/Impl/WebGPUCommandBufferImpl.h
     graphics/WebGPU/Impl/WebGPUCommandEncoderImpl.h
+    graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
     graphics/WebGPU/Impl/WebGPUComputePassEncoderImpl.h
     graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h
     graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h
@@ -67,6 +68,7 @@ set(PAL_PUBLIC_HEADERS
     graphics/WebGPU/WebGPUCompilationInfo.h
     graphics/WebGPU/WebGPUCompilationMessage.h
     graphics/WebGPU/WebGPUCompilationMessageType.h
+    graphics/WebGPU/WebGPUCompositorIntegration.h
     graphics/WebGPU/WebGPUComputePassDescriptor.h
     graphics/WebGPU/WebGPUComputePassEncoder.h
     graphics/WebGPU/WebGPUComputePassTimestampLocation.h
@@ -204,6 +206,7 @@ set(PAL_SOURCES
     graphics/WebGPU/Impl/WebGPUBufferImpl.cpp
     graphics/WebGPU/Impl/WebGPUCommandBufferImpl.cpp
     graphics/WebGPU/Impl/WebGPUCommandEncoderImpl.cpp
+    graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
     graphics/WebGPU/Impl/WebGPUComputePassEncoderImpl.cpp
     graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
     graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebGPUCompositorIntegrationImpl.h"
+
+#if HAVE(WEBGPU_IMPLEMENTATION)
+
+#include "WebGPUConvertToBackingContext.h"
+#include <CoreFoundation/CoreFoundation.h>
+#include <WebGPU/WebGPUExt.h>
+#include <wtf/spi/cocoa/IOSurfaceSPI.h>
+
+namespace PAL::WebGPU {
+
+CompositorIntegrationImpl::CompositorIntegrationImpl(ConvertToBackingContext& convertToBackingContext)
+    : m_convertToBackingContext(convertToBackingContext)
+{
+}
+
+CompositorIntegrationImpl::~CompositorIntegrationImpl() = default;
+
+#if PLATFORM(COCOA)
+Vector<MachSendRight> CompositorIntegrationImpl::getRenderBuffers()
+{
+    return m_renderBuffers.map([] (const auto& renderBuffer) {
+        return MachSendRight::adopt(IOSurfaceCreateMachPort(renderBuffer.get()));
+    });
+}
+
+static RetainPtr<CFNumberRef> toCFNumber(int x)
+{
+    return adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &x));
+}
+
+Vector<RetainPtr<IOSurfaceRef>> CompositorIntegrationImpl::recreateIOSurfaces(const WGPUSwapChainDescriptor& descriptor)
+{
+    m_renderBuffers.clear();
+
+    auto createIOSurface = [&]() -> RetainPtr<IOSurfaceRef> {
+        unsigned bytesPerElement = 4;
+        unsigned bytesPerPixel = 4;
+
+        size_t bytesPerRow = IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, descriptor.width * bytesPerPixel);
+        ASSERT(bytesPerRow);
+
+        size_t totalBytes = IOSurfaceAlignProperty(kIOSurfaceAllocSize, descriptor.height * bytesPerRow);
+        ASSERT(totalBytes);
+
+        unsigned pixelFormat = 'BGRA';
+
+        auto options = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 8, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        CFDictionaryAddValue(options.get(), kIOSurfaceWidth, toCFNumber(descriptor.width).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceHeight, toCFNumber(descriptor.height).get());
+        CFDictionaryAddValue(options.get(), kIOSurfacePixelFormat, toCFNumber(pixelFormat).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceBytesPerElement, toCFNumber(bytesPerElement).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceBytesPerRow, toCFNumber(bytesPerRow).get());
+        CFDictionaryAddValue(options.get(), kIOSurfaceAllocSize, toCFNumber(totalBytes).get());
+#if PLATFORM(IOS_FAMILY)
+        CFDictionaryAddValue(options.get(), kIOSurfaceCacheMode, toCFNumber(kIOMapWriteCombineCache).get());
+#endif
+        CFDictionaryAddValue(options.get(), kIOSurfaceElementHeight, toCFNumber(1).get());
+
+        return adoptCF(IOSurfaceCreate(options.get()));
+    };
+
+    m_renderBuffers.append(createIOSurface());
+    m_renderBuffers.append(createIOSurface());
+
+    return m_renderBuffers;
+}
+#endif
+
+} // namespace PAL::WebGPU
+
+#endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(WEBGPU_IMPLEMENTATION)
+
+#include "WebGPUCompositorIntegration.h"
+
+#include <WebGPU/WebGPU.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/MachSendRight.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+#include <wtf/spi/cocoa/IOSurfaceSPI.h>
+#endif
+
+namespace PAL::WebGPU {
+
+class ConvertToBackingContext;
+
+class CompositorIntegrationImpl final : public CompositorIntegration {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<CompositorIntegrationImpl> create(ConvertToBackingContext& convertToBackingContext)
+    {
+        return adoptRef(*new CompositorIntegrationImpl(convertToBackingContext));
+    }
+
+    virtual ~CompositorIntegrationImpl();
+
+#if PLATFORM(COCOA)
+    Vector<RetainPtr<IOSurfaceRef>> recreateIOSurfaces(const WGPUSwapChainDescriptor&);
+#endif
+
+private:
+    friend class DowncastConvertToBackingContext;
+
+    explicit CompositorIntegrationImpl(ConvertToBackingContext&);
+
+    CompositorIntegrationImpl(const CompositorIntegrationImpl&) = delete;
+    CompositorIntegrationImpl(CompositorIntegrationImpl&&) = delete;
+    CompositorIntegrationImpl& operator=(const CompositorIntegrationImpl&) = delete;
+    CompositorIntegrationImpl& operator=(CompositorIntegrationImpl&&) = delete;
+
+#if PLATFORM(COCOA)
+    Vector<MachSendRight> getRenderBuffers() override;
+
+    Vector<RetainPtr<IOSurfaceRef>> m_renderBuffers;
+#endif
+
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
+};
+
+} // namespace PAL::WebGPU
+
+#endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.h
@@ -54,6 +54,8 @@ class CommandBuffer;
 class CommandEncoder;
 enum class CompareFunction : uint8_t;
 enum class CompilationMessageType : uint8_t;
+class CompositorIntegration;
+class CompositorIntegrationImpl;
 enum class ComputePassTimestampLocation : uint8_t;
 class ComputePassEncoder;
 class ComputePipeline;
@@ -162,6 +164,7 @@ public:
     virtual WGPUSurface convertToBacking(const PresentationContext&) = 0;
     virtual WGPUTexture convertToBacking(const Texture&) = 0;
     virtual WGPUTextureView convertToBacking(const TextureView&) = 0;
+    virtual CompositorIntegrationImpl& convertToBacking(CompositorIntegration&) = 0;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.cpp
@@ -34,6 +34,7 @@
 #include "WebGPUBufferImpl.h"
 #include "WebGPUCommandBufferImpl.h"
 #include "WebGPUCommandEncoderImpl.h"
+#include "WebGPUCompositorIntegrationImpl.h"
 #include "WebGPUComputePassEncoderImpl.h"
 #include "WebGPUComputePipelineImpl.h"
 #include "WebGPUDeviceImpl.h"
@@ -162,6 +163,11 @@ WGPUTexture DowncastConvertToBackingContext::convertToBacking(const Texture& tex
 WGPUTextureView DowncastConvertToBackingContext::convertToBacking(const TextureView& textureView)
 {
     return static_cast<const TextureViewImpl&>(textureView).backing();
+}
+
+CompositorIntegrationImpl& DowncastConvertToBackingContext::convertToBacking(CompositorIntegration& compositorIntegration)
+{
+    return static_cast<CompositorIntegrationImpl&>(compositorIntegration);
 }
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDowncastConvertToBackingContext.h
@@ -63,6 +63,7 @@ public:
     WGPUShaderModule convertToBacking(const ShaderModule&) final;
     WGPUTexture convertToBacking(const Texture&) final;
     WGPUTextureView convertToBacking(const TextureView&) final;
+    CompositorIntegrationImpl& convertToBacking(CompositorIntegration&) final;
 
 private:
     DowncastConvertToBackingContext() = default;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/MachSendRight.h>
+#include <wtf/Vector.h>
+#endif
+
+namespace PAL::WebGPU {
+
+class CompositorIntegration : public RefCounted<CompositorIntegration> {
+public:
+    virtual ~CompositorIntegration() = default;
+
+#if PLATFORM(COCOA)
+    virtual Vector<MachSendRight> getRenderBuffers() = 0;
+#endif
+
+protected:
+    CompositorIntegration() = default;
+
+private:
+    CompositorIntegration(const CompositorIntegration&) = delete;
+    CompositorIntegration(CompositorIntegration&&) = delete;
+    CompositorIntegration& operator=(const CompositorIntegration&) = delete;
+    CompositorIntegration& operator=(CompositorIntegration&&) = delete;
+};
+
+} // namespace PAL::WebGPU

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -30,6 +30,7 @@ Modules/WebGPU/GPUCommandBuffer.cpp
 Modules/WebGPU/GPUCommandEncoder.cpp
 Modules/WebGPU/GPUCompilationInfo.cpp
 Modules/WebGPU/GPUCompilationMessage.cpp
+Modules/WebGPU/GPUCompositorIntegration.cpp
 Modules/WebGPU/GPUComputePassEncoder.cpp
 Modules/WebGPU/GPUComputePipeline.cpp
 Modules/WebGPU/GPUDevice.cpp

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -145,6 +145,7 @@ set(WebKit_MESSAGES_IN_FILES
     GPUProcess/graphics/WebGPU/RemoteBuffer
     GPUProcess/graphics/WebGPU/RemoteCommandBuffer
     GPUProcess/graphics/WebGPU/RemoteCommandEncoder
+    GPUProcess/graphics/WebGPU/RemoteCompositorIntegration
     GPUProcess/graphics/WebGPU/RemoteComputePassEncoder
     GPUProcess/graphics/WebGPU/RemoteComputePipeline
     GPUProcess/graphics/WebGPU/RemoteDevice

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -46,6 +46,7 @@ $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
+$(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -182,6 +182,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandBufferMessageReceiver.c
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandBufferMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandEncoderMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCommandEncoderMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCompositorIntegrationMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteCompositorIntegrationMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteComputePassEncoderMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteComputePassEncoderMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RemoteComputePipelineMessageReceiver.cpp

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -271,6 +271,7 @@ MESSAGE_RECEIVERS = \
 	GPUProcess/graphics/WebGPU/RemoteBuffer \
 	GPUProcess/graphics/WebGPU/RemoteCommandBuffer \
 	GPUProcess/graphics/WebGPU/RemoteCommandEncoder \
+	GPUProcess/graphics/WebGPU/RemoteCompositorIntegration \
 	GPUProcess/graphics/WebGPU/RemoteComputePassEncoder \
 	GPUProcess/graphics/WebGPU/RemoteComputePipeline \
 	GPUProcess/graphics/WebGPU/RemoteDevice \

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteCompositorIntegration.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteCompositorIntegrationMessages.h"
+#include "StreamServerConnection.h"
+#include "WebGPUObjectHeap.h"
+#include <pal/graphics/WebGPU/WebGPUCompositorIntegration.h>
+
+namespace WebKit {
+
+RemoteCompositorIntegration::RemoteCompositorIntegration(PAL::WebGPU::CompositorIntegration& compositorIntegration, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
+    : m_backing(compositorIntegration)
+    , m_objectHeap(objectHeap)
+    , m_streamConnection(WTFMove(streamConnection))
+    , m_identifier(identifier)
+{
+    m_streamConnection->startReceivingMessages(*this, Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+}
+
+RemoteCompositorIntegration::~RemoteCompositorIntegration() = default;
+
+void RemoteCompositorIntegration::stopListeningForIPC()
+{
+    m_streamConnection->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+}
+
+#if PLATFORM(COCOA)
+void RemoteCompositorIntegration::getRenderBuffers(CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+{
+    callback(m_backing->getRenderBuffers());
+}
+#endif
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "StreamMessageReceiver.h"
+#include "WebGPUIdentifier.h"
+#include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
+#include <wtf/Ref.h>
+#include <wtf/text/WTFString.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/MachSendRight.h>
+#include <wtf/Vector.h>
+#endif
+
+namespace PAL::WebGPU {
+class CompositorIntegration;
+}
+
+namespace IPC {
+class StreamServerConnection;
+}
+
+namespace WebKit {
+
+namespace WebGPU {
+class ObjectHeap;
+}
+
+class RemoteCompositorIntegration final : public IPC::StreamMessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<RemoteCompositorIntegration> create(PAL::WebGPU::CompositorIntegration& compositorIntegration, WebGPU::ObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebGPUIdentifier identifier)
+    {
+        return adoptRef(*new RemoteCompositorIntegration(compositorIntegration, objectHeap, WTFMove(streamConnection), identifier));
+    }
+
+    virtual ~RemoteCompositorIntegration();
+
+    void stopListeningForIPC();
+
+private:
+    friend class WebGPU::ObjectHeap;
+
+    RemoteCompositorIntegration(PAL::WebGPU::CompositorIntegration&, WebGPU::ObjectHeap&, Ref<IPC::StreamServerConnection>&&, WebGPUIdentifier);
+
+    RemoteCompositorIntegration(const RemoteCompositorIntegration&) = delete;
+    RemoteCompositorIntegration(RemoteCompositorIntegration&&) = delete;
+    RemoteCompositorIntegration& operator=(const RemoteCompositorIntegration&) = delete;
+    RemoteCompositorIntegration& operator=(RemoteCompositorIntegration&&) = delete;
+
+    PAL::WebGPU::CompositorIntegration& backing() { return m_backing; }
+
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+
+#if PLATFORM(COCOA)
+    void getRenderBuffers(CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+#endif
+
+    Ref<PAL::WebGPU::CompositorIntegration> m_backing;
+    WebGPU::ObjectHeap& m_objectHeap;
+    Ref<IPC::StreamServerConnection> m_streamConnection;
+    WebGPUIdentifier m_identifier;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -1,0 +1,32 @@
+/* Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(GPU_PROCESS)
+
+messages -> RemoteCompositorIntegration NotRefCounted Stream {
+#if PLATFORM(COCOA)
+void GetRenderBuffers() -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
+#endif
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.cpp
@@ -34,6 +34,7 @@
 #include "RemoteBuffer.h"
 #include "RemoteCommandBuffer.h"
 #include "RemoteCommandEncoder.h"
+#include "RemoteCompositorIntegration.h"
 #include "RemoteComputePassEncoder.h"
 #include "RemoteComputePipeline.h"
 #include "RemoteDevice.h"
@@ -91,6 +92,12 @@ void ObjectHeap::addObject(WebGPUIdentifier identifier, RemoteCommandBuffer& com
 void ObjectHeap::addObject(WebGPUIdentifier identifier, RemoteCommandEncoder& commandEncoder)
 {
     auto result = m_objects.add(identifier, Object { IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder> { Ref { commandEncoder } } });
+    ASSERT_UNUSED(result, result.isNewEntry);
+}
+
+void ObjectHeap::addObject(WebGPUIdentifier identifier, RemoteCompositorIntegration& querySet)
+{
+    auto result = m_objects.add(identifier, Object { IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration> { Ref { querySet } } });
     ASSERT_UNUSED(result, result.isNewEntry);
 }
 
@@ -247,6 +254,14 @@ PAL::WebGPU::CommandEncoder* ObjectHeap::convertCommandEncoderFromBacking(WebGPU
     if (iterator == m_objects.end() || !std::holds_alternative<IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder>>(iterator->value))
         return nullptr;
     return &std::get<IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder>>(iterator->value)->backing();
+}
+
+PAL::WebGPU::CompositorIntegration* ObjectHeap::convertCompositorIntegrationFromBacking(WebGPUIdentifier identifier)
+{
+    auto iterator = m_objects.find(identifier);
+    if (iterator == m_objects.end() || !std::holds_alternative<IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration>>(iterator->value))
+        return nullptr;
+    return &std::get<IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration>>(iterator->value)->backing();
 }
 
 PAL::WebGPU::ComputePassEncoder* ObjectHeap::convertComputePassEncoderFromBacking(WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
@@ -42,6 +42,7 @@ class BindGroupLayout;
 class Buffer;
 class CommandBuffer;
 class CommandEncoder;
+class CompositorIntegration;
 class ComputePassEncoder;
 class ComputePipeline;
 class Device;
@@ -68,6 +69,7 @@ class RemoteBindGroupLayout;
 class RemoteBuffer;
 class RemoteCommandBuffer;
 class RemoteCommandEncoder;
+class RemoteCompositorIntegration;
 class RemoteComputePassEncoder;
 class RemoteComputePipeline;
 class RemoteDevice;
@@ -104,6 +106,7 @@ public:
     void addObject(WebGPUIdentifier, RemoteBuffer&);
     void addObject(WebGPUIdentifier, RemoteCommandBuffer&);
     void addObject(WebGPUIdentifier, RemoteCommandEncoder&);
+    void addObject(WebGPUIdentifier, RemoteCompositorIntegration&);
     void addObject(WebGPUIdentifier, RemoteComputePassEncoder&);
     void addObject(WebGPUIdentifier, RemoteComputePipeline&);
     void addObject(WebGPUIdentifier, RemoteDevice&);
@@ -131,6 +134,7 @@ public:
     PAL::WebGPU::Buffer* convertBufferFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::CommandBuffer* convertCommandBufferFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::CommandEncoder* convertCommandEncoderFromBacking(WebGPUIdentifier) final;
+    PAL::WebGPU::CompositorIntegration* convertCompositorIntegrationFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::ComputePassEncoder* convertComputePassEncoderFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::ComputePipeline* convertComputePipelineFromBacking(WebGPUIdentifier) final;
     PAL::WebGPU::Device* convertDeviceFromBacking(WebGPUIdentifier) final;
@@ -159,6 +163,7 @@ private:
         IPC::ScopedActiveMessageReceiveQueue<RemoteBuffer>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteCommandBuffer>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteCommandEncoder>,
+        IPC::ScopedActiveMessageReceiveQueue<RemoteCompositorIntegration>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteComputePassEncoder>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteComputePipeline>,
         IPC::ScopedActiveMessageReceiveQueue<RemoteDevice>,

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertFromBackingContext.h
@@ -67,6 +67,7 @@ struct CommandBufferDescriptor;
 class CommandEncoder;
 struct CommandEncoderDescriptor;
 class CompilationMessage;
+class CompositorIntegration;
 struct ComputePassDescriptor;
 class ComputePassEncoder;
 class ComputePipeline;
@@ -280,6 +281,7 @@ public:
     virtual PAL::WebGPU::Buffer* convertBufferFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::CommandBuffer* convertCommandBufferFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::CommandEncoder* convertCommandEncoderFromBacking(WebGPUIdentifier) = 0;
+    virtual PAL::WebGPU::CompositorIntegration* convertCompositorIntegrationFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::ComputePassEncoder* convertComputePassEncoderFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::ComputePipeline* convertComputePipelineFromBacking(WebGPUIdentifier) = 0;
     virtual PAL::WebGPU::Device* convertDeviceFromBacking(WebGPUIdentifier) = 0;

--- a/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUConvertToBackingContext.h
@@ -66,6 +66,7 @@ struct CommandBufferDescriptor;
 class CommandEncoder;
 struct CommandEncoderDescriptor;
 class CompilationMessage;
+class CompositorIntegration;
 struct ComputePassDescriptor;
 class ComputePassEncoder;
 class ComputePipeline;
@@ -279,6 +280,7 @@ public:
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::Buffer&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandBuffer&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandEncoder&) = 0;
+    virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::CompositorIntegration&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePassEncoder&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePipeline&) = 0;
     virtual WebGPUIdentifier convertToBacking(const PAL::WebGPU::Device&) = 0;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -40,6 +40,7 @@ GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
 GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
 GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
 GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
 GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
 GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
 GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -686,6 +687,7 @@ WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -869,6 +871,7 @@ RemoteBindGroupLayoutMessageReceiver.cpp
 RemoteBufferMessageReceiver.cpp
 RemoteCommandBufferMessageReceiver.cpp
 RemoteCommandEncoderMessageReceiver.cpp
+RemoteCompositorIntegrationMessageReceiver.cpp
 RemoteComputePassEncoderMessageReceiver.cpp
 RemoteComputePipelineMessageReceiver.cpp
 RemoteDeviceMessageReceiver.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3616,6 +3616,11 @@
 		1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionPrivate.h; sourceTree = "<group>"; };
 		1C3D0AC0291AE6200093F67E /* WebExtensionControllerProxyCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerProxyCocoa.mm; sourceTree = "<group>"; };
 		1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionControllerParameters.serialization.in; sourceTree = "<group>"; };
+		1C4F5A1C297CB57A005BBEE9 /* RemoteCompositorIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteCompositorIntegration.h; sourceTree = "<group>"; };
+		1C4F5A1D297CB57B005BBEE9 /* RemoteCompositorIntegration.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteCompositorIntegration.messages.in; sourceTree = "<group>"; };
+		1C4F5A1E297CB57B005BBEE9 /* RemoteCompositorIntegration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCompositorIntegration.cpp; sourceTree = "<group>"; };
+		1C4F5A1F297CB5A2005BBEE9 /* RemoteCompositorIntegrationProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCompositorIntegrationProxy.cpp; sourceTree = "<group>"; };
+		1C4F5A20297CB5A3005BBEE9 /* RemoteCompositorIntegrationProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteCompositorIntegrationProxy.h; sourceTree = "<group>"; };
 		1C55A573275457C400EB7E95 /* RemoteTextureMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteTextureMessages.h; sourceTree = "<group>"; };
 		1C55A574275457C400EB7E95 /* RemoteRenderPipelineMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteRenderPipelineMessageReceiver.cpp; sourceTree = "<group>"; };
 		1C55A577275457C400EB7E95 /* RemoteComputePipelineMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteComputePipelineMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -9013,6 +9018,9 @@
 				1C98C05627446CB9002CCB78 /* RemoteCommandEncoder.cpp */,
 				1C98C05527446CB9002CCB78 /* RemoteCommandEncoder.h */,
 				1C98C0952744BD9B002CCB78 /* RemoteCommandEncoder.messages.in */,
+				1C4F5A1E297CB57B005BBEE9 /* RemoteCompositorIntegration.cpp */,
+				1C4F5A1C297CB57A005BBEE9 /* RemoteCompositorIntegration.h */,
+				1C4F5A1D297CB57B005BBEE9 /* RemoteCompositorIntegration.messages.in */,
 				1C98C05827446CBA002CCB78 /* RemoteComputePassEncoder.cpp */,
 				1C98C05A27446CBA002CCB78 /* RemoteComputePassEncoder.h */,
 				1C98C0932744BD9B002CCB78 /* RemoteComputePassEncoder.messages.in */,
@@ -9100,6 +9108,8 @@
 				1CB7462C27436EE700F19874 /* RemoteCommandBufferProxy.h */,
 				1CB7462227436EE600F19874 /* RemoteCommandEncoderProxy.cpp */,
 				1CB7464027436EEA00F19874 /* RemoteCommandEncoderProxy.h */,
+				1C4F5A1F297CB5A2005BBEE9 /* RemoteCompositorIntegrationProxy.cpp */,
+				1C4F5A20297CB5A3005BBEE9 /* RemoteCompositorIntegrationProxy.h */,
 				1CB7462327436EE600F19874 /* RemoteComputePassEncoderProxy.cpp */,
 				1CB7462627436EE600F19874 /* RemoteComputePassEncoderProxy.h */,
 				1CB7463F27436EEA00F19874 /* RemoteComputePipelineProxy.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteCompositorIntegrationProxy.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteCompositorIntegrationMessages.h"
+#include "RemoteGPUProxy.h"
+#include "WebGPUConvertToBackingContext.h"
+
+namespace WebKit::WebGPU {
+
+RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    : m_backing(identifier)
+    , m_convertToBackingContext(convertToBackingContext)
+    , m_parent(parent)
+{
+}
+
+RemoteCompositorIntegrationProxy::~RemoteCompositorIntegrationProxy() = default;
+
+#if PLATFORM(COCOA)
+Vector<MachSendRight> RemoteCompositorIntegrationProxy::getRenderBuffers()
+{
+    auto sendResult = sendSync(Messages::RemoteCompositorIntegration::GetRenderBuffers());
+    if (!sendResult)
+        return { };
+
+    auto [renderBuffers] = sendResult.takeReply();
+    return renderBuffers;
+}
+#endif
+
+} // namespace WebKit::WebGPU
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteGPUProxy.h"
+#include "WebGPUIdentifier.h"
+#include <pal/graphics/WebGPU/WebGPUCompositorIntegration.h>
+
+namespace WebKit::WebGPU {
+
+class ConvertToBackingContext;
+
+class RemoteCompositorIntegrationProxy final : public PAL::WebGPU::CompositorIntegration {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<RemoteCompositorIntegrationProxy> create(RemoteGPUProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    {
+        return adoptRef(*new RemoteCompositorIntegrationProxy(parent, convertToBackingContext, identifier));
+    }
+
+    virtual ~RemoteCompositorIntegrationProxy();
+
+    RemoteGPUProxy& parent() { return m_parent; }
+    RemoteGPUProxy& root() { return m_parent; }
+
+private:
+    friend class DowncastConvertToBackingContext;
+
+    RemoteCompositorIntegrationProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+
+    RemoteCompositorIntegrationProxy(const RemoteCompositorIntegrationProxy&) = delete;
+    RemoteCompositorIntegrationProxy(RemoteCompositorIntegrationProxy&&) = delete;
+    RemoteCompositorIntegrationProxy& operator=(const RemoteCompositorIntegrationProxy&) = delete;
+    RemoteCompositorIntegrationProxy& operator=(RemoteCompositorIntegrationProxy&&) = delete;
+
+    WebGPUIdentifier backing() const { return m_backing; }
+    
+    static inline constexpr Seconds defaultSendTimeout = 30_s;
+    template<typename T>
+    WARN_UNUSED_RETURN bool send(T&& message)
+    {
+        return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
+    }
+    template<typename T>
+    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    {
+        return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
+    }
+
+#if PLATFORM(COCOA)
+    Vector<MachSendRight> getRenderBuffers() override;
+#endif
+
+    WebGPUIdentifier m_backing;
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
+    Ref<RemoteGPUProxy> m_parent;
+};
+
+} // namespace WebKit::WebGPU
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
@@ -34,6 +34,7 @@
 #include "RemoteBufferProxy.h"
 #include "RemoteCommandBufferProxy.h"
 #include "RemoteCommandEncoderProxy.h"
+#include "RemoteCompositorIntegrationProxy.h"
 #include "RemoteComputePassEncoderProxy.h"
 #include "RemoteComputePipelineProxy.h"
 #include "RemoteDeviceProxy.h"
@@ -82,6 +83,11 @@ WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::We
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::WebGPU::CommandEncoder& commandEncoder)
 {
     return static_cast<const RemoteCommandEncoderProxy&>(commandEncoder).backing();
+}
+
+WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::WebGPU::CompositorIntegration& compositorIntegration)
+{
+    return static_cast<const RemoteCompositorIntegrationProxy&>(compositorIntegration).backing();
 }
 
 WebGPUIdentifier DowncastConvertToBackingContext::convertToBacking(const PAL::WebGPU::ComputePassEncoder& computePassEncoder)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@ public:
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::Buffer&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandBuffer&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::CommandEncoder&) final;
+    WebGPUIdentifier convertToBacking(const PAL::WebGPU::CompositorIntegration&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePassEncoder&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::ComputePipeline&) final;
     WebGPUIdentifier convertToBacking(const PAL::WebGPU::Device&) final;


### PR DESCRIPTION
#### 98794f128842c07c91cf7048e3a9e574d701f56a
<pre>
[WebGPU] Add CompositorIntegration object
<a href="https://bugs.webkit.org/show_bug.cgi?id=250955">https://bugs.webkit.org/show_bug.cgi?id=250955</a>
rdar://104517402

Reviewed by Tadeu Zagallo.

Right now, the data flow that WebGPU uses to interact with the compositor doesn&apos;t match either the
WebGPU spec&apos;s API nor WebGPU.h. Ideally, we&apos;d align them, for conceptual simplicity and to make
future hacking on this system easier.

The way this is supposed to work is the Surface gets created with a reference to a compositor
integration object. In the simple case, that&apos;s a CAMetalLayer, but in WebKit we don&apos;t use CAMetalLayer.
Instead, this patch creates an analogue for CAMetalLayer that contains the functionality to
integrate WebGPU with WebKit&apos;s compositor. Having this object means we can (eventually) get rid of
the custom APIs added to WebGPU.framework which cause leaky abstractions.

Just like CAMetalLayer, this object, named CompositorIntegration, is the owner of multiple IOSurfaces
used for render destinations. It has an API to recreate its IOSurfaces, which is mean to be called
whenever their attributes need to be changed. (For WebGPU, the creation of a swap chain indicates that
the IOSurfaces&apos; attributes need to be changed.) CompositorIntegration also has an IPC message receiver,
like almost all of the WebGPU types, and has one exposed message which returns the current IOSurfaces.
This is meant to be called just after they get recreated, so GPUSwapChain can get access to the
IOSurfaces, so GPUSwapChain can set them as the appropriate layer&apos;s contents.

There is no WGPU analog of CompositorIntegration; just like CAMetalLayer, it exists outside of
WebGPU.framework.

Other than the creation and retention of IOSurfaces, there&apos;s nothing really special about this object;
it&apos;s set up pretty much identically to every other WebGPU object.

The use of CompositorIntegration isn&apos;t hooked up yet; I made a megapatch at
<a href="https://github.com/WebKit/WebKit/pull/8931/files">https://github.com/WebKit/WebKit/pull/8931/files</a> and I&apos;m trying to split it up into smaller, more
reviewable patches. This patch is just one piece of that larger patch. CompositorIntegration will be
hooked up in a subsequent patch.

* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp: Added.
(WebCore::GPUCompositorIntegration::getRenderBuffers const):
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h: Added.
(WebCore::GPUCompositorIntegration::create):
(WebCore::GPUCompositorIntegration::backing):
(WebCore::GPUCompositorIntegration::backing const):
(WebCore::GPUCompositorIntegration::GPUCompositorIntegration):
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/CMakeLists.txt:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp: Added.
(PAL::WebGPU::CompositorIntegrationImpl::CompositorIntegrationImpl):
(PAL::WebGPU::CompositorIntegrationImpl::getRenderBuffers):
(PAL::WebGPU::toCFNumber):
(PAL::WebGPU::CompositorIntegrationImpl::recreateIOSurfaces):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h: Added.
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCompositorIntegration.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp: Added.
(WebKit::RemoteCompositorIntegration::RemoteCompositorIntegration):
(WebKit::RemoteCompositorIntegration::stopListeningForIPC):
(WebKit::RemoteCompositorIntegration::getRenderBuffers):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h: Added.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in: Added.
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp: Added.
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy):
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::getRenderBuffers):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h: Added.

Canonical link: <a href="https://commits.webkit.org/259588@main">https://commits.webkit.org/259588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829f7b38317b9ff37685db80d3f90f68013ecaab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114602 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5351 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97653 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111104 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7853 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6612 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9642 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->