### PR TITLE
REGRESSION (254522@main): HTMLSelectElement's value setter sets incorrect values if there are grouped options

### DIFF
--- a/LayoutTests/fast/forms/select-optgroup-set-value-expected.txt
+++ b/LayoutTests/fast/forms/select-optgroup-set-value-expected.txt
@@ -1,0 +1,11 @@
+Tests that setting the value of a <select> element to an <option> within an <optgroup> sets the correct value.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "A"
+PASS select.value is "B"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select-optgroup-set-value.html
+++ b/LayoutTests/fast/forms/select-optgroup-set-value.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+    <select id="select">
+        <optgroup>
+            <option value="A">A</option>
+            <option value="B">B</option>
+            <option value="C">C</option>
+        </optgroup>
+    </select>
+</body>
+<script>
+
+description("Tests that setting the value of a &lt;select&gt; element to an &lt;option&gt; within an &lt;optgroup&gt; sets the correct value.");
+
+shouldBeEqualToString("select.value", "A");
+select.value = "B";
+shouldBeEqualToString("select.value", "B");
+
+</script>
+</html>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -259,14 +259,18 @@ String HTMLSelectElement::value() const
 void HTMLSelectElement::setValue(const String& value)
 {
     // Find the option with value() matching the given parameter and make it the current selection.
-    auto optionIndex = listItems().findIf([&] (const auto& item) {
-        if (auto* optionElement = dynamicDowncast<HTMLOptionElement>(item.get()))
-            return optionElement->value() == value;
+    unsigned optionIndex = 0;
+    for (auto& item : listItems()) {
+        if (auto* option = dynamicDowncast<HTMLOptionElement>(item.get())) {
+            if (option->value() == value) {
+                setSelectedIndex(optionIndex);
+                return;
+            }
+            ++optionIndex;
+        }
+    }
 
-        return false;
-    });
-
-    setSelectedIndex(optionIndex);
+    setSelectedIndex(-1);
 }
 
 bool HTMLSelectElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const


### PR DESCRIPTION
#### 6b4b5fc1f0f6b969bf48e016f64c81f7b26387b7
<pre>
REGRESSION (254522@main): HTMLSelectElement&apos;s value setter sets incorrect values if there are grouped options
<a href="https://bugs.webkit.org/show_bug.cgi?id=251024">https://bugs.webkit.org/show_bug.cgi?id=251024</a>
rdar://103520364

Reviewed by Ryosuke Niwa.

While updating `HTMLSelectElement::listItems` to use `WeakPtr`, 254522@main
also modified `HTMLSelectElement::setValue` to use `Vector::findIf` to
obtain the index of the selected option. However, `listItems` includes
`&lt;optgroup&gt;` elements, resulting in the index of the selected option being
offset by the number of `&lt;optgroup&gt;` elements before it. `&lt;optgroup&gt;` elements
should be ignored when determining the index of the selected option.

To fix, restore the range-based for loop that was used prior to 254522@main.

* LayoutTests/fast/forms/select-optgroup-set-value-expected.txt: Added.
* LayoutTests/fast/forms/select-optgroup-set-value.html: Added.
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::setValue):

Canonical link: <a href="https://commits.webkit.org/259249@main">https://commits.webkit.org/259249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c93269895a3a926a539e36591912163ca48cdad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113604 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173897 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4382 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112643 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38862 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6827 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27260 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3809 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46818 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8751 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3378 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->