### PR TITLE
Cherry-pick 252432.838@safari-7614-branch (665170902bfa). rdar://104601528

### DIFF
--- a/LayoutTests/fast/forms/textfield-input-type-crash-onblur-expected.txt
+++ b/LayoutTests/fast/forms/textfield-input-type-crash-onblur-expected.txt
@@ -1,0 +1,1 @@
+This test passes

--- a/LayoutTests/fast/forms/textfield-input-type-crash-onblur.html
+++ b/LayoutTests/fast/forms/textfield-input-type-crash-onblur.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <script>
+
+     if (window.testRunner)
+         testRunner.dumpAsText();
+
+     function main()
+     {
+        var hVar = document.getElementById("hVar")
+        datalistVar.remove()
+        inputVar.setRangeText("")
+        inputVar.select()
+        nVar.setAttribute("hidden","")
+        inputVar.type = "tel"
+        hVar.before("")
+     }
+     function changeType()
+     {
+        inputVar.type = ""
+     }
+ </script>
+ </head>
+ <body onload="main()"><p> This test passes </p> <n id="nVar" onblur="changeType()" tabindex=0><input id="inputVar" hidden="" list="datalistVar"><datalist id="datalistVar"><option ><h id="hVar">
+ </html>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1720,7 +1720,8 @@ void HTMLInputElement::resetListAttributeTargetObserver()
 
 void HTMLInputElement::dataListMayHaveChanged()
 {
-    m_inputType->dataListMayHaveChanged();
+    auto protectedInputType = m_inputType;
+    protectedInputType->dataListMayHaveChanged();
 }
 
 bool HTMLInputElement::isFocusingWithDataListDropdown() const

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -253,8 +253,11 @@ void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation a
 void HTMLOptionElement::childrenChanged(const ChildChange& change)
 {
 #if ENABLE(DATALIST_ELEMENT)
+    Vector<Ref<HTMLDataListElement>> ancestors;
     for (auto& dataList : ancestorsOfType<HTMLDataListElement>(*this))
-        dataList.optionElementChildrenChanged();
+        ancestors.append(dataList);
+    for (auto& dataList : ancestors)
+        dataList->optionElementChildrenChanged();
 #endif
     if (RefPtr select = ownerSelectElement())
         select->optionElementChildrenChanged();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -482,7 +482,9 @@ void TextFieldInputType::createDataListDropdownIndicator()
     ASSERT(!m_dataListDropdownIndicator);
     if (!m_container)
         createContainer();
-
+    if (!element())
+        return;
+    
     ScriptDisallowedScope::EventAllowedScope allowedScope(*m_container);
     m_dataListDropdownIndicator = DataListButtonElement::create(element()->document(), *this);
     m_container->appendChild(*m_dataListDropdownIndicator);
@@ -914,7 +916,8 @@ void TextFieldInputType::dataListMayHaveChanged()
 
     if (!m_dataListDropdownIndicator)
         createDataListDropdownIndicator();
-
+    if (!element())
+        return;
     if (!shouldOnlyShowDataListDropdownButtonWhenFocusedOrEdited())
         m_dataListDropdownIndicator->setInlineStyleProperty(CSSPropertyDisplay, element()->list() ? CSSValueBlock : CSSValueNone, true);
 }


### PR DESCRIPTION
#### 0675bbf6a5db80a0dbf04ae7a7485a09b056d032
<pre>
Cherry-pick 252432.838@safari-7614-branch (665170902bfa). rdar://104601528

    UAF crash occurs during a style update when an older freed HTMLElement is accessed
    <a href="https://bugs.webkit.org/show_bug.cgi?id=247389">https://bugs.webkit.org/show_bug.cgi?id=247389</a>
    rdar://101420898

    Reviewed by Ryosuke Niwa and Ryan Haddad.

    * LayoutTests/fast/forms/textfield-input-type-crash-onblur-expected.txt: Added.
    * LayoutTests/fast/forms/textfield-input-type-crash-onblur.html: Added.
    * Source/WebCore/html/HTMLInputElement.cpp:
    (WebCore::HTMLInputElement::dataListMayHaveChanged):
    * Source/WebCore/html/HTMLOptionElement.cpp:
    (WebCore::HTMLOptionElement::childrenChanged):
    * Source/WebCore/html/TextFieldInputType.cpp:
    (WebCore::TextFieldInputType::createDataListDropdownIndicator):
    (WebCore::TextFieldInputType::dataListMayHaveChanged):

    Canonical link: <a href="https://commits.webkit.org/252432.838@safari-7614-branch">https://commits.webkit.org/252432.838@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259321@main">https://commits.webkit.org/259321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a1b5cb06d8671ec6e0963af0b8580d69d5b6e25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113830 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174058 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4557 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112787 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38955 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108030 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80619 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94536 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27387 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92442 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4770 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3960 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30030 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103390 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46943 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101128 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6431 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8895 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25095 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->