### PR TITLE
Cherry-pick 252432.816@safari-7614-branch (fa17c4664715). rdar://104600217

### DIFF
--- a/LayoutTests/editing/selection/modify-extend-iframe-orphan-expected.txt
+++ b/LayoutTests/editing/selection/modify-extend-iframe-orphan-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not hit any assertions.
+PASS

--- a/LayoutTests/editing/selection/modify-extend-iframe-orphan.html
+++ b/LayoutTests/editing/selection/modify-extend-iframe-orphan.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest() {
+    const selection = document.getSelection();
+    selection.selectAllChildren(span);
+    selection.selectAllChildren(input);
+    selection.modify("extend", "forward", "documentboundary");
+    document.execCommand("insertUnorderedList", false, null);
+    setTimeout(() => {
+        document.body.innerHTML = 'This test passes if WebKit does not hit any assertions.<br>PASS';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+function focusOut() {
+    document.getSelection().selectAllChildren(span);
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.contentDocument.body.appendChild(spanContainer);
+}
+
+function deleteAndShowModal() {
+    document.execCommand("delete", false, null);
+    dialog.showModal();
+}
+
+</script>
+<body onload="runTest()">
+<dialog id="dialog" contenteditable="true"></dialog>
+<div id="spanContainer" contenteditable="true" onblur="deleteAndShowModal()">A<span id="span"></span></div>
+<div onfocusout="focusOut()" contenteditable="true"><iframe></iframe><input id="input"></div>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -749,6 +749,14 @@ TextDirection FrameSelection::directionOfSelection()
     return directionOfEnclosingBlock();
 }
 
+static bool selectionIsOrphanedOrBelongsToWrongDocument(const VisibleSelection& selection, RefPtr<Document>&& document)
+{
+    if (selection.isOrphan())
+        return true;
+    RefPtr documentOfSelection = selection.document();
+    return document && documentOfSelection && document != documentOfSelection;
+}
+
 void FrameSelection::willBeModified(EAlteration alter, SelectionDirection direction)
 {
     if (alter != AlterationExtend)
@@ -796,6 +804,8 @@ void FrameSelection::willBeModified(EAlteration alter, SelectionDirection direct
         m_selection.setBase(end);
         m_selection.setExtent(start);
     }
+    if (selectionIsOrphanedOrBelongsToWrongDocument(m_selection, m_document.get()))
+        clear();
 }
 
 VisiblePosition FrameSelection::positionForPlatform(bool isGetStart) const


### PR DESCRIPTION
#### d85daec3645fee77f09a0f3e59928f1e1b9aa287
<pre>
Cherry-pick 252432.816@safari-7614-branch (fa17c4664715). rdar://104600217

    ASSERTION FAILED: !document().selection().selection().isOrphan() in ContainerNode::removeNodeWithScriptAssertion
    <a href="https://bugs.webkit.org/show_bug.cgi?id=247781">https://bugs.webkit.org/show_bug.cgi?id=247781</a>
    rdar://101497964

    Reviewed by Wenson Hsieh, Darin Adler and Geoffrey Garen.

    The bug was caused by VisibleSelection::setBase setting selection ends to point to nodes
    in a wrong document as a side effect of calling VisibleSelection::validate when m_anchor
    isn&apos;t cleared due to a node removal when live range selection is disabled.

    * LayoutTests/editing/selection/modify-extend-iframe-orphan-expected.txt: Added.
    * LayoutTests/editing/selection/modify-extend-iframe-orphan.html: Added.
    * Source/WebCore/editing/FrameSelection.cpp:
    (WebCore::selectionIsOrphanedOrBelongsToWrongDocument):
    (WebCore::FrameSelection::willBeModified):

    Canonical link: <a href="https://commits.webkit.org/252432.816@safari-7614-branch">https://commits.webkit.org/252432.816@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259294@main">https://commits.webkit.org/259294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b95e9631e524f37cbb60989c0da8c31b0fddf50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113822 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174055 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4549 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112784 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38953 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80617 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27386 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8891 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->