### PR TITLE
[WebGPU] Migrate from createSurfaceTexture() to getCurrentTexture()

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -118,11 +118,6 @@ Ref<GPUTexture> GPUDevice::createTexture(const GPUTextureDescriptor& textureDesc
     return GPUTexture::create(m_backing->createTexture(textureDescriptor.convertToBacking()));
 }
 
-Ref<GPUTexture> GPUDevice::createSurfaceTexture(const GPUTextureDescriptor& textureDescriptor, const GPUPresentationContext& presentationContext)
-{
-    return GPUTexture::create(m_backing->createSurfaceTexture(textureDescriptor.convertToBacking(), presentationContext.backing()));
-}
-
 static PAL::WebGPU::SamplerDescriptor convertToBacking(const std::optional<GPUSamplerDescriptor>& samplerDescriptor)
 {
     if (!samplerDescriptor) {

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -97,7 +97,6 @@ public:
 
     Ref<GPUBuffer> createBuffer(const GPUBufferDescriptor&);
     Ref<GPUTexture> createTexture(const GPUTextureDescriptor&);
-    Ref<GPUTexture> createSurfaceTexture(const GPUTextureDescriptor&, const GPUPresentationContext&);
     Ref<GPUSampler> createSampler(const std::optional<GPUSamplerDescriptor>&);
     Ref<GPUExternalTexture> importExternalTexture(const GPUExternalTextureDescriptor&);
 

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -53,15 +53,7 @@ RefPtr<GPUTexture> GPUPresentationContext::getCurrentTexture()
 
 void GPUPresentationContext::present()
 {
-    m_backing->present();
     m_currentTexture = nullptr;
 }
-
-#if PLATFORM(COCOA)
-void GPUPresentationContext::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
-{
-    m_backing->prepareForDisplay(WTFMove(completionHandler));
-}
-#endif
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -51,12 +51,7 @@ public:
     void unconfigure();
 
     RefPtr<GPUTexture> getCurrentTexture();
-
     void present();
-
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
-#endif
 
     PAL::WebGPU::PresentationContext& backing() { return m_backing; }
     const PAL::WebGPU::PresentationContext& backing() const { return m_backing; }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
@@ -44,7 +44,7 @@ CompositorIntegrationImpl::~CompositorIntegrationImpl() = default;
 
 void CompositorIntegrationImpl::prepareForDisplay(CompletionHandler<void()>&& completionHandler)
 {
-    static_cast<PresentationContext*>(m_presentationContext.get())->present();
+    m_presentationContext->present();
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250993 Wait for the results to be fully drawn
     completionHandler();

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -100,68 +100,28 @@ Ref<Buffer> DeviceImpl::createBuffer(const BufferDescriptor& descriptor)
     return BufferImpl::create(wgpuDeviceCreateBuffer(m_backing, &backingDescriptor), m_convertToBackingContext);
 }
 
-static WGPUTextureDescriptorViewFormats createBackingTextureDescriptorViewFormats(const TextureDescriptor &descriptor, const Ref<ConvertToBackingContext> &convertToBackingContext)
-{
-    auto backingTextureFormats = descriptor.viewFormats.map([&] (TextureFormat textureFormat) {
-        return convertToBackingContext->convertToBacking(textureFormat);
-    });
-
-    return WGPUTextureDescriptorViewFormats {
-        {
-            nullptr,
-            static_cast<WGPUSType>(WGPUSTypeExtended_TextureDescriptorViewFormats),
-        },
-        static_cast<uint32_t>(backingTextureFormats.size()),
-        backingTextureFormats.data(),
-    };
-}
-
-static WGPUTextureDescriptor createBackingDescriptor(WGPUTextureDescriptorViewFormats &backingViewFormats, const TextureDescriptor &descriptor, const Ref<ConvertToBackingContext> &convertToBackingContext)
-{
-    auto label = descriptor.label.utf8();
-    auto size = convertToBackingContext->convertToBacking(descriptor.size);
-
-    return WGPUTextureDescriptor {
-        &backingViewFormats.chain,
-        label.data(),
-        convertToBackingContext->convertTextureUsageFlagsToBacking(descriptor.usage),
-        convertToBackingContext->convertToBacking(descriptor.dimension),
-        size,
-        convertToBackingContext->convertToBacking(descriptor.format),
-        descriptor.mipLevelCount,
-        descriptor.sampleCount,
-        backingViewFormats.viewFormatsCount,
-        backingViewFormats.viewFormats
-    };
-}
-
 Ref<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
 {
-    auto backingViewFormats = createBackingTextureDescriptorViewFormats(descriptor, m_convertToBackingContext);
-    auto backingDescriptor = createBackingDescriptor(backingViewFormats, descriptor, m_convertToBackingContext);
-    return TextureImpl::create(wgpuDeviceCreateTexture(m_backing, &backingDescriptor), descriptor.format, descriptor.dimension, m_convertToBackingContext);
-}
+    auto label = descriptor.label.utf8();
 
-Ref<Texture> DeviceImpl::createSurfaceTexture(const TextureDescriptor& descriptor, const PresentationContext& presentationContext)
-{
-    IOSurfaceRef ioSurface = static_cast<const PresentationContextImpl&>(presentationContext).drawingBuffer();
-    ASSERT(ioSurface);
     auto backingTextureFormats = descriptor.viewFormats.map([&] (TextureFormat textureFormat) {
         return m_convertToBackingContext->convertToBacking(textureFormat);
     });
 
-    WGPUTextureDescriptorCocoaCustomSurface ioSurfaceDescriptor {
-        {
-            nullptr,
-            static_cast<WGPUSType>(WGPUSTypeExtended_TextureDescriptorCocoaSurfaceBacking)
-        },
-        ioSurface
+    WGPUTextureDescriptor backingDescriptor {
+        nullptr,
+        label.data(),
+        m_convertToBackingContext->convertTextureUsageFlagsToBacking(descriptor.usage),
+        m_convertToBackingContext->convertToBacking(descriptor.dimension),
+        m_convertToBackingContext->convertToBacking(descriptor.size),
+        m_convertToBackingContext->convertToBacking(descriptor.format),
+        descriptor.mipLevelCount,
+        descriptor.sampleCount,
+        static_cast<uint32_t>(backingTextureFormats.size()),
+        backingTextureFormats.data(),
     };
 
-    auto backingViewFormats = createBackingTextureDescriptorViewFormats(descriptor, m_convertToBackingContext);
-    backingViewFormats.chain.next = reinterpret_cast<WGPUChainedStruct*>(&ioSurfaceDescriptor);
-    WGPUTextureDescriptor backingDescriptor = createBackingDescriptor(backingViewFormats, descriptor, m_convertToBackingContext);
-    return TextureImpl::create(wgpuDeviceCreateTexture(m_backing, &backingDescriptor), descriptor.format, descriptor.dimension, m_convertToBackingContext);
+    return TextureImpl::create(wgpuDeviceCreateTexture(backing(), &backingDescriptor), descriptor.format, descriptor.dimension, m_convertToBackingContext);
 }
 
 Ref<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
@@ -65,7 +65,6 @@ private:
 
     Ref<Buffer> createBuffer(const BufferDescriptor&) final;
     Ref<Texture> createTexture(const TextureDescriptor&) final;
-    Ref<Texture> createSurfaceTexture(const TextureDescriptor&, const PresentationContext&) final;
     Ref<Sampler> createSampler(const SamplerDescriptor&) final;
     Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) final;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp
@@ -53,11 +53,6 @@ PresentationContextImpl::~PresentationContextImpl()
     wgpuSurfaceRelease(m_backing);
 }
 
-IOSurfaceRef PresentationContextImpl::drawingBuffer() const
-{
-    return wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(m_backing);
-}
-
 void PresentationContextImpl::configure(const CanvasConfiguration& canvasConfiguration)
 {
     if (m_swapChain)
@@ -111,18 +106,6 @@ void PresentationContextImpl::present()
     wgpuSwapChainPresent(m_swapChain);
     m_currentTexture = nullptr;
 }
-
-#if PLATFORM(COCOA)
-void PresentationContextImpl::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
-{
-    if (!m_swapChain)
-        return;
-
-    wgpuSwapChainPresent(m_swapChain);
-    auto ioSurface = wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(m_backing);
-    completionHandler(MachSendRight::adopt(IOSurfaceCreateMachPort(ioSurface)));
-}
-#endif
 
 } // namespace PAL::WebGPU
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h
@@ -56,7 +56,7 @@ public:
         m_height = height;
     }
 
-    IOSurfaceRef drawingBuffer() const;
+    void present();
 
     WGPUSurface backing() const { return m_backing; }
 
@@ -74,12 +74,6 @@ private:
     void unconfigure() final;
 
     RefPtr<Texture> getCurrentTexture() final;
-
-    void present() final;
-
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
-#endif
 
     TextureFormat m_format { TextureFormat::Bgra8unorm };
     uint32_t m_width { 0 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
@@ -99,7 +99,6 @@ public:
 
     virtual Ref<Buffer> createBuffer(const BufferDescriptor&) = 0;
     virtual Ref<Texture> createTexture(const TextureDescriptor&) = 0;
-    virtual Ref<Texture> createSurfaceTexture(const TextureDescriptor&, const PresentationContext&) = 0;
     virtual Ref<Sampler> createSampler(const SamplerDescriptor&) = 0;
     virtual Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) = 0;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h
@@ -48,12 +48,6 @@ public:
 
     virtual RefPtr<Texture> getCurrentTexture() = 0;
 
-    virtual void present() = 0;
-
-#if PLATFORM(COCOA)
-    virtual void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;
-#endif
-
 protected:
     PresentationContext() = default;
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -171,20 +171,8 @@ RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
     if (m_currentTexture)
         return m_currentTexture;
 
-    GPUTextureDescriptor descriptor = {
-        { "WebGPU Display texture"_s },
-        GPUExtent3DDict { static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1 },
-        1 /* mipMapCount */,
-        1 /* sampleCount */,
-        GPUTextureDimension::_2d,
-        m_configuration->format,
-        m_configuration->usage,
-        m_configuration->viewFormats
-    };
-
     markContextChangedAndNotifyCanvasObservers();
-    // FIXME: This should use PresentationContext::getCurrentTexture() instead.
-    m_currentTexture = m_configuration->device->createSurfaceTexture(descriptor, m_presentationContext);
+    m_currentTexture = m_presentationContext->getCurrentTexture();
     return m_currentTexture;
 }
 
@@ -215,6 +203,7 @@ void GPUCanvasContextCocoa::prepareForDisplay()
         m_compositingResultsNeedsUpdating = false;
         m_configuration->frameCount = (m_configuration->frameCount + 1) % m_configuration->renderBuffers.size();
         m_currentTexture = nullptr;
+        m_presentationContext->present();
     });
 }
 

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -45,10 +45,6 @@ public:
     Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
 
-    // FIXME: Delete these.
-    IOSurface *displayBuffer() const;
-    IOSurface *drawingBuffer() const;
-
     bool isPresentationContextIOSurface() const override { return true; }
 
 private:

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -54,19 +54,6 @@ PresentationContextIOSurface::PresentationContextIOSurface(const WGPUSurfaceDesc
 
 PresentationContextIOSurface::~PresentationContextIOSurface() = default;
 
-IOSurface *PresentationContextIOSurface::displayBuffer() const
-{
-    ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
-    size_t index = (m_currentIndex + 1) % m_renderBuffers.size();
-    return m_ioSurfaces[index];
-}
-
-IOSurface *PresentationContextIOSurface::drawingBuffer() const
-{
-    ASSERT(m_ioSurfaces.count == m_renderBuffers.size());
-    return m_ioSurfaces[m_currentIndex];
-}
-
 void PresentationContextIOSurface::renderBuffersWereRecreated(NSArray<IOSurface *> *ioSurfaces)
 {
     m_ioSurfaces = ioSurfaces;
@@ -149,17 +136,3 @@ TextureView* PresentationContextIOSurface::getCurrentTextureView()
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs
-
-IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(WGPUSurface surface)
-{
-    if (auto* presentationContextIOSurface = downcast<WebGPU::PresentationContextIOSurface>(&WebGPU::fromAPI(surface)))
-        return bridge_cast(presentationContextIOSurface->displayBuffer());
-    return nullptr;
-}
-
-IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(WGPUSurface surface)
-{
-    if (auto* presentationContextIOSurface = downcast<WebGPU::PresentationContextIOSurface>(&WebGPU::fromAPI(surface)))
-        return bridge_cast(presentationContextIOSurface->drawingBuffer());
-    return nullptr;
-}

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -1327,52 +1327,6 @@ bool Device::validateCreateTexture(const WGPUTextureDescriptor& descriptor, cons
     return true;
 }
 
-bool Device::validateCreateIOSurfaceBackedTexture(const WGPUTextureDescriptor& descriptor, const Vector<WGPUTextureFormat>& viewFormats, IOSurfaceRef backing)
-{
-    if (!isValid())
-        return false;
-
-    if (!backing)
-        return false;
-
-    if (!(descriptor.usage & WGPUTextureUsage_RenderAttachment))
-        return false;
-
-    // Metal only supports binding into BGRA8 and RGBA16Float IOTextures.
-    // FIXME: add support for RGBA16 if necessary.
-    if (descriptor.format != WGPUTextureFormat_BGRA8Unorm)
-        return false;
-    if (IOSurfaceGetPixelFormat(backing) != 'BGRA')
-        return false;
-    // BGRA8 is non-planar, check that the IOSurface is non-planar.
-    if (IOSurfaceGetPlaneCount(backing))
-        return false;
-
-    // Check that the texture is a 2D texture with valid width/height, and has the same dimensions as the IOSurface.
-    if (descriptor.dimension != WGPUTextureDimension_2D)
-        return false;
-    if (!descriptor.size.width || descriptor.size.width != IOSurfaceGetWidth(backing) || descriptor.size.width > limits().maxTextureDimension2D || descriptor.size.width % Texture::texelBlockWidth(descriptor.format))
-        return false;
-    if (!descriptor.size.height || descriptor.size.height != IOSurfaceGetHeight(backing) || descriptor.size.height > limits().maxTextureDimension2D || descriptor.size.height % Texture::texelBlockHeight(descriptor.format))
-        return false;
-    if (descriptor.size.depthOrArrayLayers != 1)
-        return false;
-
-    if (descriptor.mipLevelCount != 1)
-        return false;
-
-    // IOSurface-backed textures do not support multisampling.
-    if (descriptor.sampleCount != 1)
-        return false;
-
-    for (auto viewFormat : viewFormats) {
-        if (!textureViewFormatCompatible(descriptor.format, viewFormat))
-            return false;
-    }
-
-    return true;
-}
-
 MTLTextureUsage Texture::usage(WGPUTextureUsageFlags usage)
 {
     MTLTextureUsage result = MTLTextureUsageUnknown;
@@ -1981,15 +1935,8 @@ std::optional<MTLPixelFormat> Texture::stencilOnlyAspectMetalFormat(WGPUTextureF
     }
 }
 
-static MTLStorageMode storageMode(bool deviceHasUnifiedMemory, bool supportsNonPrivateDepthStencilTextures, bool isBackedByIOSurface)
+static MTLStorageMode storageMode(bool deviceHasUnifiedMemory, bool supportsNonPrivateDepthStencilTextures)
 {
-    // Metal driver requires IOSurface-backed texture to be MTLStorageModeManaged.
-    if (isBackedByIOSurface)
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-        return MTLStorageModeManaged;
-#else
-        return MTLStorageModeShared;
-#endif
 
     // FIXME: only perform this check if the texture is a depth/stencil texture.
     if (!supportsNonPrivateDepthStencilTextures)
@@ -2007,27 +1954,8 @@ static MTLStorageMode storageMode(bool deviceHasUnifiedMemory, bool supportsNonP
 
 Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
 {
-    IOSurfaceRef ioSurfaceBacking = nullptr;
-    Vector<WGPUTextureFormat> viewFormats;
-    const auto* current = descriptor.nextInChain;
-    while (current) {
-        bool viewFormatsSpecified = false;
-        if (current->sType == static_cast<WGPUSType>(WGPUSTypeExtended_TextureDescriptorViewFormats) && !viewFormatsSpecified) {
-            if (viewFormatsSpecified)
-                return Texture::createInvalid(*this);
-
-            viewFormatsSpecified = true;
-
-            const auto& descriptorViewFormats = reinterpret_cast<const WGPUTextureDescriptorViewFormats&>(*current);
-            viewFormats = Vector { descriptorViewFormats.viewFormats, descriptorViewFormats.viewFormatsCount };
-        } else if (current->sType == static_cast<WGPUSType>(WGPUSTypeExtended_TextureDescriptorCocoaSurfaceBacking)) {
-            const auto& descriptorIOSurface = reinterpret_cast<const WGPUTextureDescriptorCocoaCustomSurface&>(*current);
-            ioSurfaceBacking = descriptorIOSurface.surface;
-        } else
-            return Texture::createInvalid(*this);
-
-        current = current->next;
-    }
+    if (descriptor.nextInChain)
+        return Texture::createInvalid(*this);
 
     // https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture
 
@@ -2038,8 +1966,9 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
         }
     }
 
-    bool validationResult = ioSurfaceBacking ? validateCreateIOSurfaceBackedTexture(descriptor, viewFormats, ioSurfaceBacking) : validateCreateTexture(descriptor, viewFormats);
-    if (!validationResult) {
+    Vector viewFormats = { descriptor.viewFormats, descriptor.viewFormatCount };
+
+    if (!validateCreateTexture(descriptor, viewFormats)) {
         generateAValidationError("Validation failure."_s);
         return Texture::createInvalid(*this);
     }
@@ -2094,16 +2023,12 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
 
     textureDescriptor.sampleCount = descriptor.sampleCount;
 
-    textureDescriptor.storageMode = storageMode(hasUnifiedMemory(), baseCapabilities().supportsNonPrivateDepthStencilTextures, ioSurfaceBacking);
+    textureDescriptor.storageMode = storageMode(hasUnifiedMemory(), baseCapabilities().supportsNonPrivateDepthStencilTextures);
 
     // FIXME(PERFORMANCE): Consider write-combining CPU cache mode.
     // FIXME(PERFORMANCE): Consider implementing hazard tracking ourself.
 
-    id<MTLTexture> texture = nil;
-    if (ioSurfaceBacking)
-        texture = [m_device newTextureWithDescriptor:textureDescriptor iosurface:ioSurfaceBacking plane:0];
-    else
-        texture = [m_device newTextureWithDescriptor:textureDescriptor];
+    id<MTLTexture> texture = [m_device newTextureWithDescriptor:textureDescriptor];
 
     if (!texture)
         return Texture::createInvalid(*this);

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -46,10 +46,8 @@ typedef void (^WGPUWorkItem)(void);
 typedef void (^WGPUScheduleWorkBlock)(WGPUWorkItem workItem);
 
 typedef enum WGPUSTypeExtended {
-    WGPUSTypeExtended_TextureDescriptorViewFormats = 0x1D5BC57, // Random
     WGPUSTypeExtended_InstanceCocoaDescriptor = 0x151BBC00, // Random
     WGPUSTypeExtended_SurfaceDescriptorCocoaSurfaceBacking = 0x017E9710, // Random
-    WGPUSTypeExtended_TextureDescriptorCocoaSurfaceBacking = 0xCCE4ED61, // Random
     WGPUSTypeExtended_Force32 = 0x7FFFFFFF
 } WGPUSTypeExtended;
 
@@ -65,23 +63,12 @@ typedef struct WGPUInstanceCocoaDescriptor {
     __unsafe_unretained WGPUScheduleWorkBlock scheduleWorkBlock;
 } WGPUInstanceCocoaDescriptor;
 
-typedef struct WGPUTextureDescriptorViewFormats {
-    WGPUChainedStruct chain;
-    uint32_t viewFormatsCount;
-    WGPUTextureFormat const * viewFormats;
-} WGPUTextureDescriptorViewFormats;
-
 typedef void (^WGPURenderBuffersWereRecreatedBlockCallback)(CFArrayRef ioSurfaces);
 typedef void (^WGPUCompositorIntegrationRegisterBlockCallback)(WGPURenderBuffersWereRecreatedBlockCallback renderBuffersWereRecreated);
 typedef struct WGPUSurfaceDescriptorCocoaCustomSurface {
     WGPUChainedStruct chain;
     WGPUCompositorIntegrationRegisterBlockCallback compositorIntegrationRegister;
 } WGPUSurfaceDescriptorCocoaCustomSurface;
-
-typedef struct WGPUTextureDescriptorCocoaCustomSurface {
-    WGPUChainedStruct chain;
-    IOSurfaceRef surface;
-} WGPUTextureDescriptorCocoaCustomSurface;
 
 #if !defined(WGPU_SKIP_PROCS)
 
@@ -196,9 +183,6 @@ WGPU_EXPORT void wgpuDeviceSetUncapturedErrorCallbackWithBlock(WGPUDevice device
 WGPU_EXPORT void wgpuInstanceRequestAdapterWithBlock(WGPUInstance instance, WGPURequestAdapterOptions const * options, WGPURequestAdapterBlockCallback callback);
 WGPU_EXPORT void wgpuQueueOnSubmittedWorkDoneWithBlock(WGPUQueue queue, WGPUQueueWorkDoneBlockCallback callback);
 WGPU_EXPORT void wgpuShaderModuleGetCompilationInfoWithBlock(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
-
-WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(WGPUSurface);
-WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(WGPUSurface);
 
 // FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
 WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -130,20 +130,6 @@ void RemoteDevice::createTexture(const WebGPU::TextureDescriptor& descriptor, We
     m_objectHeap.addObject(identifier, remoteTexture);
 }
 
-void RemoteDevice::createSurfaceTexture(WebGPUIdentifier presentationContextIdentifier, const WebGPU::TextureDescriptor& descriptor, WebGPUIdentifier identifier)
-{
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
-    if (!convertedDescriptor)
-        return;
-
-    auto presentationContext = m_objectHeap.convertPresentationContextFromBacking(presentationContextIdentifier);
-    ASSERT(presentationContext);
-    auto texture = m_backing->createSurfaceTexture(*convertedDescriptor, *presentationContext);
-    auto remoteTexture = RemoteTexture::create(texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteTexture);
-}
-
 void RemoteDevice::createSampler(const WebGPU::SamplerDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -95,7 +95,6 @@ private:
 
     void createBuffer(const WebGPU::BufferDescriptor&, WebGPUIdentifier);
     void createTexture(const WebGPU::TextureDescriptor&, WebGPUIdentifier);
-    void createSurfaceTexture(WebGPUIdentifier, const WebGPU::TextureDescriptor&, WebGPUIdentifier);
     void createSampler(const WebGPU::SamplerDescriptor&, WebGPUIdentifier);
     void importExternalTexture(const WebGPU::ExternalTextureDescriptor&, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -27,7 +27,6 @@ messages -> RemoteDevice NotRefCounted Stream {
     void Destroy()
     void CreateBuffer(WebKit::WebGPU::BufferDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateTexture(WebKit::WebGPU::TextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
-    void CreateSurfaceTexture(WebKit::WebGPUIdentifier surfaceIdentifier, WebKit::WebGPU::TextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateSampler(WebKit::WebGPU::SamplerDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void ImportExternalTexture(WebKit::WebGPU::ExternalTextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateBindGroupLayout(WebKit::WebGPU::BindGroupLayoutDescriptor descriptor, WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -85,18 +85,6 @@ void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
     m_objectHeap.addObject(identifier, remoteTexture);
 }
 
-void RemotePresentationContext::present()
-{
-    m_backing->present();
-}
-
-#if PLATFORM(COCOA)
-void RemotePresentationContext::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
-{
-    m_backing->prepareForDisplay(WTFMove(completionHandler));
-}
-#endif
-
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -77,12 +77,6 @@ private:
 
     void getCurrentTexture(WebGPUIdentifier);
 
-    void present();
-
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
-#endif
-
     Ref<PAL::WebGPU::PresentationContext> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
@@ -27,10 +27,6 @@ messages -> RemotePresentationContext NotRefCounted Stream {
     void Configure(WebKit::WebGPU::CanvasConfiguration configuration)
     void Unconfigure()
     void GetCurrentTexture(WebKit::WebGPUIdentifier identifier)
-    void Present()
-#if PLATFORM(COCOA)
-    void PrepareForDisplay() -> (MachSendRight displayBuffer) Synchronous NotStreamEncodableReply
-#endif
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -102,21 +102,6 @@ Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createTexture(const PAL::WebGPU::Te
     return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
-Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createSurfaceTexture(const PAL::WebGPU::TextureDescriptor& descriptor, const PAL::WebGPU::PresentationContext& presentationContext)
-{
-    auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
-    if (!convertedDescriptor) {
-        // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
-    }
-
-    auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = send(Messages::RemoteDevice::CreateSurfaceTexture(m_convertToBackingContext->convertToBacking(presentationContext), *convertedDescriptor, identifier));
-    UNUSED_VARIABLE(sendResult);
-
-    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
-}
-
 Ref<PAL::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const PAL::WebGPU::SamplerDescriptor& descriptor)
 {
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -81,7 +81,6 @@ private:
 
     Ref<PAL::WebGPU::Buffer> createBuffer(const PAL::WebGPU::BufferDescriptor&) final;
     Ref<PAL::WebGPU::Texture> createTexture(const PAL::WebGPU::TextureDescriptor&) final;
-    Ref<PAL::WebGPU::Texture> createSurfaceTexture(const PAL::WebGPU::TextureDescriptor&, const PAL::WebGPU::PresentationContext&) final;
     Ref<PAL::WebGPU::Sampler> createSampler(const PAL::WebGPU::SamplerDescriptor&) final;
     Ref<PAL::WebGPU::ExternalTexture> importExternalTexture(const PAL::WebGPU::ExternalTextureDescriptor&) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -75,33 +75,6 @@ RefPtr<PAL::WebGPU::Texture> RemotePresentationContextProxy::getCurrentTexture()
     return m_currentTexture;
 }
 
-void RemotePresentationContextProxy::present()
-{
-    auto sendResult = send(Messages::RemotePresentationContext::Present());
-    UNUSED_VARIABLE(sendResult);
-    m_currentTexture = nullptr;
-}
-
-#if PLATFORM(COCOA)
-void RemotePresentationContextProxy::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
-{
-    MachSendRight emptyResult;
-    auto sendResult = sendSync(Messages::RemotePresentationContext::PrepareForDisplay());
-    if (!sendResult) {
-        completionHandler(WTFMove(emptyResult));
-        return;
-    }
-
-    auto [sendRight] = sendResult.takeReply();
-    if (!sendRight) {
-        completionHandler(WTFMove(emptyResult));
-        return;
-    }
-
-    completionHandler(WTFMove(sendRight));
-}
-#endif
-
 } // namespace WebKit::WebGPU
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -79,12 +79,6 @@ private:
 
     RefPtr<PAL::WebGPU::Texture> getCurrentTexture() final;
 
-    void present() final;
-
-#if PLATFORM(COCOA)
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
-#endif
-
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteGPUProxy> m_parent;


### PR DESCRIPTION
#### 501cc5c185132bd91f3c668205e8ab785e2388a3
<pre>
[WebGPU] Migrate from createSurfaceTexture() to getCurrentTexture()
<a href="https://bugs.webkit.org/show_bug.cgi?id=250995">https://bugs.webkit.org/show_bug.cgi?id=250995</a>
rdar://104541617

Reviewed by Tadeu Zagallo.

This is the last step in the &quot;align our WebGPU compositor infrastructure with the IDL spec&quot;
effort. This simply flips the switch from using the old codepath for getCurrentTexture()
to the new one. Thus, most of this patch is just deletions of the old path.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::createSurfaceTexture): Deleted.
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp:
(WebCore::GPUPresentationContext::present): Deleted.
(WebCore::GPUPresentationContext::prepareForDisplay): Deleted.
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp:
(PAL::WebGPU::CompositorIntegrationImpl::prepareForDisplay):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createTexture):
(PAL::WebGPU::createBackingTextureDescriptorViewFormats): Deleted.
(PAL::WebGPU::createBackingDescriptor): Deleted.
(PAL::WebGPU::DeviceImpl::createSurfaceTexture): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp:
(PAL::WebGPU::PresentationContextImpl::drawingBuffer const): Deleted.
(PAL::WebGPU::PresentationContextImpl::prepareForDisplay): Deleted.
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::displayBuffer const): Deleted.
(WebGPU::PresentationContextIOSurface::drawingBuffer const): Deleted.
(wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer): Deleted.
(wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer): Deleted.
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::storageMode):
(WebGPU::Device::createTexture):
(WebGPU::Device::validateCreateIOSurfaceBackedTexture): Deleted.
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::createSurfaceTexture): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::present): Deleted.
(WebKit::RemotePresentationContext::prepareForDisplay): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createSurfaceTexture): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
(WebKit::WebGPU::RemotePresentationContextProxy::present): Deleted.
(WebKit::WebGPU::RemotePresentationContextProxy::prepareForDisplay): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/259884@main">https://commits.webkit.org/259884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a1ce0fd1f31b1c984c0cbcbce6480bc562da08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115437 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175535 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6517 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115119 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40277 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81967 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28704 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5277 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6829 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10584 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->