### PR TITLE
[WebCodecs] Fix build when libwebrtc is enabled on non-Cocoa platforms

### DIFF
--- a/Source/WebCore/platform/VideoDecoder.cpp
+++ b/Source/WebCore/platform/VideoDecoder.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(WEB_CODECS)
 
-#if USE(LIBWEBRTC)
+#if PLATFORM(COCOA) && USE(LIBWEBRTC)
 #include "LibWebRTCVPXVideoDecoder.h"
 #endif
 
@@ -57,7 +57,7 @@ void VideoDecoder::create(const String& codecName, const Config& config, CreateC
 
 void VideoDecoder::createLocalDecoder(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
 {
-#if USE(LIBWEBRTC)
+#if PLATFORM(COCOA) && USE(LIBWEBRTC)
     UNUSED_PARAM(config);
     if (codecName == "vp8"_s) {
         LibWebRTCVPXVideoDecoder::create(LibWebRTCVPXVideoDecoder::Type::VP8, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback));

--- a/Source/WebCore/platform/VideoEncoder.cpp
+++ b/Source/WebCore/platform/VideoEncoder.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(WEB_CODECS)
 
-#if USE(LIBWEBRTC)
+#if PLATFORM(COCOA) && USE(LIBWEBRTC)
 #include "LibWebRTCVPXVideoEncoder.h"
 #endif
 
@@ -56,7 +56,7 @@ void VideoEncoder::create(const String& codecName, const Config& config, CreateC
 
 void VideoEncoder::createLocalEncoder(const String& codecName, const Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
 {
-#if USE(LIBWEBRTC)
+#if PLATFORM(COCOA) && USE(LIBWEBRTC)
     if (codecName == "vp8"_s) {
         LibWebRTCVPXVideoEncoder::create(LibWebRTCVPXVideoEncoder::Type::VP8, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postCallback));
         return;

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "LibWebRTCVPXVideoDecoder.h"
 
-#if ENABLE(WEB_CODECS) && USE(LIBWEBRTC)
+#if ENABLE(WEB_CODECS) && PLATFORM(COCOA) && USE(LIBWEBRTC)
 
 #include "LibWebRTCDav1dDecoder.h"
 #include "Logging.h"

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_CODECS) && USE(LIBWEBRTC)
+#if ENABLE(WEB_CODECS) && PLATFORM(COCOA) && USE(LIBWEBRTC)
 
 #include "VideoDecoder.h"
 #include <wtf/FastMalloc.h>

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "LibWebRTCVPXVideoEncoder.h"
 
-#if ENABLE(WEB_CODECS) && USE(LIBWEBRTC)
+#if ENABLE(WEB_CODECS) && PLATFORM(COCOA) && USE(LIBWEBRTC)
 
 #include "VideoFrameLibWebRTC.h"
 #include <wtf/FastMalloc.h>

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_CODECS) && USE(LIBWEBRTC)
+#if ENABLE(WEB_CODECS) && PLATFORM(COCOA) && USE(LIBWEBRTC)
 
 #include "VideoEncoder.h"
 #include <wtf/FastMalloc.h>


### PR DESCRIPTION
#### d2268e452f42757c1129942098a9143f18bf601a
<pre>
[WebCodecs] Fix build when libwebrtc is enabled on non-Cocoa platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=251019">https://bugs.webkit.org/show_bug.cgi?id=251019</a>

Reviewed by NOBODY (OOPS!).

The LibWebRTCVPXVideoDecoder and LibWebRTCVPXVideoEncoder modules
depend on the Core Video API.

* Source/WebCore/platform/VideoDecoder.cpp:
(WebCore::VideoDecoder::createLocalDecoder):
* Source/WebCore/platform/VideoEncoder.cpp:
(WebCore::VideoEncoder::createLocalEncoder):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2268e452f42757c1129942098a9143f18bf601a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113598 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173892 "Too many flaky failures: editing/execCommand/insert-list-nested-with-orphaned-live-range.html, fast/dom/tab-in-right-alignment.html, fast/forms/shadow-tree-exposure-live-range.html, fast/inline/trailing-inline-box-soft-wrap-opportunity.html, fast/repaint/leftover-after-shrinking-content.html, fast/text/international/bdo-bidi-width.html, fast/text/text-edge-property-parsing.html, fast/text/text-edge-with-margin-padding-border-simple.html, js/dom/Promise-reject-large-string.html, mathml/presentation/scripts-vertical-alignment.html, storage/indexeddb/modern/deleteindex-4-private.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4376 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112638 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38856 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25899 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80525 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27256 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3804 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46814 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8745 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->