### PR TITLE
Non-unified build fixes, late January 2023 edition

### DIFF
--- a/Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.cpp
+++ b/Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBGL)
 
 #include "WebGLShaderPrecisionFormat.h"
+#include <wtf/Ref.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -30,6 +30,7 @@
 
 #include "WebCoreOpaqueRoot.h"
 #include "WebGL2RenderingContext.h"
+#include "WebGLBuffer.h"
 #include "WebGLContextGroup.h"
 #include <JavaScriptCore/AbstractSlotVisitorInlines.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.h
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.h
@@ -28,6 +28,8 @@
 #if ENABLE(WEBGL2)
 
 #include "WebGLSharedObject.h"
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 
 namespace JSC {
 class AbstractSlotVisitor;

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -42,7 +42,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/CString.h>
-#include <wtf/text/StringHash.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.h
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.h
@@ -33,6 +33,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 typedef struct _SoupCache SoupCache;


### PR DESCRIPTION
#### 114df9fa38ba20a58bd5ca229c63d8e99f8c595b
<pre>
Non-unified build fixes, late January 2023 edition

Unreviewed non-unified build fixes.

* Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.cpp: Add missing
  wtf/Ref.h header.
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp: Add missing
  WebGLBuffer.h header.
* Source/WebCore/html/canvas/WebGLTransformFeedback.h: Add missing
  wtf/RefPtr.h and wtf/Vector.h headers.
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp: Remove
  inclusion of wtf/text/StringHash.h, as it is now done in the header.
* Source/WebCore/platform/network/soup/SoupNetworkSession.h: Add missing
  wtf/text/StringHash.h header.

Canonical link: <a href="https://commits.webkit.org/259207@main">https://commits.webkit.org/259207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07e3dea004db0959337b676f35ff1182870d7e9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113572 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173865 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4353 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112612 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27231 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6928 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46789 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6343 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8719 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->