### PR TITLE
[JSC] Clean up WasmToJS

### DIFF
--- a/JSTests/stress/sampling-profiler-wasm-name-section.js
+++ b/JSTests/stress/sampling-profiler-wasm-name-section.js
@@ -74,5 +74,5 @@ if (platformSupportsSamplingProfiler() && $vm.isWasmSupported()) {
     var wasmEntry = function() {
         return instance.exports._parrot(1);
     };
-    runTest(wasmEntry, ["_silly", "(unknown)", "<?>.wasm-function[_eggs]", "<?>.wasm-function[_bacon]", "<?>.wasm-function[_spam]", "<?>.wasm-function[_parrot]", "wasm-stub", "wasmEntry"]);
+    runTest(wasmEntry, ["_silly", "wasm-stub", "<?>.wasm-function[_eggs]", "<?>.wasm-function[_bacon]", "<?>.wasm-function[_spam]", "<?>.wasm-function[_parrot]", "wasm-stub", "wasmEntry"]);
 }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2370,7 +2370,7 @@ void CodeBlock::noticeIncomingCall(CallFrame* callerFrame)
 {
     RELEASE_ASSERT(!m_isJettisoned);
 
-    CodeBlock* callerCodeBlock = callerFrame->isAnyWasmCallee() ? nullptr : callerFrame->codeBlock();
+    CodeBlock* callerCodeBlock = callerFrame->isWasmFrame() ? nullptr : callerFrame->codeBlock();
     
     dataLogLnIf(Options::verboseCallLink(), "Noticing call link from ", pointerDump(callerCodeBlock), " to ", *this);
     

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -89,13 +89,13 @@ static void linkSlowFor(VM& vm, CallLinkInfo& callLinkInfo)
     linkSlowPathTo(vm, callLinkInfo, virtualThunk);
 }
 
-static JSCell* webAssemblyOwner(JSCell* callee)
+static JSCell* webAssemblyOwner(CallFrame* callFrame)
 {
 #if ENABLE(WEBASSEMBLY)
     // Each WebAssembly.Instance shares the stubs from their WebAssembly.Module, which are therefore the appropriate owner.
-    return jsCast<JSWebAssemblyInstance*>(callee)->module();
+    return jsCast<JSWebAssemblyInstance*>(callFrame->wasmInstance()->owner())->module();
 #else
-    UNUSED_PARAM(callee);
+    UNUSED_PARAM(callFrame);
     RELEASE_ASSERT_NOT_REACHED();
     return nullptr;
 #endif // ENABLE(WEBASSEMBLY)
@@ -108,16 +108,16 @@ void linkMonomorphicCall(
     ASSERT(!callLinkInfo.stub());
 
     CallFrame* callerFrame = callFrame->callerFrame();
-    // Our caller must have a cell for a callee. When calling
-    // this from Wasm, we ensure the callee is a cell.
-    ASSERT(callerFrame->callee().isCell());
 
     // WebAssembly -> JS stubs don't have a valid CodeBlock.
     CodeBlock* callerCodeBlock = nullptr;
     JSCell* owner = nullptr;
-    if (callerFrame->isAnyWasmCallee())
-        owner = webAssemblyOwner(callerFrame->callee().asCell());
-    else {
+    if (callerFrame->isWasmFrame()) {
+        // When calling this from Wasm, callee is Wasm::Callee.
+        owner = webAssemblyOwner(callerFrame);
+    } else {
+        // Our caller must have a cell for a callee.
+        ASSERT(callerFrame->callee().isCell());
         callerCodeBlock = callerFrame->codeBlock();
         owner = callerCodeBlock;
     }
@@ -1634,17 +1634,14 @@ void linkDirectCall(
 static void linkVirtualFor(VM& vm, CallFrame* callFrame, CallLinkInfo& callLinkInfo)
 {
     CallFrame* callerFrame = callFrame->callerFrame();
-    // Our caller must have a cell for a callee. When calling
-    // this from Wasm, we ensure the callee is a cell.
-    ASSERT(callerFrame->callee().isCell());
 
     // WebAssembly -> JS stubs don't have a valid CodeBlock.
     CodeBlock* callerCodeBlock = nullptr;
-    if (!callerFrame->isAnyWasmCallee())
+    if (!callerFrame->isWasmFrame())
         callerCodeBlock = callerFrame->codeBlock();
 
     dataLogLnIf(shouldDumpDisassemblyFor(callerCodeBlock),
-        "Linking virtual call at ", FullCodeOrigin(callerCodeBlock, callerFrame->codeOrigin()));
+        "Linking virtual call at ", FullCodeOrigin(callerCodeBlock, callerCodeBlock ? callerFrame->codeOrigin() : CodeOrigin { }));
 
     MacroAssemblerCodeRef<JITStubRoutinePtrTag> virtualThunk = vm.getCTIVirtualCall(callLinkInfo.callMode());
     revertCall(vm, callLinkInfo, virtualThunk);
@@ -1674,17 +1671,15 @@ void linkPolymorphicCall(JSGlobalObject* globalObject, CallFrame* callFrame, Cal
         return;
     }
 
-    // Our caller must be have a cell for a callee. When calling
-    // this from Wasm, we ensure the callee is a cell.
-    ASSERT(callerFrame->callee().isCell());
-
     // WebAssembly -> JS stubs don't have a valid CodeBlock.
     CodeBlock* callerCodeBlock = nullptr;
     JSCell* owner = nullptr;
-    bool isWebAssembly = callerFrame->isAnyWasmCallee();
-    if (isWebAssembly)
-        owner = webAssemblyOwner(callerFrame->callee().asCell());
-    else {
+    bool isWebAssembly = callerFrame->isWasmFrame();
+    if (isWebAssembly) {
+        // When calling this from Wasm, callee is Wasm::Callee.
+        owner = webAssemblyOwner(callerFrame);
+    } else {
+        // Our caller must have a cell for a callee.
         callerCodeBlock = callerFrame->codeBlock();
         owner = callerCodeBlock;
     }

--- a/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
@@ -149,7 +149,7 @@ DebuggerScope* DebuggerCallFrame::scope(VM& vm)
 
     if (!m_scope) {
         JSScope* scope;
-        CodeBlock* codeBlock = m_validMachineFrame->isAnyWasmCallee() ? nullptr : m_validMachineFrame->codeBlock();
+        CodeBlock* codeBlock = m_validMachineFrame->isWasmFrame() ? nullptr : m_validMachineFrame->codeBlock();
         if (isTailDeleted())
             scope = m_shadowChickenFrame.scope;
         else if (codeBlock && codeBlock->scopeRegister().isValid())
@@ -192,7 +192,7 @@ JSValue DebuggerCallFrame::thisValue(VM& vm) const
         codeBlock = m_shadowChickenFrame.codeBlock;
     } else {
         thisValue = m_validMachineFrame->thisValue();
-        codeBlock = m_validMachineFrame->isAnyWasmCallee() ? nullptr : m_validMachineFrame->codeBlock();
+        codeBlock = m_validMachineFrame->isWasmFrame() ? nullptr : m_validMachineFrame->codeBlock();
     }
 
     if (!thisValue)
@@ -219,7 +219,7 @@ JSValue DebuggerCallFrame::evaluateWithScopeExtension(VM& vm, const String& scri
             if (debuggerCallFrame->isTailDeleted())
                 codeBlock = debuggerCallFrame->m_shadowChickenFrame.codeBlock;
             else
-                codeBlock = callFrame->isAnyWasmCallee() ? nullptr : callFrame->codeBlock();
+                codeBlock = callFrame->isWasmFrame() ? nullptr : callFrame->codeBlock();
         }
 
         if (callFrame && codeBlock)
@@ -318,7 +318,7 @@ SourceID DebuggerCallFrame::sourceIDForCallFrame(CallFrame* callFrame)
 {
     if (!callFrame)
         return noSourceID;
-    if (callFrame->isAnyWasmCallee())
+    if (callFrame->isWasmFrame())
         return noSourceID;
     CodeBlock* codeBlock = callFrame->codeBlock();
     if (!codeBlock)

--- a/Source/JavaScriptCore/dfg/DFGDoesGCCheck.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGCCheck.cpp
@@ -69,7 +69,7 @@ void DoesGCCheck::verifyCanGC(VM& vm)
 
         CallFrame* callFrame = vm.topCallFrame;
         if (callFrame) {
-            if (!callFrame->isAnyWasmCallee())
+            if (!callFrame->isWasmFrame())
                 dataLogLn(" in ", callFrame->codeBlock());
             VMInspector::dumpStack(&vm, callFrame);
         }

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -685,7 +685,7 @@ static String functionName(JSC::CodeBlock& codeBlock)
 
 static String functionName(JSC::CallFrame* callFrame)
 {
-    if (callFrame->isAnyWasmCallee())
+    if (callFrame->isWasmFrame())
         return nullString();
 
     if (auto* codeBlock = callFrame->codeBlock())

--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -160,19 +160,6 @@ Register* CallFrame::topOfFrameInternal()
     return registers() + codeBlock->stackPointerOffset();
 }
 
-bool CallFrame::isAnyWasmCallee() const
-{
-    CalleeBits callee = this->callee();
-    if (callee.isWasm())
-        return true;
-
-    ASSERT(callee.isCell());
-    if (!!callee.rawPtr() && isWebAssemblyInstance(callee.asCell()))
-        return true;
-
-    return false;
-}
-
 CallFrame* CallFrame::callerFrame(EntryFrame*& currEntryFrame) const
 {
     if (callerFrameOrEntryFrame() == currEntryFrame) {
@@ -264,7 +251,7 @@ JSGlobalObject* CallFrame::globalObjectOfClosestCodeBlock(VM& vm, CallFrame* cal
 
 String CallFrame::friendlyFunctionName()
 {
-    if (this->isAnyWasmCallee())
+    if (this->isWasmFrame())
         return emptyString();
 
     CodeBlock* codeBlock = this->codeBlock();
@@ -290,7 +277,7 @@ String CallFrame::friendlyFunctionName()
 
 void CallFrame::dump(PrintStream& out) const
 {
-    if (!this->isAnyWasmCallee()) {
+    if (!this->isWasmFrame()) {
         if (CodeBlock* codeBlock = this->codeBlock()) {
             out.print(codeBlock->inferredName(), "#", codeBlock->hashAsStringIfPossible(), " [", codeBlock->jitType(), " ", bytecodeIndex(), "]");
 
@@ -353,7 +340,7 @@ void CallFrame::convertToStackOverflowFrame(VM& vm, CodeBlock* codeBlockToKeepAl
 #if ENABLE(WEBASSEMBLY)
 JSGlobalObject* CallFrame::lexicalGlobalObjectFromWasmCallee(VM&) const
 {
-    return wasmInstance()->owner<JSWebAssemblyInstance>()->globalObject();
+    return wasmInstance()->globalObject();
 }
 #endif
 

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -180,8 +180,6 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         inline SUPPRESS_ASAN CodeBlock* unsafeCodeBlock() const;
         inline JSScope* scope(int scopeRegisterOffset) const;
 
-        JS_EXPORT_PRIVATE bool isAnyWasmCallee() const;
-
         // Global object in which the currently executing code was defined.
         // Differs from VM::deprecatedVMEntryGlobalObject() during function calls across web browser frames.
         JSGlobalObject* lexicalGlobalObject(VM&) const;

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -688,7 +688,7 @@ private:
         auto catchScope = DECLARE_CATCH_SCOPE(vm);
 
         SuspendExceptionScope scope(vm);
-        if (callFrame->isAnyWasmCallee()
+        if (callFrame->isWasmFrame()
             || (callFrame->callee().isCell() && callFrame->callee().asCell()->inherits<JSFunction>()))
             debugger->unwindEvent(callFrame);
         else
@@ -765,7 +765,7 @@ NEVER_INLINE CatchInfo Interpreter::unwind(VM& vm, CallFrame*& callFrame, Except
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     ASSERT(reinterpret_cast<void*>(callFrame) != vm.topEntryFrame);
-    CodeBlock* codeBlock = callFrame->isAnyWasmCallee() ? nullptr : callFrame->codeBlock();
+    CodeBlock* codeBlock = callFrame->isWasmFrame() ? nullptr : callFrame->codeBlock();
 
     JSValue exceptionValue = exception->value();
     ASSERT(!exceptionValue.isEmpty());

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -328,7 +328,7 @@ void ShadowChicken::update(VM& vm, CallFrame* callFrame)
             bool foundFrame = advanceIndexInLogTo(callFrame, callFrame->jsCallee(), callFrame->callerFrame());
             bool isTailDeleted = false;
             JSScope* scope = nullptr;
-            CodeBlock* codeBlock = callFrame->isAnyWasmCallee() ? nullptr : callFrame->codeBlock();
+            CodeBlock* codeBlock = callFrame->isWasmFrame() ? nullptr : callFrame->codeBlock();
             JSValue scopeValue = callFrame->bytecodeIndex() && codeBlock && codeBlock->scopeRegister().isValid()
                 ? callFrame->registers()[codeBlock->scopeRegister().offset()].jsValue()
                 : jsUndefined();

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -111,7 +111,7 @@ void StackVisitor::readFrame(CallFrame* callFrame)
         return;
     }
 
-    if (callFrame->isAnyWasmCallee()) {
+    if (callFrame->isWasmFrame()) {
         readNonInlinedFrame(callFrame);
         return;
     }
@@ -167,13 +167,13 @@ void StackVisitor::readNonInlinedFrame(CallFrame* callFrame, CodeOrigin* codeOri
     m_frame.m_inlineCallFrame = nullptr;
 #endif
 
-    m_frame.m_codeBlock = callFrame->isAnyWasmCallee() ? nullptr : callFrame->codeBlock();
+    m_frame.m_codeBlock = callFrame->isWasmFrame() ? nullptr : callFrame->codeBlock();
     m_frame.m_bytecodeIndex = !m_frame.codeBlock() ? BytecodeIndex(0)
         : codeOrigin ? codeOrigin->bytecodeIndex()
         : callFrame->bytecodeIndex();
 
 #if ENABLE(WEBASSEMBLY)
-    if (callFrame->isAnyWasmCallee()) {
+    if (callFrame->isWasmFrame()) {
         m_frame.m_isWasmFrame = true;
         m_frame.m_codeBlock = nullptr;
 
@@ -264,7 +264,9 @@ std::optional<RegisterAtOffsetList> StackVisitor::Frame::calleeSaveRegistersForU
             return std::nullopt;
         }
         Wasm::Callee* wasmCallee = callee().asWasmCallee();
-        return *wasmCallee->calleeSaveRegisters();
+        if (auto* calleeSaveRegisters = wasmCallee->calleeSaveRegisters())
+            return *calleeSaveRegisters;
+        return std::nullopt;
     }
 #endif // ENABLE(WEBASSEMBLY)
 

--- a/Source/JavaScriptCore/jit/JITExceptions.cpp
+++ b/Source/JavaScriptCore/jit/JITExceptions.cpp
@@ -44,7 +44,7 @@ void genericUnwind(VM& vm, CallFrame* callFrame)
     auto scope = DECLARE_CATCH_SCOPE(vm);
     CallFrame* topJSCallFrame = vm.topJSCallFrame();
     if (UNLIKELY(Options::breakOnThrow())) {
-        CodeBlock* codeBlock = topJSCallFrame->isAnyWasmCallee() ? nullptr : topJSCallFrame->codeBlock();
+        CodeBlock* codeBlock = topJSCallFrame->isWasmFrame() ? nullptr : topJSCallFrame->codeBlock();
         dataLog("In call frame ", RawPointer(topJSCallFrame), " for code block ", codeBlock, "\n");
         WTFBreakpointTrap();
     }

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -75,7 +75,7 @@ PolymorphicCallStubRoutine::PolymorphicCallStubRoutine(
     for (unsigned index = 0; index < cases.size(); ++index) {
         const PolymorphicCallCase& callCase = cases[index];
         m_variants[index].set(vm, owner, callCase.variant().rawCalleeCell());
-        if (!callerFrame->isAnyWasmCallee()) {
+        if (!callerFrame->isWasmFrame()) {
             if (shouldDumpDisassemblyFor(callerFrame->codeBlock()))
                 dataLog("Linking polymorphic call in ", FullCodeOrigin(callerFrame->codeBlock(), callerFrame->codeOrigin()), " to ", callCase.variant(), ", codeBlock = ", pointerDump(callCase.codeBlock()), "\n");
         }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2062,11 +2062,11 @@ JSC_DEFINE_HOST_FUNCTION(functionCallerIsBBQOrOMGCompiled, (JSGlobalObject* glob
 
     CallerFunctor wasmToJSFrame;
     StackVisitor::visit(callFrame, vm, wasmToJSFrame);
-    if (!wasmToJSFrame.callerFrame() || !wasmToJSFrame.callerFrame()->isAnyWasmCallee())
+    if (!wasmToJSFrame.callerFrame() || !wasmToJSFrame.callerFrame()->isWasmFrame())
         return throwVMError(globalObject, scope, "caller is not a wasm->js import function"_s);
 
     // We have a wrapper frame that we generate for imports. If we ever can direct call from wasm we would need to change this.
-    ASSERT(!wasmToJSFrame.callerFrame()->callee().isWasm());
+    ASSERT(wasmToJSFrame.callerFrame()->callee().isWasm());
     CallerFunctor wasmFrame;
     StackVisitor::visit(wasmToJSFrame.callerFrame(), vm, wasmFrame);
     ASSERT(wasmFrame.callerFrame()->callee().isWasm());

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -872,7 +872,7 @@ static CodeBlock* getCallerCodeBlock(CallFrame* callFrame)
     CodeOrigin codeOrigin = callerFrame->codeOrigin();
     if (codeOrigin && codeOrigin.inlineCallFrame())
         return baselineCodeBlockForInlineCallFrame(codeOrigin.inlineCallFrame());
-    if (callerFrame->isAnyWasmCallee())
+    if (callerFrame->isWasmFrame())
         return nullptr;
     return callerFrame->codeBlock();
 }

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -877,7 +877,7 @@ Exception* VM::throwException(JSGlobalObject* globalObject, Exception* exception
 
     CallFrame* throwOriginFrame = topJSCallFrame();
     if (UNLIKELY(Options::breakOnThrow())) {
-        CodeBlock* codeBlock = throwOriginFrame && !throwOriginFrame->isAnyWasmCallee() ? throwOriginFrame->codeBlock() : nullptr;
+        CodeBlock* codeBlock = throwOriginFrame && !throwOriginFrame->isWasmFrame() ? throwOriginFrame->codeBlock() : nullptr;
         dataLog("Throwing exception in call frame ", RawPointer(throwOriginFrame), " for code block ", codeBlock, "\n");
         CRASH();
     }

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -186,7 +186,7 @@ void VMTraps::invalidateCodeBlocksOnStack(Locker<Lock>&, CallFrame* topCallFrame
         return; // Not running JS code. Nothing to invalidate.
 
     while (callFrame) {
-        CodeBlock* codeBlock = callFrame->isAnyWasmCallee() ? nullptr : callFrame->codeBlock();
+        CodeBlock* codeBlock = callFrame->isWasmFrame() ? nullptr : callFrame->codeBlock();
         if (codeBlock && JITCode::isOptimizingJIT(codeBlock->jitType()))
             codeBlock->jettison(Profiler::JettisonDueToVMTraps);
         callFrame = callFrame->callerFrame(entryFrame);

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -433,7 +433,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
     }
 
     // Dumping from low memory to high memory.
-    bool isWasm = callFrame->isAnyWasmCallee();
+    bool isWasm = callFrame->isWasmFrame();
     CodeBlock* codeBlock = isWasm ? nullptr : callFrame->codeBlock();
     unsigned numCalleeLocals = codeBlock ? codeBlock->numCalleeLocals() : 0;
     unsigned numVars = codeBlock ? codeBlock->numVars() : 0;

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -78,6 +78,9 @@ inline void Callee::runWithDowncast(const Func& func)
     case CompilationMode::JSToWasmICMode:
         func(static_cast<JSToWasmICCallee*>(this));
         break;
+    case CompilationMode::WasmToJSMode:
+        func(static_cast<WasmToJSCallee*>(this));
+        break;
     }
 }
 
@@ -147,6 +150,12 @@ JITCallee::JITCallee(Wasm::CompilationMode compilationMode, size_t index, std::p
 void JITCallee::setEntrypoint(Wasm::Entrypoint&& entrypoint)
 {
     m_entrypoint = WTFMove(entrypoint);
+    CalleeRegistry::singleton().registerCallee(this);
+}
+
+WasmToJSCallee::WasmToJSCallee()
+    : Callee(Wasm::CompilationMode::WasmToJSMode)
+{
     CalleeRegistry::singleton().registerCallee(this);
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -123,6 +123,29 @@ private:
     }
 };
 
+class WasmToJSCallee final : public Callee {
+public:
+    friend class Callee;
+
+    static Ref<WasmToJSCallee> create()
+    {
+        return adoptRef(*new WasmToJSCallee);
+    }
+
+private:
+    WasmToJSCallee();
+
+    std::tuple<void*, void*> rangeImpl() const
+    {
+        return { nullptr, nullptr };
+    }
+
+    CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
+
+    RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
+};
+
+
 class JSToWasmICCallee final : public JITCallee {
 public:
     static Ref<JSToWasmICCallee> create()

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
@@ -48,6 +48,8 @@ const char* makeString(CompilationMode mode)
         return "EmbedderEntrypoint";
     case CompilationMode::JSToWasmICMode:
         return "JSToWasmIC";
+    case CompilationMode::WasmToJSMode:
+        return "WasmToJS";
     }
     RELEASE_ASSERT_NOT_REACHED();
     return "";

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -35,6 +35,7 @@ enum class CompilationMode : uint8_t {
     OMGForOSREntryMode,
     EmbedderEntrypointMode,
     JSToWasmICMode,
+    WasmToJSMode,
 };
 
 const char* makeString(CompilationMode);
@@ -47,6 +48,7 @@ constexpr inline bool isOSREntry(CompilationMode compilationMode)
     case CompilationMode::OMGMode:
     case CompilationMode::EmbedderEntrypointMode:
     case CompilationMode::JSToWasmICMode:
+    case CompilationMode::WasmToJSMode:
         return false;
     case CompilationMode::BBQForOSREntryMode:
     case CompilationMode::OMGForOSREntryMode:
@@ -66,6 +68,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::OMGMode:
     case CompilationMode::EmbedderEntrypointMode:
     case CompilationMode::JSToWasmICMode:
+    case CompilationMode::WasmToJSMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
@@ -82,6 +85,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::LLIntMode:
     case CompilationMode::EmbedderEntrypointMode:
     case CompilationMode::JSToWasmICMode:
+    case CompilationMode::WasmToJSMode:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "JSCJSValueInlines.h"
+#include "JSWebAssemblyGlobal.h"
 #include "JSWebAssemblyHelpers.h"
 #include "JSWebAssemblyRuntimeError.h"
 #include "WasmTypeDefinitionInlines.h"

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -34,7 +34,11 @@
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
-namespace JSC { namespace Wasm {
+namespace JSC {
+
+class JSWebAssemblyGlobal;
+
+namespace Wasm {
 
 class Instance;
 
@@ -67,8 +71,8 @@ public:
     void set(JSGlobalObject*, JSValue);
     DECLARE_VISIT_AGGREGATE;
 
-    template<typename T> T* owner() const { return reinterpret_cast<T*>(m_owner); }
-    void setOwner(JSObject* owner)
+    JSWebAssemblyGlobal* owner() const { return m_owner; }
+    void setOwner(JSWebAssemblyGlobal* owner)
     {
         ASSERT(!m_owner);
         ASSERT(owner);
@@ -104,7 +108,7 @@ private:
 
     Wasm::Type m_type;
     Wasm::Mutability m_mutability;
-    JSObject* m_owner { nullptr };
+    JSWebAssemblyGlobal* m_owner { nullptr };
     Value m_value;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -37,6 +37,7 @@ namespace JSC { namespace Wasm {
 Module::Module(LLIntPlan& plan)
     : m_moduleInformation(plan.takeModuleInformation())
     , m_llintCallees(LLIntCallees::createFromVector(plan.takeCallees()))
+    , m_wasmToJSCallee(WasmToJSCallee::create())
     , m_llintEntryThunks(plan.takeEntryThunks())
 {
 }

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -71,6 +71,8 @@ public:
 
     void copyInitialCalleeGroupToAllMemoryModes(MemoryMode);
 
+    WasmToJSCallee& wasmToJSCallee() { return m_wasmToJSCallee.get(); }
+
 private:
     Ref<CalleeGroup> getOrCreateCalleeGroup(VM&, MemoryMode);
 
@@ -78,6 +80,7 @@ private:
     Ref<ModuleInformation> m_moduleInformation;
     RefPtr<CalleeGroup> m_calleeGroups[numberOfMemoryModes];
     Ref<LLIntCallees> m_llintCallees;
+    Ref<WasmToJSCallee> m_wasmToJSCallee;
     MacroAssemblerCodeRef<JITCompilationPtrTag> m_llintEntryThunks;
     Lock m_lock;
 };

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -53,7 +53,7 @@ void loadValuesIntoBuffer(Probe::Context&, const StackMap&, uint64_t* buffer, Sa
 JSC_DECLARE_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe::Context&));
 JSC_DECLARE_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (Instance*, uint32_t functionIndex));
 #endif
-JSC_DECLARE_JIT_OPERATION(operationWasmUnwind, void, (Instance*));
+JSC_DECLARE_JIT_OPERATION(operationWasmUnwind, void*, (Instance*));
 
 JSC_DECLARE_JIT_OPERATION(operationConvertToI64, int64_t, (Instance*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationConvertToF64, double, (Instance*, EncodedJSValue));

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -46,7 +46,7 @@ inline EncodedJSValue refFunc(Instance* instance, uint32_t index)
 
 inline EncodedJSValue arrayNew(Instance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue)
 {
-    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
+    JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = instance->vm();
 
     ASSERT(typeIndex < instance->module().moduleInformation().typeCount());
@@ -137,9 +137,9 @@ inline void arraySet(Instance* instance, uint32_t typeIndex, EncodedJSValue arra
 
 inline EncodedJSValue structNew(Instance* instance, uint32_t typeIndex, bool useDefault, uint64_t* arguments)
 {
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
-    const TypeDefinition& structTypeDefinition = jsInstance->instance().module().moduleInformation().typeSignatures[typeIndex]->expand();
+    JSWebAssemblyInstance* jsInstance = instance->owner();
+    JSGlobalObject* globalObject = instance->globalObject();
+    const TypeDefinition& structTypeDefinition = instance->module().moduleInformation().typeSignatures[typeIndex]->expand();
     const StructType& structType = *structTypeDefinition.as<StructType>();
 
     JSWebAssemblyStruct* structValue = JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex);
@@ -178,7 +178,7 @@ inline EncodedJSValue structGet(EncodedJSValue encodedStructReference, uint32_t 
 
 inline void structSet(Instance* instance, EncodedJSValue encodedStructReference, uint32_t fieldIndex, EncodedJSValue argument)
 {
-    JSGlobalObject* globalObject = instance->owner<JSWebAssemblyInstance>()->globalObject();
+    JSGlobalObject* globalObject = instance->globalObject();
     auto structReference = JSValue::decode(encodedStructReference);
     ASSERT(structReference.isObject());
     JSObject* structureAsObject = jsCast<JSObject*>(structReference);
@@ -443,8 +443,8 @@ inline int32_t memoryAtomicNotify(Instance* instance, unsigned base, unsigned of
 
 inline void* throwWasmToJSException(CallFrame* callFrame, Wasm::ExceptionType type, Instance* wasmInstance)
 {
-    JSWebAssemblyInstance* instance = wasmInstance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = instance->globalObject();
+    JSWebAssemblyInstance* instance = wasmInstance->owner();
+    JSGlobalObject* globalObject = wasmInstance->globalObject();
 
     // Do not retrieve VM& from CallFrame since CallFrame's callee is not a JSCell.
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -804,8 +804,8 @@ WASM_SLOW_PATH_DECL(throw)
 {
     SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
+    JSWebAssemblyInstance* jsInstance = instance->owner();
+    JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -839,8 +839,8 @@ WASM_SLOW_PATH_DECL(rethrow)
 {
     SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
+    JSWebAssemblyInstance* jsInstance = instance->owner();
+    JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -867,8 +867,7 @@ WASM_SLOW_PATH_DECL(rethrow)
 WASM_SLOW_PATH_DECL(retrieve_and_clear_exception)
 {
     UNUSED_PARAM(callFrame);
-    JSWebAssemblyInstance* jsInstance = instance->owner<JSWebAssemblyInstance>();
-    JSGlobalObject* globalObject = jsInstance->globalObject();
+    JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "JSCJSValueInlines.h"
+#include "JSWebAssemblyTable.h"
 #include <wtf/CheckedArithmetic.h>
 #include <type_traits>
 

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -35,7 +35,11 @@
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
-namespace JSC { namespace Wasm {
+namespace JSC {
+
+class JSWebAssemblyTable;
+
+namespace Wasm {
 
 class Instance;
 class FuncRefTable;
@@ -55,8 +59,8 @@ public:
 
     static uint32_t allocatedLength(uint32_t length);
 
-    template<typename T> T* owner() const { return reinterpret_cast<T*>(m_owner); }
-    void setOwner(JSObject* owner)
+    JSWebAssemblyTable* owner() const { return m_owner; }
+    void setOwner(JSWebAssemblyTable* owner)
     {
         ASSERT(!m_owner);
         ASSERT(owner);
@@ -93,7 +97,7 @@ protected:
     uint32_t m_length;
     const TableElementType m_type;
     const std::optional<uint32_t> m_maximum;
-    JSObject* m_owner;
+    JSWebAssemblyTable* m_owner;
 };
 
 class ExternRefTable final : public Table {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -91,7 +91,7 @@ public:
 
     void linkGlobal(VM& vm, uint32_t index, JSWebAssemblyGlobal* value)
     {
-        ASSERT(value == value->global()->owner<JSWebAssemblyGlobal>());
+        ASSERT(value == value->global()->owner());
         instance().linkGlobal(index, *value->global());
         vm.writeBarrier(this, value);
     }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -155,7 +155,7 @@ Expected<void, Wasm::BindingFailure> JSWebAssemblyModule::generateWasmToJSStubs(
         FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> stubs(moduleInformation.importFunctionCount());
         for (unsigned importIndex = 0; importIndex < moduleInformation.importFunctionCount(); ++importIndex) {
             Wasm::TypeIndex typeIndex = moduleInformation.importFunctionTypeIndices.at(importIndex);
-            auto binding = Wasm::wasmToJS(vm, callLinkInfos[importIndex], typeIndex, importIndex);
+            auto binding = Wasm::wasmToJS(vm, m_module->wasmToJSCallee(), callLinkInfos[importIndex], typeIndex, importIndex);
             if (UNLIKELY(!binding))
                 return makeUnexpected(binding.error());
             stubs[importIndex] = binding.value();

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.h
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.h
@@ -41,8 +41,9 @@ class VM;
 namespace Wasm {
 
 class Instance;
+class WasmToJSCallee;
 
-Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM&, OptimizingCallLinkInfo&, TypeIndex, unsigned importIndex);
+Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM&, WasmToJSCallee&, OptimizingCallLinkInfo&, TypeIndex, unsigned importIndex);
 
 void emitThrowWasmToJSException(CCallHelpers&, GPRReg wasmInstance, Wasm::ExceptionType);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -230,7 +230,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             auto* info = m_instance->instance().importFunctionInfo(import.kindIndex);
             info->targetInstance = calleeInstance;
             info->wasmEntrypointLoadLocation = entrypointLoadLocation;
-            m_instance->instance().importFunction<WriteBarrier<JSObject>>(import.kindIndex)->set(vm, m_instance.get(), function);
+            m_instance->instance().importFunction(import.kindIndex).set(vm, m_instance.get(), function);
             break;
         }
 
@@ -501,7 +501,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         //   i. If there is an Exported Function Exotic Object func in funcs whose func.[[Closure]] equals c, then return func.
         //   ii. (Note: At most one wrapper is created for any closure, so func is unique, even if there are multiple occurrances in the list. Moreover, if the item was an import that is already an Exported Function Exotic Object, then the original function object will be found. For imports that are regular JS functions, a new wrapper will be created.)
         if (index < functionImportCount) {
-            JSObject* functionImport = m_instance->instance().importFunction<WriteBarrier<JSObject>>(index)->get();
+            JSObject* functionImport = m_instance->instance().importFunction(index).get();
             if (isWebAssemblyHostFunction(functionImport))
                 wrapper = functionImport;
             else {
@@ -650,8 +650,8 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                     ASSERT(globalRef->type() == global.type);
                     ASSERT(globalRef->mutability() == global.mutability);
                     ASSERT(globalRef->mutability() == Wasm::Mutability::Mutable);
-                    ASSERT(globalRef->owner<JSWebAssemblyGlobal>());
-                    exportedValue = globalRef->owner<JSWebAssemblyGlobal>();
+                    ASSERT(globalRef->owner());
+                    exportedValue = globalRef->owner();
                 }
                 break;
             }
@@ -695,7 +695,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         ASSERT(!signature.argumentCount());
         ASSERT(signature.returnsVoid());
         if (startFunctionIndexSpace < calleeGroup->functionImportCount()) {
-            JSObject* startFunction = m_instance->instance().importFunction<WriteBarrier<JSObject>>(startFunctionIndexSpace)->get();
+            JSObject* startFunction = m_instance->instance().importFunction(startFunctionIndexSpace).get();
             m_startFunction.set(vm, this, startFunction);
         } else {
             Wasm::Callee& embedderEntrypointCallee = calleeGroup->embedderEntrypointCalleeFromFunctionIndexSpace(startFunctionIndexSpace);


### PR DESCRIPTION
#### db4b9bc6dd3c7674361afb564cd6c1a06c0ccd00
<pre>
[JSC] Clean up WasmToJS
<a href="https://bugs.webkit.org/show_bug.cgi?id=250966">https://bugs.webkit.org/show_bug.cgi?id=250966</a>
rdar://104523769

Reviewed by Tadeu Zagallo.

This patch fixes terrible hack in WasmToJS where we are setting JSWebAssemblyInstance to |callee| slot.

1. We should use Wasm::Callee since this is wasm code. This patch adds WasmToJSCallee and materialize this.
   We also puts Wasm::Instance* in |codeBlock| slot too so that operation function from this code can get
   Wasm::Instance*.
2. Remove indirection of types of owners. We should tightly couple JSC with wasm engine.
3. Put JSGlobalObject* in Wasm::Instance* to make WasmToJS code simpler and efficient.
4. Remove CallFrame::isAnyWasmCallee. Now all Wasm frames have Wasm::Callee*. So this hack is no longer necessary.

* JSTests/stress/sampling-profiler-wasm-name-section.js:
(platformSupportsSamplingProfiler.vm.isWasmSupported):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::noticeIncomingCall):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkMonomorphicCall):
(JSC::linkVirtualFor):
(JSC::linkPolymorphicCall):
* Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp:
(JSC::DebuggerCallFrame::scope):
(JSC::DebuggerCallFrame::thisValue const):
(JSC::DebuggerCallFrame::evaluateWithScopeExtension):
(JSC::DebuggerCallFrame::sourceIDForCallFrame):
* Source/JavaScriptCore/dfg/DFGDoesGCCheck.cpp:
(JSC::DFG::DoesGCCheck::verifyCanGC):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::functionName):
* Source/JavaScriptCore/interpreter/CallFrame.cpp:
(JSC::CallFrame::friendlyFunctionName):
(JSC::CallFrame::dump const):
(JSC::CallFrame::lexicalGlobalObjectFromWasmCallee const):
(JSC::CallFrame::isAnyWasmCallee const): Deleted.
* Source/JavaScriptCore/interpreter/CallFrame.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::UnwindFunctor::notifyDebuggerOfUnwinding):
(JSC::Interpreter::unwind):
* Source/JavaScriptCore/interpreter/ShadowChicken.cpp:
(JSC::ShadowChicken::update):
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::readFrame):
(JSC::StackVisitor::readNonInlinedFrame):
(JSC::StackVisitor::Frame::calleeSaveRegistersForUnwinding):
* Source/JavaScriptCore/jit/JITExceptions.cpp:
(JSC::genericUnwind):
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallStubRoutine::PolymorphicCallStubRoutine):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::getCallerCodeBlock):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::throwException):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::invalidateCodeBlocksOnStack):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::dumpRegisters):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
(JSC::Wasm::WasmToJSCallee::WasmToJSCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCompilationMode.cpp:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isOSREntry):
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
* Source/JavaScriptCore/wasm/WasmGlobal.h:
* Source/JavaScriptCore/wasm/WasmInstance.cpp:
(JSC::Wasm::Instance::Instance):
(JSC::Wasm::Instance::create):
(JSC::Wasm::Instance::setGlobal):
(JSC::Wasm::Instance::setFunctionWrapper):
(JSC::Wasm::Instance::initElementSegment):
* Source/JavaScriptCore/wasm/WasmInstance.h:
(JSC::Wasm::Instance::setOwner):
(JSC::Wasm::Instance::owner const):
(JSC::Wasm::Instance::offsetOfGlobalObject):
(JSC::Wasm::Instance::globalObject const):
(JSC::Wasm::Instance::allocationSize):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::Module):
* Source/JavaScriptCore/wasm/WasmModule.h:
(JSC::Wasm::Module::wasmToJSCallee):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::structNew):
(JSC::Wasm::structSet):
(JSC::Wasm::throwWasmToJSException):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::Table::owner const):
(JSC::Wasm::Table::setOwner):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::generateWasmToJSStubs):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::handleBadImportTypeUse):
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WasmToJS.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/259216@main">https://commits.webkit.org/259216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/327ecd4d67756e34aee54fff17b851ea66b0d113

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113506 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173795 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4295 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112551 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38791 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80459 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94297 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27170 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92186 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4516 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3728 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29974 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46728 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/100869 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6355 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8660 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25034 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->