### PR TITLE
[web-animations] make filter and backdrop-filter blending functions public

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+struct BlendingContext;
+
 class FilterOperations {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -60,6 +62,8 @@ public:
 
     bool transformColor(Color&) const;
     bool inverseTransformColor(Color&) const;
+
+    WEBCORE_EXPORT FilterOperations blend(const FilterOperations&, const BlendingContext&) const;
 
 private:
     Vector<RefPtr<FilterOperation>> m_operations;


### PR DESCRIPTION
#### 39c795e3ca1754e5e205d8c88357fe7349c4abf9
<pre>
[web-animations] make filter and backdrop-filter blending functions public
<a href="https://bugs.webkit.org/show_bug.cgi?id=250973">https://bugs.webkit.org/show_bug.cgi?id=250973</a>
rdar://104526202

Reviewed by Dean Jackson.

To support the work towards running accelerated animations in a separate thread, we must make
the filter and backdrop-filter blending code accessible outside of CSSPropertyAnimation.cpp.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::blendFilter):
(WebCore::blendFilterOperations): Deleted.
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::blend const):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:

Canonical link: <a href="https://commits.webkit.org/259224@main">https://commits.webkit.org/259224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/363b7a25646644f73dcdc4af423bd3fff93acc92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113511 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173800 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4300 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112556 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80463 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27174 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6879 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3732 "Found 1 new test failure: media/video-src-blob-replay.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46732 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8665 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3360 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->