### PR TITLE
[WebGPU] present() needs to wait for all command buffers to be scheduled

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
@@ -46,8 +46,7 @@ void CompositorIntegrationImpl::prepareForDisplay(CompletionHandler<void()>&& co
 {
     m_presentationContext->present();
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
-    completionHandler();
+    m_onSubmittedWorkScheduledCallback(WTFMove(completionHandler));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h
@@ -31,6 +31,7 @@
 
 #include "WebGPUPresentationContextImpl.h"
 #include <WebGPU/WebGPU.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 
@@ -60,10 +61,12 @@ public:
         m_presentationContext = &presentationContext;
     }
 
-    void registerCallbacks(WTF::Function<void(CFArrayRef)>&& renderBuffersWereRecreatedCallback)
+    void registerCallbacks(WTF::Function<void(CFArrayRef)>&& renderBuffersWereRecreatedCallback, WTF::Function<void(CompletionHandler<void()>&&)>&& onSubmittedWorkScheduledCallback)
     {
         ASSERT(!m_renderBuffersWereRecreatedCallback);
         m_renderBuffersWereRecreatedCallback = WTFMove(renderBuffersWereRecreatedCallback);
+        ASSERT(!m_onSubmittedWorkScheduledCallback);
+        m_onSubmittedWorkScheduledCallback = WTFMove(onSubmittedWorkScheduledCallback);
     }
 
 private:
@@ -84,6 +87,8 @@ private:
     Vector<RetainPtr<IOSurfaceRef>> m_renderBuffers;
     WTF::Function<void(CFArrayRef)> m_renderBuffersWereRecreatedCallback;
 #endif
+
+    WTF::Function<void(CompletionHandler<void()>&&)> m_onSubmittedWorkScheduledCallback;
 
     RefPtr<PresentationContextImpl> m_presentationContext;
     Ref<ConvertToBackingContext> m_convertToBackingContext;

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -31,6 +31,8 @@
 
 namespace WebGPU {
 
+class Device;
+
 class PresentationContextIOSurface : public PresentationContext {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -51,6 +53,7 @@ private:
     PresentationContextIOSurface(const WGPUSurfaceDescriptor&);
 
     void renderBuffersWereRecreated(NSArray<IOSurface *> *renderBuffers);
+    void onSubmittedWorkScheduled(CompletionHandler<void()>&&);
 
     NSArray<IOSurface *> *m_ioSurfaces { nil };
     struct RenderBuffer {
@@ -58,6 +61,7 @@ private:
         Ref<TextureView> textureView;
     };
     Vector<RenderBuffer> m_renderBuffers;
+    RefPtr<Device> m_device;
     size_t m_currentIndex { 0 };
 };
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -64,6 +64,8 @@ public:
     void writeTexture(const WGPUImageCopyTexture& destination, const void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize);
     void setLabel(String&&);
 
+    void onSubmittedWorkScheduled(CompletionHandler<void()>&&);
+
     bool isValid() const { return m_commandQueue; }
     void makeInvalid() { m_commandQueue = nil; }
 
@@ -83,6 +85,7 @@ private:
 
     void commitMTLCommandBuffer(id<MTLCommandBuffer>);
     bool isIdle() const { return m_submittedCommandBufferCount == m_completedCommandBufferCount; }
+    bool isSchedulingIdle() const { return m_submittedCommandBufferCount == m_scheduledCommandBufferCount; }
 
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
@@ -94,8 +97,11 @@ private:
 
     uint64_t m_submittedCommandBufferCount { 0 };
     uint64_t m_completedCommandBufferCount { 0 };
+    uint64_t m_scheduledCommandBufferCount { 0 };
+    using OnSubmittedWorkScheduledCallbacks = Vector<WTF::Function<void()>>;
+    HashMap<uint64_t, OnSubmittedWorkScheduledCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkScheduledCallbacks;
     using OnSubmittedWorkDoneCallbacks = Vector<WTF::Function<void(WGPUQueueWorkDoneStatus)>>;
-    HashMap<uint64_t, OnSubmittedWorkDoneCallbacks> m_onSubmittedWorkDoneCallbacks;
+    HashMap<uint64_t, OnSubmittedWorkDoneCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkDoneCallbacks;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -64,7 +64,8 @@ typedef struct WGPUInstanceCocoaDescriptor {
 } WGPUInstanceCocoaDescriptor;
 
 typedef void (^WGPURenderBuffersWereRecreatedBlockCallback)(CFArrayRef ioSurfaces);
-typedef void (^WGPUCompositorIntegrationRegisterBlockCallback)(WGPURenderBuffersWereRecreatedBlockCallback renderBuffersWereRecreated);
+typedef void (^WGPUOnSubmittedWorkScheduledCallback)(WGPUWorkItem);
+typedef void (^WGPUCompositorIntegrationRegisterBlockCallback)(WGPURenderBuffersWereRecreatedBlockCallback renderBuffersWereRecreated, WGPUOnSubmittedWorkScheduledCallback onSubmittedWorkScheduledCallback);
 typedef struct WGPUSurfaceDescriptorCocoaCustomSurface {
     WGPUChainedStruct chain;
     WGPUCompositorIntegrationRegisterBlockCallback compositorIntegrationRegister;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteCompositorIntegration NotRefCounted Stream {
 #if PLATFORM(COCOA)
 void RecreateRenderBuffers(int width, int height) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
 #endif
-void PrepareForDisplay() -> (bool dummy) Synchronous NotStreamEncodableReply // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
+void PrepareForDisplay() -> (bool dummy) Synchronous NotStreamEncodableReply // Because CanvasRenderingContext::prepareForDisplay() requires the layer contents synchronously, this needs to be Synchronous.
 }
 
 #endif


### PR DESCRIPTION
#### 442fabee7226138865b76fc2efded6e4aa4e4a90
<pre>
[WebGPU] present() needs to wait for all command buffers to be scheduled
<a href="https://bugs.webkit.org/show_bug.cgi?id=250993">https://bugs.webkit.org/show_bug.cgi?id=250993</a>
rdar://104538554

Reviewed by Dean Jackson.

We already had a callback set up in prepareForDisplay(). All we need to do is plumb that through to
WebGPU::Queue, and use the same kind of infrastructure that we already have for onSubmittedWorkDone(),
but for onSubmittedWorkScheduled().

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp:
(PAL::WebGPU::CompositorIntegrationImpl::prepareForDisplay):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp:
(PAL::WebGPU::WTF::Function&lt;void):
(PAL::WebGPU::GPUImpl::createPresentationContext):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::create):
(WebGPU::PresentationContextIOSurface::onSubmittedWorkScheduled):
(WebGPU::PresentationContextIOSurface::configure):
(WebGPU::PresentationContextIOSurface::unconfigure):
* Source/WebGPU/WebGPU/Queue.h:
(WebGPU::Queue::isSchedulingIdle const):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::onSubmittedWorkScheduled):
(WebGPU::Queue::commitMTLCommandBuffer):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in:

Canonical link: <a href="https://commits.webkit.org/259912@main">https://commits.webkit.org/259912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5ea971b53deb0fa1aa7c98bc58936916aa00804

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115443 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175541 "Failed to checkout and rebase branch from PR 8961") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6522 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115125 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40285 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81974 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8547 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5282 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6848 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10590 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->