### PR TITLE
Cherry-pick 252432.806@safari-7614-branch (a09205d980f6). rdar://104599817

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if it doesn't crash.
+
+
+

--- a/LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash.html
+++ b/LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash.html
@@ -1,0 +1,32 @@
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+onload = () => {
+    inputElement.setRangeText("foo");
+}
+
+function inputFocusHandler()
+{
+    datalistElement.id = "foo";
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+function selectBlurHandler()
+{
+    tableElement.cloneNode(true);
+}
+</script>
+<body>
+<p>This test passes if it doesn't crash.</p>
+<table id="tableElement" background="foo">
+<form id="formElement">
+<input id="inputElement" list="formElement" onfocus="inputFocusHandler()">
+<select onblur="selectBlurHandler()" autofocus="autofocus">
+<keygen>
+<datalist id="datalistElement">foo</datalist>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2037,7 +2037,10 @@ ListAttributeTargetObserver::ListAttributeTargetObserver(const AtomString& id, H
 
 void ListAttributeTargetObserver::idTargetChanged()
 {
-    m_element->dataListMayHaveChanged();
+    m_element->document().eventLoop().queueTask(TaskSource::DOMManipulation, [element = m_element] {
+        if (element)
+            element->dataListMayHaveChanged();
+    });
 }
 #endif
 


### PR DESCRIPTION
#### 589e3edb7b1c0d3f8d78d399fadd9a54d9c062d4
<pre>
Cherry-pick 252432.806@safari-7614-branch (a09205d980f6). rdar://104599817

    Assertion hit under IdTargetObserverRegistry::notifyObservers()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=247592">https://bugs.webkit.org/show_bug.cgi?id=247592</a>
    rdar://101454107

    Reviewed by Aditya Keerthi, Wenson Hsieh and Geoffrey Garen.

    ListAttributeTargetObserver::idTargetChanged() is not safe to re-enter. As a result,
    we have an assertion and a runtime check to protect against this. However, it was
    still possible to hit this assertion in debug.

    ListAttributeTargetObserver::idTargetChanged() would call
    TextFieldInputType::dataListMayHaveChanged() which could run script by calling
    createDataListDropdownIndicator(). The script could then change the datalist
    element&apos;s id, which would attempt to re-enter.

    This patch addresses the issue by calling dataListMayHaveChanged() asynchronously.

    * LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash-expected.txt: Added.
    * LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash.html: Added.
    * Source/WebCore/html/HTMLInputElement.cpp:
    (WebCore::ListAttributeTargetObserver::idTargetChanged):

    Canonical link: <a href="https://commits.webkit.org/252432.806@safari-7614-branch">https://commits.webkit.org/252432.806@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259290@main">https://commits.webkit.org/259290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7f03ac60c642edc2e2b52fb46020447a327d687

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113815 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174051 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4552 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112777 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110307 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38948 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80615 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6405 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8884 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->