### PR TITLE
[ews-build.webkit.org] Support PRs with many files changed (Follow-up)

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -293,7 +293,7 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
             page += 1
 
         if not files:
-            log.msg('Failed fetching files for PR #{}: response code {}'.format(number, response.code if response else '?'))
+            log.msg('Failed fetching files for PR #{}: response code {}'.format(number, response.status_code if response else '?'))
         return defer.returnValue(files)
 
     def extractProperties(self, payload):


### PR DESCRIPTION
#### c5a3b31501e438939583cea5eb92ab96c183f231
<pre>
[ews-build.webkit.org] Support PRs with many files changed (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=250714">https://bugs.webkit.org/show_bug.cgi?id=250714</a>
rdar://104339227

Unreviewed follow-up fix

* Tools/CISupport/ews-build/events.py:
(GitHubEventHandlerNoEdits._get_pr_files): Twisted response objects have a status_code, not a code.

Canonical link: <a href="https://commits.webkit.org/259282@main">https://commits.webkit.org/259282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2add0e70139bfd9944cc6fb1743c101488aedbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/104553 "The change is no longer eligible for processing.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/13633 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/113831 "The change is no longer eligible for processing.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/108472 "The change is no longer eligible for processing.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/14749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/4558 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/110318 "The change is no longer eligible for processing.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/14749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/108031 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/14749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/6988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/92443 "The change is no longer eligible for processing.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7107 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/4558 "The change is no longer eligible for processing.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/92443 "The change is no longer eligible for processing.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/103391 "The change is no longer eligible for processing.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/101129 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8896 "The change is no longer eligible for processing.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/101129 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3397 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->