### PR TITLE
Parser's PropertyNode should never be given an Identifier with a null impl.

### DIFF
--- a/JSTests/stress/parser-property-node-identifier-should-not-be-null.js
+++ b/JSTests/stress/parser-property-node-identifier-should-not-be-null.js
@@ -1,0 +1,9 @@
+//@ runDefault
+
+class Class {
+    static get c() {
+    }
+    static {
+    }
+}
+

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,6 +96,7 @@ namespace JSC {
     macro(delete) \
     macro(size) \
     macro(shift) \
+    macro(staticInitializerBlock) \
     macro(Int8Array) \
     macro(Int16Array) \
     macro(Int32Array) \

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2009-2018 Apple Inc. All rights reserved.
+ *  Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -256,6 +256,7 @@ namespace JSC {
         , m_needsSuperBinding(superBinding == SuperBinding::Needed)
         , m_classElementTag(static_cast<unsigned>(tag))
     {
+        ASSERT(name.impl());
     }
 
     inline PropertyNode::PropertyNode(const Identifier& name, ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
@@ -265,6 +266,7 @@ namespace JSC {
         , m_needsSuperBinding(superBinding == SuperBinding::Needed)
         , m_classElementTag(static_cast<unsigned>(tag))
     {
+        ASSERT(name.impl());
     }
     
     inline PropertyNode::PropertyNode(ExpressionNode* assign, Type type, SuperBinding superBinding, ClassElementTag tag)
@@ -292,6 +294,7 @@ namespace JSC {
         , m_needsSuperBinding(superBinding == SuperBinding::Needed)
         , m_classElementTag(static_cast<unsigned>(tag))
     {
+        ASSERT(ident.impl());
     }
 
     inline PropertyListNode::PropertyListNode(const JSTokenLocation& location, PropertyNode* node)

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -3208,6 +3208,8 @@ parseMethod:
             DepthManager statementDepth(&m_statementDepth);
             m_statementDepth = 1;
             failIfFalse(parseBlockStatement(context, BlockType::StaticBlock), "Cannot parse class static block");
+            auto* symbolImpl = bitwise_cast<SymbolImpl*>(m_vm.propertyNames->builtinNames().staticInitializerBlockPrivateName().impl());
+            ident = &m_parserArena.identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
             property = context.createProperty(ident, type, SuperBinding::Needed, tag);
             classScope->markLastUsedVariablesSetAsCaptured(usedVariablesSize);
         } else {


### PR DESCRIPTION
#### 90bd38013bce95b34bb0e4aa9f9501bc183a782f
<pre>
Parser&apos;s PropertyNode should never be given an Identifier with a null impl.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250931">https://bugs.webkit.org/show_bug.cgi?id=250931</a>
&lt;rdar://problem/104507750&gt;

Reviewed by Yusuke Suzuki.

For static initializer blocks, instead of passing a null Identifier, we&apos;ll use an Identifier
made from the newly introduced staticInitializerBlockPrivateName().

* JSTests/stress/parser-property-node-identifier-should-not-be-null.js: Added.
(Class.get c):
(Class):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/parser/NodeConstructors.h:
(JSC::PropertyNode::PropertyNode):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseClass):

Canonical link: <a href="https://commits.webkit.org/259187@main">https://commits.webkit.org/259187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/073daad34f9078e32dc045a1b7ad702c8b99ccc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113474 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173763 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4264 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112525 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38773 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80436 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94277 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6712 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27145 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92156 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4487 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3700 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29963 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46703 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/100839 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6329 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8632 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25027 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->