### PR TITLE
[WebGPU] Extra deref of SwapChainImpl::m_backing

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
@@ -49,7 +49,11 @@ SurfaceImpl::~SurfaceImpl()
 
 void SurfaceImpl::destroy()
 {
+    if (!m_backing)
+        return;
+
     wgpuSurfaceRelease(m_backing);
+    m_backing = nullptr;
 }
 
 void SurfaceImpl::setLabelInternal(const String&)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
@@ -45,12 +45,16 @@ SwapChainImpl::SwapChainImpl(WGPUSurface surface, WGPUSwapChain swapChain, Conve
 
 SwapChainImpl::~SwapChainImpl()
 {
-    wgpuSwapChainRelease(m_backing);
+    destroy();
 }
 
 void SwapChainImpl::destroy()
 {
+    if (!m_backing)
+        return;
+
     wgpuSwapChainRelease(m_backing);
+    m_backing = nullptr;
 }
 
 void SwapChainImpl::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)


### PR DESCRIPTION
#### 83826f3fef4076f2c5be36785b2799f351bf1c78
<pre>
[WebGPU] Extra deref of SwapChainImpl::m_backing
<a href="https://bugs.webkit.org/show_bug.cgi?id=250963">https://bugs.webkit.org/show_bug.cgi?id=250963</a>
&lt;rdar://104522929&gt;

Reviewed by Myles C. Maxfield.

WebGPUSurfaceImpl and WebGPUSwapChainImpl called release in both
destroy and their destructor, resulting in a double release.

Fix this issue by setting the backing to null when the object is released.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp:
(PAL::WebGPU::SurfaceImpl::destroy):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp:
(PAL::WebGPU::SwapChainImpl::~SwapChainImpl):
(PAL::WebGPU::SwapChainImpl::destroy):

Canonical link: <a href="https://commits.webkit.org/259318@main">https://commits.webkit.org/259318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f2805f838644e671546e3f583f5eefdb3860cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113768 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173996 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4494 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112735 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38903 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80572 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27337 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3895 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6425 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8848 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->