### PR TITLE
[WebGPU] Align SurfaceDescriptor and SwapChainDescriptor with the spec and WebGPU.h

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUSurfaceDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSurfaceDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,11 +25,7 @@
 
 #pragma once
 
-#include "GPUExtent3DDict.h"
-#include "GPUIntegralTypes.h"
 #include "GPUObjectDescriptorBase.h"
-#include "GPUTextureFormat.h"
-#include "GPUTextureUsage.h"
 #include <pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h>
 
 namespace WebCore {
@@ -39,17 +35,9 @@ struct GPUSurfaceDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            WebCore::convertToBacking(size),
-            sampleCount,
-            WebCore::convertToBacking(format),
-            convertTextureUsageFlagsToBacking(usage)
         };
     }
 
-    GPUExtent3D size;
-    GPUSize32 sampleCount { 1 };
-    GPUTextureFormat format { GPUTextureFormat::R8unorm };
-    GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUSwapChainDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUSwapChainDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include "GPUCanvasCompositingAlphaMode.h"
 #include "GPUExtent3DDict.h"
 #include "GPUIntegralTypes.h"
 #include "GPUObjectDescriptorBase.h"
 #include "GPUTextureFormat.h"
 #include "GPUTextureUsage.h"
 #include <pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -39,17 +41,25 @@ struct GPUSwapChainDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            WebCore::convertToBacking(size),
-            sampleCount,
             WebCore::convertToBacking(format),
             convertTextureUsageFlagsToBacking(usage),
+            viewFormats.map([] (auto& viewFormat) {
+                return WebCore::convertToBacking(viewFormat);
+            }),
+            WebCore::convertToBacking(colorSpace),
+            WebCore::convertToBacking(compositingAlphaMode),
+            width,
+            height,
         };
     }
 
-    GPUExtent3D size;
-    GPUSize32 sampleCount { 1 };
-    GPUTextureFormat format { GPUTextureFormat::R8unorm };
-    GPUTextureUsageFlags usage { 0 };
+    GPUTextureFormat format { GPUTextureFormat::Bgra8unorm };
+    GPUTextureUsageFlags usage { GPUTextureUsage::RENDER_ATTACHMENT };
+    Vector<GPUTextureFormat> viewFormats;
+    GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
+    GPUCanvasCompositingAlphaMode compositingAlphaMode { GPUCanvasCompositingAlphaMode::Opaque };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
 };
 
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -164,23 +164,12 @@ Ref<Texture> DeviceImpl::createSurfaceTexture(const TextureDescriptor& descripto
     return TextureImpl::create(wgpuDeviceCreateTexture(backing(), &backingDescriptor), descriptor.format, descriptor.dimension, m_convertToBackingContext);
 }
 
-static auto convertToWidthHeight(const WebGPU::Extent3D& extent3D)
-{
-    return WTF::switchOn(extent3D, [] (const Vector<PAL::WebGPU::IntegerCoordinate>& vector) {
-        return std::make_pair(vector[0], vector[1]);
-    }, [] (const WebGPU::Extent3DDict& extent3D) {
-        return std::make_pair(extent3D.width, extent3D.height);
-    });
-}
-
 Ref<Surface> DeviceImpl::createSurface(const SurfaceDescriptor& descriptor)
 {
-    auto size = convertToWidthHeight(descriptor.size);
     auto label = descriptor.label.utf8();
+
     WGPUSurfaceDescriptorCocoaCustomSurface cocoaSurface {
         { nullptr, static_cast<WGPUSType>(WGPUSTypeExtended_SurfaceDescriptorCocoaSurfaceBacking) },
-        size.first,
-        size.second
     };
 
     WGPUSurfaceDescriptor surfaceDescriptor {
@@ -193,8 +182,6 @@ Ref<Surface> DeviceImpl::createSurface(const SurfaceDescriptor& descriptor)
 
 Ref<SwapChain> DeviceImpl::createSwapChain(const Surface& surface, const SwapChainDescriptor& descriptor)
 {
-    auto size = m_convertToBackingContext->convertToBacking(descriptor.size);
-
     auto label = descriptor.label.utf8();
 
     WGPUSwapChainDescriptor backingDescriptor {
@@ -202,8 +189,8 @@ Ref<SwapChain> DeviceImpl::createSwapChain(const Surface& surface, const SwapCha
         label.data(),
         m_convertToBackingContext->convertTextureUsageFlagsToBacking(descriptor.usage),
         m_convertToBackingContext->convertToBacking(descriptor.format),
-        size.width,
-        size.height,
+        descriptor.width,
+        descriptor.height,
         WGPUPresentMode_Immediate,
     };
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,12 @@
 
 #pragma once
 
-#include "WebGPUExtent3D.h"
-#include "WebGPUIntegralTypes.h"
 #include "WebGPUObjectDescriptorBase.h"
 #include "WebGPUTextureFormat.h"
 
 namespace PAL::WebGPU {
 
 struct SurfaceDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    Size32 sampleCount { 1 };
-    TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,19 +25,23 @@
 
 #pragma once
 
-#include "WebGPUExtent3D.h"
+#include "WebGPUCanvasCompositingAlphaMode.h"
 #include "WebGPUIntegralTypes.h"
 #include "WebGPUObjectDescriptorBase.h"
+#include "WebGPUPredefinedColorSpace.h"
 #include "WebGPUTextureFormat.h"
 #include "WebGPUTextureUsage.h"
 
 namespace PAL::WebGPU {
 
 struct SwapChainDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    Size32 sampleCount { 1 };
     TextureFormat format { TextureFormat::R8unorm };
-    TextureUsageFlags usage;
+    TextureUsageFlags usage { TextureUsage::RenderAttachment };
+    Vector<TextureFormat> viewFormats;
+    PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
+    CanvasCompositingAlphaMode compositingAlphaMode { CanvasCompositingAlphaMode::Opaque };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -106,10 +106,7 @@ void GPUCanvasContextCocoa::createSwapChainIfNeeded()
 
     GPUSurfaceDescriptor surfaceDescriptor = {
         { "WebGPU Canvas surface"_s },
-        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
-        1 /* sampleCount */,
-        m_configuration->format,
-        m_configuration->usage
+        // FIXME: Include the CompositorIntegration here.
     };
 
     m_surface = m_configuration->device->createSurface(surfaceDescriptor);
@@ -117,10 +114,13 @@ void GPUCanvasContextCocoa::createSwapChainIfNeeded()
 
     GPUSwapChainDescriptor descriptor = {
         { "WebGPU Canvas swap chain"_s },
-        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
-        1 /* sampleCount */,
         m_configuration->format,
-        m_configuration->usage
+        m_configuration->usage,
+        m_configuration->viewFormats,
+        m_configuration->colorSpace,
+        m_configuration->compositingAlphaMode,
+        static_cast<uint32_t>(m_width), // FIXME: Is it possible for these to be negative?
+        static_cast<uint32_t>(m_height),
     };
 
     m_swapChain = m_configuration->device->createSwapChain(*m_surface, descriptor);

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -90,8 +90,6 @@ typedef struct WGPUTextureDescriptorViewFormats {
 
 typedef struct WGPUSurfaceDescriptorCocoaCustomSurface {
     WGPUChainedStruct chain;
-    uint32_t width;
-    uint32_t height;
 } WGPUSurfaceDescriptorCocoaCustomSurface;
 
 typedef struct WGPUTextureDescriptorCocoaCustomSurface {

--- a/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,11 +40,7 @@ std::optional<SurfaceDescriptor> ConvertToBackingContext::convertToBacking(const
     if (!base)
         return std::nullopt;
 
-    auto size = convertToBacking(surfaceDescriptor.size);
-    if (!size)
-        return std::nullopt;
-
-    return { { WTFMove(*base), WTFMove(*size), surfaceDescriptor.sampleCount, surfaceDescriptor.format, surfaceDescriptor.usage } };
+    return { { WTFMove(*base) } };
 }
 
 std::optional<PAL::WebGPU::SurfaceDescriptor> ConvertFromBackingContext::convertFromBacking(const SurfaceDescriptor& surfaceDescriptor)
@@ -53,11 +49,7 @@ std::optional<PAL::WebGPU::SurfaceDescriptor> ConvertFromBackingContext::convert
     if (!base)
         return std::nullopt;
 
-    auto size = convertFromBacking(surfaceDescriptor.size);
-    if (!size)
-        return std::nullopt;
-
-    return { { WTFMove(*base), WTFMove(*size), surfaceDescriptor.sampleCount, surfaceDescriptor.format, surfaceDescriptor.usage } };
+    return { { WTFMove(*base) } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,20 +27,12 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "WebGPUExtent3D.h"
+#include "WebGPUIdentifier.h"
 #include "WebGPUObjectDescriptorBase.h"
-#include <optional>
-#include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
-#include <pal/graphics/WebGPU/WebGPUTextureFormat.h>
-#include <pal/graphics/WebGPU/WebGPUTextureUsage.h>
 
 namespace WebKit::WebGPU {
 
 struct SurfaceDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    PAL::WebGPU::Size32 sampleCount { 1 };
-    PAL::WebGPU::TextureFormat format { PAL::WebGPU::TextureFormat::R8unorm };
-    PAL::WebGPU::TextureUsageFlags usage;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,9 +22,5 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::SurfaceDescriptor : WebKit::WebGPU::ObjectDescriptorBase {
-    WebKit::WebGPU::Extent3D size;
-    PAL::WebGPU::Size32 sampleCount;
-    PAL::WebGPU::TextureFormat format;
-    PAL::WebGPU::TextureUsageFlags usage;
 };
 #endif

--- a/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,11 +40,7 @@ std::optional<SwapChainDescriptor> ConvertToBackingContext::convertToBacking(con
     if (!base)
         return std::nullopt;
 
-    auto size = convertToBacking(swapChainDescriptor.size);
-    if (!size)
-        return std::nullopt;
-
-    return { { WTFMove(*base), WTFMove(*size),  swapChainDescriptor.sampleCount, swapChainDescriptor.format, swapChainDescriptor.usage } };
+    return { { WTFMove(*base), swapChainDescriptor.format, swapChainDescriptor.usage, swapChainDescriptor.viewFormats, swapChainDescriptor.colorSpace, swapChainDescriptor.compositingAlphaMode, swapChainDescriptor.width, swapChainDescriptor.height } };
 }
 
 std::optional<PAL::WebGPU::SwapChainDescriptor> ConvertFromBackingContext::convertFromBacking(const SwapChainDescriptor& swapChainDescriptor)
@@ -53,11 +49,7 @@ std::optional<PAL::WebGPU::SwapChainDescriptor> ConvertFromBackingContext::conve
     if (!base)
         return std::nullopt;
 
-    auto size = convertFromBacking(swapChainDescriptor.size);
-    if (!size)
-        return std::nullopt;
-
-    return { { WTFMove(*base), WTFMove(*size), swapChainDescriptor.sampleCount, swapChainDescriptor.format, swapChainDescriptor.usage } };
+    return { { WTFMove(*base), swapChainDescriptor.format, swapChainDescriptor.usage, swapChainDescriptor.viewFormats, swapChainDescriptor.colorSpace, swapChainDescriptor.compositingAlphaMode, swapChainDescriptor.width, swapChainDescriptor.height } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,18 +30,22 @@
 #include "WebGPUExtent3D.h"
 #include "WebGPUObjectDescriptorBase.h"
 #include <optional>
-#include <pal/graphics/WebGPU/WebGPUIntegralTypes.h>
-#include <pal/graphics/WebGPU/WebGPUTextureDimension.h>
+#include <pal/graphics/WebGPU/WebGPUCanvasCompositingAlphaMode.h>
+#include <pal/graphics/WebGPU/WebGPUPredefinedColorSpace.h>
 #include <pal/graphics/WebGPU/WebGPUTextureFormat.h>
 #include <pal/graphics/WebGPU/WebGPUTextureUsage.h>
+#include <wtf/Vector.h>
 
 namespace WebKit::WebGPU {
 
 struct SwapChainDescriptor : public ObjectDescriptorBase {
-    Extent3D size;
-    PAL::WebGPU::Size32 sampleCount { 1 };
     PAL::WebGPU::TextureFormat format { PAL::WebGPU::TextureFormat::R8unorm };
-    PAL::WebGPU::TextureUsageFlags usage;
+    PAL::WebGPU::TextureUsageFlags usage { PAL::WebGPU::TextureUsage::RenderAttachment };
+    Vector<PAL::WebGPU::TextureFormat> viewFormats;
+    PAL::WebGPU::PredefinedColorSpace colorSpace { PAL::WebGPU::PredefinedColorSpace::SRGB };
+    PAL::WebGPU::CanvasCompositingAlphaMode compositingAlphaMode { PAL::WebGPU::CanvasCompositingAlphaMode::Opaque };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,9 +22,12 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::SwapChainDescriptor : WebKit::WebGPU::ObjectDescriptorBase {
-    WebKit::WebGPU::Extent3D size;
-    PAL::WebGPU::Size32 sampleCount;
     PAL::WebGPU::TextureFormat format;
     PAL::WebGPU::TextureUsageFlags usage;
+    Vector<PAL::WebGPU::TextureFormat> viewFormats;
+    PAL::WebGPU::PredefinedColorSpace colorSpace;
+    PAL::WebGPU::CanvasCompositingAlphaMode compositingAlphaMode;
+    uint32_t width;
+    uint32_t height;
 };
 #endif


### PR DESCRIPTION
#### ffc98ceb72ee397bd83b6d7d711fcb760b712c34
<pre>
[WebGPU] Align SurfaceDescriptor and SwapChainDescriptor with the spec and WebGPU.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=250994">https://bugs.webkit.org/show_bug.cgi?id=250994</a>
rdar://104539553

Reviewed by Dean Jackson.

Conceptually, a Surface corresponds to a GPUCanvasContext, and a SwapChain corresponds to a call
to GPUCanvasContext.configure(). Both the spec and WebGPU.h agree that the Surface should be
constructable with almost nothing - you don&apos;t even need a device or any WebGPU objects to create
a GPUCanvasContext object from a canvas. Creating a swap chain (via GPUCanvasContext.configure())
is where the guts are - that&apos;s where all the properties of the textures are specified, so that&apos;s
where we can finally create IOSurfaces.

Right now, we treat Surfaces and SwapChains as siblings - they have the same lifetime inside
GPUCanvasContext.cpp, so this patch is purely mechanical right now. However, there will be 2
follow-up patches in the future:

1. Connecting CompositorIntegration (from <a href="https://github.com/WebKit/WebKit/pull/8933)">https://github.com/WebKit/WebKit/pull/8933)</a> to Surface.
       This will provide a natural owner for the IOSurface renderbuffers, as well as a message
       receiver so these IOSurfaces can be communicated to the compositor. Mechanically, this
       change will add a CompositorIntegration inside SurfaceDescriptor.
2. We can move the lifetime of Surface to be created a bit earlier than SwapChain, because there&apos;s
       no reason to delay creating it; it can be created with almost no information.

A special note about width and height: The WebGPU spec used to include these as arguments to
GPUCanvasContext.configure(), but we changed the spec to have that information come from the
canvas itself rather than being supplied by the site author. So, conceptually, these fields
still belong in the SwapChainDescriptor, and they are present there in this patch. This also
matches what WebGPU.h says - those fields are present in the SwapChainDescriptor.

* Source/WebCore/Modules/WebGPU/GPUSurfaceDescriptor.h:
(WebCore::GPUSurfaceDescriptor::convertToBacking const):
(): Deleted.
* Source/WebCore/Modules/WebGPU/GPUSwapChainDescriptor.h:
(WebCore::GPUSwapChainDescriptor::convertToBacking const):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createSurface):
(PAL::WebGPU::DeviceImpl::createSwapChain):
(PAL::WebGPU::convertToWidthHeight): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSurfaceDescriptor.h:
(): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUSwapChainDescriptor.h:
* Source/WebCore/html/canvas/GPUCanvasContext.cpp:
(WebCore::GPUCanvasContext::createSwapChainIfNeeded):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::createIOSurface):
(WebGPU::createSurfaceFromDescriptor):
(WebGPU::PresentationContextIOSurface::PresentationContextIOSurface):
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.h:
(): Deleted.
* Source/WebKit/Shared/WebGPU/WebGPUSurfaceDescriptor.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.h:
* Source/WebKit/Shared/WebGPU/WebGPUSwapChainDescriptor.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259312@main">https://commits.webkit.org/259312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/882ca2750c50a9c5ccba849204f7768839a1f53a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113747 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173971 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4466 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112714 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38891 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80560 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6905 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27316 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3877 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46876 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6421 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8825 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->