### PR TITLE
[GStreamer] Fix a crash for fast/speechsynthesis/speech-synthesis-real-client-version.html

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2206,7 +2206,6 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html [ WontFix ]
 
 # Missing WebSpeech implementation
 webkit.org/b/136224 fast/speechrecognition [ Skip ]
-webkit.org/b/250656 fast/speechsynthesis/speech-synthesis-real-client-version.html [ Crash ]
 webkit.org/b/250656 fast/speechsynthesis/voices-non-mock.html [ Failure ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -135,7 +135,7 @@ void GstSpeechSynthesisWrapper::speakUtterance(RefPtr<PlatformSpeechSynthesisUtt
         return;
 
     m_utterance = WTFMove(utterance);
-    webKitFliteSrcSetUtterance(WEBKIT_FLITE_SRC(m_src.get()), m_utterance->text(), *m_utterance->voice());
+    webKitFliteSrcSetUtterance(WEBKIT_FLITE_SRC(m_src.get()), m_utterance->voice(), m_utterance->text());
     webkitGstSetElementStateSynchronously(m_pipeline.get(), GST_STATE_PLAYING, [this](GstMessage* message) -> bool {
         return handleMessage(message);
     });

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
@@ -225,6 +225,9 @@ static Vector<GUniquePtr<cst_voice>>& fliteVoices()
 
 static cst_voice* fliteVoice(const char* name)
 {
+    if (!name)
+        return nullptr;
+
     for (auto& voice : fliteVoices()) {
         if (String::fromUTF8(voice->name) == String::fromUTF8(name))
             return voice.get();
@@ -250,13 +253,16 @@ Vector<Ref<PlatformSpeechSynthesisVoice>>& ensureFliteVoicesInitialized()
     return voiceList;
 }
 
-void webKitFliteSrcSetUtterance(WebKitFliteSrc* src, const String& text, const PlatformSpeechSynthesisVoice& platformSpeechSynthesisVoice)
+void webKitFliteSrcSetUtterance(WebKitFliteSrc* src, const PlatformSpeechSynthesisVoice* platformSpeechSynthesisVoice, const String& text)
 {
     WebKitFliteSrcPrivate* priv = src->priv;
 
     ASSERT(!fliteVoices().isEmpty());
 
-    cst_voice* voice = fliteVoice(platformSpeechSynthesisVoice.name().utf8().data());
+    cst_voice* voice = nullptr;
+    if (platformSpeechSynthesisVoice && !platformSpeechSynthesisVoice->name().isEmpty())
+        voice = fliteVoice(platformSpeechSynthesisVoice->name().utf8().data());
+
     // We use the first registered voice as default, where no voice is specified.
     priv->currentVoice = voice ? voice : fliteVoices()[0].get();
     priv->text = text;

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.h
@@ -35,6 +35,6 @@ typedef struct _WebKitFliteSrc WebKitFliteSrc;
 GType webkit_flite_src_get_type();
 
 Vector<Ref<WebCore::PlatformSpeechSynthesisVoice>>& ensureFliteVoicesInitialized();
-void webKitFliteSrcSetUtterance(WebKitFliteSrc*, const String&, const WebCore::PlatformSpeechSynthesisVoice&);
+void webKitFliteSrcSetUtterance(WebKitFliteSrc*, const WebCore::PlatformSpeechSynthesisVoice*, const String&);
 
 #endif // ENABLE(SPEECH_SYNTHESIS) && USE(GSTREAMER)


### PR DESCRIPTION
#### 1153afca6d716b3bc6685e910d1b48fc7b5ba73c
<pre>
[GStreamer] Fix a crash for fast/speechsynthesis/speech-synthesis-real-client-version.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=251056">https://bugs.webkit.org/show_bug.cgi?id=251056</a>

Reviewed by Xabier Rodriguez-Calvar.

The crash happens when the web content does not specify a voice to use. We handle a null pointer
of the voice with the default voice.

Test: fast/speechsynthesis/speech-synthesis-real-client-version.html

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::speakUtterance):
* Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp:
(fliteVoice):
(webKitFliteSrcSetUtterance):
* Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/259265@main">https://commits.webkit.org/259265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aa3599bf0feba07b797b948684b50133b053c90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113743 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173968 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4461 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112711 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38889 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27310 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3874 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6386 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8821 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->