### PR TITLE
[ATSPI] Make `Atspi::ScrollType` an enum class

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h
@@ -246,7 +246,7 @@ enum ComponentLayer {
     WindowLayer,
 };
 
-enum ScrollType {
+enum class ScrollType {
     TopLeft,
     BottomRight,
     TopEdge,

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -97,7 +97,7 @@ public:
 
     WEBCORE_EXPORT AccessibilityObjectAtspi* hitTest(const IntPoint&, Atspi::CoordinateType) const;
     WEBCORE_EXPORT IntRect elementRect(Atspi::CoordinateType) const;
-    WEBCORE_EXPORT void scrollToMakeVisible(uint32_t) const;
+    WEBCORE_EXPORT void scrollToMakeVisible(Atspi::ScrollType) const;
     WEBCORE_EXPORT void scrollToPoint(const IntPoint&, Atspi::CoordinateType) const;
 
     WEBCORE_EXPORT String text() const;
@@ -195,7 +195,7 @@ private:
     bool selectionBounds(int&, int&) const;
     bool selectRange(int, int);
     TextAttributes textAttributesWithUTF8Offset(std::optional<int> = std::nullopt, bool = false) const;
-    bool scrollToMakeVisible(int, int, uint32_t) const;
+    bool scrollToMakeVisible(int, int, Atspi::ScrollType) const;
     bool scrollToPoint(int, int, Atspi::CoordinateType, int, int) const;
 
     unsigned offsetInParent() const;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -72,7 +72,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_componentFunctions = {
         else if (!g_strcmp0(methodName, "ScrollTo")) {
             uint32_t scrollType;
             g_variant_get(parameters, "(u)", &scrollType);
-            atspiObject->scrollToMakeVisible(scrollType);
+            atspiObject->scrollToMakeVisible(static_cast<Atspi::ScrollType>(scrollType));
             g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", TRUE));
         } else if (!g_strcmp0(methodName, "ScrollToPoint")) {
             int x, y;
@@ -160,7 +160,7 @@ float AccessibilityObjectAtspi::opacity() const
     return 1;
 }
 
-void AccessibilityObjectAtspi::scrollToMakeVisible(uint32_t scrollType) const
+void AccessibilityObjectAtspi::scrollToMakeVisible(Atspi::ScrollType scrollType) const
 {
     auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
     if (!liveObject)

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -199,7 +199,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_textFunctions = {
             int start, end;
             uint32_t scrollType;
             g_variant_get(parameters, "(iiu)", &start, &end, &scrollType);
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", atspiObject->scrollToMakeVisible(start, end, scrollType)));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(b)", atspiObject->scrollToMakeVisible(start, end, static_cast<Atspi::ScrollType>(scrollType))));
         } else if (!g_strcmp0(methodName, "ScrollSubstringToPoint")) {
             int start, end, x, y;
             uint32_t coordinateType;
@@ -936,7 +936,7 @@ void AccessibilityObjectAtspi::textAttributesChanged()
     AccessibilityAtspi::singleton().textAttributesChanged(*this);
 }
 
-bool AccessibilityObjectAtspi::scrollToMakeVisible(int startOffset, int endOffset, uint32_t scrollType) const
+bool AccessibilityObjectAtspi::scrollToMakeVisible(int startOffset, int endOffset, Atspi::ScrollType scrollType) const
 {
     auto utf16Text = text();
     auto utf8Text = utf16Text.utf8();


### PR DESCRIPTION
#### 713642cbbedc5ba5367613be92bc69fbd7de44b4
<pre>
[ATSPI] Make `Atspi::ScrollType` an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=251076">https://bugs.webkit.org/show_bug.cgi?id=251076</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

It should improve code readability.

* Source/WebCore/accessibility/atspi/AccessibilityAtspiEnums.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::scrollToMakeVisible const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::scrollToMakeVisible const):

Canonical link: <a href="https://commits.webkit.org/259615@main">https://commits.webkit.org/259615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72d1d1d5c79543797514e529c23b7583ce77409

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113781 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174005 "Found 1 new test failure: storage/indexeddb/modern/deleteindex-4-private.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4508 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112744 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38909 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80579 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3904 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46903 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8856 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3549 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->