### PR TITLE
[WebGPU] Split Cocoa-specific parts of GPUCanvasContext into GPUCanvasContextCocoa

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+// Copyright (C) 2017-2023 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -194,6 +194,7 @@ editing/mac/TextAlternativeWithRange.mm @no-unify
 editing/mac/TextUndoInsertionMarkupMac.mm
 fileapi/FileCocoa.mm
 history/mac/HistoryItemMac.mm
+html/canvas/GPUCanvasContextCocoa.cpp
 html/shadow/YouTubeEmbedShadowElement.cpp
 inspector/mac/PageDebuggerMac.mm
 loader/archive/cf/LegacyWebArchive.cpp

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,7 +22,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#if defined(HAVE_WEBGPU_IMPLEMENTATION) && HAVE_WEBGPU_IMPLEMENTATION
 
 // https://gpuweb.github.io/gpuweb/#gpucanvascontext
 
@@ -30,7 +29,8 @@
     ActiveDOMObject,
     EnabledBySetting=WebGPU,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
-    SecureContext
+    SecureContext,
+    SkipVTableValidation,
 ]
 interface GPUCanvasContext {
     readonly attribute (HTMLCanvasElement
@@ -44,7 +44,3 @@ interface GPUCanvasContext {
 
     GPUTexture getCurrentTexture();
 };
-#else
-interface GPUCanvasContext {
-};
-#endif // HAVE_WEBGPU_IMPLEMENTATION

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GPUCanvasContextCocoa.h"
+
+#include "GPUAdapter.h"
+#include "GPUCanvasConfiguration.h"
+#include "GPUSurface.h"
+#include "GPUSurfaceDescriptor.h"
+#include "GPUSwapChain.h"
+#include "GPUSwapChainDescriptor.h"
+#include "GPUTextureDescriptor.h"
+#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "RenderBox.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+static IntSize getCanvasSizeAsIntSize(const GPUCanvasContext::CanvasType& canvas)
+{
+    return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> IntSize {
+        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
+        return { static_cast<int>(scaleFactor * htmlCanvas->width()), static_cast<int>(scaleFactor * htmlCanvas->height()) };
+    }
+#if ENABLE(OFFSCREEN_CANVAS)
+    , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> IntSize {
+        return { static_cast<int>(offscreenCanvas->width()), static_cast<int>(offscreenCanvas->height()) };
+    }
+#endif
+    );
+}
+
+static bool platformSupportsWebGPUSurface()
+{
+#if PLATFORM(COCOA)
+    return true;
+#else
+    return false;
+#endif
+}
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(GPUCanvasContextCocoa);
+
+std::unique_ptr<GPUCanvasContext> GPUCanvasContext::create(CanvasBase& canvas)
+{
+    auto context = GPUCanvasContextCocoa::create(canvas);
+    if (context)
+        context->suspendIfNeeded();
+    return context;
+}
+
+std::unique_ptr<GPUCanvasContextCocoa> GPUCanvasContextCocoa::create(CanvasBase& canvas)
+{
+    if (!platformSupportsWebGPUSurface())
+        return nullptr;
+
+    return std::unique_ptr<GPUCanvasContextCocoa>(new GPUCanvasContextCocoa(canvas));
+}
+
+GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas)
+    : GPUCanvasContext(canvas)
+    , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create())
+{
+    ASSERT(platformSupportsWebGPUSurface());
+}
+
+void GPUCanvasContextCocoa::reshape(int width, int height)
+{
+    if (m_width == width && m_height == height)
+        return;
+
+    m_width = width;
+    m_height = height;
+    m_swapChain = nullptr;
+
+    createSwapChainIfNeeded();
+}
+
+GPUCanvasContext::CanvasType GPUCanvasContextCocoa::canvas()
+{
+    return htmlCanvas();
+}
+
+void GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& configuration)
+{
+    m_configuration = WTFMove(configuration);
+
+    auto canvasSize = getCanvasSizeAsIntSize(htmlCanvas());
+    reshape(canvasSize.width(), canvasSize.height());
+}
+
+void GPUCanvasContextCocoa::createSwapChainIfNeeded()
+{
+    if (m_swapChain || !m_configuration)
+        return;
+
+    GPUSurfaceDescriptor surfaceDescriptor = {
+        { "WebGPU Canvas surface"_s },
+        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
+        1 /* sampleCount */,
+        m_configuration->format,
+        m_configuration->usage
+    };
+
+    m_surface = m_configuration->device->createSurface(surfaceDescriptor);
+    ASSERT(m_surface);
+
+    GPUSwapChainDescriptor descriptor = {
+        { "WebGPU Canvas swap chain"_s },
+        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
+        1 /* sampleCount */,
+        m_configuration->format,
+        m_configuration->usage
+    };
+
+    m_swapChain = m_configuration->device->createSwapChain(*m_surface, descriptor);
+    ASSERT(m_swapChain);
+}
+
+RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
+{
+    if (!m_configuration)
+        return nullptr;
+
+    createSwapChainIfNeeded();
+
+    GPUTextureDescriptor descriptor = {
+        { "WebGPU Display texture"_s },
+        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
+        1 /* mipMapCount */,
+        1 /* sampleCount */,
+        GPUTextureDimension::_2d,
+        m_configuration->format,
+        m_configuration->usage,
+        m_configuration->viewFormats
+    };
+
+    markContextChangedAndNotifyCanvasObservers();
+    return m_configuration->device->createSurfaceTexture(descriptor, *m_surface);
+}
+
+PixelFormat GPUCanvasContextCocoa::pixelFormat() const
+{
+    return PixelFormat::BGRA8;
+}
+
+void GPUCanvasContextCocoa::unconfigure()
+{
+    m_configuration.reset();
+}
+
+DestinationColorSpace GPUCanvasContextCocoa::colorSpace() const
+{
+    return DestinationColorSpace::SRGB();
+}
+
+RefPtr<GraphicsLayerContentsDisplayDelegate> GPUCanvasContextCocoa::layerContentsDisplayDelegate()
+{
+    return m_layerContentsDisplayDelegate.ptr();
+}
+
+void GPUCanvasContextCocoa::prepareForDisplay()
+{
+#if PLATFORM(COCOA)
+    m_swapChain->prepareForDisplay([protectedThis = Ref { *this }] (auto sendRight) {
+        protectedThis->m_layerContentsDisplayDelegate->setDisplayBuffer(WTFMove(sendRight));
+        protectedThis->m_compositingResultsNeedsUpdating = false;
+    });
+#endif
+}
+
+void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
+{
+    m_compositingResultsNeedsUpdating = true;
+
+    bool canvasIsDirty = false;
+
+    if (auto* canvas = htmlCanvas()) {
+        auto* renderBox = canvas->renderBox();
+        if (isAccelerated() && renderBox && renderBox->hasAcceleratedCompositing()) {
+            canvasIsDirty = true;
+            canvas->clearCopiedImage();
+            renderBox->contentChanged(CanvasChanged);
+        }
+    }
+
+    if (!canvasIsDirty) {
+        canvasIsDirty = true;
+        canvasBase().didDraw({ });
+    }
+
+    if (!isAccelerated())
+        return;
+
+    auto* canvas = htmlCanvas();
+    if (!canvas)
+        return;
+
+    canvas->notifyObserversCanvasChanged({ });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GPUBasedCanvasRenderingContext.h"
+#include "GPUCanvasConfiguration.h"
+#include "GPUCanvasContext.h"
+#include "GPUSurface.h"
+#include "GPUSwapChain.h"
+#include "GPUTexture.h"
+#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "HTMLCanvasElement.h"
+#include "IOSurface.h"
+#include "OffscreenCanvas.h"
+#include "PlatformCALayer.h"
+#include <variant>
+#include <wtf/MachSendRight.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class DisplayBufferDisplayDelegate final : public GraphicsLayerContentsDisplayDelegate {
+public:
+    static Ref<DisplayBufferDisplayDelegate> create(bool isOpaque = true, float contentsScale = 1)
+    {
+        return adoptRef(*new DisplayBufferDisplayDelegate(isOpaque, contentsScale));
+    }
+    // GraphicsLayerContentsDisplayDelegate overrides.
+    void prepareToDelegateDisplay(PlatformCALayer& layer) final
+    {
+        layer.setOpaque(m_isOpaque);
+        layer.setContentsScale(m_contentsScale);
+    }
+    void display(PlatformCALayer& layer) final
+    {
+        if (m_displayBuffer)
+            layer.setContents(m_displayBuffer);
+        else
+            layer.clearContents();
+    }
+    GraphicsLayer::CompositingCoordinatesOrientation orientation() const final
+    {
+        return GraphicsLayer::CompositingCoordinatesOrientation::TopDown;
+    }
+    void setDisplayBuffer(WTF::MachSendRight&& displayBuffer)
+    {
+        if (!displayBuffer) {
+            m_displayBuffer = { };
+            return;
+        }
+
+        if (m_displayBuffer && displayBuffer.sendRight() == m_displayBuffer.sendRight())
+            return;
+
+        m_displayBuffer = displayBuffer.copySendRight();
+    }
+private:
+    DisplayBufferDisplayDelegate(bool isOpaque, float contentsScale)
+        : m_contentsScale(contentsScale)
+        , m_isOpaque(isOpaque)
+    {
+    }
+    WTF::MachSendRight m_displayBuffer;
+    const float m_contentsScale;
+    const bool m_isOpaque;
+};
+
+class GPUCanvasContextCocoa final : public GPUCanvasContext {
+    WTF_MAKE_ISO_ALLOCATED(GPUCanvasContextCocoa);
+public:
+#if ENABLE(OFFSCREEN_CANVAS)
+    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
+#else
+    using CanvasType = std::variant<RefPtr<HTMLCanvasElement>>;
+#endif
+
+    static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&);
+
+    DestinationColorSpace colorSpace() const override;
+    bool compositingResultsNeedUpdating() const override { return m_compositingResultsNeedsUpdating; }
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
+    bool needsPreparationForDisplay() const override { return true; }
+    void prepareForDisplay() override;
+    PixelFormat pixelFormat() const override;
+    void reshape(int width, int height) override;
+
+    // FIXME: implement these to allow for painting
+    void prepareForDisplayWithPaint() override { }
+    void paintRenderingResultsToCanvas() override { }
+    // GPUCanvasContext methods:
+    CanvasType canvas() override;
+    void configure(GPUCanvasConfiguration&&) override;
+    void unconfigure() override;
+    RefPtr<GPUTexture> getCurrentTexture() override;
+
+    bool isWebGPU() const override { return true; }
+    const char* activeDOMObjectName() const override
+    {
+        return "GPUCanvasElement";
+    }
+
+private:
+    explicit GPUCanvasContextCocoa(CanvasBase&);
+
+    void markContextChangedAndNotifyCanvasObservers();
+    void createSwapChainIfNeeded();
+
+    std::optional<GPUCanvasConfiguration> m_configuration;
+    Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
+    RefPtr<GPUSwapChain> m_swapChain;
+    RefPtr<GPUSurface> m_surface;
+
+    int m_width { 0 };
+    int m_height { 0 };
+    bool m_compositingResultsNeedsUpdating { false };
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 5e700122a06a03d1fb535ac12a6c9507e2d19e7c
<pre>
[WebGPU] Split Cocoa-specific parts of GPUCanvasContext into GPUCanvasContextCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=250965">https://bugs.webkit.org/show_bug.cgi?id=250965</a>
rdar://104523434

Reviewed by Dean Jackson.

GPUCanvasContext has a whole bunch of PlatformCALayer and MachPort business going on.
Ideally, all ports would be able to use GPUCanvasContext, and only differ in the
specific pieces that are platform-dependent. So we can move the PlatformCALayer and
MachPort stuff into GPUCanvasContextCocoa.

I&apos;m aiming for a future where all WebKit ports support WebGPU; the Cocoa ports would
do so by linking with WebGPU.framework, and the non-Cocoa ports would do so by
linking with either WGPU or Dawn. The HAVE(WEBGPU_IMPLEMENTATION) macro is supposed
to indicate whether the port has actually started linking with one of those - and
therefore the macro itself is platform independent.

This patch doesn&apos;t actually have any behavior change; it just moves code around.

* Source/WebCore/html/canvas/GPUCanvasContext.cpp:
(WebCore::GPUCanvasContext::create):
(WebCore::GPUCanvasContext::GPUCanvasContext):
(WebCore::getCanvasSizeAsIntSize): Deleted.
(WebCore::platformSupportsWebGPUSurface): Deleted.
(WebCore::GPUCanvasContext::reshape): Deleted.
(WebCore::GPUCanvasContext::canvas): Deleted.
(WebCore::GPUCanvasContext::configure): Deleted.
(WebCore::GPUCanvasContext::createSwapChainIfNeeded): Deleted.
(WebCore::GPUCanvasContext::getCurrentTexture): Deleted.
(WebCore::GPUCanvasContext::pixelFormat const): Deleted.
(WebCore::GPUCanvasContext::unconfigure): Deleted.
(WebCore::GPUCanvasContext::colorSpace const): Deleted.
(WebCore::GPUCanvasContext::layerContentsDisplayDelegate): Deleted.
(WebCore::GPUCanvasContext::prepareForDisplay): Deleted.
(WebCore::GPUCanvasContext::markContextChangedAndNotifyCanvasObservers): Deleted.
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp: Added.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h: Added.

Canonical link: <a href="https://commits.webkit.org/259257@main">https://commits.webkit.org/259257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec0137ca7d251b9c6dc85f021836e66df7577e56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113503 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173792 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4292 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112548 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38788 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80456 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6737 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3725 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6384 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8657 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->