### PR TITLE
Fix !ENABLE(ACCESSIBILITY) build following 259169@main.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -450,8 +450,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     accessibility/AXLogger.h
     accessibility/AXObjectCache.h
-    accessibility/AXTreeStore.h
+    accessibility/AXTextMarker.h
     accessibility/AXTextStateChangeIntent.h
+    accessibility/AXTreeStore.h
     accessibility/AccessibilityListBox.h
     accessibility/AccessibilityMenuListPopup.h
     accessibility/AccessibilityMockObject.h

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AXIsolatedTree.h"
+#include "AXTextMarker.h"
 #include "AXTextStateChangeIntent.h"
 #include "AXTreeStore.h"
 #include "AccessibilityObject.h"
@@ -44,7 +45,6 @@ class TextStream;
 
 namespace WebCore {
 
-class AXTextMarker;
 class Document;
 class HTMLAreaElement;
 class HTMLTableElement;
@@ -57,7 +57,6 @@ class RenderText;
 class ScrollView;
 class VisiblePosition;
 class Widget;
-struct TextMarkerData;
 
 struct CharacterOffset {
     Node* node;
@@ -717,6 +716,10 @@ inline CharacterOffset AXObjectCache::startOrEndCharacterOffsetForRange(const Si
 inline CharacterOffset AXObjectCache::endCharacterOffsetOfLine(const CharacterOffset&) { return CharacterOffset(); }
 inline CharacterOffset AXObjectCache::nextCharacterOffset(const CharacterOffset&, bool) { return CharacterOffset(); }
 inline CharacterOffset AXObjectCache::previousCharacterOffset(const CharacterOffset&, bool) { return CharacterOffset(); }
+inline std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(const VisiblePosition&) { return std::nullopt; }
+inline TextMarkerData AXObjectCache::textMarkerDataForCharacterOffset(const CharacterOffset&) { return { }; }
+inline VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarkerData&) { return { }; }
+inline VisiblePosition AXObjectCache::visiblePositionFromCharacterOffset(const CharacterOffset&) { return { }; }
 #if PLATFORM(COCOA)
 inline void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*, const AXTextStateChangeIntent&, const VisibleSelection&) { }
 inline void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*, AXTextEditType, const String&, const VisiblePosition&) { }

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -24,9 +24,11 @@
 
 #pragma once
 
-#include "AXObjectCache.h"
+#include "AccessibilityObject.h"
 
 namespace WebCore {
+
+struct CharacterOffset;
 
 struct TextMarkerData {
     unsigned treeID;
@@ -67,38 +69,8 @@ struct TextMarkerData {
         ignored = ignoredParam;
     }
 
-    TextMarkerData(AXObjectCache& cache, Node* nodeParam, const VisiblePosition& visiblePosition,
-        int charStart = 0, int charOffset = 0, bool ignoredParam = false)
-    {
-        initializeAXIDs(cache, nodeParam);
-
-        node = nodeParam;
-        auto position = visiblePosition.deepEquivalent();
-        offset = !visiblePosition.isNull() ? std::max(position.deprecatedEditingOffset(), 0) : 0;
-        anchorType = position.anchorType();
-        affinity = visiblePosition.affinity();
-
-        characterStart = std::max(charStart, 0);
-        characterOffset = std::max(charOffset, 0);
-        ignored = ignoredParam;
-    }
-
-    TextMarkerData(AXObjectCache& cache, const CharacterOffset& characterOffset, bool ignoredParam = false)
-    {
-        initializeAXIDs(cache, characterOffset.node);
-
-        node = characterOffset.node;
-        auto visiblePosition = cache.visiblePositionFromCharacterOffset(characterOffset);
-        auto position = visiblePosition.deepEquivalent();
-        offset = !visiblePosition.isNull() ? std::max(position.deprecatedEditingOffset(), 0) : 0;
-        // When creating from a CharacterOffset, always set the anchorType to PositionIsOffsetInAnchor.
-        anchorType = Position::PositionIsOffsetInAnchor;
-        affinity = visiblePosition.affinity();
-
-        characterStart = std::max(characterOffset.startIndex, 0);
-        this->characterOffset = std::max(characterOffset.offset, 0);
-        ignored = ignoredParam;
-    }
+    TextMarkerData(AXObjectCache&, Node*, const VisiblePosition&, int charStart = 0, int charOffset = 0, bool ignoredParam = false);
+    TextMarkerData(AXObjectCache&, const CharacterOffset&, bool ignoredParam = false);
 
     AXID axTreeID() const
     {
@@ -110,14 +82,7 @@ struct TextMarkerData {
         return makeObjectIdentifier<AXIDType>(objectID);
     }
 private:
-    void initializeAXIDs(AXObjectCache& cache, Node* node)
-    {
-        memset(static_cast<void*>(this), 0, sizeof(*this));
-
-        treeID = cache.treeID().toUInt64();
-        if (RefPtr object = cache.getOrCreate(node))
-            objectID = object->objectID().toUInt64();
-    }
+    void initializeAXIDs(AXObjectCache&, Node*);
 };
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 5cf1f09b2ac867fbb8b01ebb3557bc3036c1cbdd
<pre>
Fix !ENABLE(ACCESSIBILITY) build following 259169@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251070">https://bugs.webkit.org/show_bug.cgi?id=251070</a>

Unreviewed PlayStation build fix.

This was a tricky one because the new feature was not designed in a way to allow for an ENABLE to work.
Usually the solution is just to add stub functions; here, the functions depended on a forward-declared type, TextMarkerData, which would cause a circular dependency when replaced with an include. This is resolved by removing the opposite-direction include and transplanting TextMarkerData&apos;s method definitions from the header to the impl file.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
(WebCore::AXObjectCache::textMarkerDataForCharacterOffset):
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
(WebCore::AXObjectCache::visiblePositionFromCharacterOffset):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::TextMarkerData::initializeAXIDs):
* Source/WebCore/accessibility/AXTextMarker.h:

Canonical link: <a href="https://commits.webkit.org/259268@main">https://commits.webkit.org/259268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f9cf4500ed83f254fdc215317f3d9b6c6a5be71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113782 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174006 "Failed to checkout and rebase branch from PR 9019") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4509 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96842 "Failed to checkout and rebase branch from PR 9019") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110275 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94376 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96842 "Failed to checkout and rebase branch from PR 9019") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25988 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96842 "Failed to checkout and rebase branch from PR 9019") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6942 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27345 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7062 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6388 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8857 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->