### PR TITLE
REGRESSION(259215@main): [ BigSur+ Debug ] storage/indexeddb/modern/deleteindex-4-private.html is a constant crash

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -46,6 +46,7 @@ public:
     IDBError getOrEstablishDatabaseInfo(IDBDatabaseInfo&) final;
     uint64_t databaseVersion() final;
     void setDatabaseInfo(const IDBDatabaseInfo&);
+    bool hasObjectStore(uint64_t objectStoreIdentifier) { return !!infoForObjectStore(objectStoreIdentifier); }
 
     void renameObjectStoreForVersionChangeAbort(MemoryObjectStore&, const String& oldName);
     void removeObjectStoreForVersionChangeAbort(MemoryObjectStore&);


### PR DESCRIPTION
#### 35ff6895373602491e7b649e8f15d40e92da387b
<pre>
REGRESSION(259215@main): [ BigSur+ Debug ] storage/indexeddb/modern/deleteindex-4-private.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=251051">https://bugs.webkit.org/show_bug.cgi?id=251051</a>
rdar://104579643

Reviewed by Chris Dumez.

We should not restore indexes of object stores that do not exist after transaction abort, so this patch remove indexes
of non-existent objects stores (object store created in the transaction) from m_deletedIndexes.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::indexDeleted):
(WebCore::IDBServer::MemoryBackingStoreTransaction::objectStoreDeleted):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:

Canonical link: <a href="https://commits.webkit.org/259360@main">https://commits.webkit.org/259360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71b4e0868a4eadd682b498ad0d0fdcdc59314906

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113952 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174159 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4685 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112883 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39039 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108149 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80703 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27481 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92571 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4868 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7215 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4061 "Found 1 new test failure: fast/images/background-image-relative-url-changes-document.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30134 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103505 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47040 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101257 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6452 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9002 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25202 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->