### PR TITLE
[WebGPU] Flesh out PresentationContext's API

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,41 @@ String GPUSwapChain::label() const
 void GPUSwapChain::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));
+}
+
+void GPUSwapChain::clearCurrentTextureAndView()
+{
+    m_currentTexture = nullptr;
+    m_currentTextureView = nullptr;
+}
+
+void GPUSwapChain::ensureCurrentTextureAndView()
+{
+    ASSERT(static_cast<bool>(m_currentTexture) == static_cast<bool>(m_currentTextureView));
+
+    if (m_currentTexture && m_currentTextureView)
+        return;
+
+    m_currentTexture = GPUTexture::create(m_backing->getCurrentTexture()).ptr();
+    m_currentTextureView = GPUTextureView::create(m_backing->getCurrentTextureView()).ptr();
+}
+
+GPUTexture& GPUSwapChain::getCurrentTexture()
+{
+    ensureCurrentTextureAndView();
+    return *m_currentTexture;
+}
+
+GPUTextureView& GPUSwapChain::getCurrentTextureView()
+{
+    ensureCurrentTextureAndView();
+    return *m_currentTextureView;
+}
+
+void GPUSwapChain::present()
+{
+    m_backing->present();
+    clearCurrentTextureAndView();
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/Modules/WebGPU/GPUSwapChain.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "GPUTexture.h"
+#include "GPUTextureView.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUSwapChain.h>
 #include <wtf/Ref.h>
@@ -43,6 +45,10 @@ public:
     String label() const;
     void setLabel(String&&);
 
+    GPUTexture& getCurrentTexture();
+    GPUTextureView& getCurrentTextureView();
+    void present();
+
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
 #endif
@@ -57,7 +63,12 @@ private:
     {
     }
 
+    void clearCurrentTextureAndView();
+    void ensureCurrentTextureAndView();
+
     Ref<PAL::WebGPU::SwapChain> m_backing;
+    RefPtr<GPUTexture> m_currentTexture;
+    RefPtr<GPUTextureView> m_currentTextureView;
 };
 
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -208,7 +208,7 @@ Ref<SwapChain> DeviceImpl::createSwapChain(const Surface& surface, const SwapCha
     };
 
     WGPUSurface wgpuSurface = m_convertToBackingContext->convertToBacking(surface);
-    return SwapChainImpl::create(wgpuSurface, wgpuDeviceCreateSwapChain(backing(), wgpuSurface, &backingDescriptor));
+    return SwapChainImpl::create(wgpuSurface, wgpuDeviceCreateSwapChain(backing(), wgpuSurface, &backingDescriptor), descriptor.format);
 }
 
 Ref<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,8 @@ namespace PAL::WebGPU {
 
 class Surface;
 struct SurfaceDescriptor;
+class Texture;
+class TextureView;
 
 class SwapChain : public RefCounted<SwapChain> {
 public:
@@ -46,6 +48,10 @@ public:
         m_label = WTFMove(label);
         setLabelInternal(m_label);
     }
+
+    virtual Texture& getCurrentTexture() = 0;
+    virtual TextureView& getCurrentTextureView() = 0;
+    virtual void present() = 0;
 
     virtual void destroy() = 0;
 

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -453,6 +453,8 @@ WGPUProc wgpuGetProcAddress(WGPUDevice, const char* procName)
         return reinterpret_cast<WGPUProc>(&wgpuShaderModuleSetLabel);
     if (!strcmp(procName, "wgpuSurfaceGetPreferredFormat"))
         return reinterpret_cast<WGPUProc>(&wgpuSurfaceGetPreferredFormat);
+    if (!strcmp(procName, "wgpuSwapChainGetCurrentTexture"))
+        return reinterpret_cast<WGPUProc>(&wgpuSwapChainGetCurrentTexture);
     if (!strcmp(procName, "wgpuSwapChainGetCurrentTextureView"))
         return reinterpret_cast<WGPUProc>(&wgpuSwapChainGetCurrentTextureView);
     if (!strcmp(procName, "wgpuSwapChainPresent"))

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@ namespace WebGPU {
 
 class Adapter;
 class Device;
+class Texture;
 class TextureView;
 
 class PresentationContext : public WGPUSurfaceImpl, public WGPUSwapChainImpl, public RefCounted<PresentationContext> {
@@ -59,6 +60,7 @@ public:
     virtual void configure(Device&, const WGPUSwapChainDescriptor&);
 
     virtual void present();
+    virtual Texture* getCurrentTexture(); // FIXME: This should return a Texture&.
     virtual TextureView* getCurrentTextureView(); // FIXME: This should return a TextureView&.
 
     virtual bool isPresentationContextIOSurface() const { return false; }

--- a/Source/WebGPU/WebGPU/PresentationContext.mm
+++ b/Source/WebGPU/WebGPU/PresentationContext.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,6 +71,11 @@ void PresentationContext::present()
 {
 }
 
+Texture* PresentationContext::getCurrentTexture()
+{
+    return nullptr;
+}
+
 TextureView* PresentationContext::getCurrentTextureView()
 {
     return nullptr;
@@ -93,6 +98,11 @@ void wgpuSwapChainRelease(WGPUSwapChain swapChain)
 WGPUTextureFormat wgpuSurfaceGetPreferredFormat(WGPUSurface surface, WGPUAdapter adapter)
 {
     return WebGPU::fromAPI(surface).getPreferredFormat(WebGPU::fromAPI(adapter));
+}
+
+WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain)
+{
+    return WebGPU::fromAPI(swapChain).getCurrentTexture();
 }
 
 WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain)

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 namespace WebGPU {
 
 class Device;
+class Texture;
 class TextureView;
 
 class PresentationContextCoreAnimation : public PresentationContext {
@@ -49,6 +50,7 @@ public:
     void configure(Device&, const WGPUSwapChainDescriptor&) override;
 
     void present() override;
+    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
 
     bool isPresentationContextCoreAnimation() const override { return true; }
@@ -57,9 +59,10 @@ private:
     PresentationContextCoreAnimation(const WGPUSurfaceDescriptor&);
 
     struct Configuration {
-        Configuration(uint32_t width, uint32_t height, String&& label, WGPUTextureFormat format, Device& device)
+        Configuration(uint32_t width, uint32_t height, WGPUTextureUsageFlags usage, String&& label, WGPUTextureFormat format, Device& device)
             : width(width)
             , height(height)
+            , usage(usage)
             , label(WTFMove(label))
             , format(format)
             , device(device)
@@ -68,6 +71,7 @@ private:
 
         struct FrameState {
             id<CAMetalDrawable> currentDrawable;
+            RefPtr<Texture> currentTexture;
             RefPtr<TextureView> currentTextureView;
         };
 
@@ -76,6 +80,7 @@ private:
         std::optional<FrameState> currentFrameState;
         uint32_t width { 0 };
         uint32_t height { 0 };
+        WGPUTextureUsageFlags usage { WGPUTextureUsage_None };
         String label;
         WGPUTextureFormat format { WGPUTextureFormat_Undefined };
         Ref<Device> device;

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #import "APIConversions.h"
 #import "Texture.h"
+#import "TextureView.h"
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebGPU {
@@ -68,7 +69,7 @@ void PresentationContextCoreAnimation::configure(Device& device, const WGPUSwapC
         return;
     }
 
-    m_configuration = Configuration(descriptor.width, descriptor.height, fromAPI(descriptor.label), descriptor.format, device);
+    m_configuration = Configuration(descriptor.width, descriptor.height, descriptor.usage, fromAPI(descriptor.label), descriptor.format, device);
 
     m_layer.pixelFormat = Texture::pixelFormat(descriptor.format);
     if (descriptor.usage == WGPUTextureUsage_RenderAttachment)
@@ -82,7 +83,22 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
     auto label = this->label.utf8();
 
     id<CAMetalDrawable> currentDrawable = [layer nextDrawable];
-    id<MTLTexture> texture = currentDrawable.texture;
+    id<MTLTexture> backingTexture = currentDrawable.texture;
+
+    WGPUTextureDescriptor textureDescriptor {
+        nullptr,
+        label.data(),
+        usage,
+        WGPUTextureDimension_2D, {
+            width,
+            height,
+            1,
+        },
+        format,
+        1,
+        1,
+    };
+    auto texture = Texture::create(backingTexture, textureDescriptor, { format }, device);
 
     WGPUTextureViewDescriptor textureViewDescriptor {
         nullptr,
@@ -95,8 +111,8 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
         1,
         WGPUTextureAspect_All,
     };
-    auto textureView = TextureView::create(texture, textureViewDescriptor, { { width, height, 1 } }, device);
-    return { currentDrawable, textureView.ptr() };
+    auto textureView = TextureView::create(backingTexture, textureViewDescriptor, { { width, height, 1 } }, device);
+    return { currentDrawable, texture.ptr(), textureView.ptr() };
 }
 
 void PresentationContextCoreAnimation::present()
@@ -110,6 +126,17 @@ void PresentationContextCoreAnimation::present()
     [m_configuration->currentFrameState->currentDrawable present];
 
     m_configuration->currentFrameState = std::nullopt;
+}
+
+Texture* PresentationContextCoreAnimation::getCurrentTexture()
+{
+    if (!m_configuration)
+        return nullptr;
+
+    if (!m_configuration->currentFrameState)
+        m_configuration->currentFrameState = m_configuration->generateCurrentFrameState(m_layer);
+
+    return m_configuration->currentFrameState->currentTexture.get();
 }
 
 TextureView* PresentationContextCoreAnimation::getCurrentTextureView()

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,6 +45,7 @@ public:
     void configure(Device&, const WGPUSwapChainDescriptor&) override;
 
     void present() override;
+    Texture* getCurrentTexture() override; // FIXME: This should return a TextureView&.
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
 
     RetainPtr<IOSurfaceRef> displayBuffer() const { return m_displayBuffer; }

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -100,6 +100,11 @@ void PresentationContextIOSurface::configure(Device&, const WGPUSwapChainDescrip
 void PresentationContextIOSurface::present()
 {
     nextDrawable();
+}
+
+Texture* PresentationContextIOSurface::getCurrentTexture()
+{
+    return nullptr;
 }
 
 TextureView* PresentationContextIOSurface::getCurrentTextureView()

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -153,6 +153,9 @@ typedef void (*WGPUProcInstanceRequestAdapterWithBlock)(WGPUInstance instance, W
 typedef void (*WGPUProcQueueOnSubmittedWorkDoneWithBlock)(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneBlockCallback callback);
 typedef void (*WGPUProcShaderModuleGetCompilationInfoWithBlock)(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
 
+// FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
+typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChain);
+
 #endif  // !defined(WGPU_SKIP_PROCS)
 
 #if !defined(WGPU_SKIP_DECLARATIONS)
@@ -209,6 +212,9 @@ WGPU_EXPORT void wgpuDeviceSetUncapturedErrorCallbackWithBlock(WGPUDevice device
 WGPU_EXPORT void wgpuInstanceRequestAdapterWithBlock(WGPUInstance instance, WGPURequestAdapterOptions const * options, WGPURequestAdapterBlockCallback callback);
 WGPU_EXPORT void wgpuQueueOnSubmittedWorkDoneWithBlock(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneBlockCallback callback);
 WGPU_EXPORT void wgpuShaderModuleGetCompilationInfoWithBlock(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
+
+// FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
+WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);
 
 WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(WGPUSurface);
 WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(WGPUSurface);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@
 
 #include "RemoteSurface.h"
 #include "RemoteSwapChainMessages.h"
+#include "RemoteTexture.h"
+#include "RemoteTextureView.h"
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
 #include "WebGPUSurfaceDescriptor.h"
@@ -53,6 +55,25 @@ RemoteSwapChain::~RemoteSwapChain() = default;
 void RemoteSwapChain::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteSwapChain::messageReceiverName(), m_identifier.toUInt64());
+}
+
+void RemoteSwapChain::getCurrentTexture(WebGPUIdentifier identifier)
+{
+    auto& texture = m_backing->getCurrentTexture();
+    auto remoteTexture = RemoteTexture::create(texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    m_objectHeap.addObject(identifier, remoteTexture);
+}
+
+void RemoteSwapChain::getCurrentTextureView(WebGPUIdentifier identifier)
+{
+    auto& textureView = m_backing->getCurrentTextureView();
+    auto remoteTextureView = RemoteTextureView::create(textureView, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    m_objectHeap.addObject(identifier, remoteTextureView);
+}
+
+void RemoteSwapChain::present()
+{
+    m_backing->present();
 }
 
 void RemoteSwapChain::destroy()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,10 @@ private:
     PAL::WebGPU::SwapChain& backing() { return m_backing; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+
+    void getCurrentTexture(WebGPUIdentifier);
+    void getCurrentTextureView(WebGPUIdentifier);
+    void present();
 
     void destroy();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Apple Inc. All rights reserved.
+/* Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,6 +24,9 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSwapChain NotRefCounted Stream {
+    void GetCurrentTexture(WebKit::WebGPUIdentifier identifier)
+    void GetCurrentTextureView(WebKit::WebGPUIdentifier identifier)
+    void Present()
     void Destroy()
     void SetLabel(String label)
 

--- a/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme
+++ b/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -123,14 +123,14 @@ Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createTexture(const PAL::WebGPU::Te
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
     if (!convertedDescriptor) {
         // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateTexture(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createSurfaceTexture(const PAL::WebGPU::TextureDescriptor& descriptor, const PAL::WebGPU::Surface& surface)
@@ -138,14 +138,14 @@ Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createSurfaceTexture(const PAL::Web
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
     if (!convertedDescriptor) {
         // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateSurfaceTexture(m_convertToBackingContext->convertToBacking(surface), *convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 Ref<PAL::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const PAL::WebGPU::SamplerDescriptor& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,8 @@
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
+class RemoteTextureProxy;
+class RemoteTextureViewProxy;
 
 class RemoteSwapChainProxy final : public PAL::WebGPU::SwapChain {
     WTF_MAKE_FAST_ALLOCATED;
@@ -77,13 +79,22 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
+    PAL::WebGPU::Texture& getCurrentTexture() final;
+    PAL::WebGPU::TextureView& getCurrentTextureView() final;
+    void present() final;
+
     void destroy() final;
 
     void setLabelInternal(const String&) final;
 
+    void clearCurrentTextureAndView();
+    void ensureCurrentTextureAndView();
+
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    RefPtr<RemoteTextureProxy> m_currentTexture;
+    RefPtr<RemoteTextureViewProxy> m_currentTextureView;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,10 +35,10 @@
 
 namespace WebKit::WebGPU {
 
-RemoteTextureProxy::RemoteTextureProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteTextureProxy::RemoteTextureProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 
@@ -53,7 +53,7 @@ Ref<PAL::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional
         convertedDescriptor = m_convertToBackingContext->convertToBacking(*descriptor);
         if (!convertedDescriptor) {
             // FIXME: Implement error handling.
-            return RemoteTextureViewProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+            return RemoteTextureViewProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
         }
     }
 
@@ -61,7 +61,7 @@ Ref<PAL::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional
     auto sendResult = send(Messages::RemoteTexture::CreateView(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureViewProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureViewProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 void RemoteTextureProxy::destroy()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,20 +42,19 @@ class ConvertToBackingContext;
 class RemoteTextureProxy final : public PAL::WebGPU::Texture {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteTextureProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteTextureProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextureProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteTextureProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteTextureProxy();
 
-    RemoteDeviceProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteTextureProxy(RemoteDeviceProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteTextureProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteTextureProxy(const RemoteTextureProxy&) = delete;
     RemoteTextureProxy(RemoteTextureProxy&&) = delete;
@@ -84,7 +83,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteDeviceProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,10 +33,10 @@
 
 namespace WebKit::WebGPU {
 
-RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,20 +38,19 @@ class ConvertToBackingContext;
 class RemoteTextureViewProxy final : public PAL::WebGPU::TextureView {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteTextureViewProxy> create(RemoteTextureProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteTextureViewProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextureViewProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteTextureViewProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteTextureViewProxy();
 
-    RemoteTextureProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteTextureViewProxy(RemoteTextureProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteTextureViewProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteTextureViewProxy(const RemoteTextureViewProxy&) = delete;
     RemoteTextureViewProxy(RemoteTextureViewProxy&&) = delete;
@@ -76,7 +75,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteTextureProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### 7f0c216417c17960ca6419c65d201f9f50b33bf8
<pre>
[WebGPU] Flesh out SwapChain&apos;s API
<a href="https://bugs.webkit.org/show_bug.cgi?id=250990">https://bugs.webkit.org/show_bug.cgi?id=250990</a>
rdar://104537242

Reviewed by NOBODY (OOPS!).

According to the IDL for GPUCanvasContext and WebGPU.h, SwapChain is supposed to have
2 methods: getCurrentTexture(), and present(). This patch adds those APIs to all the
various plumbing sites throught PAL, WebCore, and WebKit.

present() is straightforward; it&apos;s just a void function.

getCurrentTexture() is a getter instead of a creation method, so it is supposed to
return objects that are owned by the swap chain itself. For this reason, the
implementation of getCurrentTexture() has to internally retain the result, only
actually recreating the texture when there is no existing object retained.

There&apos;s one more hiccup - GPUCanvasContext says the function is supposed to be
getCurrentTexture(), whereas WebGPU.h says it&apos;s supposed to be getCurrentTextureView().
<a href="https://github.com/webgpu-native/webgpu-headers/issues/89">https://github.com/webgpu-native/webgpu-headers/issues/89</a> is about making these two
things match, bu that issue isn&apos;t resolved yet. For now, we can just implement both
until that upstream issue is resolved.

* Source/WebCore/Modules/WebGPU/GPUSwapChain.cpp:
(WebCore::GPUSwapChain::clearCurrentTextureAndView):
(WebCore::GPUSwapChain::ensureCurrentTextureAndView):
(WebCore::GPUSwapChain::getCurrentTexture):
(WebCore::GPUSwapChain::getCurrentTextureView):
(WebCore::GPUSwapChain::present):
* Source/WebCore/Modules/WebGPU/GPUSwapChain.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createSwapChain):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.cpp:
(PAL::WebGPU::SwapChainImpl::SwapChainImpl):
(PAL::WebGPU::SwapChainImpl::clearCurrentTextureAndView):
(PAL::WebGPU::SwapChainImpl::ensureCurrentTextureAndView):
(PAL::WebGPU::SwapChainImpl::getCurrentTexture):
(PAL::WebGPU::SwapChainImpl::getCurrentTextureView):
(PAL::WebGPU::SwapChainImpl::present):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUSwapChainImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChain.h:
* Source/WebGPU/WebGPU/Instance.mm:
(wgpuGetProcAddress):
* Source/WebGPU/WebGPU/PresentationContext.h:
* Source/WebGPU/WebGPU/PresentationContext.mm:
(WebGPU::PresentationContext::getCurrentTexture):
(wgpuSwapChainGetCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h:
(WebGPU::PresentationContextCoreAnimation::Configuration::Configuration):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm:
(WebGPU::PresentationContextCoreAnimation::configure):
(WebGPU::PresentationContextCoreAnimation::Configuration::generateCurrentFrameState):
(WebGPU::PresentationContextCoreAnimation::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::getCurrentTexture):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.cpp:
(WebKit::RemoteSwapChain::getCurrentTexture):
(WebKit::RemoteSwapChain::getCurrentTextureView):
(WebKit::RemoteSwapChain::present):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSwapChain.messages.in:
* Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createSurfaceTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.cpp:
(WebKit::WebGPU::RemoteSwapChainProxy::clearCurrentTextureAndView):
(WebKit::WebGPU::RemoteSwapChainProxy::ensureCurrentTextureAndView):
(WebKit::WebGPU::RemoteSwapChainProxy::getCurrentTexture):
(WebKit::WebGPU::RemoteSwapChainProxy::getCurrentTextureView):
(WebKit::WebGPU::RemoteSwapChainProxy::present):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSwapChainProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::RemoteTextureProxy):
(WebKit::WebGPU::RemoteTextureProxy::createView):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
(WebKit::WebGPU::RemoteTextureViewProxy::RemoteTextureViewProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f0c216417c17960ca6419c65d201f9f50b33bf8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105093 "Failed to checkout and rebase branch from PR 8958") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14172 "Failed to checkout and rebase branch from PR 8958") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37980 "Failed to checkout and rebase branch from PR 8958") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114352 "Failed to checkout and rebase branch from PR 8958") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108994 "Failed to checkout and rebase branch from PR 8958") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15311 "Failed to checkout and rebase branch from PR 8958") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5093 "Failed to checkout and rebase branch from PR 8958") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97410 "Failed to checkout and rebase branch from PR 8958") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110849 "Failed to checkout and rebase branch from PR 8958") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/15311 "Failed to checkout and rebase branch from PR 8958") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/37980 "Failed to checkout and rebase branch from PR 8958") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38816 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/15311 "Failed to checkout and rebase branch from PR 8958") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/37980 "Failed to checkout and rebase branch from PR 8958") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80484 "Passed tests") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7506 "Failed to checkout and rebase branch from PR 8958") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/37980 "Failed to checkout and rebase branch from PR 8958") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7602 "Failed to checkout and rebase branch from PR 8958") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/5093 "Failed to checkout and rebase branch from PR 8958") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13657 "Failed to checkout and rebase branch from PR 8958") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/37980 "Failed to checkout and rebase branch from PR 8958") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9389 "Failed to checkout and rebase branch from PR 8958") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->