### PR TITLE
[@property] Container units are not computationally independent

### DIFF
--- a/LayoutTests/fast/css/custom-properties/at-property-cqi-crash-expected.txt
+++ b/LayoutTests/fast/css/custom-properties/at-property-cqi-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/custom-properties/at-property-cqi-crash.html
+++ b/LayoutTests/fast/css/custom-properties/at-property-cqi-crash.html
@@ -1,0 +1,16 @@
+
+<style>
+  @property --v {
+    syntax: '<length-percentage>';
+    inherits: false;
+    initial-value: calc(min(0px, 0cqi) * 0 + 1mm + 0%);
+  }
+  body {
+    width: var(--v);
+  }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+This test passes if it doesn't crash.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-computational-independence-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-computational-independence-expected.txt
@@ -1,20 +1,8 @@
 
-FAIL Container relative unit cqw is not computationally independent assert_throws_dom: function "() => {
-        CSS.registerProperty({ name: '--x', inherits: false, syntax: '<length>', initialValue: `1${unit}` });
-      }" did not throw
-FAIL Container relative unit cqh is not computationally independent assert_throws_dom: function "() => {
-        CSS.registerProperty({ name: '--x', inherits: false, syntax: '<length>', initialValue: `1${unit}` });
-      }" threw object "InvalidModificationError: This property has already been registered." that is not a DOMException SyntaxError: property "code" is equal to 13, expected 12
-FAIL Container relative unit cqi is not computationally independent assert_throws_dom: function "() => {
-        CSS.registerProperty({ name: '--x', inherits: false, syntax: '<length>', initialValue: `1${unit}` });
-      }" threw object "InvalidModificationError: This property has already been registered." that is not a DOMException SyntaxError: property "code" is equal to 13, expected 12
-FAIL Container relative unit cqb is not computationally independent assert_throws_dom: function "() => {
-        CSS.registerProperty({ name: '--x', inherits: false, syntax: '<length>', initialValue: `1${unit}` });
-      }" threw object "InvalidModificationError: This property has already been registered." that is not a DOMException SyntaxError: property "code" is equal to 13, expected 12
-FAIL Container relative unit cqmin is not computationally independent assert_throws_dom: function "() => {
-        CSS.registerProperty({ name: '--x', inherits: false, syntax: '<length>', initialValue: `1${unit}` });
-      }" threw object "InvalidModificationError: This property has already been registered." that is not a DOMException SyntaxError: property "code" is equal to 13, expected 12
-FAIL Container relative unit cqmax is not computationally independent assert_throws_dom: function "() => {
-        CSS.registerProperty({ name: '--x', inherits: false, syntax: '<length>', initialValue: `1${unit}` });
-      }" threw object "InvalidModificationError: This property has already been registered." that is not a DOMException SyntaxError: property "code" is equal to 13, expected 12
+PASS Container relative unit cqw is not computationally independent
+PASS Container relative unit cqh is not computationally independent
+PASS Container relative unit cqi is not computationally independent
+PASS Container relative unit cqb is not computationally independent
+PASS Container relative unit cqmin is not computationally independent
+PASS Container relative unit cqmax is not computationally independent
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1690,10 +1690,85 @@ void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependenci
         dependencies.properties.appendIfNotContains(CSSPropertyFontSize);
         dependencies.properties.appendIfNotContains(CSSPropertyLineHeight);
         break;
+    case CSSUnitType::CSS_CQW:
+    case CSSUnitType::CSS_CQH:
+    case CSSUnitType::CSS_CQI:
+    case CSSUnitType::CSS_CQB:
+    case CSSUnitType::CSS_CQMIN:
+    case CSSUnitType::CSS_CQMAX:
+        dependencies.containerDimensions = true;
+        break;
     case CSSUnitType::CSS_CALC:
         m_value.calc->collectComputedStyleDependencies(dependencies);
         break;
-    default:
+    case CSSUnitType::CSS_NUMBER:
+    case CSSUnitType::CSS_INTEGER:
+    case CSSUnitType::CSS_PERCENTAGE:
+    case CSSUnitType::CSS_PX:
+    case CSSUnitType::CSS_CM:
+    case CSSUnitType::CSS_MM:
+    case CSSUnitType::CSS_IN:
+    case CSSUnitType::CSS_PT:
+    case CSSUnitType::CSS_PC:
+    case CSSUnitType::CSS_DEG:
+    case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_GRAD:
+    case CSSUnitType::CSS_TURN:
+    case CSSUnitType::CSS_MS:
+    case CSSUnitType::CSS_S:
+    case CSSUnitType::CSS_HZ:
+    case CSSUnitType::CSS_KHZ:
+    case CSSUnitType::CSS_DIMENSION:
+    case CSSUnitType::CSS_VW:
+    case CSSUnitType::CSS_VH:
+    case CSSUnitType::CSS_VMIN:
+    case CSSUnitType::CSS_VMAX:
+    case CSSUnitType::CSS_VB:
+    case CSSUnitType::CSS_VI:
+    case CSSUnitType::CSS_SVW:
+    case CSSUnitType::CSS_SVH:
+    case CSSUnitType::CSS_SVMIN:
+    case CSSUnitType::CSS_SVMAX:
+    case CSSUnitType::CSS_SVB:
+    case CSSUnitType::CSS_SVI:
+    case CSSUnitType::CSS_LVW:
+    case CSSUnitType::CSS_LVH:
+    case CSSUnitType::CSS_LVMIN:
+    case CSSUnitType::CSS_LVMAX:
+    case CSSUnitType::CSS_LVB:
+    case CSSUnitType::CSS_LVI:
+    case CSSUnitType::CSS_DVW:
+    case CSSUnitType::CSS_DVH:
+    case CSSUnitType::CSS_DVMIN:
+    case CSSUnitType::CSS_DVMAX:
+    case CSSUnitType::CSS_DVB:
+    case CSSUnitType::CSS_DVI:
+    case CSSUnitType::CSS_DPPX:
+    case CSSUnitType::CSS_X:
+    case CSSUnitType::CSS_DPI:
+    case CSSUnitType::CSS_DPCM:
+    case CSSUnitType::CSS_FR:
+    case CSSUnitType::CSS_Q:
+    case CSSUnitType::CSS_UNKNOWN:
+    case CSSUnitType::CSS_STRING:
+    case CSSUnitType::CSS_FONT_FAMILY:
+    case CSSUnitType::CSS_URI:
+    case CSSUnitType::CSS_IDENT:
+    case CSSUnitType::CustomIdent:
+    case CSSUnitType::CSS_ATTR:
+    case CSSUnitType::CSS_COUNTER:
+    case CSSUnitType::CSS_RECT:
+    case CSSUnitType::CSS_RGBCOLOR:
+    case CSSUnitType::CSS_PAIR:
+    case CSSUnitType::CSS_UNICODE_RANGE:
+    case CSSUnitType::CSS_COUNTER_NAME:
+    case CSSUnitType::CSS_SHAPE:
+    case CSSUnitType::CSS_QUAD:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_NUMBER:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
+    case CSSUnitType::CSS_UNRESOLVED_COLOR:
+    case CSSUnitType::CSS_PROPERTY_ID:
+    case CSSUnitType::CSS_VALUE_ID:
         break;
     }
 }

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -37,8 +37,9 @@ enum CSSPropertyID : uint16_t;
 struct ComputedStyleDependencies {
     Vector<CSSPropertyID> properties;
     Vector<CSSPropertyID> rootProperties;
+    bool containerDimensions { false };
 
-    bool isEmpty() const { return properties.isEmpty() && rootProperties.isEmpty(); }
+    bool isEmpty() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions; }
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);


### PR DESCRIPTION
#### 1dc6982298becf494b1554dec68a850533aa7d6b
<pre>
[@property] Container units are not computationally independent
<a href="https://bugs.webkit.org/show_bug.cgi?id=251084">https://bugs.webkit.org/show_bug.cgi?id=251084</a>
rdar://104550943

Reviewed by Alan Baradlay.

They depend on container dimensions and so should not be allowed in initial-value descriptors.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-computational-independence-expected.txt:
* LayoutTests/fast/css/custom-properties/at-property-cqi-crash-expected.txt: Added.
* LayoutTests/fast/css/custom-properties/at-property-cqi-crash.html: Added.
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const):

Set a bit indicating there are container dimension dependencies.

* Source/WebCore/css/CSSValue.h:
(WebCore::ComputedStyleDependencies::isEmpty const):

Canonical link: <a href="https://commits.webkit.org/259298@main">https://commits.webkit.org/259298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e03f838c3f79a88afeef911343bdf462058a71d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113847 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4574 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96906 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110334 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94431 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/38967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108047 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93248 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80631 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7004 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92459 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4784 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30045 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103407 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46957 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101145 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6409 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8911 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->