### PR TITLE
[web-animations] make offset-path blending functions public

### DIFF
--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PathOperation.h"
 
+#include "AnimationUtilities.h"
 #include "GeometryUtilities.h"
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
@@ -68,6 +69,20 @@ const SVGElement* ReferencePathOperation::element() const
 Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining, FloatRect&& containingBlockBoundingRect, FloatPoint&& position)
 {
     return adoptRef(*new RayPathOperation(angle, size, isContaining, WTFMove(containingBlockBoundingRect), WTFMove(position)));
+}
+
+bool RayPathOperation::canBlend(const PathOperation& to) const
+{
+    if (auto* toRayPathOperation = dynamicDowncast<RayPathOperation>(to))
+        return m_size == toRayPathOperation->size() && m_isContaining == toRayPathOperation->isContaining();
+    return false;
+}
+
+RefPtr<PathOperation> RayPathOperation::blend(const PathOperation* to, const BlendingContext& context) const
+{
+    ASSERT(is<RayPathOperation>(to));
+    auto& toRayPathOperation = downcast<RayPathOperation>(*to);
+    return RayPathOperation::create(WebCore::blend(m_angle, toRayPathOperation.angle(), context), m_size, m_isContaining);
 }
 
 double RayPathOperation::lengthForPath() const

--- a/Source/WebCore/rendering/style/ShapeValue.cpp
+++ b/Source/WebCore/rendering/style/ShapeValue.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ShapeValue.h"
 
+#include "AnimationUtilities.h"
 #include "CachedImage.h"
 #include <wtf/PointerComparison.h>
 
@@ -48,6 +49,26 @@ bool ShapeValue::operator==(const ShapeValue& other) const
         && m_cssBox == other.m_cssBox
         && arePointingToEqualData(m_shape, other.m_shape)
         && arePointingToEqualData(m_image, other.m_image);
+}
+
+bool ShapeValue::canBlend(const ShapeValue& to) const
+{
+    if (m_type != ShapeValue::Type::Shape || to.type() != ShapeValue::Type::Shape)
+        return false;
+
+    if (m_cssBox != to.cssBox())
+        return false;
+
+    if (auto* toShape = to.shape())
+        return m_shape && m_shape->canBlend(*toShape);
+
+    return false;
+}
+
+Ref<ShapeValue> ShapeValue::blend(const ShapeValue& to, const BlendingContext& context) const
+{
+    ASSERT(m_shape && to.shape());
+    return ShapeValue::create(to.shape()->blend(*m_shape, context), m_cssBox);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/ShapeValue.h
+++ b/Source/WebCore/rendering/style/ShapeValue.h
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+struct BlendingContext;
+
 class ShapeValue : public RefCounted<ShapeValue> {
 public:
     static Ref<ShapeValue> create(Ref<BasicShape>&& shape, CSSBoxType cssBox)
@@ -65,6 +67,9 @@ public:
         ASSERT(m_type == Type::Image);
         m_image = WTFMove(image);
     }
+
+    bool canBlend(const ShapeValue&) const;
+    Ref<ShapeValue> blend(const ShapeValue&, const BlendingContext&) const;
 
     bool operator==(const ShapeValue&) const;
     bool operator!=(const ShapeValue& other) const


### PR DESCRIPTION
#### 4615c0fe336d68c2840dcd6c5d251e25b3cba698
<pre>
[web-animations] make offset-path blending functions public
<a href="https://bugs.webkit.org/show_bug.cgi?id=250972">https://bugs.webkit.org/show_bug.cgi?id=250972</a>
rdar://104526180

Reviewed by Dean Jackson.

To support the work towards running accelerated animations in a separate thread, we
must make the offset-path blending code accessible outside of CSSPropertyAnimation.cpp.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::RayPathOperation::canBlend const):
(WebCore::RayPathOperation::blend const):
* Source/WebCore/rendering/PathOperation.h:
(WebCore::PathOperation::canBlend const):
(WebCore::PathOperation::blend const):
* Source/WebCore/rendering/style/ShapeValue.cpp:
(WebCore::ShapeValue::canBlend const):
(WebCore::ShapeValue::blend const):
* Source/WebCore/rendering/style/ShapeValue.h:

Canonical link: <a href="https://commits.webkit.org/259223@main">https://commits.webkit.org/259223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc87409e4bdd49955e97279f23f892f8b69d315f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113528 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173818 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4315 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96536 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112572 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94222 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38810 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6760 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27190 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3746 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46748 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8680 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3359 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->