### PR TITLE
Fix fast/scrolling/latching/scroll-div-no-latching.html with UI-side compositing

### DIFF
--- a/LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html
@@ -20,6 +20,7 @@ body {
     
 }
 </style>
+<script src="../../../resources/ui-helper.js"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>
     jsTestIsAsync = true;
@@ -41,7 +42,7 @@ body {
         finishJSTest();
     }
 
-    function scrollTest()
+    async function scrollTest()
     {
         pageScrollPositionBefore = document.scrollingElement.scrollTop;
 
@@ -53,6 +54,8 @@ body {
         var startPosY = divTarget.offsetTop + (divTarget.clientHeight / 2); // One wheel turn before end.
         eventSender.mouseMoveTo(startPosX, startPosY); // Make sure we are just outside the iFrame
 
+        await UIHelper.ensurePresentationUpdate();
+
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 1, 'none', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
@@ -67,8 +70,9 @@ body {
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
         eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'none', 'none');
 
-        // FIXME: Use await UIHelper.waitForScrollCompletion();
-        setTimeout(checkForScroll, 100);
+        await UIHelper.renderingUpdate();
+        await UIHelper.renderingUpdate();
+        checkForScroll();
     }
 
     function setupTopLevel()

--- a/LayoutTests/platform/mac-gpup/TestExpectations
+++ b/LayoutTests/platform/mac-gpup/TestExpectations
@@ -38,8 +38,6 @@ webxr [ Skip ]
 [ Ventura+ ] compositing/fixed-with-main-thread-scrolling.html [ Timeout ]
 
 # rdar://102572503
-imported/w3c/web-platform/css/css-backgrounds/box-shadow-039.html [ ImageOnlyFailure ]
-imported/w3c/web-platform/css/css-backgrounds/box-shadow-040.html [ ImageOnlyFailure ]
 compositing/backgrounds/fixed-backgrounds.html [ ImageOnlyFailure ]
 
 # rdar://102588345


### PR DESCRIPTION
#### fb0c77f9af1f66ec0776f77c01ca861b48b866c7
<pre>
Fix fast/scrolling/latching/scroll-div-no-latching.html with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251062">https://bugs.webkit.org/show_bug.cgi?id=251062</a>
rdar://104585223

Reviewed by Antti Koivisto.

The test needs to await a presentation update before dispatching events. It also can&apos;t
use `UIHelper.waitForScrollCompletion()` because it doesn&apos;t use momentum events,
but improve by waiting for two event loops instead of 100ms.

* LayoutTests/fast/scrolling/latching/scroll-div-no-latching.html:
* LayoutTests/platform/mac-gpup/TestExpectations: Remove lines referencing non-existent files

Canonical link: <a href="https://commits.webkit.org/259364@main">https://commits.webkit.org/259364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa31ea3566dafc50f1729a54abbf590cfce8caf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113752 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173976 "Found 1 new test failure: storage/indexeddb/modern/deleteindex-4-private.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4471 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112719 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38894 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80563 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3881 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6453 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8830 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->