### PR TITLE
Cherry-pick 252432.808@safari-7614-branch (b6d2a12d8d70). rdar://104600105

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -106,7 +106,7 @@
 @end
 
 @interface WKMenuTarget : NSObject {
-    WebKit::WebContextMenuProxyMac* _menuProxy;
+    WeakPtr<WebKit::WebContextMenuProxyMac> _menuProxy;
 }
 + (WKMenuTarget *)sharedMenuTarget;
 - (WebKit::WebContextMenuProxyMac*)menuProxy;
@@ -124,7 +124,7 @@
 
 - (WebKit::WebContextMenuProxyMac*)menuProxy
 {
-    return _menuProxy;
+    return _menuProxy.get();
 }
 
 - (void)setMenuProxy:(WebKit::WebContextMenuProxyMac*)menuProxy
@@ -134,6 +134,9 @@
 
 - (void)forwardContextMenuAction:(id)sender
 {
+    if (!_menuProxy)
+        return;
+
     id representedObject = [sender representedObject];
 
     // NSMenuItems with a represented selection handler belong solely to the UI process
@@ -156,9 +159,9 @@
 @end
 
 @interface WKMenuDelegate : NSObject <NSMenuDelegate> {
-    WebKit::WebContextMenuProxyMac* _menuProxy;
+    WeakPtr<WebKit::WebContextMenuProxyMac> _menuProxy;
 }
--(instancetype)initWithMenuProxy:(WebKit::WebContextMenuProxyMac&)menuProxy;
+- (instancetype)initWithMenuProxy:(WebKit::WebContextMenuProxyMac&)menuProxy;
 @end
 
 @implementation WKMenuDelegate


### PR DESCRIPTION
#### 6bac3a2a1f025e5073f2fe314405c1938775d2a1
<pre>
Cherry-pick 252432.808@safari-7614-branch (b6d2a12d8d70). rdar://104600105

    [macOS] WebContextMenuProxy use-after-free when triggering context menu presentation using IPC
    <a href="https://bugs.webkit.org/show_bug.cgi?id=247590">https://bugs.webkit.org/show_bug.cgi?id=247590</a>
    rdar://102049265

    Reviewed by Aditya Keerthi.

    Replace these raw pointers with `WeakPtr` to avoid accessing invalid memory, in the case where a
    compromised web process triggers context menu presentation on macOS by sending an out-of-band
    `WebPageProxy::ShowContextMenu` IPC message.

    * Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
    (-[WKMenuTarget menuProxy]):
    (-[WKMenuTarget forwardContextMenuAction:]):

    Canonical link: <a href="https://commits.webkit.org/252432.808@safari-7614-branch">https://commits.webkit.org/252432.808@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259293@main">https://commits.webkit.org/259293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7bddfe533b9155e62c42075d192a85cc7048d06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113821 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4548 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112783 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110313 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38950 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6985 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27389 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3962 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6410 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8890 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->