### PR TITLE
[WebGPU] Simplify GPU initialization

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,13 @@
 
 namespace WebCore {
 
+GPU::GPU(Ref<PAL::WebGPU::GPU>&& backing)
+    : m_backing(WTFMove(backing))
+{
+}
+
+GPU::~GPU() = default;
+
 static PAL::WebGPU::RequestAdapterOptions convertToBacking(const std::optional<GPURequestAdapterOptions>& options)
 {
     if (!options)
@@ -38,22 +45,8 @@ static PAL::WebGPU::RequestAdapterOptions convertToBacking(const std::optional<G
     return options->convertToBacking();
 }
 
-void GPU::setBacking(PAL::WebGPU::GPU& backing)
-{
-    m_backing = &backing;
-    while (!m_pendingRequestAdapterArguments.isEmpty()) {
-        auto arguments = m_pendingRequestAdapterArguments.takeFirst();
-        requestAdapter(arguments.options, WTFMove(arguments.promise));
-    }
-}
-
 void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options, RequestAdapterPromise&& promise)
 {
-    if (!m_backing) {
-        m_pendingRequestAdapterArguments.append({ options, WTFMove(promise) });
-        return;
-    }
-
     m_backing->requestAdapter(convertToBacking(options), [promise = WTFMove(promise)] (RefPtr<PAL::WebGPU::Adapter>&& adapter) mutable {
         if (!adapter) {
             promise.reject(nullptr);

--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,27 +39,27 @@ namespace WebCore {
 
 class GPU : public RefCounted<GPU> {
 public:
-    static Ref<GPU> create()
+    static Ref<GPU> create(Ref<PAL::WebGPU::GPU>&& backing)
     {
-        return adoptRef(*new GPU());
+        return adoptRef(*new GPU(WTFMove(backing)));
     }
+
+    ~GPU();
 
     using RequestAdapterPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<GPUAdapter>>>;
     void requestAdapter(const std::optional<GPURequestAdapterOptions>&, RequestAdapterPromise&&);
 
     GPUTextureFormat getPreferredCanvasFormat();
 
-    void setBacking(PAL::WebGPU::GPU&);
-
 private:
-    GPU() = default;
+    GPU(Ref<PAL::WebGPU::GPU>&&);
 
     struct PendingRequestAdapterArguments {
         std::optional<GPURequestAdapterOptions> options;
         RequestAdapterPromise promise;
     };
     Deque<PendingRequestAdapterArguments> m_pendingRequestAdapterArguments;
-    RefPtr<PAL::WebGPU::GPU> m_backing;
+    Ref<PAL::WebGPU::GPU> m_backing;
 };
 
 }

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -2,7 +2,7 @@
  *  Copyright (C) 2000 Harri Porten (porten@kde.org)
  *  Copyright (c) 2000 Daniel Molkentin (molkentin@kde.org)
  *  Copyright (c) 2000 Stefan Schimanski (schimmi@kde.org)
- *  Copyright (C) 2003-2022 Apple Inc.
+ *  Copyright (C) 2003-2023 Apple Inc.
  *  Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
  *
  *  This library is free software; you can redistribute it and/or
@@ -374,8 +374,7 @@ GPU* Navigator::gpu()
         if (!gpu)
             return nullptr;
 
-        m_gpuForWebGPU = GPU::create();
-        m_gpuForWebGPU->setBacking(*gpu);
+        m_gpuForWebGPU = GPU::create(*gpu);
     }
 
     return m_gpuForWebGPU.get();


### PR DESCRIPTION
#### ac769e68f0bc42f7c63b8a2b0df0cb74345d70f8
<pre>
[WebGPU] Simplify GPU initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=250961">https://bugs.webkit.org/show_bug.cgi?id=250961</a>
rdar://104522195

Reviewed by Tadeu Zagallo.

Previously, there was a 2-step initialization, where you&apos;d create the object and then
set it&apos;s backing. But this means there&apos;s an intermediate state where the object exists
but has no backing. Better to just use a 1-step initialization where the backing is
passed into the constructor, which eliminates that extra state, thereby simplifying
the class.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::GPU):
(WebCore::GPU::requestAdapter):
(WebCore::GPU::setBacking): Deleted.
* Source/WebCore/Modules/WebGPU/GPU.h:
(WebCore::GPU::create):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::gpu):

Canonical link: <a href="https://commits.webkit.org/259203@main">https://commits.webkit.org/259203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/debc630373469c015deee44312d58fea02516402

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113481 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173770 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4271 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112531 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38779 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80444 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6719 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27151 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3705 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46709 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6342 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8639 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->