### PR TITLE
Nullptr crash under CustomPropertyRegistry::registerFromStylesheet

### DIFF
--- a/LayoutTests/fast/css/at-property-registration-crash-expected.txt
+++ b/LayoutTests/fast/css/at-property-registration-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/at-property-registration-crash.html
+++ b/LayoutTests/fast/css/at-property-registration-crash.html
@@ -1,0 +1,18 @@
+<style>
+  @property --a {
+    syntax: 'foo';
+    inherits: false;
+    initial-value: foo;
+  }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  onload = () => {
+    document.open();
+    document.createElement('div').style.width = '0';
+    document.write("This test passes if it doesn't crash.");
+  };
+</script>
+

--- a/Source/WebCore/style/CustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/CustomPropertyRegistry.cpp
@@ -106,10 +106,11 @@ void CustomPropertyRegistry::registerFromStylesheet(const StyleRuleProperty::Des
         if (!dependencies.isEmpty())
             return nullptr;
 
-        auto style = RenderStyle::clone(*m_scope.resolver().rootDefaultStyle());
-        Style::Builder dummyBuilder(style, { document, style }, { }, { });
+        // We don't need to provide a real context style since only computationally independent values are allowed (no 'em' etc).
+        auto placeholderStyle = RenderStyle::create();
+        Style::Builder builder { placeholderStyle, { document, RenderStyle::defaultStyle() }, { }, { } };
 
-        return CSSPropertyParser::parseTypedCustomPropertyInitialValue(descriptor.name, *syntax, tokenRange, dummyBuilder.state(), { document });
+        return CSSPropertyParser::parseTypedCustomPropertyInitialValue(descriptor.name, *syntax, tokenRange, builder.state(), { document });
     }();
 
     if (!initialValue)


### PR DESCRIPTION
#### 9b2b18b8126202d1797a448492781b9242d3ba77
<pre>
Nullptr crash under CustomPropertyRegistry::registerFromStylesheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=250981">https://bugs.webkit.org/show_bug.cgi?id=250981</a>
rdar://104474736

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/at-property-registration-crash-expected.txt: Added.
* LayoutTests/fast/css/at-property-registration-crash.html: Added.
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):

Use the default style instead of getting the root style from the style resolver.
It might not exist yet and is not needed to resolve computationally independent values.

Canonical link: <a href="https://commits.webkit.org/259188@main">https://commits.webkit.org/259188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cd7c374d80c1cfb565b9cc99e9dc799431a0126

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113521 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4308 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112565 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11148 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93010 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6753 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6886 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12904 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6333 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8673 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->