### PR TITLE
[WGSL] Add a CallGraph

### DIFF
--- a/Source/WebGPU/WGSL/CallGraph.cpp
+++ b/Source/WebGPU/WGSL/CallGraph.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CallGraph.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+
+namespace WGSL {
+
+CallGraph::CallGraph(AST::ShaderModule& shaderModule)
+    : m_ast(shaderModule)
+{
+}
+
+class CallGraphBuilder : public AST::Visitor {
+public:
+    CallGraphBuilder(AST::ShaderModule& shaderModule)
+        : m_callGraph(shaderModule)
+    {
+    }
+
+    CallGraph build();
+
+    // FIXME: we also need to visit function calls when we add support for them
+    void visit(AST::FunctionDecl&) override;
+
+private:
+    void initializeMappings();
+
+    CallGraph m_callGraph;
+    AST::FunctionDecl* m_currentFunction;
+};
+
+CallGraph CallGraphBuilder::build()
+{
+    initializeMappings();
+    return m_callGraph;
+}
+
+void CallGraphBuilder::initializeMappings()
+{
+    for (auto& functionDecl : m_callGraph.m_ast.functions()) {
+        const auto& name = functionDecl.name();
+        {
+            auto result = m_callGraph.m_functionsByName.add(name, &functionDecl);
+            ASSERT_UNUSED(result, result.isNewEntry);
+        }
+
+        {
+            auto result = m_callGraph.m_callees.add(&functionDecl, Vector<CallGraph::Callee>());
+            ASSERT_UNUSED(result, result.isNewEntry);
+        }
+
+        for (auto& attribute : functionDecl.attributes()) {
+            if (attribute->kind() == AST::Node::Kind::StageAttribute) {
+                auto stage = downcast<AST::StageAttribute>(attribute.get()).stage();
+                m_callGraph.m_entrypoints.append({ functionDecl, stage });
+                break;
+            }
+        }
+    }
+}
+
+void CallGraphBuilder::visit(AST::FunctionDecl& functionDecl)
+{
+    m_currentFunction = &functionDecl;
+    checkErrorAndVisit(functionDecl.body());
+    m_currentFunction = nullptr;
+}
+
+CallGraph buildCallGraph(AST::ShaderModule& shaderModule)
+{
+    return CallGraphBuilder(shaderModule).build();
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -25,10 +25,45 @@
 
 #pragma once
 
+// FIXME: move Stage out of StageAttribute so we don't need to include this
+#include "ASTStageAttribute.h"
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+
 namespace WGSL {
 
-class CallGraph;
+namespace AST {
+class CallableExpression;
+class ShaderModule;
+class FunctionDecl;
+};
 
-void rewriteEntryPoints(CallGraph&);
+class CallGraph {
+    friend class CallGraphBuilder;
+
+public:
+    struct Callee {
+        AST::FunctionDecl* m_target;
+        Vector<AST::CallableExpression*> m_callSites;
+    };
+
+    struct EntryPoint {
+        AST::FunctionDecl& m_function;
+        AST::StageAttribute::Stage m_stage;
+    };
+
+    AST::ShaderModule& ast() { return m_ast; }
+    const Vector<EntryPoint>& entrypoints() { return m_entrypoints; }
+
+private:
+    CallGraph(AST::ShaderModule&);
+
+    AST::ShaderModule& m_ast;
+    Vector<EntryPoint> m_entrypoints;
+    HashMap<String, AST::FunctionDecl*> m_functionsByName;
+    HashMap<AST::FunctionDecl*, Vector<Callee>> m_callees;
+};
+
+CallGraph buildCallGraph(AST::ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -28,6 +28,7 @@
 
 #include "AST.h"
 #include "ASTVisitor.h"
+#include "CallGraph.h"
 
 namespace WGSL {
 
@@ -251,34 +252,10 @@ void EntryPointRewriter::appendBuiltins()
     }
 }
 
-class RewriteEntryPoints : public AST::Visitor {
-public:
-    RewriteEntryPoints(AST::ShaderModule& shaderModule)
-        : AST::Visitor()
-        , m_shaderModule(shaderModule)
-    {
-    }
-
-    void visit(AST::FunctionDecl&) override;
-
-private:
-    AST::ShaderModule& m_shaderModule;
-};
-
-void RewriteEntryPoints::visit(AST::FunctionDecl& functionDecl)
+void rewriteEntryPoints(CallGraph& callGraph)
 {
-    for (auto& attribute : functionDecl.attributes()) {
-        if (attribute->kind() == AST::Node::Kind::StageAttribute) {
-            EntryPointRewriter(m_shaderModule, functionDecl).rewrite();
-            return;
-        }
-    }
-
-}
-
-void rewriteEntryPoints(AST::ShaderModule& shaderModule)
-{
-    RewriteEntryPoints(shaderModule).AST::Visitor::visit(shaderModule);
+    for (auto& entryPoint : callGraph.entrypoints())
+        EntryPointRewriter(callGraph.ast(), entryPoint.m_function).rewrite();
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
+		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
+		9789C31B297EA105009E9006 /* CallGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C319297EA105009E9006 /* CallGraph.h */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -333,6 +335,8 @@
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
+		9789C318297EA105009E9006 /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallGraph.cpp; sourceTree = "<group>"; };
+		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -615,6 +619,8 @@
 			children = (
 				33EA185C27BC193D00A1DD52 /* AST */,
 				979240B1297018290050EA2C /* Metal */,
+				9789C318297EA105009E9006 /* CallGraph.cpp */,
+				9789C319297EA105009E9006 /* CallGraph.h */,
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
@@ -761,6 +767,7 @@
 				33EA187227BC1FE100A1DD52 /* ASTVariableQualifier.h in Headers */,
 				3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */,
 				3A1337E828FBD56400F29B73 /* ASTVisitor.h in Headers */,
+				9789C31B297EA105009E9006 /* CallGraph.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
@@ -945,6 +952,7 @@
 			files = (
 				3ADB94442900F7D700CFFDC2 /* ASTStringDumper.cpp in Sources */,
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
+				9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,


### PR DESCRIPTION
#### d3bb3ea55bb7bc28aa962d2b435940f2a877847e
<pre>
[WGSL] Add a CallGraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=251005">https://bugs.webkit.org/show_bug.cgi?id=251005</a>
&lt;rdar://problem/104552119&gt;

Reviewed by Dean Jackson.

Introduce a CallGraph data structure and a CallGraphBuilder pass. For
now it&apos;s still fairly limited, as we still don&apos;t support function calls,
but it helps the current passes that have to visit entry points.

* Source/WebGPU/WGSL/CallGraph.cpp: Added.
(WGSL::CallGraph::CallGraph):
(WGSL::CallGraphBuilder::CallGraphBuilder):
(WGSL::CallGraphBuilder::build):
(WGSL::CallGraphBuilder::initializeMappings):
(WGSL::CallGraphBuilder::visit):
(WGSL::buildCallGraph):
* Source/WebGPU/WGSL/CallGraph.h: Copied from Source/WebGPU/WGSL/EntryPointRewriter.h.
(WGSL::CallGraph::ast):
(WGSL::CallGraph::entrypoints):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::rewriteEntryPoints):
(WGSL::RewriteEntryPoints::RewriteEntryPoints): Deleted.
(WGSL::RewriteEntryPoints::visit): Deleted.
* Source/WebGPU/WGSL/EntryPointRewriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepare):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259230@main">https://commits.webkit.org/259230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b560806ae4eeac82ebe9df392b5b3dd1266a8e41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113576 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4357 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112616 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38836 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3787 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6364 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8723 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->