### PR TITLE
Cocoa readPixels is slower in GPUP WebGL than in-process WebGL

### DIFF
--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -66,6 +66,12 @@ public:
 
     class Handle {
     public:
+        Handle() = default;
+        Handle(const Handle&) = default;
+        Handle(Handle&&) = default;
+        Handle& operator=(const Handle&) = default;
+        Handle& operator=(Handle&&) = default;
+
         bool isNull() const;
 
         size_t size() const { return m_size; }
@@ -80,6 +86,11 @@ public:
         static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, Handle&);
 #if USE(UNIX_DOMAIN_SOCKETS)
         UnixFileDescriptor releaseHandle();
+#endif
+
+#if PLATFORM(COCOA)
+        explicit Handle(MachSendRight&&, size_t);
+        static std::optional<Handle> create(void* data, size_t, Protection);
 #endif
 
     private:
@@ -132,10 +143,6 @@ public:
     Ref<WebCore::SharedBuffer> createSharedBuffer(size_t) const;
 
 private:
-#if OS(DARWIN)
-    WTF::MachSendRight createSendRight(Protection) const;
-#endif
-
     size_t m_size;
     void* m_data;
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -329,22 +329,27 @@ void RemoteGraphicsContextGLProxy::readnPixels(GCGLint x, GCGLint y, GCGLsizei w
 void RemoteGraphicsContextGLProxy::readnPixelsSharedMemory(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLSpan<GCGLvoid> data)
 {
     if (!isContextLost()) {
+        std::optional<SharedMemory::Handle> handle;
+#if PLATFORM(COCOA)
+        handle = SharedMemory::Handle::create(data.data(), data.size(), SharedMemory::Protection::ReadWrite);
+#else
         auto buffer = SharedMemory::allocate(data.size());
-        if (!buffer) {
-            markContextLost();
-            return;
+        if (buffer) {
+            handle = buffer->createHandle(SharedMemory::Protection::ReadWrite);
+            memcpy(buffer->data(), data.data(), data.size());
         }
-        auto handle = buffer->createHandle(SharedMemory::Protection::ReadWrite);
+#endif
         if (!handle || handle->isNull()) {
             markContextLost();
             return;
         }
-        memcpy(buffer->data(), data.data(), data.size());
         auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ReadnPixels2(x, y, width, height, format, type, WTFMove(*handle)));
         if (sendResult) {
+#if !PLATFORM(COCOA)
             auto [success] = sendResult.takeReply();
             if (success)
                 memcpy(data.data(), buffer->data(), data.size());
+#endif
         } else
             markContextLost();
     }


### PR DESCRIPTION
#### 4fbc3e1ca2be55ea9b489ca4ac612317d9c68369
<pre>
Cocoa readPixels is slower in GPUP WebGL than in-process WebGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=250899">https://bugs.webkit.org/show_bug.cgi?id=250899</a>
rdar://104475196

Reviewed by Matt Woodrow.

Avoid excessive memcpy&apos;ing during readPixels by using mach capability
to send virtual memory mappings between processes. Improves
use-cases that read large regions.

Add SharedMemory::Handle::create(void*, size, Protection) to create
a handle to the virtual memory region. This is the same as
SharedMemory::wrapMap(), except the wrapMap is confusing because
the intention is to not use SharedMemory, rather create the handle. The
wrapMap also creates a defunct SharedMemory instance (data() == nullptr).
Later commits will remove uses of wrapMap().

* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::toPointer):
(WebKit::toVMAddress):
(WebKit::machProtection):
(WebKit::makeMemoryEntry):
(WebKit::SharedMemory::Handle::Handle):
(WebKit::SharedMemory::Handle::create):
(WebKit::SharedMemory::Handle::decode):
(WebKit::SharedMemory::~SharedMemory):
(WebKit::SharedMemory::createHandle):
(WebKit::SharedMemory::createSendRight const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::readnPixelsSharedMemory):

Canonical link: <a href="https://commits.webkit.org/259550@main">https://commits.webkit.org/259550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774407567b0ee77d9a80ad75cd0ad38578a37f1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113793 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4520 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112752 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38921 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80591 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3917 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6574 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8865 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->