### PR TITLE
[WK2] Remove WantsConnection IPC message attribute

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> NetworkBroadcastChannelRegistry NotRefCounted {
-    RegisterChannel(struct WebCore::ClientOrigin origin, String name) WantsConnection
-    UnregisterChannel(struct WebCore::ClientOrigin origin, String name) WantsConnection
-    PostMessage(struct WebCore::ClientOrigin origin, String name, struct WebCore::MessageWithMessagePorts message) -> () WantsConnection
+    RegisterChannel(struct WebCore::ClientOrigin origin, String name)
+    UnregisterChannel(struct WebCore::ClientOrigin origin, String name)
+    PostMessage(struct WebCore::ClientOrigin origin, String name, struct WebCore::MessageWithMessagePorts message) -> ()
 }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -27,11 +27,11 @@
     Persisted(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Persist(struct WebCore::ClientOrigin origin) -> (bool persisted)
     Estimate(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::StorageEstimate> result);
-    FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result) WantsConnection
+    FileSystemGetDirectory(struct WebCore::ClientOrigin origin) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
     CloseHandle(WebCore::FileSystemHandleIdentifier identifier)
     IsSameEntry(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (bool result)
-    GetFileHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result) WantsConnection
-    GetDirectoryHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result) WantsConnection
+    GetFileHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
+    GetDirectoryHandle(WebCore::FileSystemHandleIdentifier identifier, String name, bool createIfNecessary) -> (Expected<WebCore::FileSystemHandleIdentifier, WebKit::FileSystemStorageError> result)
     RemoveEntry(WebCore::FileSystemHandleIdentifier identifier, String name, bool deleteRecursively) -> (std::optional<WebKit::FileSystemStorageError> result)
     Resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier targetIdentifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     Move(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier destinationIdentifier, String newName) -> (std::optional<WebKit::FileSystemStorageError> result)
@@ -39,20 +39,20 @@
     CreateSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<std::pair<WebCore::FileSystemSyncAccessHandleIdentifier, IPC::SharedFileHandle>, WebKit::FileSystemStorageError> result)
     CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier) -> ()
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
-    GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, WebKit::FileSystemStorageError> result) WantsConnection
+    GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, WebKit::FileSystemStorageError> result)
 
-    ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier) WantsConnection
-    ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous WantsConnection
-    CancelConnectToStorageArea(WebCore::StorageType type, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) WantsConnection
-    DisconnectFromStorageArea(WebKit::StorageAreaIdentifier identifier) WantsConnection
+    ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier)
+    ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (WebKit::StorageAreaIdentifier identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous
+    CancelConnectToStorageArea(WebCore::StorageType type, WebKit::StorageNamespaceIdentifier namespaceIdentifier, struct WebCore::ClientOrigin origin)
+    DisconnectFromStorageArea(WebKit::StorageAreaIdentifier identifier)
     CloneSessionStorageNamespace(WebKit::StorageNamespaceIdentifier fromStorageNamespaceID, WebKit::StorageNamespaceIdentifier toStorageNamespaceID)
-    SetItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String value, String urlString) -> (bool hasError, HashMap<String, String> allItems) WantsConnection
-    RemoveItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String urlString) -> () WantsConnection
-    Clear(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String urlString) -> () WantsConnection
+    SetItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String value, String urlString) -> (bool hasError, HashMap<String, String> allItems)
+    RemoveItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String urlString) -> ()
+    Clear(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String urlString) -> ()
 
-    OpenDatabase(WebCore::IDBRequestData requestData) WantsConnection
+    OpenDatabase(WebCore::IDBRequestData requestData)
     OpenDBRequestCancelled(WebCore::IDBRequestData requestData)
-    DeleteDatabase(WebCore::IDBRequestData requestData) WantsConnection
+    DeleteDatabase(WebCore::IDBRequestData requestData)
     EstablishTransaction(uint64_t databaseConnectionIdentifier, WebCore::IDBTransactionInfo info)
     DatabaseConnectionPendingClose(uint64_t databaseConnectionIdentifier)
     DatabaseConnectionClosed(uint64_t databaseConnectionIdentifier)
@@ -68,20 +68,20 @@
     CreateIndex(WebCore::IDBRequestData requestData, WebCore::IDBIndexInfo info)
     DeleteIndex(WebCore::IDBRequestData requestData, uint64_t objectStoreIdentifier, String indexName)
     RenameIndex(WebCore::IDBRequestData requestData, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, String newName)
-    PutOrAdd(WebCore::IDBRequestData requestData, WebCore::IDBKeyData key, WebCore::IDBValue value, WebCore::IndexedDB::ObjectStoreOverwriteMode overwriteMode) WantsConnection
+    PutOrAdd(WebCore::IDBRequestData requestData, WebCore::IDBKeyData key, WebCore::IDBValue value, WebCore::IndexedDB::ObjectStoreOverwriteMode overwriteMode)
     GetRecord(WebCore::IDBRequestData requestData, struct WebCore::IDBGetRecordData getRecordData)
     GetAllRecords(WebCore::IDBRequestData requestData, struct WebCore::IDBGetAllRecordsData getAllRecordsData)
     GetCount(WebCore::IDBRequestData requestData, struct WebCore::IDBKeyRangeData range)
     DeleteRecord(WebCore::IDBRequestData requestData, struct WebCore::IDBKeyRangeData range)
     OpenCursor(WebCore::IDBRequestData requestData, WebCore::IDBCursorInfo info)
     IterateCursor(WebCore::IDBRequestData requestData, struct WebCore::IDBIterateCursorData data)
-    GetAllDatabaseNamesAndVersions(WebCore::IDBResourceIdentifier requestIdentifier, struct WebCore::ClientOrigin origin) WantsConnection
+    GetAllDatabaseNamesAndVersions(WebCore::IDBResourceIdentifier requestIdentifier, struct WebCore::ClientOrigin origin)
 
     CacheStorageOpenCache(struct WebCore::ClientOrigin origin, String cacheName) -> (WebCore::DOMCacheEngine::CacheIdentifierOrError result)
     CacheStorageRemoveCache(WebCore::DOMCacheIdentifier cacheIdentifier) -> (WebCore::DOMCacheEngine::RemoveCacheIdentifierOrError result)
     CacheStorageAllCaches(struct WebCore::ClientOrigin origin, uint64_t updateCounter) -> (WebCore::DOMCacheEngine::CacheInfosOrError result)
-    CacheStorageReference(WebCore::DOMCacheIdentifier cacheIdentifier) WantsConnection
-    CacheStorageDereference(WebCore::DOMCacheIdentifier cacheIdentifier) WantsConnection
+    CacheStorageReference(WebCore::DOMCacheIdentifier cacheIdentifier)
+    CacheStorageDereference(WebCore::DOMCacheIdentifier cacheIdentifier)
     CacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::RecordsOrError result)
     CacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
     CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record> record) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -26,7 +26,7 @@ import re
 import sys
 
 from webkit import parser
-from webkit.model import BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLYDURINGUNBOUNDEDIPC_ATTRIBUTE, MAINTHREADCALLBACK_ATTRIBUTE, STREAM_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, WANTS_CONNECTION_ATTRIBUTE, MessageReceiver, Message
+from webkit.model import BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLYDURINGUNBOUNDEDIPC_ATTRIBUTE, MAINTHREADCALLBACK_ATTRIBUTE, STREAM_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, MessageReceiver, Message
 
 _license_header = """/*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
@@ -497,9 +497,6 @@ def async_message_statement(receiver, message):
     if message.reply_parameters is not None and not message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
         dispatch_function += 'Async'
 
-    if message.has_attribute(WANTS_CONNECTION_ATTRIBUTE):
-        dispatch_function += 'WantsConnection'
-
     connection = 'connection'
     if receiver.has_attribute(STREAM_ATTRIBUTE):
         connection = 'connection.connection()'
@@ -516,8 +513,6 @@ def sync_message_statement(receiver, message):
         dispatch_function += 'Synchronous'
     elif message.reply_parameters is not None:
         dispatch_function += 'Async'
-    if message.has_attribute(WANTS_CONNECTION_ATTRIBUTE):
-        dispatch_function += 'WantsConnection'
 
     maybe_reply_encoder = ", *replyEncoder"
     if receiver.has_attribute(STREAM_ATTRIBUTE):

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -30,7 +30,6 @@ ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE = "AllowedWhenWaitingForSyncReply"
 ALLOWEDWHENWAITINGFORSYNCREPLYDURINGUNBOUNDEDIPC_ATTRIBUTE = "AllowedWhenWaitingForSyncReplyDuringUnboundedIPC"
 SYNCHRONOUS_ATTRIBUTE = 'Synchronous'
 STREAM_ATTRIBUTE = "Stream"
-WANTS_CONNECTION_ATTRIBUTE = 'WantsConnection'
 
 class MessageReceiver(object):
     def __init__(self, name, superclass, attributes, messages, condition):

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in
@@ -47,7 +47,7 @@ messages -> TestWithLegacyReceiver LegacyReceiver {
     GetPlugins(bool refresh) -> (Vector<WebCore::PluginInfo> plugins)
     GetPluginProcessConnection(String pluginPath) -> (IPC::Connection::Handle connectionHandle) Synchronous
 
-    TestMultipleAttributes() -> () WantsConnection Synchronous
+    TestMultipleAttributes() -> () Synchronous
 
     TestParameterAttributes([AttributeOne AttributeTwo] uint64_t foo, double bar, [AttributeThree] double baz)
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -140,7 +140,7 @@ bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Co
     if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name())
         return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::getPluginProcessConnection);
     if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronousWantsConnection<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
+        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in
@@ -26,7 +26,7 @@ messages -> TestWithSuperclass : WebPageBase {
     TestAsyncMessage(enum:bool WebKit::TestTwoStateEnum twoStateEnum) -> (uint64_t result) MainThreadCallback
     TestAsyncMessageWithNoArguments() -> ()
     TestAsyncMessageWithMultipleArguments() -> (bool flag, uint64_t value)
-    TestAsyncMessageWithConnection(int value) -> (bool flag) WantsConnection
+    TestAsyncMessageWithConnection(int value) -> (bool flag)
 #endif
     TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
     TestSynchronousMessage(bool value) -> (std::optional<WebKit::TestClassName> optionalReply) Synchronous

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -55,7 +55,7 @@ void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Dec
     if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name())
         return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
     if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name())
-        return IPC::handleMessageAsyncWantsConnection<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
+        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
 #endif
     WebPageBase::didReceiveMessage(connection, decoder);
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in
@@ -54,7 +54,7 @@ messages -> TestWithoutAttributes {
     GetPlugins(bool refresh) -> (Vector<WebCore::PluginInfo> plugins)
     GetPluginProcessConnection(String pluginPath) -> (IPC::Connection::Handle connectionHandle) Synchronous
 
-    TestMultipleAttributes() -> () WantsConnection Synchronous
+    TestMultipleAttributes() -> () Synchronous
 
     TestParameterAttributes([AttributeOne AttributeTwo] uint64_t foo, double bar, [AttributeThree] double baz)
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -140,7 +140,7 @@ bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, I
     if (decoder.messageName() == Messages::TestWithoutAttributes::GetPluginProcessConnection::name())
         return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::getPluginProcessConnection);
     if (decoder.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronousWantsConnection<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
+        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -23,18 +23,18 @@
 #if ENABLE(IPC_TESTING_API)
 
 messages -> IPCTester NotRefCounted {
-    StartMessageTesting(String driverName) WantsConnection
+    StartMessageTesting(String driverName)
     StopMessageTesting() -> () Synchronous
     CreateStreamTester(WebKit::IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle serverConnection)
     ReleaseStreamTester(WebKit::IPCStreamTesterIdentifier identifier) -> () Synchronous
-    CreateConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection) WantsConnection
-    CreateConnectionTesterAndSendAsyncMessages(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection, uint32_t messageCount) WantsConnection
+    CreateConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection)
+    CreateConnectionTesterAndSendAsyncMessages(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection, uint32_t messageCount)
     ReleaseConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier) -> () Synchronous
 
-    SendSameSemaphoreBack(IPC::Semaphore semaphore) WantsConnection
-    SendSemaphoreBackAndSignalProtocol(IPC::Semaphore semaphore) WantsConnection
+    SendSameSemaphoreBack(IPC::Semaphore semaphore)
+    SendSemaphoreBackAndSignalProtocol(IPC::Semaphore semaphore)
 
-    SendAsyncMessageToReceiver(uint32_t arg0) WantsConnection
+    SendAsyncMessageToReceiver(uint32_t arg0)
 }
 
 #endif

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -22,7 +22,7 @@
 
 messages -> NotificationManagerMessageHandler NotRefCounted {
     RequestSystemNotificationPermission(String originIdentifier) -> (bool allowed)
-    ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> () WantsConnection
+    ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
     CancelNotification(UUID notificationID)
     ClearNotifications(Vector<UUID> notificationIDs)
     DidDestroyNotification(UUID notificationID)

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> WebGeolocationManagerProxy {
-    StartUpdating(WebCore::RegistrableDomain registrableDomain, WebKit::WebPageProxyIdentifier pageProxyID, String authorizationToken, bool enableHighAccuracy) WantsConnection
-    StopUpdating(WebCore::RegistrableDomain registrableDomain) WantsConnection
-    SetEnableHighAccuracy(WebCore::RegistrableDomain registrableDomain, bool enabled) WantsConnection
+    StartUpdating(WebCore::RegistrableDomain registrableDomain, WebKit::WebPageProxyIdentifier pageProxyID, String authorizationToken, bool enableHighAccuracy)
+    StopUpdating(WebCore::RegistrableDomain registrableDomain)
+    SetEnableHighAccuracy(WebCore::RegistrableDomain registrableDomain, bool enabled)
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -464,8 +464,8 @@ messages -> WebPageProxy {
 #if PLATFORM(MAC)
     DidPerformImmediateActionHitTest(struct WebKit::WebHitTestResultData result, bool contentPreventsDefault, WebKit::UserData userData)
 #endif
-    HandleMessage(String messageName, WebKit::UserData messageBody) WantsConnection
-    HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous WantsConnection
+    HandleMessage(String messageName, WebKit::UserData messageBody)
+    HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous
 
     HandleAutoFillButtonClick(WebKit::UserData userData)
 

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -22,45 +22,45 @@
 
 messages -> WebPasteboardProxy NotRefCounted {
 #if PLATFORM(IOS_FAMILY)
-    WriteURLToPasteboard(struct WebCore::PasteboardURL url, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) WantsConnection
-    WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) WantsConnection
-    WriteImageToPasteboard(struct WebCore::PasteboardImage pasteboardImage, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) WantsConnection
-    WriteStringToPasteboard(String pasteboardType, String text, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) WantsConnection
+    WriteURLToPasteboard(struct WebCore::PasteboardURL url, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)
+    WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)
+    WriteImageToPasteboard(struct WebCore::PasteboardImage pasteboardImage, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)
+    WriteStringToPasteboard(String pasteboardType, String text, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)
     UpdateSupportedTypeIdentifiers(Vector<String> identifiers, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID)
 #endif
 
-    WriteCustomData(Vector<WebCore::PasteboardCustomData> data, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    TypesSafeForDOMToReadAndWrite(String pasteboardName, String origin, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> types) Synchronous WantsConnection
-    AllPasteboardItemInfo(String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<Vector<WebCore::PasteboardItemInfo>> allInfo) Synchronous WantsConnection
-    InformationForItemAtIndex(size_t index, String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<WebCore::PasteboardItemInfo> info) Synchronous WantsConnection
-    GetPasteboardItemsCount(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (uint64_t itemsCount) Synchronous WantsConnection
-    ReadStringFromPasteboard(size_t index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous WantsConnection
-    ReadURLFromPasteboard(size_t index, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
-    ReadBufferFromPasteboard(std::optional<size_t> index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous WantsConnection
-    ContainsStringSafeForDOMToReadForType(String type, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous WantsConnection
+    WriteCustomData(Vector<WebCore::PasteboardCustomData> data, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    TypesSafeForDOMToReadAndWrite(String pasteboardName, String origin, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> types) Synchronous
+    AllPasteboardItemInfo(String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<Vector<WebCore::PasteboardItemInfo>> allInfo) Synchronous
+    InformationForItemAtIndex(size_t index, String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<WebCore::PasteboardItemInfo> info) Synchronous
+    GetPasteboardItemsCount(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (uint64_t itemsCount) Synchronous
+    ReadStringFromPasteboard(size_t index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous
+    ReadURLFromPasteboard(size_t index, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous
+    ReadBufferFromPasteboard(std::optional<size_t> index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous
+    ContainsStringSafeForDOMToReadForType(String type, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous
 
 #if PLATFORM(COCOA)
     # Pasteboard messages.
-    GetNumberOfFiles(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (uint64_t numberOfFiles) Synchronous WantsConnection
-    GetPasteboardTypes(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> types) Synchronous WantsConnection
-    GetPasteboardPathnamesForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> pathnames, Vector<WebKit::SandboxExtension::Handle> sandboxExtensions) Synchronous WantsConnection
-    GetPasteboardStringForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous WantsConnection
-    GetPasteboardStringsForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> strings) Synchronous WantsConnection
-    GetPasteboardBufferForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous WantsConnection
-    GetPasteboardChangeCount(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    GetPasteboardColor(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (WebCore::Color color) Synchronous WantsConnection
-    GetPasteboardURL(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String urlString) Synchronous WantsConnection
-    AddPasteboardTypes(String pasteboardName, Vector<String> pasteboardTypes, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    SetPasteboardTypes(String pasteboardName, Vector<String> pasteboardTypes, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    SetPasteboardURL(struct WebCore::PasteboardURL pasteboardURL, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    SetPasteboardColor(String pasteboardName, WebCore::Color color, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    SetPasteboardStringForType(String pasteboardName, String pasteboardType, String string, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    SetPasteboardBufferForType(String pasteboardName, String pasteboardType, RefPtr<WebCore::SharedBuffer> buffer, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    ContainsURLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous WantsConnection
-    URLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
+    GetNumberOfFiles(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (uint64_t numberOfFiles) Synchronous
+    GetPasteboardTypes(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> types) Synchronous
+    GetPasteboardPathnamesForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> pathnames, Vector<WebKit::SandboxExtension::Handle> sandboxExtensions) Synchronous
+    GetPasteboardStringForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous
+    GetPasteboardStringsForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> strings) Synchronous
+    GetPasteboardBufferForType(String pasteboardName, String pasteboardType, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous
+    GetPasteboardChangeCount(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    GetPasteboardColor(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (WebCore::Color color) Synchronous
+    GetPasteboardURL(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String urlString) Synchronous
+    AddPasteboardTypes(String pasteboardName, Vector<String> pasteboardTypes, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    SetPasteboardTypes(String pasteboardName, Vector<String> pasteboardTypes, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    SetPasteboardURL(struct WebCore::PasteboardURL pasteboardURL, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    SetPasteboardColor(String pasteboardName, WebCore::Color color, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    SetPasteboardStringForType(String pasteboardName, String pasteboardType, String string, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    SetPasteboardBufferForType(String pasteboardName, String pasteboardType, RefPtr<WebCore::SharedBuffer> buffer, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    ContainsURLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous
+    URLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous
 
 #if ENABLE(IPC_TESTING_API)
-    TestIPCSharedMemory(String pasteboardName, String pasteboardType, WebKit::SharedMemory::Handle handle, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount, String buffer) Synchronous WantsConnection
+    TestIPCSharedMemory(String pasteboardName, String pasteboardType, WebKit::SharedMemory::Handle handle, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount, String buffer) Synchronous
 #endif
 
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessPool.messages.in
@@ -21,13 +21,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> WebProcessPool {
-    HandleMessage(String messageName, WebKit::UserData messageBody) WantsConnection
-    HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous WantsConnection
+    HandleMessage(String messageName, WebKit::UserData messageBody)
+    HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous
 
 #if ENABLE(GAMEPAD)
     // FIXME: Consider moving Gamepad messages to their own MessageListener.
-    StartedUsingGamepads() WantsConnection
-    StoppedUsingGamepads() -> () WantsConnection
+    StartedUsingGamepads()
+    StoppedUsingGamepads() -> ()
     PlayGamepadEffect(unsigned gamepadIndex, String gamepadID, enum:uint8_t WebCore::GamepadHapticEffectType type, struct WebCore::GamepadEffectParameters parameters) -> (bool success)
     StopGamepadEffects(unsigned gamepadIndex, String gamepadID) -> ()
 #endif


### PR DESCRIPTION
#### b6bf0e666f01ea3b00004e6d666d00261dbdc655
<pre>
[WK2] Remove WantsConnection IPC message attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=251030">https://bugs.webkit.org/show_bug.cgi?id=251030</a>

Reviewed by Kimmo Kinnunen.

The &apos;WantsConnection&apos; IPC message attribute imposed using the wants-connection
variants of IPC::handleMessage(), passing the Connection reference as the first
argument to the method handling a given IPC message.

The attribute can be removed, along with the relevant IPC::handleMessage()
variants. Instead, the initial Connection reference parameter on the handler
method can be indicated on the MethodSignatureValidation template class that&apos;s
already used for validation purposes. Existing variants do a constexpr check and
adjust the method invocation to pass the Connection reference as the first
argument to the method when necessary.

* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessage):
(IPC::handleMessageSynchronous):
(IPC::handleMessageAsync):
(IPC::handleMessageWantsConnection): Deleted.
(IPC::handleMessageSynchronousWantsConnection): Deleted.
(IPC::handleMessageAsyncWantsConnection): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(async_message_statement):
(sync_message_statement):
* Source/WebKit/Scripts/webkit/model.py:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiver.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclass.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributes.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):
* Source/WebKit/Shared/IPCTester.messages.in:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessPool.messages.in:

Canonical link: <a href="https://commits.webkit.org/259476@main">https://commits.webkit.org/259476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f57137feaa8d7c7785d4df17a229117a260ce30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113619 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4398 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112657 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38867 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107881 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25918 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80536 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6842 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6971 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3823 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46833 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6540 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8765 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->