### PR TITLE
[GLib] WebKitWebHitTestResult should use composition instead of subclassing

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitHitTestResult.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitHitTestResult.cpp
@@ -74,7 +74,7 @@ struct _WebKitHitTestResultPrivate {
     CString mediaURI;
 };
 
-WEBKIT_DEFINE_TYPE(WebKitHitTestResult, webkit_hit_test_result, G_TYPE_OBJECT)
+WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitHitTestResult, webkit_hit_test_result, G_TYPE_OBJECT)
 
 static void webkitHitTestResultGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
@@ -66,9 +66,21 @@ enum {
 
 struct _WebKitWebHitTestResultPrivate {
     WeakPtr<Node, WeakPtrImplWithEventTargetData> node;
+
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitHitTestResult> hitTestResult;
+#endif // ENABLE(2022_GLIB_API)
 };
 
+#if ENABLE(2022_GLIB_API)
+struct _WebKitWebHitTestResultClass {
+    GObjectClass parent;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WebKitWebHitTestResult, webkit_web_hit_test_result, G_TYPE_OBJECT)
+#else
 WEBKIT_DEFINE_TYPE(WebKitWebHitTestResult, webkit_web_hit_test_result, WEBKIT_TYPE_HIT_TEST_RESULT)
+#endif
 
 #if !ENABLE(2022_GLIB_API)
 static void webkitWebHitTestResultGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
@@ -153,24 +165,223 @@ WebKitWebHitTestResult* webkitWebHitTestResultCreate(const HitTestResult& hitTes
     String linkTitle = hitTestResult.titleDisplayString();
     String linkLabel = hitTestResult.textContent();
 
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitHitTestResult> webkitHitTestResult = adoptGRef(WEBKIT_HIT_TEST_RESULT(g_object_new(WEBKIT_TYPE_HIT_TEST_RESULT,
+#else
     auto* result = WEBKIT_WEB_HIT_TEST_RESULT(g_object_new(WEBKIT_TYPE_WEB_HIT_TEST_RESULT,
+#endif
         "context", context,
         "link-uri", context & WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK ? absoluteLinkURL.utf8().data() : nullptr,
         "image-uri", context & WEBKIT_HIT_TEST_RESULT_CONTEXT_IMAGE ? absoluteImageURL.utf8().data() : nullptr,
         "media-uri", context & WEBKIT_HIT_TEST_RESULT_CONTEXT_MEDIA ? absoluteMediaURL.utf8().data() : nullptr,
         "link-title", !linkTitle.isEmpty() ? linkTitle.utf8().data() : nullptr,
         "link-label", !linkLabel.isEmpty() ? linkLabel.utf8().data() : nullptr,
-#if !ENABLE(2022_GLIB_API)
-        "node", kit(hitTestResult.innerNonSharedNode()),
-#endif
-        nullptr));
 #if ENABLE(2022_GLIB_API)
+        nullptr)));
+#else
+        "node", kit(hitTestResult.innerNonSharedNode()),
+        nullptr));
+#endif
+
+#if ENABLE(2022_GLIB_API)
+    auto* result = WEBKIT_WEB_HIT_TEST_RESULT(g_object_new(WEBKIT_TYPE_WEB_HIT_TEST_RESULT, nullptr));
+    result->priv->hitTestResult = WTFMove(webkitHitTestResult);
     result->priv->node = hitTestResult.innerNonSharedNode();
 #endif
     return result;
 }
 
-#if !ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
+
+/**
+ * webkit_web_hit_test_result_get_context:
+ * @web_hit_test_result: a #WebKitWebHitTestResult
+ *
+ * Gets the the context flags for the hit test result.
+ *
+ * Returns: a bitmask of #WebKitHitTestResultContext flags
+ */
+guint webkit_web_hit_test_result_get_context(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), 0);
+    return webkit_hit_test_result_get_context(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_context_is_link:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Check whether there is a link element at the hit test position.
+ *
+ * Checks whether %WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK flag is present in
+ * the context flags.
+ *
+ * Returns: %TRUE if the hit test covers a link element or %FALSE otherwise.
+ */
+gboolean webkit_web_hit_test_result_context_is_link(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), FALSE);
+    return webkit_hit_test_result_context_is_link(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_context_is_image:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Check whether there is an image element at the hit test position.
+ *
+ * Checks whether %WEBKIT_HIT_TEST_RESULT_CONTEXT_IMAGE flag is present in
+ * the context flags.
+ *
+ * Returns: %TRUE if the hit test covers an image element or %FALSE otherwise.
+ */
+gboolean webkit_web_hit_test_result_context_is_image(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), FALSE);
+    return webkit_hit_test_result_context_is_image(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_context_is_media:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Check whether there is a media element at the hit test position.
+ *
+ * Checks whether %WEBKIT_HIT_TEST_RESULT_CONTEXT_MEDIA flag is present in
+ * the context flags.
+ *
+ * Returns: %TRUE if the hit test covers a media element or %FALSE otherwise.
+ */
+gboolean webkit_web_hit_test_result_context_is_media(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), FALSE);
+    return webkit_hit_test_result_context_is_media(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_context_is_editable:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Check whether there is an editable element at the hit test position.
+ *
+ * Checks whether %WEBKIT_HIT_TEST_RESULT_CONTEXT_EDITABLE flag is present in
+ * the context flags.
+ *
+ * Returns: %TRUE if the hit test covers an editable element or %FALSE otherwise.
+ */
+gboolean webkit_web_hit_test_result_context_is_editable(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), FALSE);
+    return webkit_hit_test_result_context_is_editable(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_context_is_selection:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Check whether there is a selected element at the hit test position.
+ *
+ * Checks whether %WEBKIT_HIT_TEST_RESULT_CONTEXT_SELECTION flag is present in
+ * the context flags.
+ *
+ * Returns: %TRUE if the hit test covers a selected element or %FALSE otherwise.
+ */
+gboolean webkit_web_hit_test_result_context_is_selection(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), FALSE);
+    return webkit_hit_test_result_context_is_selection(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_get_link_uri:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Obtains the URI associated with the link element at the hit test position.
+ *
+ * Returns: the URI of the link element, or %NULL if the hit test does not cover a link element.
+ */
+const gchar* webkit_web_hit_test_result_get_link_uri(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
+    return webkit_hit_test_result_get_link_uri(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_get_link_title:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Obtains the title associated with the link element at the hit test position.
+ *
+ * Returns: the title of the link element, or %NULL if the hit test does not cover a link element
+ *    or the link element does not have a title.
+ */
+const gchar* webkit_web_hit_test_result_get_link_title(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
+    return webkit_hit_test_result_get_link_title(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_get_link_label:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Obtains the label associated with the link element at the hit test position.
+ *
+ * Returns: the label of the link element, or %NULL if the hit test does not cover a link element
+ *    or the link element does not have a label.
+ */
+const gchar* webkit_web_hit_test_result_get_link_label(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
+    return webkit_hit_test_result_get_link_label(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_get_image_uri:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Obtains the URI associated with the image element at the hit test position.
+ *
+ * Returns: the URI of the image element, or %NULL if the hit test does not cover an image element.
+ */
+const gchar* webkit_web_hit_test_result_get_image_uri(WebKitWebHitTestResult *webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
+    return webkit_hit_test_result_get_image_uri(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_get_media_uri:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Obtains the URI associated with the media element at the hit test position.
+ *
+ * Returns: the URI of the media element, or %NULL if the hit test does not cover a media element.
+ */
+const gchar* webkit_web_hit_test_result_get_media_uri(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
+    return webkit_hit_test_result_get_media_uri(webHitTestResult->priv->hitTestResult.get());
+}
+
+/**
+ * webkit_web_hit_test_result_context_is_scrollbar:
+ * @web_hit_test_result: a #WebWebKitHitTestResult
+ *
+ * Check whether there is a scrollbar at the hit test position.
+ *
+ * Checks whether %WEBKIT_HIT_TEST_RESULT_CONTEXT_SCROLLBAR flag is present in
+ * the context flags.
+ *
+ * Returns: %TRUE if the hit test covers a scrollbar or %FALSE otherwise.
+ */
+gboolean webkit_web_hit_test_result_context_is_scrollbar(WebKitWebHitTestResult* webHitTestResult)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), FALSE);
+    return webkit_hit_test_result_context_is_scrollbar(webHitTestResult->priv->hitTestResult.get());
+}
+
+#else
 /**
  * webkit_web_hit_test_result_get_node:
  * @hit_test_result: a #WebKitWebHitTestResult
@@ -189,11 +400,11 @@ WebKitDOMNode* webkit_web_hit_test_result_get_node(WebKitWebHitTestResult* webHi
 
     return kit(webHitTestResult->priv->node.get());
 }
-#endif
+#endif // ENABLE(2022_GLIB_API)
 
 /**
  * webkit_web_hit_test_result_get_js_node:
- * @hit_test_result: a #WebKitWebHitTestResult
+ * @web_hit_test_result: a #WebKitWebHitTestResult
  * @world: (nullable): a #WebKitScriptWorld, or %NULL to use the default
  *
  * Get the #JSCValue for the DOM node in @world at the coordinates of the Hit Test.

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
@@ -50,11 +50,16 @@ typedef struct _WebKitWebHitTestResultClass   WebKitWebHitTestResultClass;
 typedef struct _WebKitWebHitTestResultPrivate WebKitWebHitTestResultPrivate;
 
 struct _WebKitWebHitTestResult {
+#if ENABLE(2022_GLIB_API)
+    GObject parent;
+#else
     WebKitHitTestResult parent;
+#endif
 
     WebKitWebHitTestResultPrivate *priv;
 };
 
+#if !ENABLE(2022_GLIB_API)
 struct _WebKitWebHitTestResultClass {
     WebKitHitTestResultClass parent_class;
 
@@ -63,18 +68,59 @@ struct _WebKitWebHitTestResultClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
 };
+#endif // !ENABLE(2022_GLIB_API)
 
 WEBKIT_API GType
-webkit_web_hit_test_result_get_type    (void);
+webkit_web_hit_test_result_get_type             (void);
 
-#if !ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
+
+WEBKIT_API guint
+webkit_web_hit_test_result_get_context          (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API gboolean
+webkit_web_hit_test_result_context_is_link      (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API gboolean
+webkit_web_hit_test_result_context_is_image     (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API gboolean
+webkit_web_hit_test_result_context_is_media     (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API gboolean
+webkit_web_hit_test_result_context_is_editable  (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API gboolean
+webkit_web_hit_test_result_context_is_selection (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API const gchar *
+webkit_web_hit_test_result_get_link_uri         (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API const gchar *
+webkit_web_hit_test_result_get_link_title       (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API const gchar *
+webkit_web_hit_test_result_get_link_label       (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API const gchar *
+webkit_web_hit_test_result_get_image_uri        (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API const gchar *
+webkit_web_hit_test_result_get_media_uri        (WebKitWebHitTestResult *web_hit_test_result);
+
+WEBKIT_API gboolean
+webkit_web_hit_test_result_context_is_scrollbar (WebKitWebHitTestResult *web_hit_test_result);
+
+#else
+
 WEBKIT_DEPRECATED_FOR(webkit_web_hit_test_result_get_js_node) WebKitDOMNode *
-webkit_web_hit_test_result_get_node    (WebKitWebHitTestResult *hit_test_result);
-#endif
+webkit_web_hit_test_result_get_node             (WebKitWebHitTestResult *hit_test_result);
+
+#endif // ENABLE(2022_GLIB_API)
 
 WEBKIT_API JSCValue *
-webkit_web_hit_test_result_get_js_node (WebKitWebHitTestResult *hit_test_result,
-                                        WebKitScriptWorld      *world);
+webkit_web_hit_test_result_get_js_node          (WebKitWebHitTestResult *web_hit_test_result,
+                                                 WebKitScriptWorld      *world);
 
 G_END_DECLS
 

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -67,6 +67,19 @@ accordingly.
 may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] and
 [ctor@WebKit.WebView.new_with_related_view] both remain.
 
+## Most types are final
+
+Only two types are now derivable:
+
+- [type@WebView] has been often subclassed to customize its behaviour for an
+  specific application. This possibility has been kept, as it has proved
+  useful in the past.
+- [type@InputMethodContext] is specifically designed in a way that subclassing
+  is required to make use of it.
+
+The rest of the types are no longer derivable; they are defined with the
+`G_TYPE_FLAG_FINAL` flag set. Use composition instead of derivation.
+
 ## Network session API
 
 WebKit now uses a single global network process for all web contexts, and different


### PR DESCRIPTION
#### 71df87cb0f482d857f21d1d93d13d097b14eaa42
<pre>
[GLib] WebKitWebHitTestResult should use composition instead of subclassing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251075">https://bugs.webkit.org/show_bug.cgi?id=251075</a>

Reviewed by Michael Catanzaro.

Make WebKitWebHitTestResult a final type that inherits directly from
GObject with the new 2022 GLib API, which uses a WebKitHitTestResult
instance internally. The methods which were previously inherited from
the base class are added, with their implementations forwarding to the
corresponding WebKitHitTestResult ones. While at it, WebKitHitTestResult
can now be made final and the _WebKitWebHitTestResultClass struct can be
removed from the public header.

* Source/WebKit/Shared/API/glib/WebKitHitTestResult.cpp: Make the type
  final with in new 2022 API.
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp:
(webkitWebHitTestResultCreate): Arrange to instantiate the contained
WebKitHitTestResult with the new API.
(webkit_web_hit_test_result_get_context): Added, forwards its
implementation to the corresponding WebKitHitTestResult method.
(webkit_web_hit_test_result_context_is_link): Ditto.
(webkit_web_hit_test_result_context_is_image): Ditto.
(webkit_web_hit_test_result_context_is_media): Ditto.
(webkit_web_hit_test_result_context_is_editable): Ditto.
(webkit_web_hit_test_result_context_is_selection): Ditto.
(webkit_web_hit_test_result_get_link_uri): Ditto.
(webkit_web_hit_test_result_get_link_title): Ditto.
(webkit_web_hit_test_result_get_link_label): Ditto.
(webkit_web_hit_test_result_get_image_uri): Ditto.
(webkit_web_hit_test_result_get_media_uri): Ditto.
(webkit_web_hit_test_result_context_is_scrollbar): Ditto.
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in:
  Add methods for the new 2022 API which cover the functionality which
  was previously inherited from WebKitHitTestResult.
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md: Added migration note.

Canonical link: <a href="https://commits.webkit.org/259651@main">https://commits.webkit.org/259651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0093df5437ef741accdf46ec2a114beb757f6adb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105556 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16065 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111311 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7931 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14055 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6662 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->