### PR TITLE
Module scripts should always decode using UTF-8

### DIFF
--- a/LayoutTests/http/wpt/html/semantics/scripting-1/the-script-element/module/module-fails-decoding-then-load-as-classic-script-expected.txt
+++ b/LayoutTests/http/wpt/html/semantics/scripting-1/the-script-element/module/module-fails-decoding-then-load-as-classic-script-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: SyntaxError: Invalid character '\ufffd'
+CONSOLE MESSAGE: SyntaxError: Invalid character '\ufffd'
+
+PASS UTF-16 module script with UTF-16BE BOM, then loaded as classic script (sync)
+PASS UTF-16 module script with UTF-16LE BOM, then loaded as classic script (async)
+

--- a/LayoutTests/http/wpt/html/semantics/scripting-1/the-script-element/module/module-fails-decoding-then-load-as-classic-script.html
+++ b/LayoutTests/http/wpt/html/semantics/scripting-1/the-script-element/module/module-fails-decoding-then-load-as-classic-script.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Make sure that the same script URL can be loaded as a classic script after it was loaded as a module and failed decoding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+setup({allow_uncaught_exception: true});
+</script>
+<script type="module" src="/html/semantics/scripting-1/the-script-element/serve-with-content-type.py?fn=resources/bom-utf-16be.js&ct=text/javascript"></script> <!-- Should fail decoding -->
+<script src="/html/semantics/scripting-1/the-script-element/serve-with-content-type.py?fn=resources/bom-utf-16be.js&ct=text/javascript"></script> <!-- Should succeed decoding -->
+<script type="module" src="/html/semantics/scripting-1/the-script-element/serve-with-content-type.py?fn=resources/bom-utf-16le.js&ct=text/javascript"></script> <!-- Should fail decoding -->
+<script>
+test(function() {
+  assert_not_equals(window.executed_utf16be_bom, undefined,
+                    'The bom-utf-16be.js classic script should have run');
+}, 'UTF-16 module script with UTF-16BE BOM, then loaded as classic script (sync)');
+
+async_test(function(t) {
+  let script = document.createElement("script");
+  script.src = "/html/semantics/scripting-1/the-script-element/serve-with-content-type.py?fn=resources/bom-utf-16le.js&ct=text/javascript"
+  script.onload = t.step_func_done(() => {
+    assert_not_equals(window.executed_utf16le_bom, undefined,
+                      'The bom-utf-16le.js classic script should have run');
+  });
+  document.body.append(script);
+}, 'UTF-16 module script with UTF-16LE BOM, then loaded as classic script (async)');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-01-expected.txt
@@ -1,8 +1,8 @@
 
 PASS UTF-8 module script
-FAIL UTF-8 module script with wrong charset in attribute assert_equals: Should be decoded as UTF-8 expected "śćążź" but got "Ĺ›Ä‡Ä…ĹĽĹş"
-FAIL UTF-8 module script with wrong charset in Content-Type assert_equals: Should be decoded as UTF-8 expected "śćążź" but got "Ĺ›Ä‡Ä…ĹĽĹş"
+PASS UTF-8 module script with wrong charset in attribute
+PASS UTF-8 module script with wrong charset in Content-Type
 PASS Non-UTF-8 module script
-FAIL Non-UTF-8 module script with charset in attribute assert_not_equals: Should be decoded as UTF-8 got disallowed value "śćążź"
-FAIL Non-UTF-8 module script with charset in Content-Type assert_not_equals: Should be decoded as UTF-8 got disallowed value "śćążź"
+PASS Non-UTF-8 module script with charset in attribute
+PASS Non-UTF-8 module script with charset in Content-Type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-02-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-02-expected.txt
@@ -1,5 +1,7 @@
+CONSOLE MESSAGE: SyntaxError: Invalid character '\ufffd'
+CONSOLE MESSAGE: SyntaxError: Invalid character '\ufffd'
 
 PASS UTF-8 module script with UTF-8 BOM
-FAIL UTF-16 module script with UTF-16BE BOM assert_equals: Should result in compile error because of UTF-16BE BOM expected (undefined) undefined but got (string) "三村かな子"
-FAIL UTF-16 module script with UTF-16LE BOM assert_equals: Should result in compile error because of UTF-16LE BOM expected (undefined) undefined but got (string) "三村かな子"
+PASS UTF-16 module script with UTF-16BE BOM
+PASS UTF-16 module script with UTF-16LE BOM
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-03-expected.txt
@@ -1,6 +1,6 @@
 
 PASS UTF-8 imported module script
-FAIL UTF-8 imported module script with wrong charset in Content-Type assert_equals: Should be decoded as UTF-8 expected "śćążź" but got "Ĺ›Ä‡Ä…ĹĽĹş"
+PASS UTF-8 imported module script with wrong charset in Content-Type
 PASS Non-UTF-8 imported module script
-FAIL Non-UTF-8 imported module script with charset in Content-Type assert_not_equals: Should be decoded as UTF-8 got disallowed value "śćążź"
+PASS Non-UTF-8 imported module script with charset in Content-Type
 

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -43,8 +43,8 @@ public:
         m_cachedScript->removeClient(*this);
     }
 
-    unsigned hash() const override { return m_cachedScript->scriptHash(); }
-    StringView source() const override { return m_cachedScript->script(); }
+    unsigned hash() const override;
+    StringView source() const override;
 
 private:
     CachedScriptSourceProvider(CachedScript* cachedScript, JSC::SourceProviderSourceType sourceType, Ref<CachedScriptFetcher>&& scriptFetcher)
@@ -56,5 +56,23 @@ private:
 
     CachedResourceHandle<CachedScript> m_cachedScript;
 };
+
+inline unsigned CachedScriptSourceProvider::hash() const
+{
+    // Modules should always be decoded as UTF-8.
+    // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
+    if (sourceType() == JSC::SourceProviderSourceType::Module)
+        return m_cachedScript->scriptHash(CachedScript::ShouldDecodeAsUTF8Only::Yes);
+    return m_cachedScript->scriptHash();
+}
+
+inline StringView CachedScriptSourceProvider::source() const
+{
+    // Modules should always be decoded as UTF-8.
+    // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
+    if (sourceType() == JSC::SourceProviderSourceType::Module)
+        return m_cachedScript->script(CachedScript::ShouldDecodeAsUTF8Only::Yes);
+    return m_cachedScript->script();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -53,7 +53,7 @@ String CachedScript::encoding() const
     return String::fromLatin1(m_decoder->encoding().name());
 }
 
-StringView CachedScript::script()
+StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
 {
     if (!m_data)
         return emptyString();
@@ -79,12 +79,19 @@ StringView CachedScript::script()
     if (m_decodingState == DataAndDecodedStringHaveSameBytes)
         return { contiguousData.data(), static_cast<unsigned>(m_data->size()) };
 
-    if (!m_script) {
-        m_script = m_decoder->decodeAndFlush(contiguousData.data(), encodedSize());
-        ASSERT(!m_scriptHash || m_scriptHash == m_script.impl()->hash());
-        if (m_decodingState == NeverDecoded)
+    bool shouldForceRedecoding = m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes);
+    if (!m_script || shouldForceRedecoding) {
+        if (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes) {
+            auto forceUTF8Decoder = TextResourceDecoder::create("text/javascript"_s, PAL::UTF8Encoding());
+            forceUTF8Decoder->setAlwaysUseUTF8();
+            m_script = forceUTF8Decoder->decodeAndFlush(contiguousData.data(), encodedSize());
+        } else
+            m_script = m_decoder->decodeAndFlush(contiguousData.data(), encodedSize());
+        if (m_decodingState == NeverDecoded || shouldForceRedecoding)
             m_scriptHash = m_script.impl()->hash();
+        ASSERT(!m_scriptHash || m_scriptHash == m_script.impl()->hash());
         m_decodingState = DataAndDecodedStringHaveDifferentBytes;
+        m_wasForceDecodedAsUTF8 = shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes;
         setDecodedSize(m_script.sizeInBytes());
     }
 
@@ -92,10 +99,10 @@ StringView CachedScript::script()
     return m_script;
 }
 
-unsigned CachedScript::scriptHash()
+unsigned CachedScript::scriptHash(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
 {
-    if (m_decodingState == NeverDecoded)
-        script();
+    if (m_decodingState == NeverDecoded || (m_decodingState == DataAndDecodedStringHaveDifferentBytes && m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes)))
+        script(shouldDecodeAsUTF8Only);
     return m_scriptHash;
 }
 
@@ -126,6 +133,7 @@ void CachedScript::setBodyDataFrom(const CachedResource& resource)
 
     m_script = script.m_script;
     m_scriptHash = script.m_scriptHash;
+    m_wasForceDecodedAsUTF8 = script.m_wasForceDecodedAsUTF8;
     m_decodingState = script.m_decodingState;
     m_decoder = script.m_decoder;
 }

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -36,8 +36,9 @@ public:
     CachedScript(CachedResourceRequest&&, PAL::SessionID, const CookieJar*);
     virtual ~CachedScript();
 
-    StringView script();
-    unsigned scriptHash();
+    enum class ShouldDecodeAsUTF8Only : bool { No, Yes };
+    StringView script(ShouldDecodeAsUTF8Only = ShouldDecodeAsUTF8Only::No);
+    unsigned scriptHash(ShouldDecodeAsUTF8Only = ShouldDecodeAsUTF8Only::No);
 
 private:
     bool mayTryReplaceEncodedData() const final { return true; }
@@ -55,6 +56,7 @@ private:
 
     String m_script;
     unsigned m_scriptHash { 0 };
+    bool m_wasForceDecodedAsUTF8 { false };
 
     enum DecodingState { NeverDecoded, DataAndDecodedStringHaveSameBytes, DataAndDecodedStringHaveDifferentBytes };
     DecodingState m_decodingState { NeverDecoded };


### PR DESCRIPTION
#### c40873d23eeadf0fe542b79eca7652f9f19689f5
<pre>
Module scripts should always decode using UTF-8
<a href="https://bugs.webkit.org/show_bug.cgi?id=203481">https://bugs.webkit.org/show_bug.cgi?id=203481</a>
rdar://98222621

Reviewed by Youenn Fablet.

By default, CachedScript tries to use the best encoding when decoding script
data. However, per the specification [1], we should always decode as UTF-8 when
it is used as a module (unlike in the classic script case).

This patch adds a ShouldDecodeAsUTF8Only to CachedScript::script() and
scriptHash() and updates CachedScriptSourceProvider pass
ShouldDecodeAsUTF8Only::Yes when used for a module script.

I believe that in theory, the same CachedScript could be used both for a module
script and a classic script, which is why I implemented it this way.

[1] <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script</a> (step 12.2)

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-01-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-02-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/charset-03-expected.txt:
Rebaseline tests that are now passing.

* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
(WebCore::CachedScriptSourceProvider::hash const):
(WebCore::CachedScriptSourceProvider::source const):
(): Deleted.
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script):
(WebCore::CachedScript::scriptHash):
* Source/WebCore/loader/cache/CachedScript.h:

Canonical link: <a href="https://commits.webkit.org/259251@main">https://commits.webkit.org/259251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cc6b7994b3f64dd360c37fe905c21e0829a5442

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37318 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113625 "Hash 1cc6b799 for PR 8981 does not build (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173918 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4404 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96635 "Hash 1cc6b799 for PR 8981 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112663 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110177 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94310 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96635 "Hash 1cc6b799 for PR 8981 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25921 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96635 "Hash 1cc6b799 for PR 8981 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27278 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6977 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46836 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8771 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->