### PR TITLE
Reduce compilation times by forward-declaring DOMPromiseDeferred

### DIFF
--- a/Source/JavaScriptCore/heap/Strong.h
+++ b/Source/JavaScriptCore/heap/Strong.h
@@ -49,10 +49,10 @@ public:
     {
     }
     
-    Strong(VM&, ExternalType = ExternalType());
+    inline Strong(VM&, ExternalType = ExternalType());
 
-    Strong(VM&, Handle<T>);
-    
+    inline Strong(VM&, Handle<T>);
+
     Strong(const Strong& other)
         : Handle<T>()
     {
@@ -94,7 +94,7 @@ public:
 
     ExternalType get() const { return HandleTypes<T>::getFromSlot(this->slot()); }
 
-    void set(VM&, ExternalType);
+    inline void set(VM&, ExternalType);
 
     template <typename U> Strong& operator=(const Strong<U>& other)
     {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1089,7 +1089,7 @@ public:
 
     StructureCache& structureCache() { return m_structureCache; }
 
-    void setUnhandledRejectionCallback(VM& vm, JSObject* function) { m_unhandledRejectionCallback.set(vm, function); }
+    inline void setUnhandledRejectionCallback(VM&, JSObject*);
     JSObject* unhandledRejectionCallback() const { return m_unhandledRejectionCallback.get(); }
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception*);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -34,6 +34,7 @@
 #include "JSFunction.h"
 #include "LinkTimeConstant.h"
 #include "ObjectPrototype.h"
+#include "StrongInlines.h"
 #include <wtf/Hasher.h>
 
 namespace JSC {
@@ -78,6 +79,11 @@ ALWAYS_INLINE bool JSGlobalObject::stringPrototypeChainIsSane()
 {
     ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
     return m_stringPrototypeChainIsSaneWatchpointSet.isStillValid();
+}
+
+inline void JSGlobalObject::setUnhandledRejectionCallback(VM& vm, JSObject* function)
+{
+    m_unhandledRejectionCallback.set(vm, function);
 }
 
 ALWAYS_INLINE bool JSGlobalObject::isArrayPrototypeIteratorProtocolFastAndNonObservable()

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -526,6 +526,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSDOMMicrotask.h
     bindings/js/JSDOMOperation.h
     bindings/js/JSDOMPromiseDeferred.h
+    bindings/js/JSDOMPromiseDeferredForward.h
     bindings/js/JSDOMWindowBase.h
     bindings/js/JSDOMWrapper.h
     bindings/js/JSDOMWrapperCache.h

--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GPU.h"
 
+#include "JSDOMPromiseDeferred.h"
 #include "JSGPUAdapter.h"
 
 namespace WebCore {
@@ -44,6 +45,11 @@ static PAL::WebGPU::RequestAdapterOptions convertToBacking(const std::optional<G
 
     return options->convertToBacking();
 }
+
+struct GPU::PendingRequestAdapterArguments {
+    std::optional<GPURequestAdapterOptions> options;
+    RequestAdapterPromise promise;
+};
 
 void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options, RequestAdapterPromise&& promise)
 {

--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -28,7 +28,7 @@
 #include "GPUAdapter.h"
 #include "GPURequestAdapterOptions.h"
 #include "GPUTextureFormat.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPU.h>
 #include <wtf/Deque.h>
@@ -43,7 +43,6 @@ public:
     {
         return adoptRef(*new GPU(WTFMove(backing)));
     }
-
     ~GPU();
 
     using RequestAdapterPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<GPUAdapter>>>;
@@ -54,10 +53,7 @@ public:
 private:
     GPU(Ref<PAL::WebGPU::GPU>&&);
 
-    struct PendingRequestAdapterArguments {
-        std::optional<GPURequestAdapterOptions> options;
-        RequestAdapterPromise promise;
-    };
+    struct PendingRequestAdapterArguments;
     Deque<PendingRequestAdapterArguments> m_pendingRequestAdapterArguments;
     Ref<PAL::WebGPU::GPU> m_backing;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.h
@@ -29,7 +29,7 @@
 #include "GPUDeviceDescriptor.h"
 #include "GPUSupportedFeatures.h"
 #include "GPUSupportedLimits.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ScriptExecutionContext.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUAdapter.h>

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "GPUBuffer.h"
 
+#include "JSDOMPromiseDeferred.h"
+
 namespace WebCore {
 
 String GPUBuffer::label() const

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -27,7 +27,7 @@
 
 #include "GPUIntegralTypes.h"
 #include "GPUMapMode.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <cstdint>
 #include <optional>

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GPUDevice.h"
 
+#include "DOMPromiseProxy.h"
 #include "GPUBindGroup.h"
 #include "GPUBindGroupDescriptor.h"
 #include "GPUBindGroupLayout.h"
@@ -58,6 +59,7 @@
 #include "GPUSwapChainDescriptor.h"
 #include "GPUTexture.h"
 #include "GPUTextureDescriptor.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSGPUComputePipeline.h"
 #include "JSGPUOutOfMemoryError.h"
 #include "JSGPURenderPipeline.h"
@@ -70,6 +72,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(GPUDevice);
 
 GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<PAL::WebGPU::Device>&& backing)
     : ActiveDOMObject { scriptExecutionContext }
+    , m_lostPromise(makeUniqueRef<LostPromise>())
     , m_backing(WTFMove(backing))
     , m_queue(GPUQueue::create(Ref { m_backing->queue() }))
     , m_autoPipelineLayout(createPipelineLayout({ { "autoLayout"_s, }, { } }))

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
-#include "DOMPromiseProxy.h"
 #include "EventTarget.h"
 #include "GPUComputePipeline.h"
 #include "GPUDeviceLostInfo.h"
@@ -34,7 +33,7 @@
 #include "GPUErrorFilter.h"
 #include "GPURenderPipeline.h"
 #include "GPUQueue.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ScriptExecutionContext.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUDevice.h>
@@ -150,7 +149,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    LostPromise m_lostPromise;
+    UniqueRef<LostPromise> m_lostPromise;
     Ref<PAL::WebGPU::Device> m_backing;
     Ref<GPUQueue> m_queue;
     Ref<GPUPipelineLayout> m_autoPipelineLayout;

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -32,6 +32,7 @@
 #include "GPUTexture.h"
 #include "GPUTextureDescriptor.h"
 #include "ImageBuffer.h"
+#include "JSDOMPromiseDeferred.h"
 #include "OffscreenCanvas.h"
 #include "PixelBuffer.h"
 

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.h
@@ -33,7 +33,6 @@
 #include "GPUImageCopyTextureTagged.h"
 #include "GPUImageDataLayout.h"
 #include "GPUIntegralTypes.h"
-#include "JSDOMPromiseDeferred.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUQueue.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "GPUShaderModule.h"
+
+#include "JSDOMPromiseDeferred.h"
 #include "JSGPUCompilationInfo.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.h
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.h
@@ -27,7 +27,7 @@
 
 #include "GPUBindGroupLayout.h"
 #include "GPUCompilationInfo.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <pal/graphics/WebGPU/WebGPUShaderModule.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
@@ -29,7 +29,7 @@
 
 #include "ApplePaySetupConfiguration.h"
 #include <WebCore/ActiveDOMObject.h>
-#include <WebCore/JSDOMPromiseDeferred.h>
+#include <WebCore/JSDOMPromiseDeferredForward.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -38,7 +38,6 @@
 namespace WebCore {
 
 class ApplePaySetupFeature;
-class DeferredPromise;
 class Document;
 
 class ApplePaySetup : public ActiveDOMObject, public RefCounted<ApplePaySetup> {

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -31,6 +31,7 @@
 #include "EventLoop.h"
 #include "FetchResponse.h"
 #include "HTTPParsers.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSFetchRequest.h"
 #include "JSFetchResponse.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -30,6 +30,7 @@
 #include "ClientOrigin.h"
 #include "EventLoop.h"
 #include "JSDOMCache.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSFetchResponse.h"
 #include "MultiCacheQueryOptions.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -26,9 +26,10 @@
 #include "config.h"
 #include "BasicCredential.h"
 
-#include "AuthenticatorCoordinator.h"
-
 #if ENABLE(WEB_AUTHN)
+
+#include "AuthenticatorCoordinator.h"
+#include "JSDOMPromiseDeferred.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
@@ -29,7 +29,7 @@
 
 #include "Document.h"
 #include "IDLTypes.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
@@ -28,7 +28,7 @@
 
 #include "ActiveDOMObject.h"
 #include "IDLTypes.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "MediaKeySystemRequestIdentifier.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -42,6 +42,8 @@
 
 namespace WebCore {
 
+FetchBody::~FetchBody() = default;
+
 ExceptionOr<FetchBody> FetchBody::extract(Init&& value, String& contentType)
 {
     return WTF::switchOn(value, [&](RefPtr<Blob>& value) mutable -> ExceptionOr<FetchBody> {

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -56,6 +56,9 @@ public:
     using Init = std::variant<RefPtr<Blob>, RefPtr<ArrayBufferView>, RefPtr<ArrayBuffer>, RefPtr<DOMFormData>, RefPtr<URLSearchParams>, RefPtr<ReadableStream>, String>;
     static ExceptionOr<FetchBody> extract(Init&&, String&);
     FetchBody() = default;
+    FetchBody(FetchBody&&) = default;
+    WEBCORE_EXPORT ~FetchBody();
+    FetchBody& operator=(FetchBody&&) = default;
 
     WEBCORE_EXPORT static std::optional<FetchBody> fromFormData(ScriptExecutionContext&, Ref<FormData>&&);
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -126,6 +126,15 @@ static std::optional<MimeType> parseMIMEType(const String& contentType)
     return {{ WTFMove(type), WTFMove(subtype), parseParameters(StringView(input), semicolonIndex + 1) }};
 }
 
+FetchBodyConsumer::FetchBodyConsumer(Type type)
+    : m_type(type)
+{
+}
+
+FetchBodyConsumer::FetchBodyConsumer(FetchBodyConsumer&&) = default;
+FetchBodyConsumer::~FetchBodyConsumer() = default;
+FetchBodyConsumer& FetchBodyConsumer::operator=(FetchBodyConsumer&&) = default;
+
 // https://fetch.spec.whatwg.org/#concept-body-package-data
 RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* context, const String& contentType, const uint8_t* data, size_t length)
 {

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -30,7 +30,7 @@
 
 #include "FetchBodySource.h"
 #include "FormDataConsumer.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ReadableStreamSink.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "SharedBuffer.h"
@@ -48,7 +48,10 @@ class FetchBodyConsumer {
 public:
     enum class Type { None, ArrayBuffer, Blob, JSON, Text, FormData };
 
-    explicit FetchBodyConsumer(Type type) : m_type(type) { }
+    explicit FetchBodyConsumer(Type);
+    FetchBodyConsumer(FetchBodyConsumer&&);
+    ~FetchBodyConsumer();
+    FetchBodyConsumer& operator=(FetchBodyConsumer&&);
 
     FetchBodyConsumer clone();
 

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
@@ -33,6 +33,7 @@
 #include "IDBDatabaseIdentifier.h"
 #include "IDBKey.h"
 #include "IDBOpenDBRequest.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSIDBFactory.h"
 #include "Logging.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.h
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "ExceptionOr.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <wtf/Function.h>
 #include <wtf/Forward.h>
 #include <wtf/IsoMalloc.h>

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -35,6 +35,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "EventNames.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSRTCCertificate.h"
 #include "Logging.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoKeyRaw.h"
 #include "JSDOMConvertBufferSource.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSRTCEncodedAudioFrame.h"
 #include "JSRTCEncodedVideoFrame.h"
 #include "JSWritableStreamSink.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -29,7 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "RTCRtpSFrameTransformer.h"
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -30,6 +30,7 @@
 
 #include "DedicatedWorkerGlobalScope.h"
 #include "EventLoop.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSRTCEncodedAudioFrame.h"
 #include "JSRTCEncodedVideoFrame.h"
 #include "MessageWithMessagePorts.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -29,9 +29,10 @@
 
 #include "ActiveDOMObject.h"
 #include "ExceptionOr.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "RTCRtpTransformBackend.h"
 #include <JavaScriptCore/JSCJSValue.h>
+#include <wtf/Deque.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -32,7 +32,7 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "MediaStreamTrack.h"
 #include "RTCDtlsTransport.h"
 #include "RTCRtpSenderBackend.h"

--- a/Source/WebCore/Modules/push-api/PushManager.cpp
+++ b/Source/WebCore/Modules/push-api/PushManager.cpp
@@ -32,6 +32,7 @@
 #include "DocumentInlines.h"
 #include "EventLoop.h"
 #include "Exception.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSPushPermissionState.h"
 #include "JSPushSubscription.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/push-api/PushManager.h
+++ b/Source/WebCore/Modules/push-api/PushManager.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "PushPermissionState.h"
 #include "PushSubscription.h"
 #include "PushSubscriptionOptionsInit.h"

--- a/Source/WebCore/Modules/push-api/PushSubscription.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscription.cpp
@@ -33,6 +33,7 @@
 #include "PushSubscriptionOptions.h"
 #include "ScriptExecutionContext.h"
 #include "ServiceWorkerContainer.h"
+#include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/Base64.h>
 

--- a/Source/WebCore/Modules/push-api/PushSubscription.h
+++ b/Source/WebCore/Modules/push-api/PushSubscription.h
@@ -29,7 +29,7 @@
 
 #include "EpochTimeStamp.h"
 #include "ExceptionOr.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "PushEncryptionKeyName.h"
 #include "PushSubscriptionData.h"
 #include "PushSubscriptionJSON.h"
@@ -38,6 +38,10 @@
 #include <variant>
 #include <wtf/IsoMalloc.h>
 #include <wtf/RefCounted.h>
+
+namespace JSC {
+class ArrayBuffer;
+}
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
@@ -27,8 +27,11 @@
 #include "config.h"
 #include "ReadableStreamSource.h"
 
+#include "JSDOMPromiseDeferred.h"
+
 namespace WebCore {
 
+ReadableStreamSource::ReadableStreamSource() = default;
 ReadableStreamSource::~ReadableStreamSource() = default;
 
 void ReadableStreamSource::start(ReadableStreamDefaultController&& controller, DOMPromiseDeferred<void>&& promise)

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ReadableStreamDefaultController.h"
 #include <wtf/WeakPtr.h>
 
@@ -36,6 +36,7 @@ namespace WebCore {
 
 class ReadableStreamSource : public RefCounted<ReadableStreamSource> {
 public:
+    ReadableStreamSource();
     virtual ~ReadableStreamSource();
 
     void start(ReadableStreamDefaultController&&, DOMPromiseDeferred<void>&&);

--- a/Source/WebCore/Modules/streams/WritableStreamSink.h
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -33,7 +33,7 @@
 #include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/Forward.h>
-#include <JavaScriptCore/GenericTypedArrayView.h>
+#include <JavaScriptCore/TypedArrayAdaptersForwardDeclarations.h>
 #include <wtf/Lock.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -281,6 +281,11 @@ ExceptionOr<Ref<AudioBuffer>> BaseAudioContext::createBuffer(unsigned numberOfCh
     return AudioBuffer::create(AudioBufferOptions {numberOfChannels, length, sampleRate});
 }
 
+void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<AudioBufferCallback>&& successCallback, RefPtr<AudioBufferCallback>&& errorCallback)
+{
+    decodeAudioData(WTFMove(audioData), WTFMove(successCallback), WTFMove(errorCallback), std::nullopt);
+}
+
 void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<AudioBufferCallback>&& successCallback, RefPtr<AudioBufferCallback>&& errorCallback, std::optional<Ref<DeferredPromise>>&& promise)
 {
     if (promise && (!document() || !document()->isFullyActive())) {

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -31,7 +31,7 @@
 #include "AudioDestinationNode.h"
 #include "AudioIOCallback.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "OscillatorType.h"
 #include "PeriodicWaveConstraints.h"
 #include <atomic>
@@ -42,6 +42,12 @@
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
+
+namespace JSC {
+class ArrayBuffer;
+enum class MessageLevel : uint8_t;
+enum class MessageSource : uint8_t;
+}
 
 namespace WebCore {
 
@@ -75,8 +81,6 @@ class WaveShaperNode;
 
 struct AudioIOPosition;
 struct AudioParamDescriptor;
-
-template<typename IDLType> class DOMPromiseDeferred;
 
 // AudioContext is the cornerstone of the web audio API and all AudioNodes are created from it.
 // For thread safety between the audio thread and the main thread, it has a rendering graph locking mechanism. 
@@ -113,7 +117,8 @@ public:
     float sampleRate() const { return destination().sampleRate(); }
 
     // Asynchronous audio file data decoding.
-    void decodeAudioData(Ref<ArrayBuffer>&&, RefPtr<AudioBufferCallback>&&, RefPtr<AudioBufferCallback>&&, std::optional<Ref<DeferredPromise>>&& = std::nullopt);
+    void decodeAudioData(Ref<JSC::ArrayBuffer>&&, RefPtr<AudioBufferCallback>&&, RefPtr<AudioBufferCallback>&&);
+    void decodeAudioData(Ref<JSC::ArrayBuffer>&&, RefPtr<AudioBufferCallback>&&, RefPtr<AudioBufferCallback>&&, std::optional<Ref<DeferredPromise>>&&);
 
     AudioListener& listener() { return m_listener; }
 
@@ -215,7 +220,7 @@ public:
     void postTask(Function<void()>&&);
     bool isStopped() const { return m_isStopScheduled; }
     const SecurityOrigin* origin() const;
-    void addConsoleMessage(MessageSource, MessageLevel, const String& message);
+    void addConsoleMessage(JSC::MessageSource, JSC::MessageLevel, const String& message);
 
     virtual void lazyInitialize();
 

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -34,6 +34,7 @@
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
 #include "Reverb.h"
+#include <JavaScriptCore/TypedArrays.h>
 #include <wtf/IsoMallocInlines.h>
 
 // Note about empirical tuning:

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
@@ -31,6 +31,7 @@
 #include "BaseAudioContext.h"
 #include "IIRFilter.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/TypedArrays.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -33,6 +33,7 @@
 #include "AudioUtilities.h"
 #include "Document.h"
 #include "JSAudioBuffer.h"
+#include "JSDOMPromiseDeferred.h"
 #include "OfflineAudioCompletionEvent.h"
 #include "OfflineAudioContextOptions.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "BaseAudioContext.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "OfflineAudioDestinationNode.h"
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -32,6 +32,7 @@
 
 #include "PeriodicWave.h"
 
+#include <JavaScriptCore/TypedArrays.h>
 #include "BaseAudioContext.h"
 #include "FFTFrame.h"
 #include "VectorMath.h"

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
@@ -30,6 +30,7 @@
 #include "AudioContext.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>
+#include <JavaScriptCore/TypedArrays.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MainThread.h>
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -31,6 +31,7 @@
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsVideoDecoderSupport.h"
 #include "ScriptExecutionContext.h"
 #include "WebCodecsEncodedVideoChunk.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -29,7 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "VideoDecoder.h"
 #include "WebCodecsCodecState.h"
 #include "WebCodecsEncodedVideoChunkType.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -31,6 +31,7 @@
 #include "DOMException.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsVideoEncoderSupport.h"
 #include "Logging.h"
 #include "WebCodecsEncodedVideoChunk.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -29,7 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "VideoEncoder.h"
 #include "WebCodecsCodecState.h"
 #include "WebCodecsVideoEncoderConfig.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -37,6 +37,7 @@
 #include "HTMLVideoElement.h"
 #include "ImageBitmap.h"
 #include "ImageBuffer.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSPlaneLayout.h"
 #include "OffscreenCanvas.h"
 #include "PixelBuffer.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -29,7 +29,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "DOMRectReadOnly.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "PlaneLayout.h"
 #include "VideoColorSpaceInit.h"
 #include "WebCodecsAlphaOption.h"
@@ -37,6 +37,7 @@
 
 namespace WebCore {
 
+class BufferSource;
 class CSSStyleImageValue;
 class DOMRectReadOnly;
 class HTMLCanvasElement;

--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -34,6 +34,7 @@
 #include "WebXRReferenceSpace.h"
 #include "WebXRSession.h"
 #include "WebXRViewerPose.h"
+#include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -31,6 +31,7 @@
 
 #include "Document.h"
 #include "EventNames.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebXRReferenceSpace.h"
 #include "SecurityOrigin.h"
 #include "WebCoreOpaqueRoot.h"
@@ -378,7 +379,7 @@ void WebXRSession::didCompleteShutdown()
     // Resolve end promise from XRSession::end()
     if (m_endPromise) {
         m_endPromise->resolve();
-        m_endPromise = std::nullopt;
+        m_endPromise = nullptr;
     }
 
     // From https://immersive-web.github.io/webxr/#shut-down-the-session
@@ -398,7 +399,7 @@ ExceptionOr<void> WebXRSession::end(EndPromise&& promise)
         return Exception { InvalidStateError, "Cannot end a session more than once"_s };
 
     ASSERT(!m_endPromise);
-    m_endPromise = WTFMove(promise);
+    m_endPromise = makeUnique<EndPromise>(WTFMove(promise));
 
     // 1. Let promise be a new Promise.
     // 2. Shut down the target XRSession object.

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -29,7 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "WebXRFrame.h"
 #include "WebXRInputSourceArray.h"
 #include "WebXRRenderState.h"
@@ -138,7 +138,7 @@ private:
     XRVisibilityState m_visibilityState { XRVisibilityState::Visible };
     UniqueRef<WebXRInputSourceArray> m_inputSources;
     bool m_ended { false };
-    std::optional<EndPromise> m_endPromise;
+    std::unique_ptr<EndPromise> m_endPromise;
 
     WebXRSystem& m_xrSystem;
     XRSessionMode m_mode;

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -35,6 +35,7 @@
 #include "Document.h"
 #include "FeaturePolicy.h"
 #include "IDLTypes.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebXRSession.h"
 #include "JSXRReferenceSpaceType.h"
 #include "Navigator.h"

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -30,7 +30,7 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "HTMLCanvasElement.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "WebGLContextAttributes.h"
 #include "WebGLRenderingContextBase.h"
 #include "XRReferenceSpaceType.h"

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferredForward.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferredForward.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class DeferredPromise;
+
+template <typename IDLType> class DOMPromiseDeferred;
+template <typename IDLType> class DOMPromiseProxy;
+
+struct IDLUnsupportedType;
+struct IDLNull;
+struct IDLAny;
+struct IDLUndefined;
+struct IDLBoolean;
+struct IDLByte;
+struct IDLOctet;
+struct IDLShort;
+struct IDLUnsignedShort;
+struct IDLLong;
+struct IDLUnsignedLong;
+struct IDLLongLong;
+struct IDLUnsignedLongLong;
+struct IDLFloat;
+struct IDLUnrestrictedFloat;
+struct IDLDouble;
+struct IDLUnrestrictedDouble;
+struct IDLDOMString;
+struct IDLByteString;
+struct IDLUSVString;
+struct IDLObject;
+
+template<typename T> struct IDLInterface;
+template<typename T> struct IDLCallbackInterface;
+template<typename T> struct IDLCallbackFunction;
+template<typename T> struct IDLDictionary;
+template<typename T> struct IDLEnumeration;
+template<typename T> struct IDLNullable;
+template<typename T> struct IDLSequence;
+template<typename T> struct IDLFrozenArray;
+template<typename K, typename V> struct IDLRecord;
+template<typename T> struct IDLPromise;
+
+struct IDLError;
+struct IDLDOMException;
+
+template<typename... Ts> struct IDLUnion;
+template<typename T> struct IDLBufferSource;
+
+struct IDLArrayBuffer;
+struct IDLArrayBufferView;
+struct IDLDataView;
+struct IDLDate;
+struct IDLJSON;
+struct IDLScheduledAction;
+struct IDLIDBKey;
+struct IDLIDBKeyData;
+struct IDLIDBValue;
+
+#if ENABLE(WEBGL)
+struct IDLWebGLAny;
+struct IDLWebGLExtension;
+#endif
+
+}

--- a/Source/WebCore/css/DOMCSSPaintWorklet.cpp
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.cpp
@@ -30,6 +30,7 @@
 
 #include "DOMCSSNamespace.h"
 #include "Document.h"
+#include "JSDOMPromiseDeferred.h"
 #include "PaintWorkletGlobalScope.h"
 #include "WorkletGlobalScopeProxy.h"
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -27,7 +27,6 @@
 
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
 #include "JSValueInWrappedObject.h"
 #include <wtf/Function.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -63,6 +63,7 @@
 #include "ImageData.h"
 #include "InspectorInstrumentation.h"
 #include "IntSize.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSExecState.h"
 #include "KHRParallelShaderCompile.h"
 #include "Logging.h"

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -63,7 +63,7 @@
 #endif
 
 #if ENABLE(WEBXR)
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #endif
 
 #include "GCGLSpan.h"

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ExceptionDetails.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
 #include <wtf/JSONValues.h>
@@ -41,7 +42,6 @@ namespace WebCore {
 class DOMPromise;
 class JSDOMGlobalObject;
 class Page;
-struct ExceptionDetails;
 
 class InspectorFrontendAPIDispatcher final
     : public RefCounted<InspectorFrontendAPIDispatcher>

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "NavigatorBase.h"
 #include "Supplementable.h"
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -30,6 +30,7 @@
 
 #include "FetchEvent.h"
 #include "FetchRequest.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSFetchResponse.h"
 #include "PushSubscription.h"
 #include "PushSubscriptionData.h"

--- a/Source/WebCore/testing/ServiceWorkerInternals.h
+++ b/Source/WebCore/testing/ServiceWorkerInternals.h
@@ -29,7 +29,7 @@
 
 #include "EpochTimeStamp.h"
 #include "IDLTypes.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ServiceWorkerIdentifier.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -27,11 +27,13 @@
 
 #if ENABLE(WEBXR)
 
+#include "ExceptionOr.h"
 #include "FakeXRBoundsPoint.h"
 #include "FakeXRInputSourceInit.h"
 #include "FakeXRViewInit.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "PlatformXR.h"
+#include "Timer.h"
 #include "WebFakeXRInputController.h"
 #include "XRVisibilityState.h"
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebFakeXRDevice.h"
 #include "JSXRReferenceSpaceType.h"
 #include "PlatformXR.h"

--- a/Source/WebCore/testing/WebXRTest.h
+++ b/Source/WebCore/testing/WebXRTest.h
@@ -27,7 +27,8 @@
 
 #if ENABLE(WEBXR)
 
-#include "JSDOMPromiseDeferred.h"
+#include "EventTarget.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "WebFakeXRDevice.h"
 #include "XRSessionMode.h"
 #include "XRSimulateUserActivationFunction.h"
@@ -36,6 +37,7 @@
 
 namespace WebCore {
 
+class Document;
 class WebXRSystem;
 
 class WebXRTest final : public RefCounted<WebXRTest> {

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -27,6 +27,7 @@
 #include "FetchEvent.h"
 
 #include "CachedResourceRequestInitiatorTypes.h"
+#include "DOMPromiseProxy.h"
 #include "EventNames.h"
 #include "FetchRequest.h"
 #include "JSDOMPromise.h"

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-#include "DOMPromiseProxy.h"
 #include "ExtendableEvent.h"
 #include "FetchIdentifier.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ResourceError.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
@@ -43,6 +43,7 @@ namespace WebCore {
 class DOMPromise;
 class FetchRequest;
 class FetchResponse;
+class ResourceResponse;
 
 class FetchEvent final : public ExtendableEvent {
     WTF_MAKE_ISO_ALLOCATED(FetchEvent);

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -31,7 +31,7 @@
 #include "AddEventListenerOptions.h"
 #include "EventTarget.h"
 #include "IDLTypes.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "MessageEvent.h"
 #include "PushPermissionState.h"
 #include "PushSubscription.h"
@@ -52,8 +52,6 @@ class ServiceWorker;
 
 enum class ServiceWorkerUpdateViaCache : uint8_t;
 enum class WorkerType : bool;
-
-template<typename IDLType> class DOMPromiseProxy;
 
 class ServiceWorkerContainer final : public EventTarget, public ActiveDOMObject, public ServiceWorkerJobClient {
     WTF_MAKE_NONCOPYABLE(ServiceWorkerContainer);

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -29,7 +29,7 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "Notification.h"
 #include "NotificationOptions.h"
 #include "PushPermissionState.h"

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -28,6 +28,7 @@
 
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
+#include "JSDOMPromiseDeferred.h"
 #include "ScriptSourceCode.h"
 #include "SecurityOrigin.h"
 #include "WorkerRunLoop.h"

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -28,7 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserver.h"
 #include "ExceptionOr.h"
-#include "JSDOMPromiseDeferred.h"
+#include "JSDOMPromiseDeferredForward.h"
 #include "ScriptWrappable.h"
 #include "WorkletOptions.h"
 #include <wtf/HashSet.h>

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/FrameView.h>
 #include <WebCore/FullscreenManager.h>
 #include <WebCore/HTMLVideoElement.h>
+#include <WebCore/JSDOMPromiseDeferred.h>
 #include <WebCore/Quirks.h>
 #include <WebCore/RenderLayerBacking.h>
 #include <WebCore/RenderView.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
@@ -56,6 +56,7 @@
 #include <WebCore/DOMException.h>
 #include <WebCore/DocumentInlines.h>
 #include <WebCore/FullscreenManager.h>
+#include <WebCore/JSDOMPromiseDeferred.h>
 #include <WebCore/JSExecState.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/VisibilityState.h>


### PR DESCRIPTION
#### 6211ce9e4d8de65866fd884f3b021f88b0aa5863
<pre>
Reduce compilation times by forward-declaring DOMPromiseDeferred
<a href="https://bugs.webkit.org/show_bug.cgi?id=251029">https://bugs.webkit.org/show_bug.cgi?id=251029</a>
rdar://104567742

Reviewed by Brent Fulgham.

Add a new forwarding header, JSDOMPromiseDeferredForward.h, that forward declares DeferredPromise,
DOMPromiseDeferred&lt;&gt;, and all the necssary IDL types which might be used in a header.

Use this new forwarding header everywhere, and move the JSDOMPromiseDeferred.h include into the
implementation files.

Elsewhere, classes declared ivars of these promise classes; those either require the class&apos;s constructors and
destructors to be moved to the implementation file, move std::optional -&gt; std::unique_ptr, or for the bare
promise to be wrapped in a UniqueRef.

These changes reduce the overall cost of including JSDOMPromiseDeferred to be reduced by 66%, from 300s of
compile time to 100s on this machine.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
* Source/WebCore/Modules/WebGPU/GPU.h:
(WebCore::GPU::create):
* Source/WebCore/Modules/WebGPU/GPUAdapter.h:
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
* Source/WebCore/Modules/WebGPU/GPUQueue.h:
* Source/WebCore/Modules/WebGPU/GPUShaderModule.cpp:
* Source/WebCore/Modules/WebGPU/GPUShaderModule.h:
* Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
* Source/WebCore/Modules/credentialmanagement/BasicCredential.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h:
* Source/WebCore/Modules/fetch/FetchBody.cpp:
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::FetchBodyConsumer):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
(WebCore::FetchBodyConsumer::FetchBodyConsumer): Deleted.
* Source/WebCore/Modules/indexeddb/IDBFactory.cpp:
* Source/WebCore/Modules/indexeddb/IDBFactory.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/push-api/PushManager.cpp:
* Source/WebCore/Modules/push-api/PushManager.h:
* Source/WebCore/Modules/push-api/PushSubscription.h:
* Source/WebCore/Modules/streams/ReadableStreamSource.cpp:
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
* Source/WebCore/Modules/streams/WritableStreamSink.h:
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::decodeAudioData):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
* Source/WebCore/Modules/webaudio/OfflineAudioContext.h:
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
* Source/WebCore/Modules/webaudio/WaveShaperNode.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::didCompleteShutdown):
(WebCore::WebXRSession::end):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/DOMCSSPaintWorklet.cpp:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/page/WorkerNavigator.h:
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
* Source/WebCore/testing/ServiceWorkerInternals.h:
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebCore/testing/WebXRTest.cpp:
* Source/WebCore/testing/WebXRTest.h:
* Source/WebCore/workers/service/FetchEvent.cpp:
* Source/WebCore/workers/service/FetchEvent.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/worklets/Worklet.cpp:
* Source/WebCore/worklets/Worklet.h:

Canonical link: <a href="https://commits.webkit.org/259392@main">https://commits.webkit.org/259392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e0821815f817d77579d35aa0a43a7d32e9535f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104736 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114011 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174210 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4745 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112934 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39097 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108203 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80764 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27537 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92627 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4913 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4113 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30185 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103553 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47097 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101315 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9059 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->