### PR TITLE
Remove the empty CATransaction in RemoteLayerTreeDrawingArea::displayDidRefresh()

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -393,9 +393,11 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
     }
 
-    // This empty transaction serves to trigger CA's garbage collection of IOSurfaces. See <rdar://problem/16110687>
-    [CATransaction begin];
-    [CATransaction commit];
+    if (!WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM)) {
+        // This empty transaction serves to trigger CA's garbage collection of IOSurfaces. See <rdar://problem/16110687>
+        [CATransaction begin];
+        [CATransaction commit];
+    }
 
     HashSet<RemoteLayerTreeDisplayRefreshMonitor*> monitorsToNotify = m_displayRefreshMonitors;
     ASSERT(!m_displayRefreshMonitorsToNotify);


### PR DESCRIPTION
#### 608305feff3b865bec12c37926617707d6c41bba
<pre>
Remove the empty CATransaction in RemoteLayerTreeDrawingArea::displayDidRefresh()
<a href="https://bugs.webkit.org/show_bug.cgi?id=249735">https://bugs.webkit.org/show_bug.cgi?id=249735</a>
rdar://103608610

Reviewed by Tim Horton.

The empty CA transaction was done to garbage-collect IOSurfaces (rdar://problem/16110687). We only
need that if we&apos;re making IOSurfaces in the web process, which we only do if GPU Process for
DOM Rendering is disabled.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):

Canonical link: <a href="https://commits.webkit.org/259296@main">https://commits.webkit.org/259296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e1520ccb3676955b99f350fac6237b33c67316b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113653 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4433 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96772 "Failed to checkout and rebase branch from PR 8999") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112689 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94325 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96772 "Failed to checkout and rebase branch from PR 8999") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25936 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96772 "Failed to checkout and rebase branch from PR 8999") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27293 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3851 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6407 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8797 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->