### PR TITLE
[WebGPU] Give a ConvertToBackingContext to SurfaceImpl and SwapChainImpl

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -188,7 +188,7 @@ Ref<Surface> DeviceImpl::createSurface(const SurfaceDescriptor& descriptor)
         label.data()
     };
 
-    return SurfaceImpl::create(wgpuInstanceCreateSurface(nullptr, &surfaceDescriptor));
+    return SurfaceImpl::create(wgpuInstanceCreateSurface(nullptr, &surfaceDescriptor), m_convertToBackingContext);
 }
 
 Ref<SwapChain> DeviceImpl::createSwapChain(const Surface& surface, const SwapChainDescriptor& descriptor)
@@ -208,7 +208,7 @@ Ref<SwapChain> DeviceImpl::createSwapChain(const Surface& surface, const SwapCha
     };
 
     WGPUSurface wgpuSurface = m_convertToBackingContext->convertToBacking(surface);
-    return SwapChainImpl::create(wgpuSurface, wgpuDeviceCreateSwapChain(backing(), wgpuSurface, &backingDescriptor));
+    return SwapChainImpl::create(wgpuSurface, wgpuDeviceCreateSwapChain(backing(), wgpuSurface, &backingDescriptor), m_convertToBackingContext);
 }
 
 Ref<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,8 +36,9 @@
 
 namespace PAL::WebGPU {
 
-SurfaceImpl::SurfaceImpl(WGPUSurface surface)
+SurfaceImpl::SurfaceImpl(WGPUSurface surface, ConvertToBackingContext& convertToBackingContext)
     : m_backing(surface)
+    , m_convertToBackingContext(convertToBackingContext)
 {
 }
 
@@ -51,9 +52,8 @@ void SurfaceImpl::destroy()
     wgpuSurfaceRelease(m_backing);
 }
 
-void SurfaceImpl::setLabelInternal(const String& label)
+void SurfaceImpl::setLabelInternal(const String&)
 {
-    UNUSED_PARAM(label);
 }
 
 IOSurfaceRef SurfaceImpl::drawingBuffer() const

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,9 +41,9 @@ class ConvertToBackingContext;
 class SurfaceImpl final : public Surface {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<SurfaceImpl> create(WGPUSurface surface)
+    static Ref<SurfaceImpl> create(WGPUSurface surface, ConvertToBackingContext& convertToBackingContext)
     {
-        return adoptRef(*new SurfaceImpl(surface));
+        return adoptRef(*new SurfaceImpl(surface, convertToBackingContext));
     }
 
     virtual ~SurfaceImpl();
@@ -54,7 +54,7 @@ public:
 private:
     friend class DowncastConvertToBackingContext;
 
-    SurfaceImpl(WGPUSurface);
+    SurfaceImpl(WGPUSurface, ConvertToBackingContext&);
 
     SurfaceImpl(const SurfaceImpl&) = delete;
     SurfaceImpl(SurfaceImpl&&) = delete;
@@ -66,6 +66,7 @@ private:
     void setLabelInternal(const String&) final;
 
     WGPUSurface m_backing { nullptr };
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,9 +36,10 @@
 
 namespace PAL::WebGPU {
 
-SwapChainImpl::SwapChainImpl(WGPUSurface surface, WGPUSwapChain swapChain)
+SwapChainImpl::SwapChainImpl(WGPUSurface surface, WGPUSwapChain swapChain, ConvertToBackingContext& convertToBackingContext)
     : m_backing(swapChain)
     , m_surface(surface)
+    , m_convertToBackingContext(convertToBackingContext)
 {
 }
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,12 +34,14 @@
 
 namespace PAL::WebGPU {
 
+class ConvertToBackingContext;
+
 class SwapChainImpl final : public SwapChain {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<SwapChainImpl> create(WGPUSurface surface, WGPUSwapChain swapChain)
+    static Ref<SwapChainImpl> create(WGPUSurface surface, WGPUSwapChain swapChain, ConvertToBackingContext& convertToBackingContext)
     {
-        return adoptRef(*new SwapChainImpl(surface, swapChain));
+        return adoptRef(*new SwapChainImpl(surface, swapChain, convertToBackingContext));
     }
 
     virtual ~SwapChainImpl();
@@ -47,7 +49,7 @@ public:
 private:
     friend class DowncastConvertToBackingContext;
 
-    SwapChainImpl(WGPUSurface, WGPUSwapChain);
+    SwapChainImpl(WGPUSurface, WGPUSwapChain, ConvertToBackingContext&);
 
     SwapChainImpl(const SwapChainImpl&) = delete;
     SwapChainImpl(SwapChainImpl&&) = delete;
@@ -65,6 +67,7 @@ private:
 
     WGPUSwapChain m_backing { nullptr };
     WGPUSurface m_surface { nullptr };
+    Ref<ConvertToBackingContext> m_convertToBackingContext;
 };
 
 } // namespace PAL::WebGPU


### PR DESCRIPTION
#### db1acf95baa0e9acf5deb029a23c9baccd2460d3
<pre>
[WebGPU] Give a ConvertToBackingContext to SurfaceImpl and SwapChainImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=250964">https://bugs.webkit.org/show_bug.cgi?id=250964</a>
rdar://104522936

Reviewed by Kimmo Kinnunen.

SurfaceImpl and SwapChainImpl don&apos;t actually need a ConvertToBackingContext right now, but
most of the other ***Impl classes need one and have one, so I think it&apos;s just generally a
good idea to be consistent with the pattern and give one to all the ***Impl classes. In the
future, when we&apos;re developing, I don&apos;t think we should have to remember which classes have
a ConvertToBackingContext and which don&apos;t.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.cpp:
(PAL::WebGPU::SurfaceImpl::SurfaceImpl):
(PAL::WebGPU::SurfaceImpl::setLabelInternal):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSurfaceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp:
(PAL::WebGPU::SwapChainImpl::SwapChainImpl):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h:

Canonical link: <a href="https://commits.webkit.org/259235@main">https://commits.webkit.org/259235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfb1b1f6aea59c7c6aa850716ba0345fd1213db9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113491 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173779 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4280 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112539 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38783 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80449 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6727 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3713 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46715 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6366 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8647 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->