### PR TITLE
Use WeakPtr to store RenderSVGResourceContainer

### DIFF
--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -179,11 +179,11 @@ void LegacyRenderSVGRoot::layout()
     m_isLayoutSizeChanged = needsLayout || (svgSVGElement().hasRelativeLengths() && oldSize != size());
     SVGRenderSupport::layoutChildren(*this, needsLayout || SVGRenderSupport::filtersForceContainerLayout(*this));
 
-    if (!m_resourcesNeedingToInvalidateClients.isEmpty()) {
+    if (!m_resourcesNeedingToInvalidateClients.isEmptyIgnoringNullReferences()) {
         // Invalidate resource clients, which may mark some nodes for layout.
         for (auto& resource :  m_resourcesNeedingToInvalidateClients) {
-            resource->removeAllClientsFromCache();
-            SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, nullptr, resource->style());
+            resource.removeAllClientsFromCache();
+            SVGResourcesCache::clientStyleChanged(resource, StyleDifference::Layout, nullptr, resource.style());
         }
 
         m_isLayoutSizeChanged = false;
@@ -470,7 +470,7 @@ void LegacyRenderSVGRoot::addResourceForClientInvalidation(RenderSVGResourceCont
     LegacyRenderSVGRoot* svgRoot = SVGRenderSupport::findTreeRootObject(*resource);
     if (!svgRoot)
         return;
-    svgRoot->m_resourcesNeedingToInvalidateClients.add(resource);
+    svgRoot->m_resourcesNeedingToInvalidateClients.add(*resource);
 }
 
 }

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
@@ -25,6 +25,7 @@
 #include "FloatRect.h"
 #include "RenderReplaced.h"
 #include "SVGRenderSupport.h"
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -116,7 +117,7 @@ private:
     FloatRect m_repaintBoundingBox;
     mutable AffineTransform m_localToParentTransform;
     AffineTransform m_localToBorderBoxTransform;
-    HashSet<RenderSVGResourceContainer*> m_resourcesNeedingToInvalidateClients;
+    WeakHashSet<RenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
     bool m_isLayoutSizeChanged : 1;
     bool m_needsBoundariesOrTransformUpdate : 1;
     bool m_hasBoxDecorations : 1;

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -245,11 +245,11 @@ void RenderSVGRoot::layoutChildren()
     m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
     containerLayout.positionChildrenRelativeToContainer();
 
-    if (!m_resourcesNeedingToInvalidateClients.isEmpty()) {
+    if (!m_resourcesNeedingToInvalidateClients.isEmptyIgnoringNullReferences()) {
         // Invalidate resource clients, which may mark some nodes for layout.
         for (auto& resource :  m_resourcesNeedingToInvalidateClients) {
-            resource->removeAllClientsFromCache();
-            SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, nullptr, resource->style());
+            resource.removeAllClientsFromCache();
+            SVGResourcesCache::clientStyleChanged(resource, StyleDifference::Layout, nullptr, resource.style());
         }
 
         SetForScope clearLayoutSizeChanged(m_isLayoutSizeChanged, false);

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -125,7 +125,7 @@ private:
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     FloatRect m_strokeBoundingBox;
-    HashSet<RenderSVGResourceContainer*> m_resourcesNeedingToInvalidateClients;
+    WeakHashSet<RenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -360,28 +360,28 @@ void SVGResources::removeClientFromCache(RenderElement& renderer, bool markForIn
     }
 
     if (m_clipperFilterMaskerData) {
-        if (m_clipperFilterMaskerData->clipper)
-            m_clipperFilterMaskerData->clipper->removeClientFromCache(renderer, markForInvalidation);
-        if (m_clipperFilterMaskerData->filter)
-            m_clipperFilterMaskerData->filter->removeClientFromCache(renderer, markForInvalidation);
-        if (m_clipperFilterMaskerData->masker)
-            m_clipperFilterMaskerData->masker->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* clipper = m_clipperFilterMaskerData->clipper.get())
+            clipper->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* filter = m_clipperFilterMaskerData->filter.get())
+            filter->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* masker = m_clipperFilterMaskerData->masker.get())
+            masker->removeClientFromCache(renderer, markForInvalidation);
     }
 
     if (m_markerData) {
-        if (m_markerData->markerStart)
-            m_markerData->markerStart->removeClientFromCache(renderer, markForInvalidation);
-        if (m_markerData->markerMid)
-            m_markerData->markerMid->removeClientFromCache(renderer, markForInvalidation);
-        if (m_markerData->markerEnd)
-            m_markerData->markerEnd->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* markerStart = m_markerData->markerStart.get())
+            markerStart->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* markerMid = m_markerData->markerMid.get())
+            markerMid->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* markerEnd = m_markerData->markerEnd.get())
+            markerEnd->removeClientFromCache(renderer, markForInvalidation);
     }
 
     if (m_fillStrokeData) {
-        if (m_fillStrokeData->fill)
-            m_fillStrokeData->fill->removeClientFromCache(renderer, markForInvalidation);
-        if (m_fillStrokeData->stroke)
-            m_fillStrokeData->stroke->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* fill = m_fillStrokeData->fill.get())
+            fill->removeClientFromCache(renderer, markForInvalidation);
+        if (auto* stroke = m_fillStrokeData->stroke.get())
+            stroke->removeClientFromCache(renderer, markForInvalidation);
     }
 }
 
@@ -405,7 +405,7 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
         if (!m_clipperFilterMaskerData)
             break;
         if (m_clipperFilterMaskerData->masker == &resource) {
-            m_clipperFilterMaskerData->masker->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_clipperFilterMaskerData->masker = nullptr;
             foundResources = true;
         }
@@ -414,17 +414,17 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
         if (!m_markerData)
             break;
         if (m_markerData->markerStart == &resource) {
-            m_markerData->markerStart->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_markerData->markerStart = nullptr;
             foundResources = true;
         }
         if (m_markerData->markerMid == &resource) {
-            m_markerData->markerMid->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_markerData->markerMid = nullptr;
             foundResources = true;
         }
         if (m_markerData->markerEnd == &resource) {
-            m_markerData->markerEnd->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_markerData->markerEnd = nullptr;
             foundResources = true;
         }
@@ -435,12 +435,12 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
         if (!m_fillStrokeData)
             break;
         if (m_fillStrokeData->fill == &resource) {
-            m_fillStrokeData->fill->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_fillStrokeData->fill = nullptr;
             foundResources = true;
         }
         if (m_fillStrokeData->stroke == &resource) {
-            m_fillStrokeData->stroke->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_fillStrokeData->stroke = nullptr;
             foundResources = true;
         }
@@ -449,7 +449,7 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
         if (!m_clipperFilterMaskerData)
             break;
         if (m_clipperFilterMaskerData->filter == &resource) {
-            m_clipperFilterMaskerData->filter->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_clipperFilterMaskerData->filter = nullptr;
             foundResources = true;
         }
@@ -458,7 +458,7 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
         if (!m_clipperFilterMaskerData)
             break; 
         if (m_clipperFilterMaskerData->clipper == &resource) {
-            m_clipperFilterMaskerData->clipper->removeAllClientsFromCache();
+            resource.removeAllClientsFromCache();
             m_clipperFilterMaskerData->clipper = nullptr;
             foundResources = true;
         }
@@ -469,42 +469,42 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
     return foundResources;
 }
 
-void SVGResources::buildSetOfResources(HashSet<RenderSVGResourceContainer*>& set)
+void SVGResources::buildSetOfResources(WeakHashSet<RenderSVGResourceContainer>& set)
 {
     if (isEmpty())
         return;
 
-    if (m_linkedResource) {
+    if (auto* linkedResource = m_linkedResource.get()) {
         ASSERT(!m_clipperFilterMaskerData);
         ASSERT(!m_markerData);
         ASSERT(!m_fillStrokeData);
-        set.add(m_linkedResource);
+        set.add(*linkedResource);
         return;
     }
 
     if (m_clipperFilterMaskerData) {
-        if (m_clipperFilterMaskerData->clipper)
-            set.add(m_clipperFilterMaskerData->clipper);
-        if (m_clipperFilterMaskerData->filter)
-            set.add(m_clipperFilterMaskerData->filter);
-        if (m_clipperFilterMaskerData->masker)
-            set.add(m_clipperFilterMaskerData->masker);
+        if (auto* clipper = m_clipperFilterMaskerData->clipper.get())
+            set.add(*clipper);
+        if (auto* filter = m_clipperFilterMaskerData->filter.get())
+            set.add(*filter);
+        if (auto* masker = m_clipperFilterMaskerData->masker.get())
+            set.add(*masker);
     }
 
     if (m_markerData) {
-        if (m_markerData->markerStart)
-            set.add(m_markerData->markerStart);
-        if (m_markerData->markerMid)
-            set.add(m_markerData->markerMid);
-        if (m_markerData->markerEnd)
-            set.add(m_markerData->markerEnd);
+        if (auto* markerStart = m_markerData->markerStart.get())
+            set.add(*markerStart);
+        if (auto* markerMid = m_markerData->markerMid.get())
+            set.add(*markerMid);
+        if (auto* markerEnd = m_markerData->markerEnd.get())
+            set.add(*markerEnd);
     }
 
     if (m_fillStrokeData) {
-        if (m_fillStrokeData->fill)
-            set.add(m_fillStrokeData->fill);
-        if (m_fillStrokeData->stroke)
-            set.add(m_fillStrokeData->stroke);
+        if (auto* fill = m_fillStrokeData->fill.get())
+            set.add(*fill);
+        if (auto* stroke = m_fillStrokeData->stroke.get())
+            set.add(*stroke);
     }
 }
 
@@ -707,32 +707,32 @@ void SVGResources::dump(const RenderObject* object)
 
     fprintf(stderr, "\n | List of resources:\n");
     if (m_clipperFilterMaskerData) {
-        if (RenderSVGResourceClipper* clipper = m_clipperFilterMaskerData->clipper)
+        if (auto* clipper = m_clipperFilterMaskerData->clipper.get())
             fprintf(stderr, " |-> Clipper    : %p (node=%p)\n", clipper, &clipper->clipPathElement());
-        if (RenderSVGResourceFilter* filter = m_clipperFilterMaskerData->filter)
+        if (auto* filter = m_clipperFilterMaskerData->filter.get())
             fprintf(stderr, " |-> Filter     : %p (node=%p)\n", filter, &filter->filterElement());
-        if (RenderSVGResourceMasker* masker = m_clipperFilterMaskerData->masker)
+        if (auto* masker = m_clipperFilterMaskerData->masker.get())
             fprintf(stderr, " |-> Masker     : %p (node=%p)\n", masker, &masker->maskElement());
     }
 
     if (m_markerData) {
-        if (RenderSVGResourceMarker* markerStart = m_markerData->markerStart)
+        if (auto* markerStart = m_markerData->markerStart.get())
             fprintf(stderr, " |-> MarkerStart: %p (node=%p)\n", markerStart, &markerStart->markerElement());
-        if (RenderSVGResourceMarker* markerMid = m_markerData->markerMid)
+        if (auto* markerMid = m_markerData->markerMid.get())
             fprintf(stderr, " |-> MarkerMid  : %p (node=%p)\n", markerMid, &markerMid->markerElement());
-        if (RenderSVGResourceMarker* markerEnd = m_markerData->markerEnd)
+        if (auto* markerEnd = m_markerData->markerEnd.get())
             fprintf(stderr, " |-> MarkerEnd  : %p (node=%p)\n", markerEnd, &markerEnd->markerElement());
     }
 
     if (m_fillStrokeData) {
-        if (RenderSVGResourceContainer* fill = m_fillStrokeData->fill)
+        if (auto* fill = m_fillStrokeData->fill.get())
             fprintf(stderr, " |-> Fill       : %p (node=%p)\n", fill, &fill->element());
-        if (RenderSVGResourceContainer* stroke = m_fillStrokeData->stroke)
+        if (auto* stroke = m_fillStrokeData->stroke.get())
             fprintf(stderr, " |-> Stroke     : %p (node=%p)\n", stroke, &stroke->element());
     }
 
     if (m_linkedResource)
-        fprintf(stderr, " |-> xlink:href : %p (node=%p)\n", m_linkedResource, &m_linkedResource->element());
+        fprintf(stderr, " |-> xlink:href : %p (node=%p)\n", m_linkedResource.get(), &m_linkedResource->element());
 }
 #endif
 

--- a/Source/WebCore/rendering/svg/SVGResources.h
+++ b/Source/WebCore/rendering/svg/SVGResources.h
@@ -19,10 +19,14 @@
 
 #pragma once
 
+#include "RenderSVGResourceClipper.h"
+#include "RenderSVGResourceFilter.h"
 #include "RenderSVGResourceMarker.h"
+#include "RenderSVGResourceMasker.h"
 #include <memory>
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -30,11 +34,7 @@ class Document;
 class RenderElement;
 class RenderObject;
 class RenderStyle;
-class RenderSVGResourceClipper;
 class RenderSVGResourceContainer;
-class RenderSVGResourceFilter;
-class RenderSVGResourceMarker;
-class RenderSVGResourceMasker;
 class LegacyRenderSVGRoot;
 class SVGRenderStyle;
 
@@ -48,22 +48,22 @@ public:
     void layoutDifferentRootIfNeeded(const LegacyRenderSVGRoot*);
 
     // Ordinary resources
-    RenderSVGResourceClipper* clipper() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->clipper : nullptr; }
-    RenderSVGResourceMarker* markerStart() const { return m_markerData ? m_markerData->markerStart : nullptr; }
-    RenderSVGResourceMarker* markerMid() const { return m_markerData ? m_markerData->markerMid : nullptr; }
-    RenderSVGResourceMarker* markerEnd() const { return m_markerData ? m_markerData->markerEnd : nullptr; }
+    RenderSVGResourceClipper* clipper() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->clipper.get() : nullptr; }
+    RenderSVGResourceMarker* markerStart() const { return m_markerData ? m_markerData->markerStart.get() : nullptr; }
+    RenderSVGResourceMarker* markerMid() const { return m_markerData ? m_markerData->markerMid.get() : nullptr; }
+    RenderSVGResourceMarker* markerEnd() const { return m_markerData ? m_markerData->markerEnd.get() : nullptr; }
     bool markerReverseStart() const;
-    RenderSVGResourceMasker* masker() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->masker : nullptr; }
-    RenderSVGResourceFilter* filter() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->filter : nullptr; }
+    RenderSVGResourceMasker* masker() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->masker.get() : nullptr; }
+    RenderSVGResourceFilter* filter() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->filter.get() : nullptr; }
 
     // Paint servers
-    RenderSVGResourceContainer* fill() const { return m_fillStrokeData ? m_fillStrokeData->fill : nullptr; }
-    RenderSVGResourceContainer* stroke() const { return m_fillStrokeData ? m_fillStrokeData->stroke : nullptr; }
+    RenderSVGResourceContainer* fill() const { return m_fillStrokeData ? m_fillStrokeData->fill.get() : nullptr; }
+    RenderSVGResourceContainer* stroke() const { return m_fillStrokeData ? m_fillStrokeData->stroke.get() : nullptr; }
 
     // Chainable resources - linked through xlink:href
-    RenderSVGResourceContainer* linkedResource() const { return m_linkedResource; }
+    RenderSVGResourceContainer* linkedResource() const { return m_linkedResource.get(); }
 
-    void buildSetOfResources(HashSet<RenderSVGResourceContainer*>&);
+    void buildSetOfResources(WeakHashSet<RenderSVGResourceContainer>&);
 
     // Methods operating on all cached resources
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) const;
@@ -110,9 +110,9 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         ClipperFilterMaskerData() = default;
-        RenderSVGResourceClipper* clipper { nullptr };
-        RenderSVGResourceFilter* filter { nullptr };
-        RenderSVGResourceMasker* masker { nullptr };
+        WeakPtr<RenderSVGResourceClipper> clipper;
+        WeakPtr<RenderSVGResourceFilter> filter;
+        WeakPtr<RenderSVGResourceMasker> masker;
     };
 
     // From SVG 1.1 2nd Edition
@@ -121,9 +121,9 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         MarkerData() = default;
-        RenderSVGResourceMarker* markerStart { nullptr };
-        RenderSVGResourceMarker* markerMid { nullptr };
-        RenderSVGResourceMarker* markerEnd { nullptr };
+        WeakPtr<RenderSVGResourceMarker> markerStart;
+        WeakPtr<RenderSVGResourceMarker> markerMid;
+        WeakPtr<RenderSVGResourceMarker> markerEnd;
     };
 
     // From SVG 1.1 2nd Edition
@@ -134,14 +134,14 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         FillStrokeData() = default;
-        RenderSVGResourceContainer* fill { nullptr };
-        RenderSVGResourceContainer* stroke { nullptr };
+        WeakPtr<RenderSVGResourceContainer> fill;
+        WeakPtr<RenderSVGResourceContainer> stroke;
     };
 
     std::unique_ptr<ClipperFilterMaskerData> m_clipperFilterMaskerData;
     std::unique_ptr<MarkerData> m_markerData;
     std::unique_ptr<FillStrokeData> m_fillStrokeData;
-    RenderSVGResourceContainer* m_linkedResource { nullptr };
+    WeakPtr<RenderSVGResourceContainer> m_linkedResource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -48,11 +48,11 @@ void SVGResourcesCache::addResourcesFromRenderer(RenderElement& renderer, const 
     solver.resolveCycles();
 
     // Walk resources and register the render object at each resources.
-    HashSet<RenderSVGResourceContainer*> resourceSet;
+    WeakHashSet<RenderSVGResourceContainer> resourceSet;
     resources.buildSetOfResources(resourceSet);
 
-    for (auto* resourceContainer : resourceSet)
-        resourceContainer->addClient(renderer);
+    for (auto& resourceContainer : resourceSet)
+        resourceContainer.addClient(renderer);
 }
 
 void SVGResourcesCache::removeResourcesFromRenderer(RenderElement& renderer)
@@ -62,11 +62,11 @@ void SVGResourcesCache::removeResourcesFromRenderer(RenderElement& renderer)
         return;
 
     // Walk resources and register the render object at each resources.
-    HashSet<RenderSVGResourceContainer*> resourceSet;
+    WeakHashSet<RenderSVGResourceContainer> resourceSet;
     resources->buildSetOfResources(resourceSet);
 
-    for (auto* resourceContainer : resourceSet)
-        resourceContainer->removeClient(renderer);
+    for (auto& resourceContainer : resourceSet)
+        resourceContainer.removeClient(renderer);
 }
 
 static inline SVGResourcesCache& resourcesCacheFromRenderer(const RenderElement& renderer)

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h
@@ -21,6 +21,7 @@
 
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ private:
 
     RenderElement& m_renderer;
     SVGResources& m_resources;
-    HashSet<RenderSVGResourceContainer*> m_allResources; 
+    WeakHashSet<RenderSVGResourceContainer> m_allResources; 
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 28504233c3512f3d3c163d4bf0ab5a59819317a6
<pre>
Use WeakPtr to store RenderSVGResourceContainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251077">https://bugs.webkit.org/show_bug.cgi?id=251077</a>

Reviewed by Chris Dumez.

Replaced the use of raw pointers to RenderSVGResourceContainer by WeakPtr.

* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::layout):
(WebCore::LegacyRenderSVGRoot::addResourceForClientInvalidation):
* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layoutChildren):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::removeClientFromCache const):
(WebCore::SVGResources::resourceDestroyed):
(WebCore::SVGResources::buildSetOfResources):
(WebCore::SVGResources::dump):
* Source/WebCore/rendering/svg/SVGResources.h:
(WebCore::SVGResources::clipper const):
(WebCore::SVGResources::markerStart const):
(WebCore::SVGResources::markerMid const):
(WebCore::SVGResources::markerEnd const):
(WebCore::SVGResources::masker const):
(WebCore::SVGResources::filter const):
(WebCore::SVGResources::fill const):
(WebCore::SVGResources::stroke const):
(WebCore::SVGResources::linkedResource const):
(): Deleted.
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::addResourcesFromRenderer):
(WebCore::SVGResourcesCache::removeResourcesFromRenderer):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles const):
(WebCore::SVGResourcesCycleSolver::resolveCycles):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h:

Canonical link: <a href="https://commits.webkit.org/259498@main">https://commits.webkit.org/259498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a31db95d25319582441106d20022eb0aec1529a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114241 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174426 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4980 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113258 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39254 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80919 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27726 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7490 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4310 "Found 2 new test failures: fast/forms/fieldset/fieldset-grid.html, imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47278 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9278 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3492 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->