### PR TITLE
[web-animations] make offset-rotate blending functions public

### DIFF
--- a/Source/WebCore/rendering/style/OffsetRotation.cpp
+++ b/Source/WebCore/rendering/style/OffsetRotation.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "OffsetRotation.h"
 
+#include "AnimationUtilities.h"
+#include <wtf/MathExtras.h>
+
 namespace WebCore {
 
 OffsetRotation::OffsetRotation(bool hasAuto, float angle)
@@ -37,6 +40,22 @@ OffsetRotation::OffsetRotation(bool hasAuto, float angle)
 bool OffsetRotation::operator==(const OffsetRotation& o) const
 {
     return m_hasAuto == o.m_hasAuto && m_angle == o.m_angle;
+}
+
+bool OffsetRotation::canBlend(const OffsetRotation& to) const
+{
+    return m_hasAuto == to.hasAuto();
+}
+
+OffsetRotation OffsetRotation::blend(const OffsetRotation& to, const BlendingContext& context) const
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1.0);
+        return context.progress ? to : *this;
+    }
+
+    ASSERT(canBlend(to));
+    return OffsetRotation(m_hasAuto, clampTo<float>(WebCore::blend(m_angle, to.angle(), context)));
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const OffsetRotation& rotation)

--- a/Source/WebCore/rendering/style/OffsetRotation.h
+++ b/Source/WebCore/rendering/style/OffsetRotation.h
@@ -29,12 +29,17 @@
 
 namespace WebCore {
 
+struct BlendingContext;
+
 class OffsetRotation {
 public:
     OffsetRotation(bool hasAuto = false, float angle = 0);
 
     bool hasAuto() const { return m_hasAuto; }
     float angle() const { return m_angle; }
+
+    bool canBlend(const OffsetRotation&) const;
+    OffsetRotation blend(const OffsetRotation&, const BlendingContext&) const;
 
     bool operator==(const OffsetRotation&) const;
     bool operator!=(const OffsetRotation& o) const { return !(*this == o); }


### PR DESCRIPTION
#### b70c536fec72b75791aefcad62bcad68fddac011
<pre>
[web-animations] make offset-rotate blending functions public
<a href="https://bugs.webkit.org/show_bug.cgi?id=250971">https://bugs.webkit.org/show_bug.cgi?id=250971</a>
rdar://104526186

Reviewed by Tim Nguyen.

To support the work towards running accelerated animations in a separate thread, we must
make the offset-rotate blending code accessible outside of CSSPropertyAnimation.cpp.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/OffsetRotation.cpp:
(WebCore::OffsetRotation::canBlend const):
(WebCore::OffsetRotation::blend const):
* Source/WebCore/rendering/style/OffsetRotation.h:

Canonical link: <a href="https://commits.webkit.org/259192@main">https://commits.webkit.org/259192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df50bc05a1f2183f14b9a19cf13e2ce33c4e1ccc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113527 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173816 "Failed to checkout and rebase branch from PR 8948") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4314 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96535 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110082 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6759 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/6892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/12910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8679 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3353 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->