### PR TITLE
HTMLInputElement::setValueForUser should dispatch an input event

### DIFF
--- a/LayoutTests/fast/events/onchange-js-expected.txt
+++ b/LayoutTests/fast/events/onchange-js-expected.txt
@@ -4,9 +4,11 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS input.value is "foo bar baz"
+PASS changeEventCounter is 0
 PASS changeEventCounter is 1
 PASS input.value is ""
 PASS input.value is "foo bar baz"
+PASS changeEventCounter is 1
 PASS changeEventCounter is 2
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/onchange-js.html
+++ b/LayoutTests/fast/events/onchange-js.html
@@ -17,12 +17,14 @@ function changeHandler()
 input.focus();
 document.execCommand('InsertText', false, 'foo bar baz');
 shouldBeEqualToString('input.value', 'foo bar baz');
+shouldBe('changeEventCounter', '0');
 input.blur();
 shouldBe('changeEventCounter', '1');
 shouldBeEqualToString('input.value', '');
 input.focus();
 document.execCommand('InsertText', false, 'foo bar baz');
 shouldBeEqualToString('input.value', 'foo bar baz');
+shouldBe('changeEventCounter', '1');
 input.blur();
 shouldBe('changeEventCounter', '2');
 </script>

--- a/LayoutTests/fast/forms/onchange-setvalueforuser.html
+++ b/LayoutTests/fast/forms/onchange-setvalueforuser.html
@@ -12,20 +12,9 @@
 
         if (window.testRunner) {
             testRunner.dumpAsText();
-        }
-
-        tf.focus();
-        if (window.testRunner) {
             testRunner.setValueForUser(tf, 'Hello!');
         }
 
-        // Should not fire the event until focus is lost.
-        if (didFireOnChange) {
-            testFailed('onchange fired too early');
-            return;
-        }
-
-        tf.blur();
         if (didFireOnChange) {
             testPassed('');
         } else {

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -83,7 +83,7 @@ public:
     WEBCORE_EXPORT void setType(const AtomString&);
     WEBCORE_EXPORT String value() const final;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
-    void setValueForUser(const String& value) { setValue(value, DispatchChangeEvent); }
+    void setValueForUser(const String& value) { setValue(value, DispatchInputAndChangeEvent); }
     WEBCORE_EXPORT WallTime valueAsDate() const;
     WEBCORE_EXPORT ExceptionOr<void> setValueAsDate(WallTime);
     WEBCORE_EXPORT double valueAsNumber() const;

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -146,7 +146,7 @@ auto SearchInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBase
     const String& key = event.keyIdentifier();
     if (key == "U+001B"_s) {
         Ref<HTMLInputElement> protectedInputElement(*element());
-        protectedInputElement->setValueForUser(emptyString());
+        protectedInputElement->setValue(emptyString(), DispatchChangeEvent);
         protectedInputElement->onSearch();
         event.setDefaultHandled();
         return ShouldCallBaseEventHandler::Yes;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -353,7 +353,7 @@ void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
     }
 
     if (event.type() == eventNames().clickEvent) {
-        input->setValueForUser(emptyString());
+        input->setValue(emptyString(), DispatchChangeEvent);
         input->onSearch();
         event.setDefaultHandled();
     }


### PR DESCRIPTION
#### fd13c500871d368b9f0b6d2f31a7ae57e4234e32
<pre>
HTMLInputElement::setValueForUser should dispatch an input event
<a href="https://bugs.webkit.org/show_bug.cgi?id=226023">https://bugs.webkit.org/show_bug.cgi?id=226023</a>
rdar://78571564

Reviewed by Aditya Keerthi.

HTMLInputElement::setValueForUser is used to autofill form elements. It
differs from setting the form value normally because it creates a change
event to trick websites into detecting user input. However, this is not
enough for some websites that only look for input events and not change
events to decide whether the user modified the form. On such websites,
the user has to enter an extra character and then delete it as a
workaround.

This fixes password autofill on <a href="https://my.cigna.com">https://my.cigna.com</a> and
<a href="https://myaccount.spireenergy.com">https://myaccount.spireenergy.com</a> in Epiphany.

* LayoutTests/fast/events/onchange-js-expected.txt:
* LayoutTests/fast/events/onchange-js.html: Add test to ensure change
  event is not sent until blur, since I&apos;ve removed that from the
  onchange-setvalueforuser.html test.
* LayoutTests/fast/forms/onchange-setvalueforuser.html: Change this test
  to not complain about the change event being sent before focus out.
* Source/WebCore/html/HTMLInputElement.h:
(WebCore::HTMLInputElement::setValueForUser): Fix the bug.
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::handleKeydownEvent): This seems to be using
setValueForUser by mistake. Call setValue directly instead to avoid
breaking fast/forms/search-cancel-button-events.html.
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldCancelButtonElement::defaultEventHandler): Ditto.

Canonical link: <a href="https://commits.webkit.org/259434@main">https://commits.webkit.org/259434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/247c20ffe7a02e531769cac6e81588dbe2ecebd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114051 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174254 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4778 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112967 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39115 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108237 "webkitpy-tests (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80779 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94682 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7204 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27573 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92661 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4944 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4155 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30216 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103583 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47125 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101351 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6502 "Build was cancelled. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by Aditya Keerthi; Validated commit message; compiling; layout-tests (exception)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9090 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25290 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3456 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->