### PR TITLE
Fix IsoCellSet::remove()'s return value.

### DIFF
--- a/Source/JavaScriptCore/heap/IsoCellSetInlines.h
+++ b/Source/JavaScriptCore/heap/IsoCellSetInlines.h
@@ -33,6 +33,10 @@ namespace JSC {
 
 inline bool IsoCellSet::add(HeapCell* cell)
 {
+    // We want to return true if the cell is newly added. concurrentTestAndSet() returns the
+    // previous bit value. Since we're trying to set the bit for this add, the cell would be
+    // newly added only if the previous bit was not set. Hence, our result will be the
+    // inverse of the concurrentTestAndSet() result.
     if (cell->isPreciseAllocation())
         return !m_lowerTierBits.concurrentTestAndSet(cell->preciseAllocation().lowerTierIndex());
     AtomIndices atomIndices(cell);
@@ -45,8 +49,12 @@ inline bool IsoCellSet::add(HeapCell* cell)
 
 inline bool IsoCellSet::remove(HeapCell* cell)
 {
+    // We want to return true if the cell was previously present and will be removed now.
+    // concurrentTestAndClear() returns the previous bit value. Since we're trying to clear
+    // the bit for this remove, the cell would be newly removed only if the previous bit
+    // was set. Hence, our result matches the concurrentTestAndClear() result.
     if (cell->isPreciseAllocation())
-        return !m_lowerTierBits.concurrentTestAndClear(cell->preciseAllocation().lowerTierIndex());
+        return m_lowerTierBits.concurrentTestAndClear(cell->preciseAllocation().lowerTierIndex());
     AtomIndices atomIndices(cell);
     auto& bitsPtrRef = m_bits[atomIndices.blockIndex];
     auto* bits = bitsPtrRef.get();

--- a/Source/WTF/wtf/Atomics.h
+++ b/Source/WTF/wtf/Atomics.h
@@ -133,6 +133,8 @@ struct Atomic {
     
     ALWAYS_INLINE T exchange(T newValue, std::memory_order order = std::memory_order_seq_cst) { return value.exchange(newValue, order); }
 
+    // func is supposed to return false if the value is already in the desired state.
+    // Returns true if the value was changed. Else returns false.
     template<typename Func>
     ALWAYS_INLINE bool transaction(const Func& func, std::memory_order order = std::memory_order_seq_cst)
     {
@@ -146,6 +148,8 @@ struct Atomic {
         }
     }
 
+    // func is supposed to return false if the value is already in the desired state.
+    // Returns true if the value was changed. Else returns false.
     template<typename Func>
     ALWAYS_INLINE bool transactionRelaxed(const Func& func)
     {


### PR DESCRIPTION
#### 3589dd6fe56969756161494cf76b92588a1e841b
<pre>
Fix IsoCellSet::remove()&apos;s return value.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251071">https://bugs.webkit.org/show_bug.cgi?id=251071</a>
&lt;rdar://problem/104590361&gt;

Reviewed by Yusuke Suzuki.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=250847">https://bugs.webkit.org/show_bug.cgi?id=250847</a>, Yijia Huang found a bug in
Bitmap::concurrentTestAndClear() where it&apos;s returning the inverse of its expected
result.  Checking for all uses of concurrentTestAndClear(), we find that one
result of IsoCellSet::remove() is also similarly incorrect.

This patch fixes these errors, and also adds comments to document the intended
return values of some relevant functions, as well as the reasoning behind how
some of the return values are computed.

Note: currently, the result of Bitmap::concurrentTestAndClear() only impacts
the return value of IsoCellSet::remove(), and, in turn, the return value of
IsoCellSet::remove() is not used anywhere.  Hence, these bugs do not currently
cause any harm.  However, it is good to fix them just for correctness and to
avoid potential future issues should we start using their return values in a
meaningful way.

* Source/JavaScriptCore/heap/IsoCellSetInlines.h:
(JSC::IsoCellSet::add):
(JSC::IsoCellSet::remove):
* Source/WTF/wtf/Atomics.h:
* Source/WTF/wtf/Bitmap.h:
(WTF::WordType&gt;::testAndSet):
(WTF::WordType&gt;::testAndClear):
(WTF::WordType&gt;::concurrentTestAndSet):
(WTF::WordType&gt;::concurrentTestAndClear):

Canonical link: <a href="https://commits.webkit.org/259287@main">https://commits.webkit.org/259287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1ab5f5adcd35e1992fe5c1d63a549d8000294fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113770 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173998 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4496 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112737 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38912 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80582 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94490 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6931 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27339 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92389 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4718 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3899 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30018 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46899 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101075 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6401 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8849 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25081 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->