### PR TITLE
Factor out shorthand serialization into its own class

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1720,18 +1720,18 @@
         "border": {
             "codegen-properties": {
                 "longhands": [
-                    "border-top-color",
-                    "border-top-style",
                     "border-top-width",
-                    "border-right-color",
-                    "border-right-style",
                     "border-right-width",
-                    "border-bottom-color",
-                    "border-bottom-style",
                     "border-bottom-width",
-                    "border-left-color",
-                    "border-left-style",
                     "border-left-width",
+                    "border-top-style",
+                    "border-right-style",
+                    "border-bottom-style",
+                    "border-left-style",
+                    "border-top-color",
+                    "border-right-color",
+                    "border-bottom-color",
+                    "border-left-color",
                     "border-image-source",
                     "border-image-slice",
                     "border-image-width",
@@ -1747,12 +1747,12 @@
         "border-block": {
             "codegen-properties": {
                 "longhands": [
-                    "border-block-start-color",
-                    "border-block-start-style",
                     "border-block-start-width",
-                    "border-block-end-color",
+                    "border-block-end-width",
+                    "border-block-start-style",
                     "border-block-end-style",
-                    "border-block-end-width"
+                    "border-block-start-color",
+                    "border-block-end-color"
                 ]
             },
             "specification": {
@@ -2247,12 +2247,12 @@
         "border-inline": {
             "codegen-properties": {
                 "longhands": [
-                    "border-inline-start-color",
-                    "border-inline-start-style",
                     "border-inline-start-width",
-                    "border-inline-end-color",
+                    "border-inline-end-width",
+                    "border-inline-start-style",
                     "border-inline-end-style",
-                    "border-inline-end-width"
+                    "border-inline-start-color",
+                    "border-inline-end-color"
                 ]
             },
             "specification": {

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -71,19 +71,4 @@ constexpr bool isShorthandCSSProperty(CSSPropertyID id)
     return id >= firstShorthandProperty && id <= lastShorthandProperty;
 }
 
-constexpr std::pair<CSSPropertyID, CSSValueID> fontShorthandSubpropertiesResetToInitialValues[] = {
-    { CSSPropertyFontSizeAdjust, CSSValueNone },
-    { CSSPropertyFontKerning, CSSValueAuto },
-    { CSSPropertyFontVariantAlternates, CSSValueNormal },
-    { CSSPropertyFontVariantLigatures, CSSValueNormal },
-    { CSSPropertyFontVariantNumeric, CSSValueNormal },
-    { CSSPropertyFontVariantEastAsian, CSSValueNormal },
-    { CSSPropertyFontVariantPosition, CSSValueNormal },
-    { CSSPropertyFontFeatureSettings, CSSValueNormal },
-#if ENABLE(VARIATION_FONTS)
-    { CSSPropertyFontOpticalSizing, CSSValueAuto },
-    { CSSPropertyFontVariationSettings, CSSValueNormal },
-#endif
-};
-
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -623,13 +623,14 @@ bool CSSPropertyParser::consumeFont(bool important)
 
     auto range = m_range;
 
-    RefPtr<CSSValue> fontStyle;
-    RefPtr<CSSValue> fontVariantCaps;
-    RefPtr<CSSValue> fontWeight;
-    RefPtr<CSSValue> fontStretch;
-    RefPtr<CSSValue> fontSize;
-    RefPtr<CSSValue> lineHeight;
-    RefPtr<CSSValue> fontFamily;
+    RefPtr<CSSValue> values[7];
+    auto& fontStyle = values[0];
+    auto& fontVariantCaps = values[1];
+    auto& fontWeight = values[2];
+    auto& fontStretch = values[3];
+    auto& fontSize = values[4];
+    auto& lineHeight = values[5];
+    auto& fontFamily = values[6];
 
     // Optional font-style, font-variant, font-stretch and font-weight, in any order.
     for (unsigned i = 0; i < 4 && !range.atEnd(); ++i) {
@@ -667,29 +668,10 @@ bool CSSPropertyParser::consumeFont(bool important)
     if (!fontFamily || !range.atEnd())
         return false;
 
-    auto reset = [&] (CSSPropertyID property, CSSValueID initialValue) {
-        ASSERT(initialValue != CSSValueInvalid);
-        addProperty(property, CSSPropertyFont, CSSPrimitiveValue::create(initialValue), important, true);
-    };
-    auto add = [&] (CSSPropertyID property, RefPtr<CSSValue>& value) {
-        if (value)
-            addProperty(property, CSSPropertyFont, value.releaseNonNull(), important);
-        else
-            reset(property, CSSValueNormal);
-    };
-
-    // This must be in the same order as the list of shorthands in CSSProperties.json.
-    add(CSSPropertyFontStyle, fontStyle);
-    add(CSSPropertyFontVariantCaps, fontVariantCaps);
-    add(CSSPropertyFontWeight, fontWeight);
-    add(CSSPropertyFontStretch, fontStretch);
-    add(CSSPropertyFontSize, fontSize);
-    add(CSSPropertyLineHeight, lineHeight);
-    add(CSSPropertyFontFamily, fontFamily);
-    for (auto [property, initialValue] : fontShorthandSubpropertiesResetToInitialValues)
-        reset(property, initialValue);
-
     m_range = range;
+    auto shorthand = fontShorthand();
+    for (unsigned i = 0; i < shorthand.length(); ++i)
+        addProperty(shorthand.properties()[i], CSSPropertyFont, i < std::size(values) ? WTFMove(values[i]) : nullptr, important, true);
     return true;
 }
 


### PR DESCRIPTION
#### 66b28324b8b97037caca3b9f1c9d2f724abaaf7d
<pre>
Factor out shorthand serialization into its own class
<a href="https://bugs.webkit.org/show_bug.cgi?id=250953">https://bugs.webkit.org/show_bug.cgi?id=250953</a>
rdar://problem/104517006

Reviewed by Oriol Brufau.

Factoring out shorthand serialization into a separate class and breaking it out of StyleProperties
has a few benefits:

- Moves details of shorthand serialization out of StyleProperties.h; these are no longer private
members of StyleProperties class.
- Reorganizes shorthand serialization so longhand property values are gathered during the common
checks. This means we won&apos;t repeatedly search style properties for the same properties.
- Prepares for moving shorthand serialization into a separate file, making StyleProperties.cpp
a more manageable size.
- Prepares for sharing shorthand serialization with computed style. We don&apos;t need to repeat all
this logic twice the way we do today. However, computed style has a WebKit-only feature where it
will produce CSS values for shorthands; we have to decide whether to remove that entirely or at
least remove if for most shorthand properties. Shorthands don&apos;t need to be expressible as CSS
values; they are a parsing and serialization format and don&apos;t have a specified object model.

Also made a small number of other minor improvements to StyleProperties.

* Source/WebCore/css/CSSProperties.json: Reordered the longhands in border, border-block, and
border-inline so they are in serialization order: width, style, color. The new serialization code
depends on this, and it&apos;s also a logical order.

* Source/WebCore/css/StyleProperties.cpp: Updated the maxShorthandLength constant, which was
incorrect. It&apos;s still a good idea to generate it and we should do that in a future change.
(WebCore::isCSSWideValueKeyword): Deleted.
(WebCore::isValueIDIncludingList): Removed an unused overload.
(WebCore::serializeLonghandValue): Renamed from textExpandingInitialValuePlaceholder and moved
the special logic for opacity properties in here. Also added an overload that takes a pointer.
(WebCore::ShorthandSerializer::commonSerializationChecks): Renamed from
SyleProperties::commonShorthandChecks. Assert length is not zero since ShorthandSerializer must
only be used for shorthands. Use a boolean return value instead of using empty string and null
string to express the two different outcomes. Store all the values in m_longhandValues as we check
them. Also added the m_gridTemplateAreasWasSetFromShorthand logic.
(WebCore::StyleProperties::serializeLonghandValue const): Added. Uses serializeLonghandValue and
getPropertyCSSValue.
(WebCore::StyleProperties::serializeShorthandValue const): Added. Uses ShorthandSerializer.
(WebCore::StyleProperties::getPropertyValue const): Use serializeLonghandValue and
serializeShorthandValue.
(WebCore::ShorthandSerializer::ShorthandSerializer): Added.
(WebCore::ShorthandSerializer::longhandProperty const): Added.
(WebCore::ShorthandSerializer::longhandValue const): Added.
(WebCore::ShorthandSerializer::serializeValue): Added.
(WebCore::ShorthandSerializer::isInitialValue): Added.
(WebCore::ShorthandSerializer::longhandIndex const): Added.
(WebCore::ShorthandSerializer::longhandValueID const): Added.
(WebCore::ShorthandSerializer::serializeLonghandValue const): Added.
(WebCore::ShorthandSerializer::serialize): Added. Moved the large switch statment from
StyleProperties::getPropertyValue in here. Besides name changes, changed serialization specifics:
for &quot;all&quot;, don&apos;t try to find a common value, since the only ones are the CSS-wide keywords already
handled by the common serialization checks. For border, border-block, and border-inline, pass in
the size of each section of the shorthand, allowing us to simplify the shared code. For container,
use serializeLonghandsOmittingTrailingInitialValue. For flex and perspective-origin, use
serializeLonghands. for transform-origin, use serializeLonghandsOmittingTrailingInitialValue.
(WebCore::StyleProperties::propertyAsColor const): Use serializeLonghandValue.
(WebCore::ShorthandSerializer::serializeFont const): Get longhand values by index. Use makeString.
(WebCore::ShorthandSerializer::serializeOffset const): Ditto.
(WebCore::ShorthandSerializer::serializeFontVariant const): Use
serializeLonghandsOmittingInitialValues after doing some additional needed checks.
(WebCore::ShorthandSerializer::serializeFontSynthesis const): Get longhand values by index.
Use ASCII literals instead of StringBuilder.
(WebCore::ShorthandSerializer::serializePair const): Get longhand values by index.
(WebCore::ShorthandSerializer::serializeQuad const): Ditto.
(WebCore::LayerValues::serialize const): Use serializeLonghandValue.
(WebCore::ShorthandSerializer::serializeLayered const): Get longhand values by index.
(WebCore::ShorthandSerializer::serializeGridTemplate const): Ditto.
(WebCore::gridAutoFlowContains): Argument type is now CSSValue&amp;.
(WebCore::ShorthandSerializer::serializeGrid const): Get longhand values by index. Use makeString.
(WebCore::ShorthandSerializer::serializeGridRowColumn const): Use serializeLonghands.
(WebCore::ShorthandSerializer::serializeGridArea const): Ditto.
(WebCore::ShorthandSerializer::serializeLonghands const): Added. This is like
StyleProperties::getShorthandValue was, but does not omit initial values and is more versatile
since it can be used to serialize only some properties up to a limit. Also use makeString for
common short lengths.
(WebCore::ShorthandSerializer::serializeLonghandsOmittingInitialValues const): This is the new
name for StyleProperties::getShorthandValue.
(WebCore::ShorthandSerializer::serializeLonghandsOmittingTrailingInitialValue const): Added.
Convenient for cases where the last value is optional, but other values are not.
(WebCore::ShorthandSerializer::serializeCommonValue const): Removed unneeded code to handle
missing longhands; that&apos;s checked by commonSerializationChecks. Refactored into two functions,
so this can be used on a subset of the shorthand or the whole thing.
(WebCore::ShorthandSerializer::serializeBorderImage const): Get longhand values by index.
(WebCore::ShorthandSerializer::serializeBorderRadius const): Ditto.
(WebCore::ShorthandSerializer::serializeBorder const): Use a new approach where we serialize
these border-related shorthands by section. Get longhand values by index. Use
serializeCommonValue and subsequentLonghandsHaveInitialValues.
(WebCore::ShorthandSerializer::serializeBreakInside const): Use longhandValueID.
(WebCore::ShorthandSerializer::serializePageBreak const): Ditto.
(WebCore::ShorthandSerializer::serializeColumnBreak const): Ditto.
(WebCore::ShorthandSerializer::subsequentLonghandsHaveInitialValues const): Replaces
hasAllInitialValues.
(WebCore::MutableStyleProperties::removeShorthandProperty): Added a returnText argument so we can
implement the return value for shorthands here. Still using a FIXME for this for now, we&apos;ll make
that change separately.
(WebCore::MutableStyleProperties::removePropertyAtIndex): Added. Helps factor out common
code and give us slightly better efficiency. Also use null string to mean no result rather
than empty string.
(WebCore::MutableStyleProperties::removeLonghandProperty): Added. Calls findPropertyIndex and
removePropertyAtIndex.
(WebCore::MutableStyleProperties::removeProperty): Call removeShorthandProperty and
removeLonghandProperty.
(WebCore::MutableStyleProperties::removeCustomProperty): Call removePropertyAtIndex.
(WebCore::MutableStyleProperties::setProperty): Removed the unneeded overload for the case where
the property&apos;s value is a property ID. Removed the unneeded call to removeShorthandProperty
in the overload that takes a CSSProperty that is never called for shorthands, adding an
assertion to check that invariant.
(WebCore::StyleProperties::asTextInternal const): Use serializeShorthandValue and
serializeLonghandValue.
(WebCore::MutableStyleProperties::removePropertiesInSet): Use the HashSet::add function that
takes iterators.
(WebCore::ImmutableStyleProperties::findCustomPropertyIndex const): Take a StringView instead
of a const String&amp;.
(WebCore::MutableStyleProperties::findCustomPropertyIndex const): Ditto.
(WebCore::MutableStyleProperties::findCSSPropertyWithID): Use nullptr.
(WebCore::MutableStyleProperties::findCustomCSSPropertyWithName): Ditto.
(WebCore::StyleProperties::PropertyReference::cssText const): Use serializeLonghandValue.

* Source/WebCore/css/StyleProperties.h: Made findPropertyIndex and findCustomPropertyIndex
public in StyleProperties. There are other functions that work based on the index in the
interface. Doing this allows ShorthandSerializer to work using only public functions.
Initialize m_arraySize to 0. Removed unneeded default constructor, most private functions,
and friend relationship with PropertySetCSSStyleDeclaration. Updated MutableStyleProperties
functions for changes above.

* Source/WebCore/css/StylePropertyShorthand.h: Removed unneeded
fontShorthandSubpropertiesResetToInitialValues; we now base this on CSSProperties.json.
Added functions mentioned above.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeFont): Set to initial values intead of explicitly
allocating CSSValueNormal. This may be slightly more efficient and it&apos;s consistent with
other property parsing. Set all properties in a loop, takes care of the properties
reset to initial values without fontShorthandSubpropertiesResetToInitialValues.

Canonical link: <a href="https://commits.webkit.org/259211@main">https://commits.webkit.org/259211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e0b7a5a2fe5b89b74352142a0e3e30915d5f617

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113563 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173856 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4347 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96572 "Failed to checkout and rebase branch from PR 8956") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112604 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94255 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96572 "Failed to checkout and rebase branch from PR 8956") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25866 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96572 "Failed to checkout and rebase branch from PR 8956") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3777 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8712 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->