### PR TITLE
[GStreamer] Rewrite inner decoder leveraging the GStreamerElementHarness

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1041,6 +1041,19 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
         GST_VIDEO_INFO_COLORIMETRY(info).range = GST_VIDEO_COLOR_RANGE_UNKNOWN;
 }
 
+void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>& element)
+{
+    auto elementHasProperty = [&](const char* name) -> bool {
+        return g_object_class_find_property(G_OBJECT_GET_CLASS(element.get()), name);
+    };
+
+    if (elementHasProperty("max-threads"))
+        g_object_set(element.get(), "max-threads", 1, nullptr);
+
+    if (elementHasProperty("max-errors"))
+        g_object_set(element.get(), "max-errors", 0, nullptr);
+}
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -344,6 +344,8 @@ PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps*);
 PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo&);
 void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoColorSpace&);
 
+void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);
+
 } // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -28,11 +28,10 @@
 #include "MediaSampleGStreamer.h"
 #include "NotImplemented.h"
 #include "RuntimeApplicationChecks.h"
-#include <gst/app/gstappsink.h>
-#include <wtf/Lock.h>
+#include "VideoFrameGStreamer.h"
+#include <gst/base/gsttypefindhelper.h>
 #include <wtf/MainThread.h>
 #include <wtf/Scope.h>
-#include <wtf/Threading.h>
 
 namespace WebCore {
 
@@ -63,9 +62,11 @@ private:
     ImageDecoderGStreamerSample(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize)
         : MediaSampleGStreamer(WTFMove(sample), presentationSize, { })
     {
-        m_image = ImageGStreamer::createImage(GRefPtr<GstSample>(platformSample().sample.gstSample));
+        m_frame = VideoFrameGStreamer::createWrappedSample(platformSample().sample.gstSample, MediaTime::invalidTime());
+        m_image = m_frame->convertToImage();
     }
 
+    RefPtr<VideoFrameGStreamer> m_frame;
     RefPtr<ImageGStreamer> m_image;
 };
 
@@ -131,8 +132,6 @@ EncodedDataStatus ImageDecoderGStreamer::encodedDataStatus() const
         return EncodedDataStatus::Complete;
     if (m_size)
         return EncodedDataStatus::SizeAvailable;
-    if (m_innerDecoder)
-        return m_innerDecoder->encodedDataStatus();
     return EncodedDataStatus::Unknown;
 }
 
@@ -228,254 +227,80 @@ const ImageDecoderGStreamerSample* ImageDecoderGStreamer::sampleAtIndex(size_t i
     return toSample(iter);
 }
 
-ImageDecoderGStreamer::InnerDecoder::~InnerDecoder()
+void ImageDecoderGStreamer::storeDecodedSample(GRefPtr<GstSample>&& sample)
 {
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Destructing decoder");
-    g_signal_handlers_disconnect_by_func(m_decodebin.get(), reinterpret_cast<gpointer>(decodebinPadAddedCallback), this);
-    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
-    gst_bus_set_sync_handler(bus.get(), nullptr, nullptr, nullptr);
-    disconnectSimpleBusMessageCallback(m_pipeline.get());
-    gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+    auto presentationSize = getVideoResolutionFromCaps(gst_sample_get_caps(sample.get()));
+    if (presentationSize && !presentationSize->isEmpty() && (!m_size || m_size != roundedIntSize(*presentationSize)))
+        m_size = roundedIntSize(*presentationSize);
+    m_sampleData.addSample(ImageDecoderGStreamerSample::create(WTFMove(sample), *m_size));
 }
 
-void ImageDecoderGStreamer::InnerDecoder::decodebinPadAddedCallback(ImageDecoderGStreamer::InnerDecoder* decoder, GstPad* pad)
+void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& sharedBuffer)
 {
-    decoder->connectDecoderPad(pad);
-}
-
-void ImageDecoderGStreamer::InnerDecoder::connectDecoderPad(GstPad* pad)
-{
-    auto padCaps = adoptGRef(gst_pad_query_caps(pad, nullptr));
-    GST_DEBUG_OBJECT(m_pipeline.get(), "New decodebin pad %" GST_PTR_FORMAT " caps: %" GST_PTR_FORMAT, pad, padCaps.get());
-
-    // Decodebin3 in GStreamer <= 1.16 does not respect user-supplied select-stream events. So we
-    // need to relax the release assert for these versions. This bug was fixed in:
-    // https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/commit/b41b87522f59355bb21c001e9e2df96dc6956928
-    bool isVideo = doCapsHaveType(padCaps.get(), "video");
-    if (webkitGstCheckVersion(1, 18, 0))
-        RELEASE_ASSERT(isVideo);
-    else if (!isVideo)
-        return;
-
-    GstElement* sink = makeGStreamerElement("appsink", nullptr);
-    static GstAppSinkCallbacks callbacks = {
-        nullptr,
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            auto sample = adoptGRef(gst_app_sink_try_pull_preroll(sink, 0));
-            static_cast<ImageDecoderGStreamer*>(userData)->notifySample(WTFMove(sample));
-            return GST_FLOW_OK;
-        },
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            auto sample = adoptGRef(gst_app_sink_try_pull_sample(sink, 0));
-            static_cast<ImageDecoderGStreamer*>(userData)->notifySample(WTFMove(sample));
-            return GST_FLOW_OK;
-        },
-#if GST_CHECK_VERSION(1, 20, 0)
-        // new_event
-        nullptr,
-#endif
-        { nullptr }
-    };
-    gst_app_sink_set_callbacks(GST_APP_SINK(sink), &callbacks, &m_decoder, nullptr);
-
-    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_from_string("video/x-raw, format=(string)RGBA"));
-    g_object_set(sink, "sync", false, "caps", caps.get(), nullptr);
-
-    GstElement* videoconvert = makeGStreamerElement("videoconvert", nullptr);
-
-    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), videoconvert, sink, nullptr);
-    gst_element_link(videoconvert, sink);
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(videoconvert, "sink"));
-    gst_pad_link(pad, sinkPad.get());
-    gst_element_sync_state_with_parent(videoconvert);
-    gst_element_sync_state_with_parent(sink);
-}
-
-void ImageDecoderGStreamer::setHasEOS()
-{
-    GST_DEBUG("EOS on decoder %p", this);
-    {
-        Locker locker { m_sampleLock };
-        m_eos = true;
-        m_sampleCondition.notifyOne();
-    }
-    {
-        Locker locker { m_handlerLock };
-        m_handlerCondition.wait(m_handlerLock);
-    }
-}
-
-void ImageDecoderGStreamer::notifySample(GRefPtr<GstSample>&& sample)
-{
-    {
-        Locker locker { m_sampleLock };
-        m_sample = WTFMove(sample);
-        m_sampleCondition.notifyOne();
-    }
-    {
-        Locker locker { m_handlerLock };
-        m_handlerCondition.wait(m_handlerLock);
-    }
-}
-
-void ImageDecoderGStreamer::InnerDecoder::handleMessage(GstMessage* message)
-{
-    ASSERT(&m_runLoop == &RunLoop::current());
-
-    auto scopeExit = makeScopeExit([protectedThis = WeakPtr { *this }] {
-        if (!protectedThis)
-            return;
-        Locker locker { protectedThis->m_messageLock };
-        protectedThis->m_messageDispatched = true;
-        protectedThis->m_messageCondition.notifyOne();
-    });
-
-    GUniqueOutPtr<GError> error;
-    GUniqueOutPtr<gchar> debug;
-
-    switch (GST_MESSAGE_TYPE(message)) {
-    case GST_MESSAGE_EOS:
-        m_decoder.setHasEOS();
-        break;
-    case GST_MESSAGE_WARNING:
-        gst_message_parse_warning(message, &error.outPtr(), &debug.outPtr());
-        g_warning("Warning: %d, %s. Debug output: %s", error->code, error->message, debug.get());
-        break;
-    case GST_MESSAGE_ERROR:
-        gst_message_parse_error(message, &error.outPtr(), &debug.outPtr());
-        g_warning("Error: %d, %s. Debug output: %s", error->code, error->message, debug.get());
-        m_decoder.setHasEOS();
-        break;
-    case GST_MESSAGE_STREAM_COLLECTION: {
-        GRefPtr<GstStreamCollection> collection;
-        gst_message_parse_stream_collection(message, &collection.outPtr());
-        if (collection && GST_MESSAGE_SRC(message) == GST_OBJECT_CAST(m_decodebin.get())) {
-            unsigned size = gst_stream_collection_get_size(collection.get());
-            GList* streams = nullptr;
-            for (unsigned i = 0 ; i < size; i++) {
-                auto* stream = gst_stream_collection_get_stream(collection.get(), i);
-                auto streamType = gst_stream_get_stream_type(stream);
-                if (streamType == GST_STREAM_TYPE_VIDEO) {
-                    streams = g_list_append(streams, const_cast<char*>(gst_stream_get_stream_id(stream)));
-                    break;
-                }
-            }
-            if (streams) {
-                gst_element_send_event(m_decodebin.get(), gst_event_new_select_streams(streams));
-                g_list_free(streams);
-            }
-        }
-        break;
-    }
-    default:
-        break;
-    }
-}
-
-void ImageDecoderGStreamer::InnerDecoder::preparePipeline()
-{
-    static Atomic<uint32_t> pipelineId;
-    m_pipeline = gst_pipeline_new(makeString("image-decoder-", pipelineId.exchangeAdd(1)).utf8().data());
-
-    connectSimpleBusMessageCallback(m_pipeline.get());
-
-    GRefPtr<GstBus> bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
-    ASSERT(bus);
-
-    gst_bus_set_sync_handler(bus.get(), [](GstBus*, GstMessage* message, gpointer userData) {
-        auto& decoder = *static_cast<ImageDecoderGStreamer::InnerDecoder*>(userData);
-
-        {
-            Locker locker { decoder.m_messageLock };
-            decoder.m_messageDispatched = false;
-        }
-        if (&decoder.m_runLoop == &RunLoop::current())
-            decoder.handleMessage(message);
-        else {
-            GRefPtr<GstMessage> protectedMessage(message);
-            WeakPtr weakThis { decoder };
-            decoder.m_runLoop.dispatch([weakThis, protectedMessage] {
-                if (weakThis)
-                    weakThis->handleMessage(protectedMessage.get());
-            });
-            {
-                Locker locker { decoder.m_messageLock };
-                if (!decoder.m_messageDispatched)
-                    decoder.m_messageCondition.wait(decoder.m_messageLock);
-            }
-        }
-        gst_message_unref(message);
-        return GST_BUS_DROP;
-    }, this, nullptr);
-
-    GstElement* source = makeGStreamerElement("giostreamsrc", nullptr);
-    g_object_set(source, "stream", m_memoryStream.get(), nullptr);
-
-    m_decodebin = makeGStreamerElement("decodebin3", nullptr);
-    g_signal_connect_swapped(m_decodebin.get(), "pad-added", G_CALLBACK(decodebinPadAddedCallback), this);
-
-    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), source, m_decodebin.get(), nullptr);
-    gst_element_link(source, m_decodebin.get());
-    gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
-}
-
-void ImageDecoderGStreamer::InnerDecoder::run()
-{
-    m_runLoop.dispatch([this]() {
-        preparePipeline();
-    });
-
-    m_runLoop.run();
-}
-
-EncodedDataStatus ImageDecoderGStreamer::InnerDecoder::encodedDataStatus() const
-{
-    GstState state;
-    gst_element_get_state(m_pipeline.get(), &state, nullptr, 0);
-    if (state >= GST_STATE_READY)
-        return EncodedDataStatus::TypeAvailable;
-    return EncodedDataStatus::Unknown;
-}
-
-void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& buffer)
-{
-    auto contiguousBuffer = buffer.makeContiguous();
+    auto data = sharedBuffer.makeContiguous();
+    auto bytes = data->createGBytes();
+    auto buffer = adoptGRef(gst_buffer_new_wrapped_bytes(bytes.get()));
     m_eos = false;
-    auto thread = Thread::create("ImageDecoderGStreamer", [this, data = contiguousBuffer->data(), size = buffer.size()] {
-        m_innerDecoder = ImageDecoderGStreamer::InnerDecoder::create(*this, data, size);
-        m_innerDecoder->run();
-    }, ThreadType::Graphics);
-    thread->detach();
-    bool isEOS = false;
-    {
-        Locker locker { m_sampleLock };
-        isEOS = m_eos;
-    }
-    while (!isEOS) {
-        {
-            Locker locker { m_sampleLock };
-            m_sampleCondition.wait(m_sampleLock);
-            isEOS = m_eos;
-            if (m_sample) {
-                auto* caps = gst_sample_get_caps(m_sample.get());
-                GST_DEBUG("Handling sample with caps %" GST_PTR_FORMAT " on decoder %p", caps, this);
-                auto presentationSize = getVideoResolutionFromCaps(caps);
-                if (presentationSize && !presentationSize->isEmpty() && (!m_size || m_size != roundedIntSize(*presentationSize)))
-                    m_size = roundedIntSize(*presentationSize);
-                m_sampleData.addSample(ImageDecoderGStreamerSample::create(WTFMove(m_sample), *m_size));
-            }
-        }
-        {
-            Locker locker { m_handlerLock };
-            m_handlerCondition.notifyAll();
-        }
-    }
-    m_innerDecoder = nullptr;
-    callOnMainThreadAndWait([&] {
-        if (m_encodedDataStatusChangedCallback)
-            m_encodedDataStatusChangedCallback(encodedDataStatus());
+
+    auto scopeExit = makeScopeExit([&] {
+        callOnMainThreadAndWait([&] {
+            if (m_encodedDataStatusChangedCallback)
+                m_encodedDataStatusChangedCallback(encodedDataStatus());
+        });
     });
+
+    static Atomic<uint32_t> decoderId;
+    GRefPtr<GstElement> parsebin = gst_element_factory_make("parsebin", makeString("image-decoder-parser-", decoderId.exchangeAdd(1)).utf8().data());
+    auto parserHarness = GStreamerElementHarness::create(WTFMove(parsebin), [](auto&, const auto&) { }, [this](auto& pad) -> RefPtr<GStreamerElementHarness> {
+        auto caps = adoptGRef(gst_pad_query_caps(pad.get(), nullptr));
+        if (!caps || !doCapsHaveType(caps.get(), "video"))
+            return nullptr;
+
+        if (m_decoderHarness) {
+            GST_WARNING_OBJECT(m_decoderHarness->element(), "The media has more than one video track, only the first one will be decoded");
+            return nullptr;
+        }
+
+        auto& scanner = GStreamerRegistryScanner::singleton();
+        auto lookupResult = scanner.areCapsSupported(GStreamerRegistryScanner::Configuration::Decoding, caps, false);
+        if (!lookupResult)
+            return nullptr;
+
+        GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
+        configureVideoDecoderForHarnessing(element);
+        m_decoderHarness = GStreamerElementHarness::create(WTFMove(element), [this](auto& stream, const auto& outputBuffer) {
+            auto outputCaps = stream.outputCaps();
+            auto sample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
+            storeDecodedSample(WTFMove(sample));
+        }, { });
+        m_decoderHarness->start(WTFMove(caps));
+        return m_decoderHarness;
+    });
+
+    auto caps = adoptGRef(gst_type_find_helper_for_buffer(GST_OBJECT_CAST(parserHarness->element()), buffer.get(), nullptr));
+    GST_DEBUG_OBJECT(parserHarness->element(), "Caps typefind result: %" GST_PTR_FORMAT, caps.get());
+    if (!caps) {
+        GST_WARNING_OBJECT(parserHarness->element(), "Typefinding failed");
+        return;
+    }
+
+    parserHarness->start(WTFMove(caps));
+    parserHarness->pushBuffer(buffer.leakRef());
+
+    if (!m_decoderHarness) {
+        GST_WARNING_OBJECT(parserHarness->element(), "Parsing failed");
+        return;
+    }
+
+    for (auto& stream : parserHarness->outputStreams()) {
+        while (auto event = stream->pullEvent())
+            m_decoderHarness->pushEvent(event.leakRef());
+    }
+
+    m_decoderHarness->flush();
+    m_eos = true;
 }
 
-}
-#endif
+} // namespace WebCore
+
+#endif // USE(GSTREAMER) && ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -128,17 +128,7 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
     : m_outputCallback(WTFMove(outputCallback))
     , m_postTaskCallback(WTFMove(postTaskCallback))
 {
-    GUniquePtr<char> elementName(gst_element_get_name(element.get()));
-    auto elementHasProperty = [&](const char* name) -> bool {
-        return g_object_class_find_property(G_OBJECT_GET_CLASS(element.get()), name);
-    };
-    if (g_str_has_prefix(elementName.get(), "avdec")) {
-        if (elementHasProperty("max-threads"))
-            g_object_set(element.get(), "max-threads", 1, nullptr);
-    }
-
-    if (elementHasProperty("max-errors"))
-        g_object_set(element.get(), "max-errors", 0, nullptr);
+    configureVideoDecoderForHarnessing(element);
 
     GST_DEBUG_OBJECT(element.get(), "Configuring decoder for codec %s", codecName.ascii().data());
     GRefPtr<GstCaps> inputCaps;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -565,6 +565,11 @@ RefPtr<JSC::Uint8ClampedArray> VideoFrameGStreamer::computeRGBAImageData() const
     return JSC::Uint8ClampedArray::tryCreate(WTFMove(bufferStorage), 0, byteLength);
 }
 
+RefPtr<ImageGStreamer> VideoFrameGStreamer::convertToImage()
+{
+    return GstSampleColorConverter::singleton().convertSampleToImage(m_sample);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class PixelBuffer;
 class IntSize;
+class ImageGStreamer;
 
 class VideoFrameGStreamer final : public VideoFrame {
 public:
@@ -51,6 +52,8 @@ public:
 
     GstSample* sample() const { return m_sample.get(); }
     RefPtr<JSC::Uint8ClampedArray> computeRGBAImageData() const;
+
+    RefPtr<ImageGStreamer> convertToImage();
 
     FloatSize presentationSize() const final { return m_presentationSize; }
     uint32_t pixelFormat() const final;

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -78,9 +78,10 @@ static GstStaticPadTemplate s_harnessSinkPadTemplate = GST_STATIC_PAD_TEMPLATE("
  * source pads. Support for different topologies can be added as-needed.
  */
 
-GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback)
+GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback, std::optional<PadLinkCallback>&& padLinkCallback)
     : m_element(WTFMove(element))
     , m_processOutputBufferCallback(WTFMove(processOutputBufferCallback))
+    , m_padLinkCallback(WTFMove(padLinkCallback))
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
@@ -104,8 +105,17 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
         g_signal_connect(m_element.get(), "pad-added", reinterpret_cast<GCallback>(+[](GstElement* element, GstPad* pad, gpointer userData) {
             GST_DEBUG_OBJECT(element, "Pad added: %" GST_PTR_FORMAT, pad);
             auto& harness = *reinterpret_cast<GStreamerElementHarness*>(userData);
-            auto stream = GStreamerElementHarness::Stream::create(GRefPtr<GstPad>(pad));
-            harness.m_outputStreams.append(WTFMove(stream));
+            RefPtr<GStreamerElementHarness> downstreamHarness;
+            GRefPtr<GstPad> outputPad(pad);
+            if (harness.m_padLinkCallback) {
+                downstreamHarness = harness.m_padLinkCallback.value()(outputPad);
+                if (!downstreamHarness) {
+                    GST_DEBUG_OBJECT(element, "Unable to create a Stream for pad %" GST_PTR_FORMAT, pad);
+                    return;
+                }
+            }
+
+            harness.m_outputStreams.append(GStreamerElementHarness::Stream::create(WTFMove(outputPad), WTFMove(downstreamHarness)));
         }), this);
 
         g_signal_connect(m_element.get(), "pad-removed", reinterpret_cast<GCallback>(+[](GstElement* element, GstPad* pad, gpointer userData) {
@@ -119,7 +129,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
     } else {
         GST_DEBUG_OBJECT(m_element.get(), "Expecting output buffers on static src pad.");
         auto elementSrcPad = adoptGRef(gst_element_get_static_pad(m_element.get(), "src"));
-        auto stream = GStreamerElementHarness::Stream::create(WTFMove(elementSrcPad));
+        auto stream = GStreamerElementHarness::Stream::create(WTFMove(elementSrcPad), nullptr);
         m_outputStreams.append(WTFMove(stream));
     }
 
@@ -207,10 +217,16 @@ bool GStreamerElementHarness::pushBuffer(GstBuffer* buffer)
     if (!m_stickyEventsSent.load())
         return false;
 
+    auto result = pushBufferFull(buffer);
+    return result == GST_FLOW_OK || result == GST_FLOW_EOS;
+}
+
+GstFlowReturn GStreamerElementHarness::pushBufferFull(GstBuffer* buffer)
+{
     GST_TRACE_OBJECT(m_element.get(), "Pushing %" GST_PTR_FORMAT, buffer);
     auto result = gst_pad_push(m_srcPad.get(), buffer);
     GST_TRACE_OBJECT(m_element.get(), "Buffer push result: %s", gst_flow_get_name(result));
-    return result == GST_FLOW_OK || result == GST_FLOW_EOS;
+    return result;
 }
 
 bool GStreamerElementHarness::pushEvent(GstEvent* event)
@@ -221,14 +237,17 @@ bool GStreamerElementHarness::pushEvent(GstEvent* event)
     return result;
 }
 
-GStreamerElementHarness::Stream::Stream(GRefPtr<GstPad>&& pad)
+GStreamerElementHarness::Stream::Stream(GRefPtr<GstPad>&& pad, RefPtr<GStreamerElementHarness>&& downstreamHarness)
     : m_pad(WTFMove(pad))
+    , m_downstreamHarness(WTFMove(downstreamHarness))
 {
     m_targetPad = gst_pad_new_from_static_template(&s_harnessSinkPadTemplate, "sink");
     gst_pad_link(m_pad.get(), m_targetPad.get());
 
     gst_pad_set_chain_function_full(m_targetPad.get(), reinterpret_cast<GstPadChainFunction>(+[](GstPad* pad, GstObject*, GstBuffer* buffer) -> GstFlowReturn {
         auto& stream = *reinterpret_cast<GStreamerElementHarness::Stream*>(pad->chaindata);
+        if (stream.m_downstreamHarness)
+            return stream.m_downstreamHarness->pushBufferFull(buffer);
         return stream.chainBuffer(buffer);
     }),  this, nullptr);
     gst_pad_set_query_function_full(m_targetPad.get(), reinterpret_cast<GstPadQueryFunction>(+[](GstPad* pad, GstObject* parent, GstQuery* query) -> gboolean {

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -39,10 +39,11 @@ public:
         WTF_MAKE_FAST_ALLOCATED;
 
     public:
-        static Ref<Stream> create(GRefPtr<GstPad>&& pad)
+        static Ref<Stream> create(GRefPtr<GstPad>&& pad, RefPtr<GStreamerElementHarness>&& downstreamHarness)
         {
-            return adoptRef(*new Stream(WTFMove(pad)));
+            return adoptRef(*new Stream(WTFMove(pad), WTFMove(downstreamHarness)));
         }
+
         ~Stream();
 
         GRefPtr<GstBuffer> pullBuffer();
@@ -54,12 +55,15 @@ public:
         const GRefPtr<GstCaps>& outputCaps();
 
     private:
-        Stream(GRefPtr<GstPad>&&);
+        Stream(GRefPtr<GstPad>&&, RefPtr<GStreamerElementHarness>&&);
+
         GstFlowReturn chainBuffer(GstBuffer*);
         bool sinkQuery(GstPad*, GstObject*, GstQuery*);
         bool sinkEvent(GstEvent*);
 
         GRefPtr<GstPad> m_pad;
+        RefPtr<GStreamerElementHarness> m_downstreamHarness;
+
         GRefPtr<GstPad> m_targetPad;
         GRefPtr<GstCaps> m_outputCaps;
 
@@ -70,10 +74,11 @@ public:
         Deque<GRefPtr<GstEvent>> m_sinkEventQueue WTF_GUARDED_BY_LOCK(m_sinkEventQueueLock);
     };
 
+    using PadLinkCallback = Function<RefPtr<GStreamerElementHarness>(const GRefPtr<GstPad>&)>;
     using ProcessBufferCallback = Function<void(Stream&, const GRefPtr<GstBuffer>&)>;
-    static Ref<GStreamerElementHarness> create(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback)
+    static Ref<GStreamerElementHarness> create(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback, std::optional<PadLinkCallback> padLinkCallback = std::nullopt)
     {
-        return adoptRef(*new GStreamerElementHarness(WTFMove(element), WTFMove(processOutputBufferCallback)));
+        return adoptRef(*new GStreamerElementHarness(WTFMove(element), WTFMove(processOutputBufferCallback), WTFMove(padLinkCallback)));
     }
     ~GStreamerElementHarness();
 
@@ -83,6 +88,8 @@ public:
     bool pushBuffer(GstBuffer*);
     bool pushEvent(GstEvent*);
 
+    GstPad* inputPad() const { return m_srcPad.get(); }
+    const GRefPtr<GstCaps>& inputCaps() const { return m_inputCaps; }
     const Vector<RefPtr<Stream>>& outputStreams() const { return m_outputStreams; }
 
     GstElement* element() const { return m_element.get(); }
@@ -91,7 +98,9 @@ public:
     void flush();
 
 private:
-    GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessBufferCallback&&);
+    GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessBufferCallback&&, std::optional<PadLinkCallback>&&);
+
+    GstFlowReturn pushBufferFull(GstBuffer*);
 
     bool srcQuery(GstPad*, GstObject*, GstQuery*);
     bool srcEvent(GstEvent*);
@@ -100,6 +109,7 @@ private:
 
     GRefPtr<GstElement> m_element;
     ProcessBufferCallback m_processOutputBufferCallback;
+    std::optional<PadLinkCallback> m_padLinkCallback;
 
     GRefPtr<GstCaps> m_inputCaps;
 


### PR DESCRIPTION
#### fa3503d135d0820bcdbb68e51516ebfd75fd090d
<pre>
[GStreamer] Rewrite inner decoder leveraging the GStreamerElementHarness
<a href="https://bugs.webkit.org/show_bug.cgi?id=250934">https://bugs.webkit.org/show_bug.cgi?id=250934</a>

Reviewed by Xabier Rodriguez-Calvar.

The previous decoder implementation relied on a GStreamer pipeline involving giostreamsrc,
decodebin3 and appsinks. Due to the highly asynchronous behavior of that pipeline the decoder
heavily relied on Locks and Conditions making the code hard to follow and debug.

The new implementation relies on two element harnesses, the first one is in charge of parsing (with
parsebin), the first parsed video output stream is then plugged to a decode harness, directly hooked
to the platform video decoder, so no queue is involved. The decoding no longer involves additional
threads, so we can simplify the code and entirely get rid of InnerDecoder.

Canonical link: <a href="https://commits.webkit.org/259430@main">https://commits.webkit.org/259430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50b69133b0213ad646470401b46c50c31c0237b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113993 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174195 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4726 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112919 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39072 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108187 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80739 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94648 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27516 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92610 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4898 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4095 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30169 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103539 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47075 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101297 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6507 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9042 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25239 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->