### PR TITLE
`InlineTextBox`es containing `Zero Width Joiner`, `Zero Width Non-Joiner`, or ﻿`Zero Width No-Break Space` characters must not use simplified text measuring

### DIFF
--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -515,9 +515,6 @@ bool WidthIterator::characterCanUseSimplifiedTextMeasuring(UChar character, bool
     switch (character) {
     case newlineCharacter:
     case carriageReturn:
-    case zeroWidthNoBreakSpace:
-    case zeroWidthNonJoiner:
-    case zeroWidthJoiner:
         return true;
     case tabCharacter:
         if (!whitespaceIsCollapsed)
@@ -537,6 +534,9 @@ bool WidthIterator::characterCanUseSimplifiedTextMeasuring(UChar character, bool
     case popDirectionalIsolate:
     case firstStrongIsolate:
     case objectReplacementCharacter:
+    case zeroWidthNoBreakSpace:
+    case zeroWidthNonJoiner:
+    case zeroWidthJoiner:
         return false;
         break;
     }


### PR DESCRIPTION
#### f7b4df2d3a2cacd74bf240875b9bd025570631ca
<pre>
`InlineTextBox`es containing `Zero Width Joiner`, `Zero Width Non-Joiner`, or ﻿`Zero Width No-Break Space` characters must not use simplified text measuring
<a href="https://bugs.webkit.org/show_bug.cgi?id=251009">https://bugs.webkit.org/show_bug.cgi?id=251009</a>

Reviewed by Alan Baradlay.

When calculating the width of an InlineTexBox using simplified measuring,
we simply sum up the width of every glyph. Some fonts
(at least FreeType fonts) specify the non-zero width of
`Zero Width Joiner`, `Zero Width Non-Joiner`, and ﻿`Zero Width No-Break Space`.

Later, during the rendering, these glyphs are skipped causing
the `InlineTextBox`es to become wider than they should be.

Originally, `WidthIterator::characterCanUseSimplifiedTextMeasuring`
was returning `false` for these characters. It was flipped by
<a href="https://commits.webkit.org/241351@main">https://commits.webkit.org/241351@main</a> along with `New Line`
and `Carriage Return`.

Fixes `css2.1/20110323/word-spacing-characters-003.htm` for WPE port.

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::characterCanUseSimplifiedTextMeasuring):

Canonical link: <a href="https://commits.webkit.org/259618@main">https://commits.webkit.org/259618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/570cad93ef2f487d491c8b95c2be666f85b466c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113587 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173880 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4366 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112627 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38844 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80515 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6811 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3794 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46802 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6632 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8734 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->