### PR TITLE
Fix clang-tidy bugprone-infinite-loop warnings in WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks()

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -293,6 +293,10 @@ bool AudioSampleDataSource::pullAvailableSamplesAsChunks(AudioBufferList& buffer
 {
     ASSERT(buffer.mNumberBuffers == m_ringBuffer->channelCount());
     if (buffer.mNumberBuffers != m_ringBuffer->channelCount())
+        return false;
+
+    ASSERT(sampleCountPerChunk);
+    if (!sampleCountPerChunk)
         return false;
 
     auto [startFrame, endFrame] = m_ringBuffer->getFetchTimeBounds();


### PR DESCRIPTION
#### 963f2a417e1f1ea8b4145d97fe44824109b75313
<pre>
Fix clang-tidy bugprone-infinite-loop warnings in WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251044">https://bugs.webkit.org/show_bug.cgi?id=251044</a>
&lt;rdar://104575403&gt;

Reviewed by NOBODY (OOPS!).

Return early if `sampleCountPerChunk` is zero to prevent an
infinite loop.

* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks):
- Add debug assert, and early return if `sampleCountPerChunk` is
  zero.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/963f2a417e1f1ea8b4145d97fe44824109b75313

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113732 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173953 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4444 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96783 "Failed to checkout and rebase branch from PR 9001") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112696 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94334 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96783 "Failed to checkout and rebase branch from PR 9001") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25945 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96783 "Failed to checkout and rebase branch from PR 9001") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6885 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3860 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46860 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8806 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->