### PR TITLE
[JSC] Purify NaN before passing it to Intl because they can distinguish between -NaN and +NaN

### DIFF
--- a/JSTests/stress/intl-negative-nan.js
+++ b/JSTests/stress/intl-negative-nan.js
@@ -1,0 +1,15 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function foo() {
+    eval(`function bar() {}`);
+    const x = -undefined;
+    let s = x.toLocaleString();
+    shouldBe(s, "NaN");
+    return s;
+}
+for (let i = 0; i < 1000; i++) {
+    foo();
+}

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -382,6 +382,7 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
             skeletonBuilder.append('0');
 
         // 3.l. If value is not 0 or display is not "auto", then
+        value = purifyNaN(value);
         if (value != 0 || unitData.display() != IntlDurationFormat::Display::Auto) {
             auto formatDouble = [&](const String& skeleton) -> String {
                 auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -766,6 +766,8 @@ JSValue IntlNumberFormat::format(JSGlobalObject* globalObject, double value) con
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    value = purifyNaN(value);
+
     Vector<UChar, 32> buffer;
 #if HAVE(ICU_U_NUMBER_FORMATTER)
     ASSERT(m_numberFormatter);
@@ -1519,6 +1521,8 @@ JSValue IntlNumberFormat::formatToParts(JSGlobalObject* globalObject, double val
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    value = purifyNaN(value);
 
     UErrorCode status = U_ZERO_ERROR;
     auto fieldItr = std::unique_ptr<UFieldPositionIterator, UFieldPositionIteratorDeleter>(ufieldpositer_open(&status));

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -89,15 +89,15 @@ public:
     IntlMathematicalValue() = default;
 
     explicit IntlMathematicalValue(double value)
-        : m_numberType(numberTypeFromDouble(value))
-        , m_sign(std::signbit(value))
-        , m_value(value)
+        : m_value(purifyNaN(value))
+        , m_numberType(numberTypeFromDouble(value))
+        , m_sign(!std::isnan(value) && std::signbit(value))
     { }
 
     explicit IntlMathematicalValue(NumberType numberType, bool sign, CString value)
-        : m_numberType(numberType)
+        : m_value(value)
+        , m_numberType(numberType)
         , m_sign(sign)
-        , m_value(value)
     {
     }
 
@@ -147,9 +147,9 @@ public:
     }
 
 private:
+    Value m_value { 0.0 };
     NumberType m_numberType { NumberType::Integer };
     bool m_sign { false };
-    Value m_value { 0.0 };
 };
 
 class IntlNumberFormat final : public JSNonFinalObject {


### PR DESCRIPTION
#### 92ddbfbb8cb5936bb005e83bba6776ca8ea9809d
<pre>
[JSC] Purify NaN before passing it to Intl because they can distinguish between -NaN and +NaN
<a href="https://bugs.webkit.org/show_bug.cgi?id=251055">https://bugs.webkit.org/show_bug.cgi?id=251055</a>
rdar://104439690

Reviewed by Ross Kirsling.

This patch purifies NaN before passing it to ICU APIs since they can distinguish -NaN and +NaN.
In JSC, -NaN and +NaN can appear so long as bit patterns are not Impure-NaN. And both are handled
in the same way, except for ICU.

* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::format const):
(JSC::IntlNumberFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
(JSC::IntlMathematicalValue::IntlMathematicalValue):

Canonical link: <a href="https://commits.webkit.org/259259@main">https://commits.webkit.org/259259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92b4fa6f4ae4afee01d8c2d581acacbb06d0c00d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37368 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/113742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/173967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4460 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/25958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6900 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92355 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4686 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7026 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30006 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46873 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101038 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8820 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25066 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3383 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->