### PR TITLE
[webkitcorepy] Autoinstall should install specified module/package [webkitcorepy] Autoinstall should install specified module/package version

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.13.20',
+    version='0.13.21',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -46,7 +46,7 @@ from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
 from webkitcorepy.null_context import NullContext
 
-version = Version(0, 13, 20)
+version = Version(0, 13, 21)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -221,7 +221,7 @@ class Package(object):
                     if not version_candidate:
                         continue
                     version = Version(*version_candidate.group().split('.'))
-                    if self.version and version not in self.version:
+                    if self.version and version != self.version:
                         continue
 
                     link = package['href'].split('#')[0]


### PR DESCRIPTION
#### 400677313c7e1d92de7b2c2a531e47f51b99e339
<pre>
[webkitcorepy] Autoinstall should install specified module/package [webkitcorepy] Autoinstall should install specified module/package version
<a href="https://bugs.webkit.org/show_bug.cgi?id=251043">https://bugs.webkit.org/show_bug.cgi?id=251043</a>

Reviewed by Jonathan Bedard.

Do a strict eqaulity check for package versions instead of allowing partial matches.

* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.archives):

Canonical link: <a href="https://commits.webkit.org/259248@main">https://commits.webkit.org/259248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f79ae4c663b142bdb757b1fa203445a1bdd6ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13514 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/113651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4431 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110203 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/107915 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6873 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103279 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13030 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3377 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->