### PR TITLE
touch-action-region-clip-and-transform.html is a consistent failure

### DIFF
--- a/LayoutTests/pointerevents/ios/touch-action-region-clip-and-transform-expected.txt
+++ b/LayoutTests/pointerevents/ios/touch-action-region-clip-and-transform-expected.txt
@@ -84,9 +84,7 @@
           (contentsOpaque 1)
           (drawsContent 1)
           (event region
-            (rect (0,0) width=200 height=150)
-            (rect (0,150) width=350 height=50)
-            (rect (150,200) width=200 height=150)
+            (rect (0,0) width=200 height=200)
             (touch-action
               (none
                 (rect (150,150) width=50 height=50)


### PR DESCRIPTION
#### d64bf428fb59d306c6723e38f69d90e7d2b92c90
<pre>
touch-action-region-clip-and-transform.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=251074">https://bugs.webkit.org/show_bug.cgi?id=251074</a>
&lt;radar://104584590&gt;

Reviewed by Dean Jackson.

We made some changes to the event region clipping in August but missed this test
which appears to be a progression.

The GraphicsLayer between the last and 4th from last appear identical, but the
test expecation was different for them. That seems incorrect. Now the test expectations
for the two GraphicsLayers are the same, which seems correct.

* LayoutTests/pointerevents/ios/touch-action-region-clip-and-transform-expected.txt:
Update the test expectation due to the progression.

Canonical link: <a href="https://commits.webkit.org/259292@main">https://commits.webkit.org/259292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfc5eb0f2b2ea1da49a7b9449403ab7e8f165204

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113777 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174003 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4504 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112742 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38907 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27341 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3901 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6406 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8854 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->