### PR TITLE
Rename FileSystem::FileOpenMode::Write to FileSystem::FileOpenMode::Truncate

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1115,7 +1115,7 @@ public:
         });
 
         String filename = cachePath();
-        auto fd = FileSystem::openAndLockFile(filename, FileSystem::FileOpenMode::Write, {FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking});
+        auto fd = FileSystem::openAndLockFile(filename, FileSystem::FileOpenMode::ReadWrite, { FileSystem::FileLockMode::Exclusive, FileSystem::FileLockMode::Nonblocking });
         if (!FileSystem::isHandleValid(fd))
             return;
 
@@ -1828,7 +1828,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWriteFile, (JSGlobalObject* globalObject, CallF
         RETURN_IF_EXCEPTION(scope, { });
     }
 
-    auto handle = FileSystem::openFile(fileName, FileSystem::FileOpenMode::Write);
+    auto handle = FileSystem::openFile(fileName, FileSystem::FileOpenMode::Truncate);
     if (!FileSystem::isHandleValid(handle))
         return throwVMError(globalObject, scope, "Could not open file."_s);
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -78,7 +78,7 @@ static void dumpWasmSource(const Vector<uint8_t>& source)
     if (!file)
         return;
     auto fileHandle = FileSystem::openFile(WTF::makeString(file, (count++), ".wasm"_s), 
-        FileSystem::FileOpenMode::Write,
+        FileSystem::FileOpenMode::Truncate,
         FileSystem::FileAccessPermission::All,
         /* failIfFileExists = */ true);
     if (fileHandle == FileSystem::invalidPlatformFileHandle) {

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -355,7 +355,7 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
     case FileOpenMode::Read:
         pageProtection = PROT_READ;
         break;
-    case FileOpenMode::Write:
+    case FileOpenMode::Truncate:
         pageProtection = PROT_WRITE;
         break;
     case FileOpenMode::ReadWrite:
@@ -526,7 +526,7 @@ std::optional<Salt> readOrMakeSalt(const String& path)
 
     Salt salt = makeSalt();
     FileSystem::makeAllDirectories(FileSystem::parentPath(path));
-    auto file = FileSystem::openFile(path, FileSystem::FileOpenMode::Write, FileSystem::FileAccessPermission::User);
+    auto file = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::User);
     if (!FileSystem::isHandleValid(file))
         return { };
 
@@ -575,15 +575,12 @@ std::optional<Vector<uint8_t>> readEntireFile(const String& path)
 
 int overwriteEntireFile(const String& path, Span<uint8_t> span)
 {
-    auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite);
+    auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate);
     auto closeFile = makeScopeExit([&] {
         FileSystem::closeFile(fileHandle);
     });
 
     if (!FileSystem::isHandleValid(fileHandle))
-        return -1;
-
-    if (!FileSystem::truncateFile(fileHandle, 0))
         return -1;
 
     return FileSystem::writeToFile(fileHandle, span.data(), span.size());

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -86,7 +86,7 @@ typedef ino_t PlatformFileID;
 
 enum class FileOpenMode {
     Read,
-    Write,
+    Truncate,
     ReadWrite,
 #if OS(DARWIN)
     EventsOnly,

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -193,13 +193,11 @@ PlatformFileHandle openFile(const String& path, FileOpenMode mode, FileAccessPer
         return ioStream.leakRef();
     }
 
-    if (mode == FileOpenMode::Read)
+    if (mode == FileOpenMode::Read || mode == FileOpenMode::ReadWrite)
         ioStream = adoptGRef(g_file_open_readwrite(file.get(), nullptr, nullptr));
-    else if (mode == FileOpenMode::Write || mode == FileOpenMode::ReadWrite) {
-        if (g_file_test(filename.data(), static_cast<GFileTest>(G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR)))
-            ioStream = adoptGRef(g_file_open_readwrite(file.get(), nullptr, nullptr));
-        else
-            ioStream = adoptGRef(g_file_create_readwrite(file.get(), permissionFlag, nullptr, nullptr));
+    else {
+        ASSERT(mode == FileOpenMode::Truncate);
+        ioStream = adoptGRef(g_file_replace_readwrite(file.get(), nullptr, FALSE, permissionFlag, nullptr, nullptr));
     }
 
     return ioStream.leakRef();

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -61,7 +61,7 @@ PlatformFileHandle openFile(const String& path, FileOpenMode mode, FileAccessPer
     case FileOpenMode::Read:
         platformFlag |= O_RDONLY;
         break;
-    case FileOpenMode::Write:
+    case FileOpenMode::Truncate:
         platformFlag |= (O_WRONLY | O_CREAT | O_TRUNC);
         break;
     case FileOpenMode::ReadWrite:

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -263,7 +263,7 @@ PlatformFileHandle openFile(const String& path, FileOpenMode mode, FileAccessPer
         creationDisposition = OPEN_EXISTING;
         shareMode = FILE_SHARE_READ;
         break;
-    case FileOpenMode::Write:
+    case FileOpenMode::Truncate:
         desiredAccess = GENERIC_WRITE;
         creationDisposition = CREATE_ALWAYS;
         break;
@@ -420,7 +420,7 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
         pageProtection = PAGE_READONLY;
         desiredAccess = FILE_MAP_READ;
         break;
-    case FileOpenMode::Write:
+    case FileOpenMode::Truncate:
         pageProtection = PAGE_READWRITE;
         desiredAccess = FILE_MAP_WRITE;
         break;

--- a/Source/WebCore/Modules/webdatabase/OriginLock.cpp
+++ b/Source/WebCore/Modules/webdatabase/OriginLock.cpp
@@ -45,7 +45,7 @@ void OriginLock::lock() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     m_mutex.lock();
 
 #if USE(FILE_LOCK)
-    m_lockHandle = FileSystem::openAndLockFile(m_lockFileName, FileSystem::FileOpenMode::Write);
+    m_lockHandle = FileSystem::openAndLockFile(m_lockFileName, FileSystem::FileOpenMode::Truncate);
     if (m_lockHandle == FileSystem::invalidPlatformFileHandle) {
         // The only way we can get here is if the directory containing the lock
         // has been deleted or we were given a path to a non-existant directory.

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1284,7 +1284,7 @@ bool ApplicationCacheStorage::writeDataToUniqueFileInDirectory(FragmentedSharedB
         fullPath = FileSystem::pathByAppendingComponent(directory, path);
     } while (FileSystem::parentPath(fullPath) != directory || FileSystem::fileExists(fullPath));
     
-    FileSystem::PlatformFileHandle handle = FileSystem::openFile(fullPath, FileSystem::FileOpenMode::Write);
+    FileSystem::PlatformFileHandle handle = FileSystem::openFile(fullPath, FileSystem::FileOpenMode::Truncate);
     if (!handle)
         return false;
     

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -379,7 +379,7 @@ void BlobRegistryImpl::writeBlobToFilePath(const URL& blobURL, const String& pat
     }
 
     blobUtilityQueue().dispatch([path, blobsForWriting = WTFMove(blobsForWriting), completionHandler = WTFMove(completionHandler)]() mutable {
-        bool success = writeFilePathsOrDataBuffersToFile(blobsForWriting.first().filePathsOrDataBuffers, FileSystem::openFile(path, FileSystem::FileOpenMode::Write), path);
+        bool success = writeFilePathsOrDataBuffersToFile(blobsForWriting.first().filePathsOrDataBuffers, FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate), path);
         callOnMainThread([success, completionHandler = WTFMove(completionHandler)]() {
             completionHandler(success);
         });

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -235,7 +235,7 @@ void CookieJarDB::flagDatabaseCorruption()
     if (isOnMemory())
         return;
 
-    auto handle = FileSystem::openFile(getCorruptionMarkerPath(), FileSystem::FileOpenMode::Write);
+    auto handle = FileSystem::openFile(getCorruptionMarkerPath(), FileSystem::FileOpenMode::Truncate);
     if (FileSystem::isHandleValid(handle))
         FileSystem::closeFile(handle);
 }

--- a/Source/WebCore/platform/network/curl/CurlCacheEntry.cpp
+++ b/Source/WebCore/platform/network/curl/CurlCacheEntry.cpp
@@ -123,7 +123,7 @@ bool CurlCacheEntry::readCachedData(ResourceHandle* job)
 
 bool CurlCacheEntry::saveResponseHeaders(const ResourceResponse& response)
 {
-    FileSystem::PlatformFileHandle headerFile = FileSystem::openFile(m_headerFilename, FileSystem::FileOpenMode::Write);
+    FileSystem::PlatformFileHandle headerFile = FileSystem::openFile(m_headerFilename, FileSystem::FileOpenMode::Truncate);
     if (!FileSystem::isHandleValid(headerFile)) {
         LOG(Network, "Cache Error: Could not open %s for write\n", m_headerFilename.latin1().data());
         return false;
@@ -311,7 +311,7 @@ bool CurlCacheEntry::openContentFile()
     if (FileSystem::isHandleValid(m_contentFile))
         return true;
     
-    m_contentFile = FileSystem::openFile(m_contentFilename, FileSystem::FileOpenMode::Write);
+    m_contentFile = FileSystem::openFile(m_contentFilename, FileSystem::FileOpenMode::Truncate);
 
     if (FileSystem::isHandleValid(m_contentFile))
         return true;

--- a/Source/WebCore/platform/network/curl/CurlCacheManager.cpp
+++ b/Source/WebCore/platform/network/curl/CurlCacheManager.cpp
@@ -141,7 +141,7 @@ void CurlCacheManager::saveIndex()
     auto indexFilePath = makeString(m_cacheDir, "index.dat"_s);
 
     FileSystem::deleteFile(indexFilePath);
-    FileSystem::PlatformFileHandle indexFile = FileSystem::openFile(indexFilePath, FileSystem::FileOpenMode::Write);
+    FileSystem::PlatformFileHandle indexFile = FileSystem::openFile(indexFilePath, FileSystem::FileOpenMode::Truncate);
     if (!FileSystem::isHandleValid(indexFile)) {
         LOG(Network, "Cache Error: Could not open %s for write\n", indexFilePath.latin1().data());
         return;

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -96,7 +96,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     FileSystem::deleteFile(scriptPath);
 
     if (!shouldUseFileMapping(script.buffer()->size())) {
-        auto handle = FileSystem::openFile(scriptPath, FileSystem::FileOpenMode::Write);
+        auto handle = FileSystem::openFile(scriptPath, FileSystem::FileOpenMode::Truncate);
         if (!FileSystem::isHandleValid(handle)) {
             RELEASE_LOG_ERROR(ServiceWorker, "SWScriptStorage::store: Failure to store %s, FileSystem::openFile() failed", scriptPath.utf8().data());
             return { };

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -464,7 +464,7 @@ void NetworkDataTaskBlob::download()
 
     LOG(NetworkSession, "%p - NetworkDataTaskBlob::download to %s", this, m_pendingDownloadLocation.utf8().data());
 
-    m_downloadFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Write);
+    m_downloadFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate);
     if (m_downloadFile == FileSystem::invalidPlatformFileHandle) {
         didFailDownload(cancelledError(m_firstRequest));
         return;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -155,7 +155,7 @@ void ServiceWorkerDownloadTask::setPendingDownloadLocation(const WTF::String& fi
             }
         }
 
-        m_downloadFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Write);
+        m_downloadFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate);
         if (m_downloadFile == FileSystem::invalidPlatformFileHandle)
             didFailDownload();
     });

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngine.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngine.cpp
@@ -498,17 +498,8 @@ void Engine::writeSizeFile(String&& path, uint64_t size, CompletionHandler<void(
 
     m_ioQueue->dispatch([path = WTFMove(path).isolatedCopy(), size, completionHandler = WTFMove(completionHandler)]() mutable {
         Locker locker { globalSizeFileLock };
-        auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Write);
-
-        if (FileSystem::isHandleValid(fileHandle)) {
-            FileSystem::truncateFile(fileHandle, 0);
-
-            auto value = String::number(size).utf8();
-            FileSystem::writeToFile(fileHandle, value.data(), value.length());
-
-            FileSystem::closeFile(fileHandle);
-        }
-
+        auto value = String::number(size).utf8();
+        FileSystem::overwriteEntireFile(path, Span { reinterpret_cast<uint8_t*>(const_cast<char*>(value.data())), value.length() });
         RunLoop::main().dispatch(WTFMove(completionHandler));
     });
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -605,7 +605,7 @@ String Cache::dumpFilePath() const
 
 void Cache::dumpContentsToFile()
 {
-    auto fd = openFile(dumpFilePath(), FileOpenMode::Write);
+    auto fd = openFile(dumpFilePath(), FileOpenMode::Truncate);
     if (!isHandleValid(fd))
         return;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
@@ -41,10 +41,10 @@ IOChannel::IOChannel(String&& filePath, Type type, std::optional<WorkQueue::QOS>
         mode = FileSystem::FileOpenMode::Read;
         break;
     case Type::Write:
-        mode = FileSystem::FileOpenMode::Write;
+        mode = FileSystem::FileOpenMode::ReadWrite;
         break;
     case Type::Create:
-        mode = FileSystem::FileOpenMode::Write;
+        mode = FileSystem::FileOpenMode::ReadWrite;
         break;
     }
     m_fileDescriptor = FileSystem::openFile(m_path, mode);

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -298,7 +298,7 @@ void NetworkDataTaskCurl::invokeDidReceiveResponse()
             invalidateAndCancel();
             break;
         case PolicyAction::Download: {
-            m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Write);
+            m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate);
             if (!FileSystem::isHandleValid(m_downloadDestinationFile)) {
                 if (m_client)
                     m_client->didCompleteWithError(ResourceError(CURLE_WRITE_ERROR, m_response.url()));

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -105,16 +105,6 @@ static bool writeCachesList(const String& cachesListDirectoryPath, const Vector<
     }
 
     FileSystem::makeAllDirectories(FileSystem::parentPath(cachesListFilePath));
-    auto cachesListHandle = FileSystem::openFile(cachesListFilePath, FileSystem::FileOpenMode::ReadWrite);
-    if (!FileSystem::isHandleValid(cachesListHandle))
-        return false;
-    auto closeFileOnExit = makeScopeExit([&cachesListHandle]() mutable {
-        FileSystem::closeFile(cachesListHandle);
-    });
-
-    if (!FileSystem::truncateFile(cachesListHandle, 0))
-        return false;
-
     WTF::Persistence::Encoder encoder;
     uint64_t count = caches.size();
     if (skippedCachesIndex && *skippedCachesIndex < caches.size())
@@ -126,7 +116,8 @@ static bool writeCachesList(const String& cachesListDirectoryPath, const Vector<
         encoder << caches[index]->name();
         encoder << caches[index]->uniqueName();
     }
-    FileSystem::writeToFile(cachesListHandle, encoder.buffer(), encoder.bufferSize());
+
+    FileSystem::overwriteEntireFile(cachesListFilePath, Span { const_cast<uint8_t*>(encoder.buffer()), encoder.bufferSize() });
     return true;
 }
 

--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -54,7 +54,7 @@ void writeToDisk(std::unique_ptr<KeyedEncoder>&& encoder, String&& path)
     if (!rawData)
         return;
 
-    FileSystem::PlatformFileHandle handle = FileSystem::openAndLockFile(path, FileSystem::FileOpenMode::Write);
+    FileSystem::PlatformFileHandle handle = FileSystem::openAndLockFile(path, FileSystem::FileOpenMode::Truncate);
     if (handle == FileSystem::invalidPlatformFileHandle)
         return;
 

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -137,7 +137,7 @@ void WebMemorySampler::initializeSandboxedLogFile(SandboxExtension::Handle&& sam
     if (m_sampleLogSandboxExtension)
         m_sampleLogSandboxExtension->consume();
     m_sampleLogFilePath = sampleLogFilePath;
-    m_sampleLogFile = FileSystem::openFile(m_sampleLogFilePath, FileSystem::FileOpenMode::Write);
+    m_sampleLogFile = FileSystem::openFile(m_sampleLogFilePath, FileSystem::FileOpenMode::Truncate);
     writeHeaders();
 }
 

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -392,7 +392,7 @@ static bool ensureSandboxCacheDirectory(const SandboxInfo& info)
 
 static bool writeSandboxDataToCacheFile(const SandboxInfo& info, const Vector<char>& cacheFile)
 {
-    FileHandle file { info.filePath, FileSystem::FileOpenMode::Write, FileSystem::FileLockMode::Exclusive };
+    FileHandle file { info.filePath, FileSystem::FileOpenMode::Truncate, FileSystem::FileLockMode::Exclusive };
     return file.write(cacheFile.data(), cacheFile.size()) == safeCast<int>(cacheFile.size());
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -597,7 +597,7 @@ void ContentRuleListStore::synchronousRemoveAllContentRuleLists()
 
 void ContentRuleListStore::invalidateContentRuleListVersion(const WTF::String& identifier)
 {
-    auto file = openFile(constructedPath(m_storePath, identifier, false), FileOpenMode::Write);
+    auto file = openFile(constructedPath(m_storePath, identifier, false), FileOpenMode::Truncate);
     if (file == invalidPlatformFileHandle)
         return;
     ContentRuleListMetaData invalidHeader = {0, 0, 0, 0, 0, 0};

--- a/Source/WebKit/UIProcess/ios/WKModelView.mm
+++ b/Source/WebKit/UIProcess/ios/WKModelView.mm
@@ -104,7 +104,7 @@ SOFT_LINK_CLASS(AssetViewer, ASVInlinePreview);
 
     String fileName = makeString(UUID::createVersion4(), ".usdz"_s);
     auto filePath = FileSystem::pathByAppendingComponent(pathToDirectory, fileName);
-    auto file = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Write);
+    auto file = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Truncate);
     if (file <= 0)
         return NO;
 

--- a/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
+++ b/Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
@@ -109,7 +109,7 @@ void ARKitInlinePreviewModelPlayerMac::createFile(WebCore::Model& modelSource)
     // We need to support .reality files as well, https://bugs.webkit.org/show_bug.cgi?id=227568.
     String fileName = makeString(UUID::createVersion4(), ".usdz"_s);
     auto filePath = FileSystem::pathByAppendingComponent(pathToDirectory, fileName);
-    auto file = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Write);
+    auto file = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Truncate);
     if (file <= 0)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -38,7 +38,7 @@ const char* FileSystemTestData = "This is a test";
 
 static void createTestFile(const String& path)
 {
-    auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Write);
+    auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate);
     EXPECT_TRUE(FileSystem::isHandleValid(fileHandle));
     FileSystem::writeToFile(fileHandle, FileSystemTestData, strlen(FileSystemTestData));
     FileSystem::closeFile(fileHandle);
@@ -345,7 +345,7 @@ TEST_F(FileSystemTest, deleteEmptyDirectoryContainingDSStoreFile)
 
     // Create .DSStore file.
     auto dsStorePath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), ".DS_Store"_s);
-    auto dsStoreHandle = FileSystem::openFile(dsStorePath, FileSystem::FileOpenMode::Write);
+    auto dsStoreHandle = FileSystem::openFile(dsStorePath, FileSystem::FileOpenMode::Truncate);
     FileSystem::writeToFile(dsStoreHandle, FileSystemTestData, strlen(FileSystemTestData));
     FileSystem::closeFile(dsStoreHandle);
     EXPECT_TRUE(FileSystem::fileExists(dsStorePath));
@@ -361,14 +361,14 @@ TEST_F(FileSystemTest, deleteEmptyDirectoryOnNonEmptyDirectory)
 
     // Create .DSStore file.
     auto dsStorePath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), ".DS_Store"_s);
-    auto dsStoreHandle = FileSystem::openFile(dsStorePath, FileSystem::FileOpenMode::Write);
+    auto dsStoreHandle = FileSystem::openFile(dsStorePath, FileSystem::FileOpenMode::Truncate);
     FileSystem::writeToFile(dsStoreHandle, FileSystemTestData, strlen(FileSystemTestData));
     FileSystem::closeFile(dsStoreHandle);
     EXPECT_TRUE(FileSystem::fileExists(dsStorePath));
 
     // Create a dummy file.
     auto dummyFilePath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "dummyFile"_s);
-    auto dummyFileHandle = FileSystem::openFile(dummyFilePath, FileSystem::FileOpenMode::Write);
+    auto dummyFileHandle = FileSystem::openFile(dummyFilePath, FileSystem::FileOpenMode::Truncate);
     FileSystem::writeToFile(dummyFileHandle, FileSystemTestData, strlen(FileSystemTestData));
     FileSystem::closeFile(dummyFileHandle);
     EXPECT_TRUE(FileSystem::fileExists(dummyFilePath));
@@ -438,7 +438,7 @@ TEST_F(FileSystemTest, moveDirectory)
     EXPECT_TRUE(FileSystem::deleteFile(temporaryTestFolder));
     EXPECT_TRUE(FileSystem::makeAllDirectories(temporaryTestFolder));
     auto testFilePath = FileSystem::pathByAppendingComponent(temporaryTestFolder, "testFile"_s);
-    auto fileHandle = FileSystem::openFile(testFilePath, FileSystem::FileOpenMode::Write);
+    auto fileHandle = FileSystem::openFile(testFilePath, FileSystem::FileOpenMode::Truncate);
     FileSystem::writeToFile(fileHandle, FileSystemTestData, strlen(FileSystemTestData));
     FileSystem::closeFile(fileHandle);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -343,7 +343,7 @@ TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)
     testQueue->dispatch([this] () mutable {
         EXPECT_FALSE(FileSystem::fileExists(tempFilePath()));
 
-        auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Write);
+        auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate);
         ASSERT_NE(handle, FileSystem::invalidPlatformFileHandle);
 
         int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().data(), FileMonitorTestData.length());

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
@@ -86,7 +86,7 @@ static void removeDirectoryAndAllContents(const String& directoryPath)
 
 static void createFileAtPath(const String& path)
 {
-    FileSystem::PlatformFileHandle fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Write);
+    FileSystem::PlatformFileHandle fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate);
     EXPECT_NE(-1, fileHandle);
     FileSystem::closeFile(fileHandle);
     EXPECT_TRUE(FileSystem::fileExists(path));


### PR DESCRIPTION
#### 22004f62ebe45a346a22574601e6b5191cc62cc5
<pre>
Rename FileSystem::FileOpenMode::Write to FileSystem::FileOpenMode::Truncate
<a href="https://bugs.webkit.org/show_bug.cgi?id=251073">https://bugs.webkit.org/show_bug.cgi?id=251073</a>
rdar://104590894

Reviewed by Žan Doberšek.

In existing implementation, file opened with FileSystem::FileOpenMode::Write will be truncated or recreated if it
exists. This behavior is not clearly indicated in the name, and it causes confusion to users. For example, some places
check file size or truncate file after opening it with FileSystem::FileOpenMode::Write mode. They may actually need to
use FileSystem::FileOpenMode::ReadWrite mode. Therefore, this patch renames FileSystem::FileOpenMode::Write to
FileSystem::FileOpenMode::Truncate. Also, this patch makes glib implementation of FileSystem::FileOpenMode::Truncate
mode aligned with POSIX and win implementation, which recreates file when file with same name already exists.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::dumpWasmSource):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::MappedFileData::mapFileHandle):
(WTF::FileSystemImpl::readOrMakeSalt):
(WTF::FileSystemImpl::overwriteEntireFile):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::FileSystemImpl::openFile):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openFile):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::openFile):
(WTF::FileSystemImpl::MappedFileData::mapFileHandle):
* Source/WebCore/Modules/webdatabase/OriginLock.cpp:
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::writeDataToUniqueFileInDirectory):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::writeBlobToFilePath):
* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
(WebCore::CookieJarDB::flagDatabaseCorruption):
* Source/WebCore/platform/network/curl/CurlCacheEntry.cpp:
(WebCore::CurlCacheEntry::saveResponseHeaders):
(WebCore::CurlCacheEntry::openContentFile):
* Source/WebCore/platform/network/curl/CurlCacheManager.cpp:
(WebCore::CurlCacheManager::saveIndex):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::download):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::setPendingDownloadLocation):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngine.cpp:
(WebKit::CacheStorage::Engine::writeSizeFile):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::dumpContentsToFile):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp:
(WebKit::NetworkCache::IOChannel::IOChannel):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::invokeDidReceiveResponse):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::writeCachesList):
* Source/WebKit/Shared/PersistencyUtils.cpp:
(WebKit::writeToDisk):
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::initializeSandboxedLogFile):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::writeSandboxDataToCacheFile):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::ContentRuleListStore::invalidateContentRuleListVersion):
* Source/WebKit/UIProcess/ios/WKModelView.mm:
(-[WKModelView createFileForModel:]):
* Source/WebKit/WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm:
(WebKit::ARKitInlinePreviewModelPlayerMac::createFile):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::createTestFile):
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm:
(TestWebKitAPI::createFileAtPath):

Canonical link: <a href="https://commits.webkit.org/259689@main">https://commits.webkit.org/259689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56492e78df52958a8f1f9cf44246eed99d960f97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114860 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5922 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97899 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111386 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39744 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26883 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95365 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28236 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93531 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5774 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8491 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30407 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47784 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102244 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6696 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10042 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25496 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->