### PR TITLE
[Cocoa] _WKFeature instances fail bincompat isKindOfClass: check

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm
@@ -25,6 +25,8 @@
 
 #import "config.h"
 #import "_WKFeatureInternal.h"
+#import "_WKExperimentalFeature.h"
+#import "_WKInternalDebugFeature.h"
 
 #import <WebCore/WebCoreObjCExtras.h>
 
@@ -92,6 +94,15 @@
 - (BOOL)isHidden
 {
     return _wrappedFeature->isHidden();
+}
+
+// For binary compatibility, some interfaces declare that they use the old
+// _WKExperimentalFeature and _WKInternalDebugFeature classes, even though all
+// instantiated features are actually instances of _WKFeature. Override
+// isKindOfClass to prevent clients from detecting the change in instance type.
+- (BOOL)isKindOfClass:(Class)aClass
+{
+    return [super isKindOfClass:aClass] || [aClass isEqual:[_WKExperimentalFeature class]] || [aClass isEqual:[_WKInternalDebugFeature class]];
 }
 
 #pragma mark WKObject protocol implementation


### PR DESCRIPTION
#### dd7dffb5b05602e62d281bfb91d240bd166fcfb2
<pre>
[Cocoa] _WKFeature instances fail bincompat isKindOfClass: check
<a href="https://bugs.webkit.org/show_bug.cgi?id=251028">https://bugs.webkit.org/show_bug.cgi?id=251028</a>
rdar://104543339

Reviewed by Patrick Angle.

As part of the feature status rollout, we replaced the
_WKExperimentalFeature / _WKInternalDebugFeature class dichotomy with a
single _WKFeature base class. For bincompat, our legacy endpoints lie
about their instance type and declare e.g. an NSArray&lt;_WKExperimentalFeature *&gt;,
when the actual instance types are _WKFeature.

This matches existing behavior but causes feature instances to fail a
isKindOfClass:[_WKExperimentalFeature class] check.

Prevent this by overriding isKindOfClass. It&apos;s unsavory, but can be
removed when we deprecate and then remove the legacy subclasses.

* Source/WebKit/UIProcess/API/Cocoa/_WKFeature.mm:
(-[_WKFeature isKindOfClass:]):

Canonical link: <a href="https://commits.webkit.org/259245@main">https://commits.webkit.org/259245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5513a93e07e82c79c6f58037bbc7603a68aa1226

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113617 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4396 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112656 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94303 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25914 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6840 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27271 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6970 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6375 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8764 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->