### PR TITLE
REGRESSION: File input button layout looks bad at various zoom levels

### DIFF
--- a/LayoutTests/accessibility/node-only-object-element-rect-expected.txt
+++ b/LayoutTests/accessibility/node-only-object-element-rect-expected.txt
@@ -1,7 +1,7 @@
 This test ensures we calculate the frame correctly for objects that don't have a renderer (like display: contents elements).
 
 #toolbar: {width: 784, height: 18}
-#group: {width: 46, height: 28}
+#group: {width: 48, height: 27}
 #button: {width: 784, height: 10}
 
 PASS successfullyParsed is true

--- a/LayoutTests/platform/mac/compositing/contents-opaque/control-layer-expected.txt
+++ b/LayoutTests/platform/mac/compositing/contents-opaque/control-layer-expected.txt
@@ -8,10 +8,10 @@
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (offsetFromRenderer width=-5 height=-4)
-          (position 3.00 4.00)
-          (anchor 0.51 0.46)
-          (bounds 126.00 28.00)
+          (offsetFromRenderer width=-6 height=-4)
+          (position 2.00 4.00)
+          (anchor 0.51 0.48)
+          (bounds 128.00 27.00)
           (drawsContent 1)
         )
       )

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -49,9 +49,9 @@ IntSize ButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) cons
 {
     // Buttons really only constrain height. They respect width.
     static const IntSize cellSizes[] = {
-        { 0, 21 },
-        { 0, 18 },
-        { 0, 15 },
+        { 0, 20 },
+        { 0, 16 },
+        { 0, 13 },
         { 0, 28 }
     };
     return cellSizes[controlSize];
@@ -59,15 +59,14 @@ IntSize ButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) cons
 
 IntOutsets ButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
 {
-    // FIXME: These values may need to be reevaluated. They appear to have been originally chosen
-    // to reflect the size of shadows around native form controls on macOS, but as of macOS 10.15,
-    // these margins extend well past the boundaries of a native button cell's shadows.
+    // FIXME: Determine these values programmatically.
+    // https://bugs.webkit.org/show_bug.cgi?id=251066
     static const IntOutsets cellOutsets[] = {
         // top right bottom left
+        { 5, 7, 7, 7 },
         { 4, 6, 7, 6 },
-        { 4, 5, 6, 5 },
-        { 0, 1, 1, 1 },
-        { 4, 6, 7, 6 },
+        { 1, 2, 2, 2 },
+        { 6, 6, 6, 6 },
     };
     return cellOutsets[controlSize];
 }
@@ -98,17 +97,18 @@ FloatRect ButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& 
         return bounds;
 
     auto controlSize = [m_buttonCell controlSize];
-    auto size = cellSize(controlSize, style);
-    auto outsets = cellOutsets(controlSize, style);
 
+    // Explicitly use `FloatSize` to support non-integral sizes following zoom.
+    FloatSize size = cellSize(controlSize, style);
     size.scale(style.zoomFactor);
     size.setWidth(bounds.width());
 
     auto rect = bounds;
     auto delta = rect.height() - size.height();
     if (delta > 0)
-        rect.expand(0, delta / 2);
+        rect.inflateY(-delta / 2);
 
+    auto outsets = cellOutsets(controlSize, style);
     return inflatedRect(rect, size, outsets, style);
 }
 

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -412,7 +412,7 @@ static bool drawCellFocusRing(NSCell *cell, NSRect cellFrame, NSView *controlVie
 // Buttons really only constrain height. They respect width.
 static const std::array<IntSize, 4>& buttonSizes()
 {
-    static const std::array<IntSize, 4> sizes = { { IntSize(0, 21), IntSize(0, 18), IntSize(0, 15), IntSize(0, 28) } };
+    static const std::array<IntSize, 4> sizes = { { IntSize(0, 20), IntSize(0, 16), IntSize(0, 13), IntSize(0, 28) } };
     return sizes;
 }
 
@@ -423,10 +423,10 @@ static const int* buttonMargins(NSControlSize controlSize)
     // these margins extend well past the boundaries of a native button cell's shadows.
     static const int margins[4][4] =
     {
+        { 5, 7, 7, 7 },
         { 4, 6, 7, 6 },
-        { 4, 5, 6, 5 },
-        { 0, 1, 1, 1 },
-        { 4, 6, 7, 6 },
+        { 1, 2, 2, 2 },
+        { 6, 6, 6, 6 },
     };
     return margins[controlSize];
 }


### PR DESCRIPTION
#### 3d8bc4adc4366c9b57b2aa50e2c62c3056b9c2a5
<pre>
REGRESSION: File input button layout looks bad at various zoom levels
<a href="https://bugs.webkit.org/show_bug.cgi?id=251065">https://bugs.webkit.org/show_bug.cgi?id=251065</a>
rdar://104197684

Reviewed by Tim Nguyen.

On macOS, at different zoom levels, the “Choose File” text in the file input
button is poorly aligned relative to the button outline.

This bug is the consequence of three distinct changes, each of which are
described below. However, in order to understand the individual causes, a
baseline understanding of form control rendering on macOS must be established.

Form controls on macOS are painted by drawing `NSCell`s vended from AppKit.
This approach is essential in ensuring that WebKit form controls have a native
look and feel. A major limitation of AppKit controls is that they are almost all
backed by fixed-size bitmaps, whereas form controls on the web have no inherent
sizing limitations.

AppKit defines four fixed sizes, `NSControlSizeRegular`, `NSControlSizeSmall`,
`NSControlSizeMini`, and `NSControlSizeLarge`. WebKit takes various approaches
to reconcile fixed AppKit control sizes with arbitrary element sizes. In all
cases, the `NSControlSize` corresponding to the fixed size closest to the
element&apos;s box size (adjusted for zoom) is determined. Buttons have historically
done one of two things with a given `NSControlSize`:

1. Adjust (force) the element&apos;s size to match the fixed size.
2. Paint the `NSCell` in the center of the element&apos;s box.

Until 258754@main, `&lt;input type=button&gt;` (and file input buttons) used the first
approach, while `&lt;button&gt;` used the second. 258754@main unified
`&lt;input type=button&gt;` and `&lt;button`&gt; styling/painting, using the second approach,
to resolve numerous web compatibility issues. In doing so, all bugs with `&lt;button&gt;`
painting were also brought to file input buttons. While 258754@main regressed
file input buttons, it is not the root cause of the issue.

The root cause of the issue revolves around how the bitmap image vended from
AppKit is centered in the element&apos;s box. Specifically, the frame (rect) used
to draw an `NSCell` is not equivalent to the size of the bitmap. The actual
image is inset from the frame. Consequently, in order to paint the button at a
particular size/position, the frame passed to AppKit must be inflated. WebKit
currently achieves this by using a hardcoded list of cell sizes and outsets.
However, these values are long out-of-date, as macOS theme definitions have
evolved.

The result of incorrect outsets is that the rendered position of the button
outline does not align with the text. Some outset values (for a given
`NSControlSize`) are more accurate than others. When the zoom level changes the
used `NSControlSize` can also change, resulting in an effect where it appears
as though the text moves relative to the button. To fix this issue, WebKit needs
to use correct values for the outsets, so that the button outline is drawn at
the intended position.

However, fixing the outsets revealed yet another regression in the logic
responsible for determining the &quot;inflated rect&quot; `NSButtonCell`s. 258492@main
moved button painting code from `ThemeMac` into `ButtonMac`, but made two
errors:

1. The use of `auto` to store the cell size prior to scaling by the zoom factor.
   Since cell sizes are integer values, the scaled height ends up as an integer,
   which throws off the position of the renderered bitmap. Before 258492@main,
   the logic explicitly used `FloatSize`.

2. The use of `expand` to inflate the rect. `expand` does not adjust the position
   of the rect – it merely increases the size. Consequently, the position of the
   rect is not adjusted to center it. Before 258492@main, the logic used `setY`
   and `setHeight`.

In summary, AppKit changes, 258492@main, and 258754@main all combined to result
in file input button layout looking bad at various zoom levels.

* LayoutTests/accessibility/node-only-object-element-rect-expected.txt: Rebaseline.
* LayoutTests/platform/mac/compositing/contents-opaque/control-layer-expected.txt: Rebaseline.
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm:
(WebCore::ButtonMac::cellSize const):

Use updated values from AppKit.

(WebCore::ButtonMac::cellOutsets const):

Use updated values from AppKit. These should be determined programmatically
once the `ControlPart` refactor is complete, and an additional refactor to use
`NSControl`s (that own `NSCell`s) can be made.

(WebCore::ButtonMac::rectForBounds const):

Fix the two logic errors described above. Explicitly use `FloatSize` to avoid
clamping to integers and use `inflateY` to ensure the position of the inflated
rect is correct.

* Source/WebCore/platform/mac/ThemeMac.mm:

Use updated values from AppKit. This code duplication will eventually be removed,
once the ongoing `ControlPart` refactor is complete, but for now, the values need
to be updated to adjust the repaint rect.

(WebCore::buttonSizes):
(WebCore::buttonMargins):

Canonical link: <a href="https://commits.webkit.org/259359@main">https://commits.webkit.org/259359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61151317807e6c9cdd1e3e694a1d50043a78f96a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113942 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174152 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4675 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96997 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112876 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39030 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108139 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80694 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27475 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4861 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7205 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4052 "Found 2 new test failures: fast/images/avif-heif-container-as-image.html, fast/images/avif-image-document.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30125 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103496 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47033 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101247 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8993 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25193 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3422 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->