### PR TITLE
[WTF] Use SizeEfficientPtr

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -55,7 +55,7 @@ struct BaselineUnlinkedCallLinkInfo;
 
 using CompileTimeCallLinkInfo = std::variant<OptimizingCallLinkInfo*, BaselineUnlinkedCallLinkInfo*, DFG::UnlinkedCallLinkInfo*>;
 
-class CallLinkInfo : public PackedRawSentinelNode<CallLinkInfo> {
+class CallLinkInfo : public SizeEfficientRawSentinelNode<CallLinkInfo> {
 public:
     friend class LLIntOffsetsExtractor;
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -951,9 +951,9 @@ private:
     VM* const m_vm;
 
     const void* const m_instructionsRawPointer { nullptr };
-    SentinelLinkedList<CallLinkInfo, PackedRawSentinelNode<CallLinkInfo>> m_incomingCalls;
+    SentinelLinkedList<CallLinkInfo, SizeEfficientRawSentinelNode<CallLinkInfo>> m_incomingCalls;
 #if ENABLE(JIT)
-    SentinelLinkedList<PolymorphicCallNode, PackedRawSentinelNode<PolymorphicCallNode>> m_incomingPolymorphicCalls;
+    SentinelLinkedList<PolymorphicCallNode, SizeEfficientRawSentinelNode<PolymorphicCallNode>> m_incomingPolymorphicCalls;
 #endif
     StructureWatchpointMap m_llintGetByIdWatchpointMap;
     RefPtr<JITCode> m_jitCode;

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -54,7 +54,7 @@ public:
     void fireInternal(VM&, const FireDetail&);
 
 private:
-    PackedPtr<WatchpointsOnStructureStubInfo> m_holder;
+    SizeEfficientPtr<WatchpointsOnStructureStubInfo> m_holder;
     ObjectPropertyCondition m_key;
 };
 
@@ -75,7 +75,7 @@ public:
 
 
 private:
-    PackedPtr<WatchpointsOnStructureStubInfo> m_holder;
+    SizeEfficientPtr<WatchpointsOnStructureStubInfo> m_holder;
 };
 
 class WatchpointsOnStructureStubInfo final {

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -433,8 +433,8 @@ private:
     unsigned m_lineCount { 0 };
     unsigned m_endColumn { UINT_MAX };
 
-    PackedRefPtr<StringImpl> m_sourceURLDirective;
-    PackedRefPtr<StringImpl> m_sourceMappingURLDirective;
+    SizeEfficientRefPtr<StringImpl> m_sourceURLDirective;
+    SizeEfficientRefPtr<StringImpl> m_sourceMappingURLDirective;
 
     FixedVector<JSInstructionStream::Offset> m_jumpTargets;
     Ref<UnlinkedMetadataTable> m_metadata;

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -120,7 +120,7 @@ class WatchpointSet;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Watchpoint);
 
-class Watchpoint : public PackedRawSentinelNode<Watchpoint> {
+class Watchpoint : public SizeEfficientRawSentinelNode<Watchpoint> {
     WTF_MAKE_NONCOPYABLE(Watchpoint);
     WTF_MAKE_NONMOVABLE(Watchpoint);
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Watchpoint);
@@ -283,7 +283,7 @@ private:
     int8_t m_state;
     int8_t m_setIsNotEmpty;
 
-    SentinelLinkedList<Watchpoint, PackedRawSentinelNode<Watchpoint>> m_set;
+    SentinelLinkedList<Watchpoint, SizeEfficientRawSentinelNode<Watchpoint>> m_set;
 };
 
 // InlineWatchpointSet is a low-overhead, non-copyable watchpoint set in which

--- a/Source/JavaScriptCore/heap/IsoCellSet.cpp
+++ b/Source/JavaScriptCore/heap/IsoCellSet.cpp
@@ -42,7 +42,7 @@ IsoCellSet::IsoCellSet(IsoSubspace& subspace)
 IsoCellSet::~IsoCellSet()
 {
     if (isOnList())
-        PackedRawSentinelNode<IsoCellSet>::remove();
+        SizeEfficientRawSentinelNode<IsoCellSet>::remove();
 }
 
 Ref<SharedTask<MarkedBlock::Handle*()>> IsoCellSet::parallelNotEmptyMarkedBlockSource()

--- a/Source/JavaScriptCore/heap/IsoCellSet.h
+++ b/Source/JavaScriptCore/heap/IsoCellSet.h
@@ -42,7 +42,7 @@ class IsoSubspace;
 // Create a set of cells that are in an IsoSubspace. This allows concurrent O(1) set insertion and
 // removal. Each such set should be thought of as a 0.8% increase in object size for objects in that
 // IsoSubspace (it's like adding 1 bit every 16 bytes, or 1 bit every 128 bits).
-class IsoCellSet final : public PackedRawSentinelNode<IsoCellSet> {
+class IsoCellSet final : public SizeEfficientRawSentinelNode<IsoCellSet> {
     WTF_MAKE_NONCOPYABLE(IsoCellSet);
     WTF_MAKE_NONMOVABLE(IsoCellSet);
 public:

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -66,8 +66,8 @@ private:
 
     BlockDirectory m_directory;
     std::unique_ptr<IsoMemoryAllocatorBase> m_isoAlignedMemoryAllocator;
-    SentinelLinkedList<PreciseAllocation, PackedRawSentinelNode<PreciseAllocation>> m_lowerTierFreeList;
-    SentinelLinkedList<IsoCellSet, PackedRawSentinelNode<IsoCellSet>> m_cellSets;
+    SentinelLinkedList<PreciseAllocation, SizeEfficientRawSentinelNode<PreciseAllocation>> m_lowerTierFreeList;
+    SentinelLinkedList<IsoCellSet, SizeEfficientRawSentinelNode<IsoCellSet>> m_cellSets;
 };
 
 

--- a/Source/JavaScriptCore/heap/PackedCellPtr.h
+++ b/Source/JavaScriptCore/heap/PackedCellPtr.h
@@ -32,6 +32,7 @@
 
 namespace JSC {
 
+// We cannot use CompactPtr since JSCell is 8-byte aligned.
 template<typename T>
 class PackedCellPtr : public PackedAlignedPtr<T, 8> {
 public:

--- a/Source/JavaScriptCore/heap/PreciseAllocation.h
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.h
@@ -38,7 +38,7 @@ class SlotVisitor;
 // objects directly using malloc, and put the PreciseAllocation header just before them. We can detect
 // when a HeapCell* is a PreciseAllocation because it will have the MarkedBlock::atomSize / 2 bit set.
 
-class PreciseAllocation : public PackedRawSentinelNode<PreciseAllocation> {
+class PreciseAllocation : public SizeEfficientRawSentinelNode<PreciseAllocation> {
 public:
     friend class LLIntOffsetsExtractor;
     friend class IsoSubspace;

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -111,7 +111,7 @@ protected:
     
     BlockDirectory* m_firstDirectory { nullptr };
     BlockDirectory* m_directoryForEmptyAllocation { nullptr }; // Uses the MarkedSpace linked list of blocks.
-    SentinelLinkedList<PreciseAllocation, PackedRawSentinelNode<PreciseAllocation>> m_preciseAllocations;
+    SentinelLinkedList<PreciseAllocation, SizeEfficientRawSentinelNode<PreciseAllocation>> m_preciseAllocations;
 
     bool m_isIsoSubspace { false };
     uint8_t m_remainingLowerTierCellCount { 0 };

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -171,7 +171,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JITThunks::ctiStubImpl(ThunkGenerator key,
     MacroAssemblerCodeRef<JITThunkPtrTag> codeRef = generateThunk();
 
     bool needsCrossModifyingCodeFence = isCompilationThread();
-    auto addResult = m_ctiStubMap.add(key, Entry { PackedRefPtr<ExecutableMemoryHandle>(codeRef.executableMemory()), needsCrossModifyingCodeFence });
+    auto addResult = m_ctiStubMap.add(key, Entry { SizeEfficientRefPtr<ExecutableMemoryHandle>(codeRef.executableMemory()), needsCrossModifyingCodeFence });
     RELEASE_ASSERT(addResult.isNewEntry); // Thunks aren't recursive, so anything we generated transitively shouldn't have generated 'key'.
     return handleEntry(addResult.iterator->value);
 }

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -38,9 +38,9 @@
 #include <tuple>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
-#include <wtf/PackedRefPtr.h>
-#include <wtf/RecursiveLockAdapter.h>
 #include <wtf/Hasher.h>
+#include <wtf/RecursiveLockAdapter.h>
+#include <wtf/SizeEfficientPtr.h>
 
 namespace JSC {
 namespace DOMJIT {
@@ -79,7 +79,7 @@ private:
     void finalize(Handle<Unknown>, void* context) final;
     
     struct Entry {
-        PackedRefPtr<ExecutableMemoryHandle> handle;
+        SizeEfficientRefPtr<ExecutableMemoryHandle> handle;
         bool needsCrossModifyingCodeFence;
     };
     using CTIStubMap = HashMap<ThunkGenerator, Entry>;

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -38,7 +38,7 @@ namespace JSC {
 
 class CallLinkInfo;
 
-class PolymorphicCallNode : public PackedRawSentinelNode<PolymorphicCallNode> {
+class PolymorphicCallNode : public SizeEfficientRawSentinelNode<PolymorphicCallNode> {
     WTF_MAKE_NONCOPYABLE(PolymorphicCallNode);
 public:
     PolymorphicCallNode(CallLinkInfo* info)
@@ -54,7 +54,7 @@ public:
     void clearCallLinkInfo();
     
 private:
-    PackedPtr<CallLinkInfo> m_callLinkInfo;
+    SizeEfficientPtr<CallLinkInfo> m_callLinkInfo;
 };
 
 class PolymorphicCallCase {

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -105,12 +105,12 @@ public:
     unsigned constructorKind : 2; // ConstructorKind
     bool usesImportMeta : 1 { false };
 
-    PackedPtr<UniquedStringImpl>* usedVariables() const { return const_cast<PackedPtr<UniquedStringImpl>*>(m_variables); }
+    SizeEfficientPtr<UniquedStringImpl>* usedVariables() const { return const_cast<SizeEfficientPtr<UniquedStringImpl>*>(m_variables); }
 
 private:
     SourceProviderCacheItem(const SourceProviderCacheItemCreationParameters&);
 
-    PackedPtr<UniquedStringImpl> m_variables[0];
+    SizeEfficientPtr<UniquedStringImpl> m_variables[0];
 };
 
 inline SourceProviderCacheItem::~SourceProviderCacheItem()

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -219,7 +219,7 @@ void CompactTDZEnvironment::sortCompact(Compact& compact)
 CompactTDZEnvironment::CompactTDZEnvironment(const TDZEnvironment& env)
 {
     m_hash = 0; // Note: XOR is commutative so order doesn't matter here.
-    Compact variables = WTF::map(env, [this](auto& key) -> PackedRefPtr<UniquedStringImpl> {
+    Compact variables = WTF::map(env, [this](auto& key) -> SizeEfficientRefPtr<UniquedStringImpl> {
         m_hash ^= key->hash();
         return key.get();
     });

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -140,12 +140,12 @@ struct PrivateNameEntryHashTraits : HashTraits<PrivateNameEntry> {
     static constexpr bool needsDestruction = false;
 };
 
-typedef HashMap<PackedRefPtr<UniquedStringImpl>, PrivateNameEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, PrivateNameEntryHashTraits> PrivateNameEnvironment;
+typedef HashMap<SizeEfficientRefPtr<UniquedStringImpl>, PrivateNameEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, PrivateNameEntryHashTraits> PrivateNameEnvironment;
 
 class VariableEnvironment {
     WTF_MAKE_FAST_ALLOCATED;
 private:
-    typedef HashMap<PackedRefPtr<UniquedStringImpl>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> Map;
+    typedef HashMap<SizeEfficientRefPtr<UniquedStringImpl>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> Map;
 
 public:
 
@@ -341,7 +341,7 @@ class CompactTDZEnvironment {
 
     friend class CachedCompactTDZEnvironment;
 
-    using Compact = Vector<PackedRefPtr<UniquedStringImpl>>;
+    using Compact = Vector<SizeEfficientRefPtr<UniquedStringImpl>>;
     using Inflated = TDZEnvironment;
     using Variables = std::variant<Compact, Inflated>;
 

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -32,8 +32,8 @@
 #include "Weak.h"
 #include <wtf/CagedPtr.h>
 #include <wtf/CheckedArithmetic.h>
-#include <wtf/PackedRefPtr.h>
 #include <wtf/SharedTask.h>
+#include <wtf/SizeEfficientPtr.h>
 #include <wtf/StdIntExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -977,7 +977,7 @@ private:
     unsigned m_privateBrandRequirement : 1;
 };
 
-typedef CachedHashMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::PackedPtrTraits<UniquedStringImpl>>, PrivateNameEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, PrivateNameEntryHashTraits> CachedPrivateNameEnvironment;
+typedef CachedHashMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::SizeEfficientPtrTraits<UniquedStringImpl>>, PrivateNameEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, PrivateNameEntryHashTraits> CachedPrivateNameEnvironment;
 
 class CachedVariableEnvironmentRareData : public CachedObject<VariableEnvironment::RareData> {
 public:
@@ -1016,7 +1016,7 @@ public:
 
 private:
     bool m_isEverythingCaptured;
-    CachedHashMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::PackedPtrTraits<UniquedStringImpl>>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> m_map;
+    CachedHashMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::SizeEfficientPtrTraits<UniquedStringImpl>>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> m_map;
     CachedPtr<CachedVariableEnvironmentRareData> m_rareData;
 };
 
@@ -1054,7 +1054,7 @@ public:
     }
 
 private:
-    CachedVector<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::PackedPtrTraits<UniquedStringImpl>>> m_variables;
+    CachedVector<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::SizeEfficientPtrTraits<UniquedStringImpl>>> m_variables;
     unsigned m_hash;
 };
 

--- a/Source/JavaScriptCore/runtime/RegExpKey.h
+++ b/Source/JavaScriptCore/runtime/RegExpKey.h
@@ -30,14 +30,14 @@
 
 #include "YarrFlags.h"
 #include <wtf/OptionSet.h>
-#include <wtf/PackedRefPtr.h>
+#include <wtf/SizeEfficientPtr.h>
 #include <wtf/text/StringHash.h>
 
 namespace JSC {
 
 struct RegExpKey {
     OptionSet<Yarr::Flags> flagsValue;
-    PackedRefPtr<StringImpl> pattern;
+    SizeEfficientRefPtr<StringImpl> pattern;
 
     RegExpKey()
     {

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -209,7 +209,7 @@ void StreamingCompiler::fail(JSGlobalObject* globalObject, JSValue error)
     JSPromise* promise = jsCast<JSPromise*>(ticket->target());
     // The pending work TicketData was keeping the promise alive. We need to
     // make sure it is reachable from the stack before we remove it from the
-    // pending work list. Note: m_ticket stores it as a PackedPtr, which is not
+    // pending work list. Note: m_ticket stores it as a SizeEfficientPtr, which is not
     // scannable by the GC.
     WTF::compilerFence();
     m_vm.deferredWorkTimer->cancelPendingWork(ticket);

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		E3A32BC41FC830E2007D7E76 /* JSValueMalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A32BC21FC830E2007D7E76 /* JSValueMalloc.cpp */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		E3B8E41D24E7CE92003655D8 /* LineBreakIteratorPoolICU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3B8E41C24E7CE92003655D8 /* LineBreakIteratorPoolICU.cpp */; };
 		E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3BB487C297F635E00566DF0 /* SizeEfficientPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BB487B297F635E00566DF0 /* SizeEfficientPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BE09A724A5854D009DF2B4 /* ICUHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BE09A624A58545009DF2B4 /* ICUHelpers.cpp */; };
 		E3DA37E7287AD1A10066808F /* StringCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DA37E6287AD1A10066808F /* StringCommon.cpp */; };
 		E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD371A96245500536DF6 /* WorkQueue.cpp */; };
@@ -1719,6 +1720,7 @@
 		E3A32BC31FC830E2007D7E76 /* JSValueMalloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSValueMalloc.h; sourceTree = "<group>"; };
 		E3B8E41C24E7CE92003655D8 /* LineBreakIteratorPoolICU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LineBreakIteratorPoolICU.cpp; sourceTree = "<group>"; };
 		E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibleAddress.h; sourceTree = "<group>"; };
+		E3BB487B297F635E00566DF0 /* SizeEfficientPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SizeEfficientPtr.h; sourceTree = "<group>"; };
 		E3BE09A624A58545009DF2B4 /* ICUHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ICUHelpers.cpp; sourceTree = "<group>"; };
 		E3C583C826127ADD00C57568 /* RobinHoodHashMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RobinHoodHashMap.h; sourceTree = "<group>"; };
 		E3CF76902115D6BA0091DE48 /* CompactPointerTuple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompactPointerTuple.h; sourceTree = "<group>"; };
@@ -2266,6 +2268,7 @@
 				0F4D8C711FC1E7CE001D32AC /* SinglyLinkedListWithTail.h */,
 				A748744F17A0BDAE00FA04CB /* SixCharacterHash.cpp */,
 				A748745017A0BDAE00FA04CB /* SixCharacterHash.h */,
+				E3BB487B297F635E00566DF0 /* SizeEfficientPtr.h */,
 				A8A4730C151A825B004123FF /* SizeLimits.cpp */,
 				0FA6F39220CC73A200A03DCD /* SmallSet.cpp */,
 				7936D6A91C99F8AE000D1AED /* SmallSet.h */,
@@ -3215,6 +3218,7 @@
 				DD3DC89627A4BF8E007E5B61 /* SinglyLinkedList.h in Headers */,
 				DD3DC99427A4BF8E007E5B61 /* SinglyLinkedListWithTail.h in Headers */,
 				DD3DC92F27A4BF8E007E5B61 /* SixCharacterHash.h in Headers */,
+				E3BB487C297F635E00566DF0 /* SizeEfficientPtr.h in Headers */,
 				DD3DC8DE27A4BF8E007E5B61 /* SmallSet.h in Headers */,
 				DDF3076727C086CD006A526F /* SoftLinking.h in Headers */,
 				DD3DC8D727A4BF8E007E5B61 /* SoftLinking.h in Headers */,

--- a/Source/WTF/wtf/Bag.h
+++ b/Source/WTF/wtf/Bag.h
@@ -27,8 +27,8 @@
 
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/Packed.h>
 #include <wtf/RawPtrTraits.h>
+#include <wtf/SizeEfficientPtr.h>
 
 namespace WTF {
 
@@ -165,9 +165,9 @@ private:
 };
 
 template<typename T>
-using PackedBag = Bag<T, PackedPtrTraits<T>>;
+using SizeEfficientBag = Bag<T, SizeEfficientPtrTraits<T>>;
 
 } // namespace WTF
 
 using WTF::Bag;
-using WTF::PackedBag;
+using WTF::SizeEfficientBag;

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -257,6 +257,7 @@ set(WTF_PUBLIC_HEADERS
     SinglyLinkedList.h
     SinglyLinkedListWithTail.h
     SixCharacterHash.h
+    SizeEfficientPtr.h
     SmallSet.h
     SoftLinking.h
     SortedArrayMap.h

--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -39,7 +39,7 @@
 #include <iterator>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
-#include <wtf/Packed.h>
+#include <wtf/SizeEfficientPtr.h>
 
 namespace WTF {
 
@@ -320,10 +320,10 @@ inline void SentinelLinkedList<T, RawNode>::takeFrom(SentinelLinkedList<T, RawNo
 }
 
 template<typename T>
-using PackedRawSentinelNode = BasicRawSentinelNode<T, PackedPtrTraits<T>>;
+using SizeEfficientRawSentinelNode = BasicRawSentinelNode<T, SizeEfficientPtrTraits<T>>;
 
 }
 
 using WTF::BasicRawSentinelNode;
-using WTF::PackedRawSentinelNode;
+using WTF::SizeEfficientRawSentinelNode;
 using WTF::SentinelLinkedList;

--- a/Source/WTF/wtf/SizeEfficientPtr.h
+++ b/Source/WTF/wtf/SizeEfficientPtr.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CompactPtr.h>
+#include <wtf/CompactRefPtr.h>
+#include <wtf/Packed.h>
+#include <wtf/PackedRefPtr.h>
+
+namespace WTF {
+
+// Keep in mind that updating this pointer is not atomic since it can be a PackedPtr.
+//
+// This is interim migration type from PackedPtr to CompactPtr. Once CompactPtr becomes available with efficient size in macOS, we will replace them with CompactPtr and remove this type.
+// But until that, we need to switch the underlying implementation.
+//
+// If CompactPtr is 32bit, it is more efficient than PackedPtr (6 bytes).
+// We select underlying implementation based on CompactPtr's efficacy.
+template<typename T>
+using SizeEfficientPtr = std::conditional_t<CompactPtrTraits<T>::is32Bit, CompactPtr<T>, PackedPtr<T>>;
+
+template<typename T>
+using SizeEfficientRefPtr = std::conditional_t<CompactPtrTraits<T>::is32Bit, CompactRefPtr<T>, PackedRefPtr<T>>;
+
+template<typename T>
+using SizeEfficientPtrTraits = std::conditional_t<CompactPtrTraits<T>::is32Bit, CompactPtrTraits<T>, PackedPtrTraits<T>>;
+
+}
+
+using WTF::SizeEfficientPtr;
+using WTF::SizeEfficientRefPtr;
+using WTF::SizeEfficientPtrTraits;

--- a/Source/WTF/wtf/text/AtomStringTable.h
+++ b/Source/WTF/wtf/text/AtomStringTable.h
@@ -24,7 +24,7 @@
 
 #include <wtf/CompactPtr.h>
 #include <wtf/HashSet.h>
-#include <wtf/Packed.h>
+#include <wtf/SizeEfficientPtr.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringImpl.h>
 
@@ -35,9 +35,7 @@ class StringImpl;
 class AtomStringTable {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    // If CompactPtr is 32bit, it is more efficient than PackedPtr (6 bytes).
-    // We select underlying implementation based on CompactPtr's efficacy.
-    using StringEntry = std::conditional_t<CompactPtrTraits<StringImpl>::is32Bit, CompactPtr<StringImpl>, PackedPtr<StringImpl>>;
+    using StringEntry = SizeEfficientPtr<StringImpl>;
     using StringTableImpl = HashSet<StringEntry>;
 
     WTF_EXPORT_PRIVATE ~AtomStringTable();

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -65,7 +65,7 @@ constexpr unsigned maxShorthandsForLonghand = 4; // FIXME: Generate this from CS
 
 static size_t sizeForImmutableStylePropertiesWithPropertyCount(unsigned count)
 {
-    return sizeof(ImmutableStyleProperties) - sizeof(void*) + sizeof(StylePropertyMetadata) * count + sizeof(PackedPtr<const CSSValue>) * count;
+    return sizeof(ImmutableStyleProperties) - sizeof(void*) + sizeof(StylePropertyMetadata) * count + sizeof(SizeEfficientPtr<const CSSValue>) * count;
 }
 
 static bool isValueIDIncludingList(const CSSValue& value, CSSValueID id)
@@ -111,7 +111,7 @@ ImmutableStyleProperties::ImmutableStyleProperties(const CSSProperty* properties
     : StyleProperties(cssParserMode, length)
 {
     StylePropertyMetadata* metadataArray = const_cast<StylePropertyMetadata*>(this->metadataArray());
-    PackedPtr<CSSValue>* valueArray = bitwise_cast<PackedPtr<CSSValue>*>(this->valueArray());
+    SizeEfficientPtr<CSSValue>* valueArray = bitwise_cast<SizeEfficientPtr<CSSValue>*>(this->valueArray());
     for (unsigned i = 0; i < length; ++i) {
         metadataArray[i] = properties[i].metadata();
         auto* value = properties[i].value();
@@ -122,7 +122,7 @@ ImmutableStyleProperties::ImmutableStyleProperties(const CSSProperty* properties
 
 ImmutableStyleProperties::~ImmutableStyleProperties()
 {
-    PackedPtr<CSSValue>* valueArray = bitwise_cast<PackedPtr<CSSValue>*>(this->valueArray());
+    SizeEfficientPtr<CSSValue>* valueArray = bitwise_cast<SizeEfficientPtr<CSSValue>*>(this->valueArray());
     for (unsigned i = 0; i < m_arraySize; ++i)
         valueArray[i]->deref();
 }

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -201,14 +201,14 @@ public:
     void* m_storage;
 
 private:
-    PackedPtr<const CSSValue>* valueArray() const;
+    SizeEfficientPtr<const CSSValue>* valueArray() const;
     const StylePropertyMetadata* metadataArray() const;
     ImmutableStyleProperties(const CSSProperty*, unsigned count, CSSParserMode);
 };
 
-inline PackedPtr<const CSSValue>* ImmutableStyleProperties::valueArray() const
+inline SizeEfficientPtr<const CSSValue>* ImmutableStyleProperties::valueArray() const
 {
-    return bitwise_cast<PackedPtr<const CSSValue>*>(bitwise_cast<const uint8_t*>(metadataArray()) + (m_arraySize * sizeof(StylePropertyMetadata)));
+    return bitwise_cast<SizeEfficientPtr<const CSSValue>*>(bitwise_cast<const uint8_t*>(metadataArray()) + (m_arraySize * sizeof(StylePropertyMetadata)));
 }
 
 inline const StylePropertyMetadata* ImmutableStyleProperties::metadataArray() const


### PR DESCRIPTION
#### d934a26ffddb755605f5973a2921f228cc712051
<pre>
[WTF] Use SizeEfficientPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=251053">https://bugs.webkit.org/show_bug.cgi?id=251053</a>
rdar://104580900

Reviewed by NOBODY (OOPS!).

This patch adds SizeEfficientPtr. This is *interim* solution to migrate from PackedPtr to CompactPtr.
PackedPtr and CompactPtr have difference.

1. PackedPtr does not guarantee atomic update of pointers. But CompactPtr does.
2. CompactPtr is 4-bytes on iOS. But on the other platforms, it is 8-bytes. On the other hand, PackedPtr is 5- or 6-bytes.

As a result, if we would like to have smallest possible pointers,

1. On iOS, use CompactPtr
2. On the other platforms, use PackedPtr.

This will be fixed once we make CompactPtr 4-bytes on macOS too by introducing 64GB libpas cage &amp; drop libmalloc support.
But until that, we introduce an interim solution for this *size-efficient* requirement. SizeEfficientPtr can be switched to PackedPtr
or CompactPtr on each architecture. So if we would like to have smallest pointer representation without atomic update requirement,
then we can use SizeEfficientPtr for now. Once CompactPtr becomes 4-bytes on macOS, we will remove SizeEfficientPtr and replace it with
CompactPtr.

* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/heap/IsoCellSet.cpp:
(JSC::IsoCellSet::~IsoCellSet):
* Source/JavaScriptCore/heap/IsoCellSet.h:
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/PackedCellPtr.h:
* Source/JavaScriptCore/heap/PreciseAllocation.h:
* Source/JavaScriptCore/heap/Subspace.h:
* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::ctiStubImpl):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
(JSC::SourceProviderCacheItem::usedVariables const):
* Source/JavaScriptCore/parser/VariableEnvironment.cpp:
(JSC::CompactTDZEnvironment::CompactTDZEnvironment):
* Source/JavaScriptCore/parser/VariableEnvironment.h:
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
* Source/JavaScriptCore/runtime/RegExpKey.h:
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::fail):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Bag.h:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/SentinelLinkedList.h:
* Source/WTF/wtf/SizeEfficientPtr.h: Added.
* Source/WTF/wtf/text/AtomStringTable.h:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::sizeForImmutableStylePropertiesWithPropertyCount):
(WebCore::ImmutableStyleProperties::ImmutableStyleProperties):
(WebCore::ImmutableStyleProperties::~ImmutableStyleProperties):
* Source/WebCore/css/StyleProperties.h:
(WebCore::ImmutableStyleProperties::valueArray const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d934a26ffddb755605f5973a2921f228cc712051

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104454 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13532 "Hash d934a26f for PR 9004 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113745 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173958 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4450 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112701 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38886 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80555 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94455 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6891 "Hash d934a26f for PR 9004 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27309 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92345 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4677 "Built successfully and passed tests") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7017 "Hash d934a26f for PR 9004 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3867 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30002 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13048 "Hash d934a26f for PR 9004 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46867 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101028 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8811 "Hash d934a26f for PR 9004 does not build (failure)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25063 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->