### PR TITLE
Move style build time functions from CSSParser to Style::Builder

### DIFF
--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -28,7 +28,6 @@
 #include "config.h"
 #include "CSSParser.h"
 
-#include "CSSCustomPropertyValue.h"
 #include "CSSKeyframeRule.h"
 #include "CSSParserFastPaths.h"
 #include "CSSParserImpl.h"
@@ -36,23 +35,16 @@
 #include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserHelpers.h"
-#include "CSSRegisteredCustomProperty.h"
 #include "CSSSelectorParser.h"
 #include "CSSSupportsParser.h"
 #include "CSSTokenizer.h"
 #include "CSSValuePool.h"
-#include "CSSVariableData.h"
-#include "CSSVariableReferenceValue.h"
-#include "CustomPropertyRegistry.h"
 #include "Document.h"
 #include "Element.h"
 #include "Page.h"
-#include "RenderStyle.h"
 #include "RenderTheme.h"
 #include "Settings.h"
-#include "StyleBuilder.h"
 #include "StyleColor.h"
-#include "StyleResolver.h"
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
 #include <wtf/NeverDestroyed.h>
@@ -189,75 +181,6 @@ bool CSSParser::parseDeclaration(MutableStyleProperties& declaration, const Stri
 void CSSParser::parseDeclarationForInspector(const CSSParserContext& context, const String& string, CSSParserObserver& observer)
 {
     CSSParserImpl::parseDeclarationListForInspector(string, context, observer);
-}
-
-RefPtr<CSSValue> CSSParser::parseValueWithVariableReferences(CSSPropertyID propID, const CSSValue& value, Style::BuilderState& builderState)
-{
-    if (is<CSSPendingSubstitutionValue>(value)) {
-        // FIXME: Should have a resolvedShorthands cache to stop this from being done over and over for each longhand value.
-        auto& substitution = downcast<CSSPendingSubstitutionValue>(value);
-
-        auto shorthandID = substitution.shorthandPropertyId();
-
-        auto resolvedData = substitution.shorthandValue().resolveVariableReferences(builderState);
-        if (!resolvedData)
-            return nullptr;
-
-        ParsedPropertyVector parsedProperties;
-        if (!CSSPropertyParser::parseValue(shorthandID, false, resolvedData->tokens(), substitution.shorthandValue().context(), parsedProperties, StyleRuleType::Style))
-            return nullptr;
-
-        for (auto& property : parsedProperties) {
-            if (property.id() == propID)
-                return property.value();
-        }
-
-        return nullptr;
-    }
-
-    const CSSVariableReferenceValue& valueWithReferences = downcast<CSSVariableReferenceValue>(value);
-    auto resolvedData = valueWithReferences.resolveVariableReferences(builderState);
-    if (!resolvedData)
-        return nullptr;
-
-    return CSSPropertyParser::parseSingleValue(propID, resolvedData->tokens(), valueWithReferences.context());
-}
-
-RefPtr<CSSCustomPropertyValue> CSSParser::parseCustomPropertyValueWithVariableReferences(const CSSCustomPropertyValue& value, Style::BuilderState& builderState)
-{
-    const auto& customPropValue = downcast<CSSCustomPropertyValue>(value);
-    const auto& valueWithReferences = std::get<Ref<CSSVariableReferenceValue>>(customPropValue.value()).get();
-
-    auto& name = downcast<CSSCustomPropertyValue>(value).name();
-    auto* registered = builderState.document().customPropertyRegistry().get(name);
-    auto& syntax = registered ? registered->syntax : CSSCustomPropertySyntax::universal();
-
-    auto resolvedData = valueWithReferences.resolveVariableReferences(builderState);
-    if (!resolvedData)
-        return nullptr;
-
-    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(syntax, resolvedData->tokens(), valueWithReferences.context());
-
-    // https://drafts.css-houdini.org/css-properties-values-api/#dependency-cycles
-    bool hasCycles = false;
-    auto checkForCycles = [&](auto& propertyDependencies) {
-        for (auto property : propertyDependencies) {
-            if (builderState.inProgressProperties().get(property)) {
-                builderState.inUnitCycleProperties().set(property);
-                hasCycles = true;
-            }
-        }
-    };
-
-    checkForCycles(dependencies.properties);
-
-    if (builderState.element() == builderState.document().documentElement())
-        checkForCycles(dependencies.rootProperties);
-
-    if (hasCycles)
-        return nullptr;
-
-    return CSSPropertyParser::parseTypedCustomPropertyValue(AtomString { name }, syntax, resolvedData->tokens(), builderState, valueWithReferences.context());
 }
 
 Vector<double> CSSParser::parseKeyframeKeyList(const String& selector)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -31,7 +31,6 @@
 
 namespace WebCore {
 
-class CSSCustomPropertyValue;
 class CSSParserObserver;
 class CSSSelectorList;
 class CSSValueList;
@@ -43,14 +42,9 @@ class MutableStyleProperties;
 class StyleRuleBase;
 class StyleRuleKeyframe;
 class StyleSheetContents;
-class RenderStyle;
 
 namespace CSSPropertyParserHelpers {
 struct FontRaw;
-}
-
-namespace Style {
-class BuilderState;
 }
 
 class CSSParser {
@@ -85,9 +79,6 @@ public:
     static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element*);
 
     WEBCORE_EXPORT std::optional<CSSSelectorList> parseSelector(const String&, StyleSheetContents* = nullptr, CSSSelectorParser::IsNestedContext = CSSSelectorParser::IsNestedContext::No);
-
-    RefPtr<CSSValue> parseValueWithVariableReferences(CSSPropertyID, const CSSValue&, Style::BuilderState&);
-    RefPtr<CSSCustomPropertyValue> parseCustomPropertyValueWithVariableReferences(const CSSCustomPropertyValue&, Style::BuilderState&);
 
     WEBCORE_EXPORT static Color parseColor(const String&, const CSSParserContext&);
     // FIXME: All callers are not getting the right Settings for parsing due to lack of CSSParserContext and should switch to the parseColor function above.

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -108,9 +108,6 @@ public:
 
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
 
-    auto& inProgressProperties() const { return m_inProgressProperties; }
-    auto& inUnitCycleProperties() { return m_inUnitCycleProperties; }
-
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.
     friend void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);


### PR DESCRIPTION
#### fe6107c38245cb617a14c3d96783dcc96b6702ab
<pre>
Move style build time functions from CSSParser to Style::Builder
<a href="https://bugs.webkit.org/show_bug.cgi?id=250980">https://bugs.webkit.org/show_bug.cgi?id=250980</a>

Reviewed by Alan Baradlay.

They don&apos;t really belong to the CSS parser.

* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseValueWithVariableReferences): Deleted.
(WebCore::CSSParser::parseCustomPropertyValueWithVariableReferences): Deleted.

The code in these functions moves to their only callers.
CSSParser does not depend on the style builder state anymore.

* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveVariableReferences):
(WebCore::Style::Builder::resolveCustomPropertyValueWithVariableReferences):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::inProgressProperties const): Deleted.
(WebCore::Style::BuilderState::inUnitCycleProperties): Deleted.

These can be private to the style builder.

Canonical link: <a href="https://commits.webkit.org/259191@main">https://commits.webkit.org/259191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad433ccef5a54a9203907129a9c0c3a64c0eedf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113518 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4306 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96527 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112563 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94214 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25825 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3738 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6328 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8670 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->