### PR TITLE
[webkitbugspy] Handle empty description

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.9.2',
+    version='0.9.3',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 9, 2)
+version = Version(0, 9, 3)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -230,6 +230,8 @@ class Tracker(GenericTracker):
             # Attempt to match radar importer first
             if self.radar_importer:
                 for comment in issue.comments:
+                    if not comment:
+                        continue
                     if comment.user != self.radar_importer:
                         continue
                     candidate = GenericTracker.from_string(comment.content)
@@ -238,7 +240,9 @@ class Tracker(GenericTracker):
                     issue._references.append(candidate)
                     refs.add(candidate.link)
 
-            for text in [issue.description] + [comment.content for comment in issue.comments]:
+            for text in [issue.description] + [comment.content for comment in issue.comments if comment]:
+                if not text:
+                    continue
                 for match in self.REFERENCE_RE.findall(text):
                     candidate = GenericTracker.from_string(match[0]) or self.from_string(match[0])
                     if not candidate or candidate.link in refs or (isinstance(candidate.tracker, type(issue.tracker)) and candidate.id == issue.id):


### PR DESCRIPTION
#### f94dc3fc469d521b341e725ccce2bfb55c1aa08b
<pre>
[webkitbugspy] Handle empty description
<a href="https://bugs.webkit.org/show_bug.cgi?id=251090">https://bugs.webkit.org/show_bug.cgi?id=251090</a>
rdar://104602830

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): Bail out of loops if descritions or comments are empty.

Canonical link: <a href="https://commits.webkit.org/259297@main">https://commits.webkit.org/259297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f02abe3bfb524fe16db84642f6f8edcddfa6913d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104584 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/13663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/113863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/108502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14780 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/4588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/110349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/108061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/92474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/4588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/92474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/103421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101160 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3402 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->