### PR TITLE
Remove ASSERT(m_element) in WebFullScreenManager::setAnimatingFullScreen

### DIFF
--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -323,7 +323,6 @@ void WebFullScreenManager::didExitFullScreen()
 
 void WebFullScreenManager::setAnimatingFullScreen(bool animating)
 {
-    ASSERT(m_element);
     if (!m_element)
         return;
     m_element->document().fullscreenManager().setAnimatingFullscreen(animating);


### PR DESCRIPTION
#### 176d9e990e1894917a72a4affec2f0354c206694
<pre>
Remove ASSERT(m_element) in WebFullScreenManager::setAnimatingFullScreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=251027">https://bugs.webkit.org/show_bug.cgi?id=251027</a>
rdar://104564945

Reviewed by NOBODY (OOPS!).

The assertion has been triggering for a couple of months now (since September 2022?), every time fullscreen is exited on debug builds.

Removing it since it is bogus for debugging exit fullscreen-related tasks.

For release, there&apos;s an early return that handles this case.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::setAnimatingFullScreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/176d9e990e1894917a72a4affec2f0354c206694

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113612 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4391 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112651 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38863 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80532 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27266 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3817 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46824 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8759 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->