### PR TITLE
[WebGPU] Delete dead code: Surface::destroy() and SwapChain::destroy()

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUSurface.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUSurface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,10 +42,6 @@ String GPUSurface::label() const
 void GPUSurface::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));
-}
-
-void GPUSurface::destroy()
-{
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSurface.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,8 +42,6 @@ public:
 
     String label() const;
     void setLabel(String&&);
-
-    void destroy();
 
     PAL::WebGPU::Surface& backing() { return m_backing; }
     const PAL::WebGPU::Surface& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,9 +44,5 @@ void GPUSwapChain::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&
     m_backing->prepareForDisplay(WTFMove(completionHandler));
 }
 #endif
-
-void GPUSwapChain::destroy()
-{
-}
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSwapChain.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,7 +46,6 @@ public:
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
 #endif
-    void destroy();
 
     PAL::WebGPU::SwapChain& backing() { return m_backing; }
     const PAL::WebGPU::SwapChain& backing() const { return m_backing; }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,11 +42,6 @@ SurfaceImpl::SurfaceImpl(WGPUSurface surface)
 }
 
 SurfaceImpl::~SurfaceImpl()
-{
-    destroy();
-}
-
-void SurfaceImpl::destroy()
 {
     wgpuSurfaceRelease(m_backing);
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,8 +60,6 @@ private:
     SurfaceImpl(SurfaceImpl&&) = delete;
     SurfaceImpl& operator=(const SurfaceImpl&) = delete;
     SurfaceImpl& operator=(SurfaceImpl&&) = delete;
-
-    void destroy() final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,11 +43,6 @@ SwapChainImpl::SwapChainImpl(WGPUSurface surface, WGPUSwapChain swapChain)
 }
 
 SwapChainImpl::~SwapChainImpl()
-{
-    wgpuSwapChainRelease(m_backing);
-}
-
-void SwapChainImpl::destroy()
 {
     wgpuSwapChainRelease(m_backing);
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +56,6 @@ private:
 
     WGPUSwapChain backing() const { return m_backing; }
 
-    void destroy() final;
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
 #endif

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurface.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,8 +42,6 @@ public:
         m_label = WTFMove(label);
         setLabelInternal(m_label);
     }
-
-    virtual void destroy() = 0;
 
 protected:
     Surface() = default;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,8 +46,6 @@ public:
         m_label = WTFMove(label);
         setLabelInternal(m_label);
     }
-
-    virtual void destroy() = 0;
 
 #if PLATFORM(COCOA)
     virtual void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,11 +50,6 @@ RemoteSurface::~RemoteSurface() = default;
 void RemoteSurface::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteSurface::messageReceiverName(), m_identifier.toUInt64());
-}
-
-void RemoteSurface::destroy()
-{
-    m_backing->destroy();
 }
 
 void RemoteSurface::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,8 +71,6 @@ private:
     PAL::WebGPU::Surface& backing() { return m_backing; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
-
-    void destroy();
 
     void setLabel(String&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Apple Inc. All rights reserved.
+/* Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,7 +24,6 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSurface NotRefCounted Stream {
-    void Destroy()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,11 +53,6 @@ RemoteSwapChain::~RemoteSwapChain() = default;
 void RemoteSwapChain::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteSwapChain::messageReceiverName(), m_identifier.toUInt64());
-}
-
-void RemoteSwapChain::destroy()
-{
-    m_backing->destroy();
 }
 
 void RemoteSwapChain::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,8 +72,6 @@ private:
     PAL::WebGPU::SwapChain& backing() { return m_backing; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
-
-    void destroy();
 
     void setLabel(String&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Apple Inc. All rights reserved.
+/* Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,7 +24,6 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSwapChain NotRefCounted Stream {
-    void Destroy()
     void SetLabel(String label)
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,12 +42,6 @@ RemoteSurfaceProxy::RemoteSurfaceProxy(RemoteDeviceProxy& parent, ConvertToBacki
 
 RemoteSurfaceProxy::~RemoteSurfaceProxy()
 {
-}
-
-void RemoteSurfaceProxy::destroy()
-{
-    auto sendResult = send(Messages::RemoteSurface::Destroy());
-    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteSurfaceProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,8 +72,6 @@ private:
     {
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
-
-    void destroy() final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,12 +45,6 @@ RemoteSwapChainProxy::RemoteSwapChainProxy(RemoteDeviceProxy& parent, ConvertToB
 
 RemoteSwapChainProxy::~RemoteSwapChainProxy()
 {
-}
-
-void RemoteSwapChainProxy::destroy()
-{
-    auto sendResult = send(Messages::RemoteSwapChain::Destroy());
-    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteSwapChainProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,8 +76,6 @@ private:
     {
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
-
-    void destroy() final;
 
     void setLabelInternal(const String&) final;
 


### PR DESCRIPTION
#### c686a58cdac9254e69b6ab9d128c7843815f3580
<pre>
[WebGPU] Delete dead code: Surface::destroy() and SwapChain::destroy()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250962">https://bugs.webkit.org/show_bug.cgi?id=250962</a>
rdar://104522497

Reviewed by NOBODY (OOPS!).

In WebGPU, a few specific objects (Texture, Buffer, Device, and Query Set) have destroy() functions.
These are web-exposed methods that authors can call when they know they&apos;re done with an object and
don&apos;t want the GPU allocation to hang around until the next GC. These methods are not for internal
use, which means that Surface::destroy() and SwapChain::destroy() are dead code and can be deleted.

* Source/WebCore/Modules/WebGPU/GPUSurface.cpp:
(WebCore::GPUSurface::destroy): Deleted.
* Source/WebCore/Modules/WebGPU/GPUSurface.h:
* Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp:
(WebCore::GPUSwapChain::destroy): Deleted.
* Source/WebCore/Modules/WebGPU/GPUSwapChain.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp:
(PAL::WebGPU::SurfaceImpl::~SurfaceImpl):
(PAL::WebGPU::SurfaceImpl::destroy): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp:
(PAL::WebGPU::SwapChainImpl::destroy): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurface.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.cpp:
(WebKit::RemoteSurface::destroy): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSurface.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp:
(WebKit::RemoteSwapChain::destroy): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.cpp:
(WebKit::WebGPU::RemoteSurfaceProxy::destroy): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSurfaceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp:
(WebKit::WebGPU::RemoteSwapChainProxy::destroy): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c686a58cdac9254e69b6ab9d128c7843815f3580

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113488 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173777 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4277 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112537 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38780 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80451 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27156 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6859 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3710 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46714 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8645 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->