### PR TITLE
DOMTimerHoldingTank should use WeakHashSet

### DIFF
--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.cpp
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.cpp
@@ -47,7 +47,7 @@ DOMTimerHoldingTank::~DOMTimerHoldingTank() = default;
 
 void DOMTimerHoldingTank::add(const DOMTimer& timer)
 {
-    m_timers.add(&timer);
+    m_timers.add(timer);
     if (!m_exceededMaximumHoldTimer.isActive())
         m_exceededMaximumHoldTimer.startOneShot(maximumHoldTimeLimit);
 }
@@ -55,12 +55,12 @@ void DOMTimerHoldingTank::add(const DOMTimer& timer)
 void DOMTimerHoldingTank::remove(const DOMTimer& timer)
 {
     stopExceededMaximumHoldTimer();
-    m_timers.remove(&timer);
+    m_timers.remove(timer);
 }
 
 bool DOMTimerHoldingTank::contains(const DOMTimer& timer)
 {
-    return m_timers.contains(&timer);
+    return m_timers.contains(timer);
 }
 
 void DOMTimerHoldingTank::removeAll()

--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.h
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.h
@@ -48,7 +48,7 @@ public:
 private:
     void stopExceededMaximumHoldTimer();
 
-    HashSet<const DOMTimer*> m_timers;
+    WeakHashSet<DOMTimer> m_timers;
     Timer m_exceededMaximumHoldTimer;
 };
 


### PR DESCRIPTION
#### fc633484894797049f99bb709aa7bb9588cf4d02
<pre>
DOMTimerHoldingTank should use WeakHashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=251069">https://bugs.webkit.org/show_bug.cgi?id=251069</a>

Reviewed by Chris Dumez.

Use WeakHashSet of DOMTimer instead of HashMap of raw pointers.

* Source/WebCore/page/ios/DOMTimerHoldingTank.cpp:
(WebCore::DOMTimerHoldingTank::add):
(WebCore::DOMTimerHoldingTank::remove):
(WebCore::DOMTimerHoldingTank::contains):
* Source/WebCore/page/ios/DOMTimerHoldingTank.h:

Canonical link: <a href="https://commits.webkit.org/259300@main">https://commits.webkit.org/259300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9caa264a3af09b7051318b39e66e513d6a43c1a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113767 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173995 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4493 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112734 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38902 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80571 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6928 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27338 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3897 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46898 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8847 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3403 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->