### PR TITLE
Move Opaque Origin Identifier from SecurityOrigin to SecurityOriginData

### DIFF
--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -36,6 +36,7 @@
 
 #include <optional>
 #include <type_traits>
+#include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -153,6 +154,11 @@ public:
 private:
     T m_value;
 };
+
+template <typename T, typename Traits> inline void add(Hasher& hasher, const Markable<T, Traits>& value)
+{
+    add(hasher, value.asOptional());
+}
 
 template <typename T, typename Traits> constexpr bool operator==(const Markable<T, Traits>& x, const Markable<T, Traits>& y)
 {

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -176,7 +176,14 @@ bool shouldTreatAsPotentiallyTrustworthy(const URL& url)
 }
 
 SecurityOrigin::SecurityOrigin(const URL& url)
-    : m_data(SecurityOriginData::fromURL(url))
+    : SecurityOrigin(SecurityOriginData::fromURL(url))
+{
+    if (m_canLoadLocalResources)
+        m_filePath = url.fileSystemPath(); // In case enforceFilePathSeparation() is called.
+}
+
+SecurityOrigin::SecurityOrigin(SecurityOriginData&& data)
+    : m_data(WTFMove(data))
     , m_isLocal(LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(m_data.protocol))
 {
     // document.domain starts as m_data.host, but can be set by the DOM.
@@ -187,15 +194,11 @@ SecurityOrigin::SecurityOrigin(const URL& url)
 
     // By default, only local SecurityOrigins can load local resources.
     m_canLoadLocalResources = isLocal();
-
-    if (m_canLoadLocalResources)
-        m_filePath = url.fileSystemPath(); // In case enforceFilePathSeparation() is called.
 }
 
 SecurityOrigin::SecurityOrigin()
-    : m_data { emptyString(), emptyString(), std::nullopt }
+    : m_data { SecurityOriginData::createOpaque() }
     , m_domain { emptyString() }
-    , m_opaqueOriginIdentifier { OpaqueOriginIdentifier::generateThreadSafe() }
     , m_isPotentiallyTrustworthy { false }
 {
 }
@@ -204,7 +207,6 @@ SecurityOrigin::SecurityOrigin(const SecurityOrigin* other)
     : m_data { other->m_data.isolatedCopy() }
     , m_domain { other->m_domain.isolatedCopy() }
     , m_filePath { other->m_filePath.isolatedCopy() }
-    , m_opaqueOriginIdentifier { other->m_opaqueOriginIdentifier }
     , m_universalAccess { other->m_universalAccess }
     , m_domainWasSetInDOM { other->m_domainWasSetInDOM }
     , m_canLoadLocalResources { other->m_canLoadLocalResources }
@@ -277,7 +279,7 @@ bool SecurityOrigin::isSameOriginDomain(const SecurityOrigin& other) const
         return true;
 
     if (isOpaque() || other.isOpaque())
-        return m_opaqueOriginIdentifier == other.m_opaqueOriginIdentifier;
+        return data().opaqueOriginIdentifier == other.data().opaqueOriginIdentifier;
 
     // Here are two cases where we should permit access:
     //
@@ -435,7 +437,7 @@ bool SecurityOrigin::isSameOriginAs(const SecurityOrigin& other) const
         return true;
 
     if (isOpaque() || other.isOpaque())
-        return m_opaqueOriginIdentifier == other.m_opaqueOriginIdentifier;
+        return data().opaqueOriginIdentifier == other.data().opaqueOriginIdentifier;
 
     return isSameSchemeHostPort(other);
 }
@@ -596,13 +598,17 @@ Ref<SecurityOrigin> SecurityOrigin::create(const String& protocol, const String&
     return origin;
 }
 
-Ref<SecurityOrigin> SecurityOrigin::create(WebCore::SecurityOriginData&& data, String&& domain, String&& filePath, Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>&& opaqueOriginIdentifier, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal)
+Ref<SecurityOrigin> SecurityOrigin::create(SecurityOriginData&& data)
+{
+    return adoptRef(*new SecurityOrigin(WTFMove(data)));
+}
+
+Ref<SecurityOrigin> SecurityOrigin::create(WebCore::SecurityOriginData&& data, String&& domain, String&& filePath, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal)
 {
     auto origin = adoptRef(*new SecurityOrigin);
     origin->m_data = WTFMove(data);
     origin->m_domain = WTFMove(domain);
     origin->m_filePath = WTFMove(filePath);
-    origin->m_opaqueOriginIdentifier = WTFMove(opaqueOriginIdentifier);
     origin->m_universalAccess = universalAccess;
     origin->m_domainWasSetInDOM = domainWasSetInDOM;
     origin->m_canLoadLocalResources = canLoadLocalResources;
@@ -619,7 +625,7 @@ bool SecurityOrigin::equal(const SecurityOrigin* other) const
         return true;
 
     if (isOpaque() || other->isOpaque())
-        return m_opaqueOriginIdentifier == other->m_opaqueOriginIdentifier;
+        return data().opaqueOriginIdentifier == other->data().opaqueOriginIdentifier;
     
     if (!isSameSchemeHostPort(*other))
         return false;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -28,19 +28,14 @@
 
 #pragma once
 
-#include "ProcessQualified.h"
 #include "SecurityOriginData.h"
 #include <wtf/ArgumentCoder.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/Hasher.h>
-#include <wtf/Markable.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-enum OpaqueOriginIdentifierType { };
-using OpaqueOriginIdentifier = ProcessQualified<ObjectIdentifier<OpaqueOriginIdentifierType>>;
 
 class SecurityOrigin : public ThreadSafeRefCounted<SecurityOrigin> {
 public:
@@ -55,7 +50,8 @@ public:
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> createFromString(const String&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const String& protocol, const String& host, std::optional<uint16_t> port);
-    WEBCORE_EXPORT static Ref<SecurityOrigin> create(WebCore::SecurityOriginData&&, String&& domain, String&& filePath, Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>&&, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> create(SecurityOriginData&&);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> create(WebCore::SecurityOriginData&&, String&& domain, String&& filePath, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal);
 
     // QuickLook documents are in non-local origins even when loaded from file: URLs. They need to
     // be allowed to display their own file: URLs in order to perform reloads and same-document
@@ -162,7 +158,7 @@ public:
     // There's a subtle difference between an opaque origin and an origin that
     // has the SandboxOrigin flag set. The latter implies the former, and, in
     // addition, the SandboxOrigin flag is inherited by iframes.
-    bool isOpaque() const { return !!m_opaqueOriginIdentifier; }
+    bool isOpaque() const { return m_data.isOpaque(); }
 
     // Marks a file:// origin as being in a domain defined by its path.
     // FIXME 81578: The naming of this is confusing. Files with restricted access to other local files
@@ -226,6 +222,7 @@ private:
     WEBCORE_EXPORT SecurityOrigin();
     explicit SecurityOrigin(const URL&);
     explicit SecurityOrigin(const SecurityOrigin*);
+    explicit SecurityOrigin(SecurityOriginData&&);
 
     // FIXME: Rename this function to something more semantic.
     bool passesFileCheck(const SecurityOrigin&) const;
@@ -240,7 +237,6 @@ private:
     SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
-    Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
     bool m_universalAccess { false };
     bool m_domainWasSetInDOM { false };
     bool m_canLoadLocalResources { false };
@@ -258,7 +254,7 @@ bool serializedOriginsMatch(const SecurityOrigin*, const SecurityOrigin*);
 
 inline void add(Hasher& hasher, const SecurityOrigin& origin)
 {
-    add(hasher, origin.protocol(), origin.host(), origin.port());
+    add(hasher, origin.data());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOriginData.cpp
+++ b/Source/WebCore/page/SecurityOriginData.cpp
@@ -68,7 +68,7 @@ SecurityOriginData SecurityOriginData::fromFrame(Frame* frame)
 
 Ref<SecurityOrigin> SecurityOriginData::securityOrigin() const
 {
-    return SecurityOrigin::create(protocol.isolatedCopy(), host.isolatedCopy(), port);
+    return SecurityOrigin::create(isolatedCopy());
 }
 
 static const char separatorCharacter = '_';
@@ -127,6 +127,7 @@ SecurityOriginData SecurityOriginData::isolatedCopy() const &
     result.protocol = protocol.isolatedCopy();
     result.host = host.isolatedCopy();
     result.port = port;
+    result.opaqueOriginIdentifier = opaqueOriginIdentifier;
 
     return result;
 }
@@ -138,6 +139,7 @@ SecurityOriginData SecurityOriginData::isolatedCopy() &&
     result.protocol = WTFMove(protocol).isolatedCopy();
     result.host = WTFMove(host).isolatedCopy();
     result.port = port;
+    result.opaqueOriginIdentifier = opaqueOriginIdentifier;
 
     return result;
 }
@@ -149,7 +151,7 @@ bool operator==(const SecurityOriginData& a, const SecurityOriginData& b)
 
     return a.protocol == b.protocol
         && a.host == b.host
-        && a.port == b.port;
+        && a.port == b.port
+        && a.opaqueOriginIdentifier == b.opaqueOriginIdentifier;
 }
-
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#include "ProcessQualified.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Hasher.h>
+#include <wtf/Markable.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -34,6 +37,10 @@ class Frame;
 class SecurityOrigin;
 
 struct SecurityOriginData {
+    enum OpaqueOriginIdentifierType { };
+    using OpaqueOriginIdentifier = ProcessQualified<ObjectIdentifier<OpaqueOriginIdentifierType>>;
+    using MarkableOpaqueOriginIdentifier = Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>;
+
     SecurityOriginData() = default;
     SecurityOriginData(const String& protocol, const String& host, std::optional<uint16_t> port)
         : protocol(protocol)
@@ -41,6 +48,13 @@ struct SecurityOriginData {
         , port(port)
     {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isHashTableDeletedValue());
+    }
+    explicit SecurityOriginData(OpaqueOriginIdentifier opaqueOriginIdentifier)
+        : protocol(emptyString())
+        , host(emptyString())
+        , port(std::nullopt)
+        , opaqueOriginIdentifier(opaqueOriginIdentifier)
+    {
     }
     SecurityOriginData(WTF::HashTableDeletedValueType)
         : protocol(WTF::HashTableDeletedValue)
@@ -57,6 +71,11 @@ struct SecurityOriginData {
         };
     }
 
+    static SecurityOriginData createOpaque()
+    {
+        return SecurityOriginData { SecurityOriginData::OpaqueOriginIdentifier::generateThreadSafe() };
+    }
+
     WEBCORE_EXPORT Ref<SecurityOrigin> securityOrigin() const;
 
     // FIXME <rdar://9018386>: We should be sending more state across the wire than just the protocol,
@@ -65,6 +84,7 @@ struct SecurityOriginData {
     String protocol;
     String host;
     std::optional<uint16_t> port;
+    MarkableOpaqueOriginIdentifier opaqueOriginIdentifier;
 
     WEBCORE_EXPORT SecurityOriginData isolatedCopy() const &;
     WEBCORE_EXPORT SecurityOriginData isolatedCopy() &&;
@@ -80,7 +100,7 @@ struct SecurityOriginData {
     }
     bool isOpaque() const
     {
-        return protocol == emptyString() && host == emptyString() && !port;
+        return !!opaqueOriginIdentifier;
     }
 
     bool isHashTableDeletedValue() const
@@ -95,14 +115,53 @@ struct SecurityOriginData {
 #if !LOG_DISABLED
     String debugString() const { return toString(); }
 #endif
+
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<SecurityOriginData> decode(Decoder&);
 };
+
+template<class Encoder>
+void SecurityOriginData::encode(Encoder& encoder) const
+{
+    encoder << opaqueOriginIdentifier;
+    if (opaqueOriginIdentifier)
+        return;
+    encoder << protocol << host << port;
+}
+
+template<class Decoder>
+std::optional<SecurityOriginData> SecurityOriginData::decode(Decoder& decoder)
+{
+    std::optional<SecurityOriginData::MarkableOpaqueOriginIdentifier> opaqueOriginIdentifier;
+    decoder >> opaqueOriginIdentifier;
+    if (!opaqueOriginIdentifier)
+        return std::nullopt;
+    if (*opaqueOriginIdentifier)
+        return SecurityOriginData(**opaqueOriginIdentifier);
+    std::optional<String> protocol;
+    decoder >> protocol;
+    if (!protocol)
+        return std::nullopt;
+    if (protocol->isHashTableDeletedValue())
+        return std::nullopt;
+    std::optional<String> host;
+    decoder >> host;
+    if (!host)
+        return std::nullopt;
+    std::optional<std::optional<uint16_t>> port;
+    decoder >> port;
+    if (!port)
+        return std::nullopt;
+    return SecurityOriginData(WTFMove(*protocol), WTFMove(*host), *port);
+}
+
 
 WEBCORE_EXPORT bool operator==(const SecurityOriginData&, const SecurityOriginData&);
 inline bool operator!=(const SecurityOriginData& first, const SecurityOriginData& second) { return !(first == second); }
 
 inline void add(Hasher& hasher, const SecurityOriginData& data)
 {
-    add(hasher, data.protocol, data.host, data.port);
+    add(hasher, data.protocol, data.host, data.port, data.opaqueOriginIdentifier);
 }
 
 struct SecurityOriginDataHashTraits : SimpleClassHashTraits<SecurityOriginData> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1620,12 +1620,6 @@ struct WebCore::DataListSuggestionInformation {
 };
 #endif
 
-struct WebCore::SecurityOriginData {
-    [Validator='!protocol->isHashTableDeletedValue()'] String protocol;
-    String host;
-    std::optional<uint16_t> port;
-};
-
 struct WebCore::ClientOrigin {
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData topOrigin;
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData clientOrigin;
@@ -2710,7 +2704,6 @@ struct WebCore::SameSiteInfo {
     WebCore::SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
-    Markable<WebCore::OpaqueOriginIdentifier, WebCore::OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
     bool m_universalAccess;
     bool m_domainWasSetInDOM;
     bool m_canLoadLocalResources;


### PR DESCRIPTION
#### 714cbd04ecd4d8a57932d8e8d4f6af3a4f81dfe3
<pre>
Move Opaque Origin Identifier from SecurityOrigin to SecurityOriginData
<a href="https://bugs.webkit.org/show_bug.cgi?id=251048">https://bugs.webkit.org/show_bug.cgi?id=251048</a>
rdar://104578586

Reviewed by Chris Dumez.

This change should not make any noticable difference, but it will be needed in
later patches. In that use case, SecurityOriginData will be used in a hashmap
and that hashmap must correctly take the opaqueOriginIdentifier into account.

* Source/WTF/wtf/Markable.h:
(WTF::add):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::SecurityOrigin):
(WebCore::SecurityOrigin::isSameOriginDomain const):
(WebCore::SecurityOrigin::isSameOriginAs const):
(WebCore::SecurityOrigin::create):
(WebCore::SecurityOrigin::equal const):
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::SecurityOrigin::isOpaque const):
(WebCore::add):
* Source/WebCore/page/SecurityOriginData.cpp:
(WebCore::SecurityOriginData::securityOrigin const):
(WebCore::SecurityOriginData::isolatedCopy const):
(WebCore::SecurityOriginData::isolatedCopy):
(WebCore::operator==):
* Source/WebCore/page/SecurityOriginData.h:
(WebCore::SecurityOriginData::SecurityOriginData):
(WebCore::SecurityOriginData::createOpaque):
(WebCore::SecurityOriginData::isOpaque const):
(WebCore::SecurityOriginData::encode const):
(WebCore::SecurityOriginData::decode):
(WebCore::add):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259432@main">https://commits.webkit.org/259432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/731122b8b748f0c8626456b94709ffd7dbaaf08f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114086 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174286 "Failed to checkout and rebase branch from PR 9000") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4821 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113007 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11615 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94620 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.GetUserMediaCaptureState (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39137 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93475 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.GetUserMediaCaptureState (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26234 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80801 "Found 4 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/audio-usermedia-permission-request, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-permission-requests, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94710 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27594 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92706 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4976 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7342 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4191 "Found 1 new test failure: fast/forms/fieldset/fieldset-flexbox.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30228 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47144 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101397 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9128 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25302 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3454 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->