### PR TITLE
Port the remaining editing related types to the new serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -870,6 +870,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     editing/TextIterator.h
     editing/TextIteratorBehavior.h
     editing/TextManipulationController.h
+    editing/TextManipulationControllerExclusionRule.h
+    editing/TextManipulationControllerManipulationFailure.h
     editing/TextManipulationItem.h
     editing/TextManipulationToken.h
     editing/UndoStep.h

--- a/Source/WebCore/editing/CompositionHighlight.h
+++ b/Source/WebCore/editing/CompositionHighlight.h
@@ -47,38 +47,6 @@ struct CompositionHighlight {
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };
     Color color { defaultCompositionFillColor };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CompositionHighlight> decode(Decoder&);
 };
-
-template<class Encoder>
-void CompositionHighlight::encode(Encoder& encoder) const
-{
-    encoder << startOffset;
-    encoder << endOffset;
-    encoder << color;
-}
-
-template<class Decoder>
-std::optional<CompositionHighlight> CompositionHighlight::decode(Decoder& decoder)
-{
-    std::optional<unsigned> startOffset;
-    decoder >> startOffset;
-    if (!startOffset)
-        return std::nullopt;
-
-    std::optional<unsigned> endOffset;
-    decoder >> endOffset;
-    if (!endOffset)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    return {{ *startOffset, *endOffset, *color }};
-}
 
 } // namespace WebCore

--- a/Source/WebCore/editing/FontAttributeChanges.cpp
+++ b/Source/WebCore/editing/FontAttributeChanges.cpp
@@ -37,6 +37,17 @@
 
 namespace WebCore {
 
+FontChanges::FontChanges(String&& fontName, String&& fontFamily, std::optional<double>&& fontSize, std::optional<double>&& fontSizeDelta, std::optional<bool>&& bold, std::optional<bool>&& italic)
+    : m_fontName(WTFMove(fontName))
+    , m_fontFamily(WTFMove(fontFamily))
+    , m_fontSize(WTFMove(fontSize))
+    , m_fontSizeDelta(WTFMove(fontSizeDelta))
+    , m_bold(WTFMove(bold))
+    , m_italic(WTFMove(italic))
+{
+    ASSERT(!m_fontSize || !m_fontSizeDelta);
+}
+
 #if !PLATFORM(COCOA)
 
 const String& FontChanges::platformFontFamilyNameForCSS() const
@@ -89,6 +100,17 @@ static RefPtr<CSSValueList> cssValueListForShadow(const FontShadow& shadow)
     auto color = CSSValuePool::singleton().createColorValue(shadow.color);
     list->prepend(CSSShadowValue::create(WTFMove(width), WTFMove(height), WTFMove(blurRadius), { }, { }, WTFMove(color)));
     return list.ptr();
+}
+
+FontAttributeChanges::FontAttributeChanges(std::optional<VerticalAlignChange>&& verticalAlign, std::optional<Color>&& backgroundColor, std::optional<Color>&& foregroundColor, std::optional<FontShadow>&& shadow, std::optional<bool>&& strikeThrough, std::optional<bool>&& underline, FontChanges&& fontChanges)
+    : m_verticalAlign(WTFMove(verticalAlign))
+    , m_backgroundColor(WTFMove(backgroundColor))
+    , m_foregroundColor(WTFMove(foregroundColor))
+    , m_shadow(WTFMove(shadow))
+    , m_strikeThrough(WTFMove(strikeThrough))
+    , m_underline(WTFMove(underline))
+    , m_fontChanges(WTFMove(fontChanges))
+{
 }
 
 EditAction FontAttributeChanges::editAction() const

--- a/Source/WebCore/editing/FontAttributes.h
+++ b/Source/WebCore/editing/FontAttributes.h
@@ -40,9 +40,6 @@ struct TextList {
     int startingItemNumber { 0 };
     bool ordered { false };
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<TextList> decode(Decoder&);
-
 #if PLATFORM(COCOA)
     RetainPtr<NSTextList> createTextList() const;
 #endif

--- a/Source/WebCore/editing/FontShadow.h
+++ b/Source/WebCore/editing/FontShadow.h
@@ -37,9 +37,6 @@ OBJC_CLASS NSShadow;
 namespace WebCore {
 
 struct FontShadow {
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, FontShadow&);
-
 #if PLATFORM(COCOA)
     RetainPtr<NSShadow> createShadow() const;
 #endif
@@ -48,27 +45,6 @@ struct FontShadow {
     FloatSize offset;
     double blurRadius { 0 };
 };
-
-template<class Encoder>
-void FontShadow::encode(Encoder& encoder) const
-{
-    encoder << color << offset << blurRadius;
-}
-
-template<class Decoder>
-bool FontShadow::decode(Decoder& decoder, FontShadow& shadow)
-{
-    if (!decoder.decode(shadow.color))
-        return false;
-
-    if (!decoder.decode(shadow.offset))
-        return false;
-
-    if (!decoder.decode(shadow.blurRadius))
-        return false;
-
-    return true;
-}
 
 #if PLATFORM(COCOA)
 WEBCORE_EXPORT FontShadow fontShadowFromNSShadow(NSShadow *);

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -27,6 +27,8 @@
 
 #include "Position.h"
 #include "QualifiedName.h"
+#include "TextManipulationControllerExclusionRule.h"
+#include "TextManipulationControllerManipulationFailure.h"
 #include "TextManipulationItem.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/EnumTraits.h>
@@ -44,40 +46,9 @@ class TextManipulationController : public CanMakeWeakPtr<TextManipulationControl
     WTF_MAKE_FAST_ALLOCATED;
 public:
     TextManipulationController(Document&);
-
-    struct ExclusionRule {
-        enum class Type : uint8_t { Exclude, Include };
-
-        struct ElementRule {
-            AtomString localName;
-
-            template<class Encoder> void encode(Encoder&) const;
-            template<class Decoder> static std::optional<ElementRule> decode(Decoder&);
-        };
-
-        struct AttributeRule {
-            AtomString name;
-            String value;
-
-            template<class Encoder> void encode(Encoder&) const;
-            template<class Decoder> static std::optional<AttributeRule> decode(Decoder&);
-        };
-
-        struct ClassRule {
-            AtomString className;
-
-            template<class Encoder> void encode(Encoder&) const;
-            template<class Decoder> static std::optional<ClassRule> decode(Decoder&);
-        };
-
-        Type type;
-        std::variant<ElementRule, AttributeRule, ClassRule> rule;
-
-        bool match(const Element&) const;
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<ExclusionRule> decode(Decoder&);
-    };
+    
+    using ManipulationFailure = TextManipulationControllerManipulationFailure;
+    using ExclusionRule = TextManipulationControllerExclusionRule;
 
     using ManipulationItemCallback = Function<void(Document&, const Vector<TextManipulationItem>&)>;
     WEBCORE_EXPORT void startObservingParagraphs(ManipulationItemCallback&&, Vector<ExclusionRule>&& = { });
@@ -85,22 +56,6 @@ public:
     void didUpdateContentForNode(Node&);
     void didAddOrCreateRendererForNode(Node&);
     void removeNode(Node&);
-
-    enum class ManipulationFailureType : uint8_t {
-        ContentChanged,
-        InvalidItem,
-        InvalidToken,
-        ExclusionViolation,
-    };
-
-    struct ManipulationFailure {
-        TextManipulationItemIdentifier identifier;
-        uint64_t index;
-        ManipulationFailureType type;
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<ManipulationFailure> decode(Decoder&);
-    };
 
     WEBCORE_EXPORT Vector<ManipulationFailure> completeManipulation(const Vector<TextManipulationItem>&);
 
@@ -143,7 +98,7 @@ private:
     using NodeEntry = std::pair<Ref<Node>, Ref<Node>>;
     Vector<Ref<Node>> getPath(Node*, Node*);
     void updateInsertions(Vector<NodeEntry>&, const Vector<Ref<Node>>&, Node*, HashSet<Ref<Node>>&, Vector<NodeInsertion>&);
-    std::optional<ManipulationFailureType> replace(const ManipulationItemData&, const Vector<TextManipulationToken>&, HashSet<Ref<Node>>& containersWithoutVisualOverflowBeforeReplacement);
+    std::optional<ManipulationFailure::Type> replace(const ManipulationItemData&, const Vector<TextManipulationToken>&, HashSet<Ref<Node>>& containersWithoutVisualOverflowBeforeReplacement);
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithNewRenderer;
@@ -165,111 +120,4 @@ private:
     TextManipulationTokenIdentifier m_tokenIdentifier;
 };
 
-template<class Encoder>
-void TextManipulationController::ExclusionRule::encode(Encoder& encoder) const
-{
-    encoder << type << rule;
-}
-
-template<class Decoder>
-std::optional<TextManipulationController::ExclusionRule> TextManipulationController::ExclusionRule::decode(Decoder& decoder)
-{
-    ExclusionRule result;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.rule))
-        return std::nullopt;
-    return result;
-}
-
-template<class Encoder>
-void TextManipulationController::ExclusionRule::ElementRule::encode(Encoder& encoder) const
-{
-    encoder << localName;
-}
-
-template<class Decoder>
-std::optional<TextManipulationController::ExclusionRule::ElementRule> TextManipulationController::ExclusionRule::ElementRule::decode(Decoder& decoder)
-{
-    ElementRule result;
-    if (!decoder.decode(result.localName))
-        return std::nullopt;
-    return result;
-}
-
-template<class Encoder>
-void TextManipulationController::ExclusionRule::AttributeRule::encode(Encoder& encoder) const
-{
-    encoder << name << value;
-}
-
-template<class Decoder>
-std::optional<TextManipulationController::ExclusionRule::AttributeRule> TextManipulationController::ExclusionRule::AttributeRule::decode(Decoder& decoder)
-{
-    AttributeRule result;
-    if (!decoder.decode(result.name))
-        return std::nullopt;
-    if (!decoder.decode(result.value))
-        return std::nullopt;
-    return result;
-}
-
-template<class Encoder>
-void TextManipulationController::ExclusionRule::ClassRule::encode(Encoder& encoder) const
-{
-    encoder << className;
-}
-
-template<class Decoder>
-std::optional<TextManipulationController::ExclusionRule::ClassRule> TextManipulationController::ExclusionRule::ClassRule::decode(Decoder& decoder)
-{
-    ClassRule result;
-    if (!decoder.decode(result.className))
-        return std::nullopt;
-    return result;
-}
-
-template<class Encoder>
-void TextManipulationController::ManipulationFailure::encode(Encoder& encoder) const
-{
-    encoder << identifier << index << type;
-}
-
-template<class Decoder>
-std::optional<TextManipulationController::ManipulationFailure> TextManipulationController::ManipulationFailure::decode(Decoder& decoder)
-{
-    ManipulationFailure result;
-    if (!decoder.decode(result.identifier))
-        return std::nullopt;
-    if (!decoder.decode(result.index))
-        return std::nullopt;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    return result;
-}
-
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TextManipulationController::ExclusionRule::Type> {
-    using ExclusionRule = WebCore::TextManipulationController::ExclusionRule;
-    using values = EnumValues<
-        ExclusionRule::Type,
-        ExclusionRule::Type::Include,
-        ExclusionRule::Type::Exclude
-    >;
-};
-
-template<> struct EnumTraits<WebCore::TextManipulationController::ManipulationFailureType> {
-    using ManipulationFailureType = WebCore::TextManipulationController::ManipulationFailureType;
-    using values = EnumValues<
-        ManipulationFailureType,
-        ManipulationFailureType::ContentChanged,
-        ManipulationFailureType::InvalidItem,
-        ManipulationFailureType::InvalidToken,
-        ManipulationFailureType::ExclusionViolation
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/editing/TextManipulationControllerExclusionRule.h
+++ b/Source/WebCore/editing/TextManipulationControllerExclusionRule.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class Element;
+
+struct TextManipulationControllerExclusionRule {
+    enum class Type : uint8_t { Exclude, Include };
+
+    struct ElementRule {
+        AtomString localName;
+    };
+
+    struct AttributeRule {
+        AtomString name;
+        String value;
+    };
+
+    struct ClassRule {
+        AtomString className;
+    };
+
+    Type type;
+    std::variant<ElementRule, AttributeRule, ClassRule> rule;
+
+    bool match(const Element&) const;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/editing/TextManipulationControllerManipulationFailure.h
+++ b/Source/WebCore/editing/TextManipulationControllerManipulationFailure.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TextManipulationItem.h"
+
+namespace WebCore {
+
+struct TextManipulationControllerManipulationFailure {
+    enum class Type : uint8_t {
+        ContentChanged,
+        InvalidItem,
+        InvalidToken,
+        ExclusionViolation,
+    };
+    
+    TextManipulationItemIdentifier identifier;
+    uint64_t index;
+    Type type;
+};
+
+} // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2809,3 +2809,78 @@ enum class WebCore::MediaEncodingType : bool;
 class WebCore::BufferSource {
     Span<const uint8_t> span()
 }
+
+struct WebCore::FontShadow {
+    WebCore::Color color;
+    WebCore::FloatSize offset;
+    double blurRadius;
+};
+
+struct WebCore::CompositionHighlight {
+    unsigned startOffset;
+    unsigned endOffset;
+    WebCore::Color color;
+};
+
+header: <WebCore/FontAttributeChanges.h>
+[CustomHeader] class WebCore::FontChanges {
+    String m_fontName;
+    String m_fontFamily;
+    std::optional<double> m_fontSize;
+    [Validator='!*m_fontSize || !*m_fontSizeDelta'] std::optional<double> m_fontSizeDelta;
+    std::optional<bool> m_bold;
+    std::optional<bool> m_italic;
+};
+
+class WebCore::FontAttributeChanges {
+    std::optional<WebCore::VerticalAlignChange> m_verticalAlign;
+    std::optional<WebCore::Color> m_backgroundColor;
+    std::optional<WebCore::Color> m_foregroundColor;
+    std::optional<WebCore::FontShadow> m_shadow;
+    std::optional<bool> m_strikeThrough;
+    std::optional<bool> m_underline;
+    WebCore::FontChanges m_fontChanges;
+};
+
+header: <WebCore/TextManipulationController.h>
+[Nested, CustomHeader] enum class WebCore::TextManipulationControllerExclusionRule::Type : uint8_t {
+    Exclude,
+    Include
+};
+
+header: <WebCore/TextManipulationController.h>
+[Nested, CustomHeader] struct WebCore::TextManipulationControllerExclusionRule::ElementRule {
+    AtomString localName;
+};
+
+header: <WebCore/TextManipulationController.h>
+[Nested, CustomHeader] struct WebCore::TextManipulationControllerExclusionRule::AttributeRule {
+    AtomString name;
+    String value;
+};
+
+header: <WebCore/TextManipulationController.h>
+[Nested, CustomHeader] struct WebCore::TextManipulationControllerExclusionRule::ClassRule {
+    AtomString className;
+};
+
+header: <WebCore/TextManipulationController.h>
+[CustomHeader] struct WebCore::TextManipulationControllerExclusionRule {
+    WebCore::TextManipulationControllerExclusionRule::Type type;
+    std::variant<WebCore::TextManipulationControllerExclusionRule::ElementRule, WebCore::TextManipulationControllerExclusionRule::AttributeRule, WebCore::TextManipulationControllerExclusionRule::ClassRule> rule;
+};
+
+header: <WebCore/TextManipulationController.h>
+[Nested, CustomHeader] enum class WebCore::TextManipulationControllerManipulationFailure::Type : uint8_t {
+    ContentChanged,
+    InvalidItem,
+    InvalidToken,
+    ExclusionViolation,
+};
+
+header: <WebCore/TextManipulationController.h>
+[CustomHeader] struct WebCore::TextManipulationControllerManipulationFailure {
+    WebCore::TextManipulationItemIdentifier identifier;
+    uint64_t index;
+    WebCore::TextManipulationControllerManipulationFailure::Type type;
+};

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2307,7 +2307,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
         if (coreFailure.index >= items.count)
             return nil;
         auto errorCode = static_cast<NSInteger>(([&coreFailure] {
-            using Type = WebCore::TextManipulationController::ManipulationFailureType;
+            using Type = WebCore::TextManipulationController::ManipulationFailure::Type;
             switch (coreFailure.type) {
             case Type::ContentChanged:
                 return _WKTextManipulationItemErrorContentChanged;


### PR DESCRIPTION
#### 761e29f6a5fd18be9dd2d161de77239d1368e986
<pre>
Port the remaining editing related types to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251025">https://bugs.webkit.org/show_bug.cgi?id=251025</a>
rdar://104574856

Reviewed by Ryosuke Niwa.

This change ports the remaining editing base types to the new serialization
format. This includes:
    - FontShadow
    - CompositionHighlight
    - FontChanges
    - FontAttributeChanges
    - TextManipulationControllerExclusionRule
    - TextManipulationControllerExclusionRule::Type
    - TextManipulationControllerExclusionRule::ElementRule
    - TextManipulationControllerExclusionRule::AttributeRule
    - TextManipulationControllerExclusionRule::ClassRule
    - TextManipulationControllerManipulationFailure
    - TextManipulationControllerManipulationFailure::Type

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/CompositionHighlight.h:
(WebCore::CompositionHighlight::encode const): Deleted.
(WebCore::CompositionHighlight::decode): Deleted.
* Source/WebCore/editing/FontAttributeChanges.cpp:
(WebCore::FontChanges::FontChanges):
(WebCore::FontAttributeChanges::FontAttributeChanges):
* Source/WebCore/editing/FontAttributeChanges.h:
(WebCore::FontChanges::encode const): Deleted.
(WebCore::FontChanges::decode): Deleted.
(WebCore::FontAttributeChanges::encode const): Deleted.
(WebCore::FontAttributeChanges::decode): Deleted.
* Source/WebCore/editing/FontAttributes.h:
* Source/WebCore/editing/FontShadow.h:
(WebCore::FontShadow::encode const): Deleted.
(WebCore::FontShadow::decode): Deleted.
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationControllerExclusionRule::match const):
(WebCore::TextManipulationController::completeManipulation):
(WebCore::TextManipulationController::replace):
(WebCore::TextManipulationController::ExclusionRule::match const): Deleted.
* Source/WebCore/editing/TextManipulationController.h:
(WebCore::TextManipulationController::startObservingParagraphs):
(WebCore::TextManipulationController::ExclusionRule::encode const): Deleted.
(WebCore::TextManipulationController::ExclusionRule::decode): Deleted.
(WebCore::TextManipulationController::ExclusionRule::ElementRule::encode const): Deleted.
(WebCore::TextManipulationController::ExclusionRule::ElementRule::decode): Deleted.
(WebCore::TextManipulationController::ExclusionRule::AttributeRule::encode const): Deleted.
(WebCore::TextManipulationController::ExclusionRule::AttributeRule::decode): Deleted.
(WebCore::TextManipulationController::ExclusionRule::ClassRule::encode const): Deleted.
(WebCore::TextManipulationController::ExclusionRule::ClassRule::decode): Deleted.
(WebCore::TextManipulationController::ManipulationFailure::encode const): Deleted.
(WebCore::TextManipulationController::ManipulationFailure::decode): Deleted.
* Source/WebCore/editing/TextManipulationControllerExclusionRule.h: Copied from Source/WebCore/editing/FontShadow.h.
* Source/WebCore/editing/TextManipulationControllerManipulationFailure.h: Copied from Source/WebCore/editing/FontShadow.h.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259302@main">https://commits.webkit.org/259302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/861671add28eaf30c9ae6ab3daa44de080be5aca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113808 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174049 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4535 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96868 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112765 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38946 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6967 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27376 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3946 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6414 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8878 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->