### PR TITLE
GamepadManager should use WeakHashMap instead of HashMap of raw pointers

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.h
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.h
@@ -30,6 +30,7 @@
 #include "GamepadProviderClient.h"
 #include <wtf/HashSet.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -37,6 +38,7 @@ namespace WebCore {
 class DOMWindow;
 class Gamepad;
 class NavigatorGamepad;
+class WeakPtrImplWithEventTargetData;
 
 class GamepadManager : public GamepadProviderClient {
     WTF_MAKE_NONCOPYABLE(GamepadManager);
@@ -48,15 +50,15 @@ public:
     void platformGamepadDisconnected(PlatformGamepad&) final;
     void platformGamepadInputActivity(EventMakesGamepadsVisible) final;
 
-    void registerNavigator(NavigatorGamepad*);
-    void unregisterNavigator(NavigatorGamepad*);
-    void registerDOMWindow(DOMWindow*);
-    void unregisterDOMWindow(DOMWindow*);
+    void registerNavigator(NavigatorGamepad&);
+    void unregisterNavigator(NavigatorGamepad&);
+    void registerDOMWindow(DOMWindow&);
+    void unregisterDOMWindow(DOMWindow&);
 
 private:
     GamepadManager();
 
-    void makeGamepadVisible(PlatformGamepad&, HashSet<NavigatorGamepad*>&, HashSet<DOMWindow*>&);
+    void makeGamepadVisible(PlatformGamepad&, WeakHashSet<NavigatorGamepad>&, WeakHashSet<DOMWindow, WeakPtrImplWithEventTargetData>&);
     void dispatchGamepadEvent(const AtomString& eventName, PlatformGamepad&);
 
     void maybeStartMonitoringGamepads();
@@ -64,10 +66,10 @@ private:
 
     bool m_isMonitoringGamepads;
 
-    HashSet<NavigatorGamepad*> m_navigators;
-    HashSet<NavigatorGamepad*> m_gamepadBlindNavigators;
-    HashSet<DOMWindow*> m_domWindows;
-    HashSet<DOMWindow*> m_gamepadBlindDOMWindows;
+    WeakHashSet<NavigatorGamepad> m_navigators;
+    WeakHashSet<NavigatorGamepad> m_gamepadBlindNavigators;
+    WeakHashSet<DOMWindow, WeakPtrImplWithEventTargetData> m_domWindows;
+    WeakHashSet<DOMWindow, WeakPtrImplWithEventTargetData> m_gamepadBlindDOMWindows;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -40,12 +40,12 @@ namespace WebCore {
 NavigatorGamepad::NavigatorGamepad(Navigator& navigator)
     : m_navigator(navigator)
 {
-    GamepadManager::singleton().registerNavigator(this);
+    GamepadManager::singleton().registerNavigator(*this);
 }
 
 NavigatorGamepad::~NavigatorGamepad()
 {
-    GamepadManager::singleton().unregisterNavigator(this);
+    GamepadManager::singleton().unregisterNavigator(*this);
 }
 
 const char* NavigatorGamepad::supplementName()

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -29,6 +29,7 @@
 
 #include "Supplementable.h"
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class Gamepad;
 class Navigator;
 class PlatformGamepad;
 
-class NavigatorGamepad : public Supplement<Navigator> {
+class NavigatorGamepad : public Supplement<Navigator>, public CanMakeWeakPtr<NavigatorGamepad> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit NavigatorGamepad(Navigator&);

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -452,7 +452,7 @@ DOMWindow::~DOMWindow()
 
 #if ENABLE(GAMEPAD)
     if (m_gamepadEventListenerCount)
-        GamepadManager::singleton().unregisterDOMWindow(this);
+        GamepadManager::singleton().unregisterDOMWindow(*this);
 #endif
 
     removeLanguageChangeObserver(this);
@@ -526,7 +526,7 @@ void DOMWindow::willDetachDocumentFromFrame()
 void DOMWindow::incrementGamepadEventListenerCount()
 {
     if (++m_gamepadEventListenerCount == 1)
-        GamepadManager::singleton().registerDOMWindow(this);
+        GamepadManager::singleton().registerDOMWindow(*this);
 }
 
 void DOMWindow::decrementGamepadEventListenerCount()
@@ -534,7 +534,7 @@ void DOMWindow::decrementGamepadEventListenerCount()
     ASSERT(m_gamepadEventListenerCount);
 
     if (!--m_gamepadEventListenerCount)
-        GamepadManager::singleton().unregisterDOMWindow(this);
+        GamepadManager::singleton().unregisterDOMWindow(*this);
 }
 
 #endif


### PR DESCRIPTION
#### 0b02c29900705e60f0f8f6acbe01158e1126e086
<pre>
GamepadManager should use WeakHashMap instead of HashMap of raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=251072">https://bugs.webkit.org/show_bug.cgi?id=251072</a>

Reviewed by Chris Dumez.

Use WeakHashMap instead of HashMap of raw pointers in GamepadManager.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::navigatorGamepadFromDOMWindow):
(WebCore::GamepadManager::platformGamepadDisconnected):
(WebCore::GamepadManager::platformGamepadInputActivity):
(WebCore::GamepadManager::makeGamepadVisible):
(WebCore::GamepadManager::registerNavigator):
(WebCore::GamepadManager::unregisterNavigator):
(WebCore::GamepadManager::registerDOMWindow):
(WebCore::GamepadManager::unregisterDOMWindow):
(WebCore::GamepadManager::maybeStartMonitoringGamepads):
(WebCore::GamepadManager::maybeStopMonitoringGamepads):
* Source/WebCore/Modules/gamepad/GamepadManager.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::NavigatorGamepad):
(WebCore::NavigatorGamepad::~NavigatorGamepad):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::~DOMWindow):
(WebCore::DOMWindow::incrementGamepadEventListenerCount):
(WebCore::DOMWindow::decrementGamepadEventListenerCount):

Canonical link: <a href="https://commits.webkit.org/259301@main">https://commits.webkit.org/259301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb3c4b468291adbb0760595f35b4f100bad52d27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113776 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174002 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4503 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112741 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38906 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7058 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3902 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46907 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8853 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3404 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->