### PR TITLE
[WGSL] Add `role`s to structs and parameters to aid codegen

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTFunctionDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunctionDecl.h
@@ -35,14 +35,21 @@
 
 namespace WGSL::AST {
 
+enum class ParameterRole {
+    UserDefined,
+    StageIn,
+    GlobalVariable,
+};
+
 class Parameter final : public Node {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
     using List = UniqueRefVector<Parameter>;
 
-    Parameter(SourceSpan span, const String& name, Ref<TypeDecl>&& type, Attribute::List&& attributes)
+    Parameter(SourceSpan span, const String& name, Ref<TypeDecl>&& type, Attribute::List&& attributes, ParameterRole role)
         : Node(span)
+        , m_role(role)
         , m_name(name)
         , m_type(WTFMove(type))
         , m_attributes(WTFMove(attributes))
@@ -53,8 +60,10 @@ public:
     const String& name() const { return m_name; }
     TypeDecl& type() { return m_type.get(); }
     Attribute::List& attributes() { return m_attributes; }
+    ParameterRole role() { return m_role; }
 
 private:
+    ParameterRole m_role;
     String m_name;
     Ref<TypeDecl> m_type;
     Attribute::List m_attributes;

--- a/Source/WebGPU/WGSL/AST/ASTStructureDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureDecl.h
@@ -57,14 +57,23 @@ private:
     Ref<TypeDecl> m_type;
 };
 
+enum class StructRole : uint8_t {
+    UserDefined,
+    VertexInput,
+    FragmentInput,
+    ComputeInput,
+    VertexOutput,
+};
+
 class StructDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
     using List = UniqueRefVector<StructDecl>;
 
-    StructDecl(SourceSpan sourceSpan, const String& name, StructMember::List&& members, Attribute::List&& attributes)
+    StructDecl(SourceSpan sourceSpan, const String& name, StructMember::List&& members, Attribute::List&& attributes, StructRole role)
         : Decl(sourceSpan)
+        , m_role(role)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
         , m_members(WTFMove(members))
@@ -72,11 +81,15 @@ public:
     }
 
     Kind kind() const override;
+    StructRole role() const { return m_role; }
     const String& name() const { return m_name; }
     Attribute::List& attributes() { return m_attributes; }
     StructMember::List& members() { return m_members; }
 
+    void setRole(StructRole role) { m_role = role; }
+
 private:
+    StructRole m_role;
     String m_name;
     Attribute::List m_attributes;
     StructMember::List m_members;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -85,8 +85,10 @@ public:
 
     void visit(AST::Parameter&) override;
 
+private:
     StringBuilder& m_stringBuilder;
     Indentation<4> m_indent { 0 };
+    std::optional<AST::StructRole> m_structRole;
 };
 
 void FunctionDefinitionWriter::visit(AST::ShaderModule& shaderModule)
@@ -108,16 +110,18 @@ void FunctionDefinitionWriter::visit(AST::FunctionDecl& functionDefinition)
     for (auto& parameter : functionDefinition.parameters()) {
         if (!first)
             m_stringBuilder.append(", ");
-        bool isBuiltin = false;
-        for (auto& attribute : parameter.attributes()) {
-            if (attribute->kind() == AST::Node::Kind::BuiltinAttribute) {
-                isBuiltin = true;
-                break;
-            }
-        }
-        checkErrorAndVisit(parameter);
-        if (!isBuiltin)
+        switch (parameter.role()) {
+        case AST::ParameterRole::UserDefined:
+            checkErrorAndVisit(parameter);
+            break;
+        case AST::ParameterRole::StageIn:
+            checkErrorAndVisit(parameter);
             m_stringBuilder.append(" [[stage_in]]");
+            break;
+        case AST::ParameterRole::GlobalVariable:
+            // FIXME: add support for global variables
+            break;
+        }
         first = false;
     }
     m_stringBuilder.append(")\n");
@@ -130,6 +134,7 @@ void FunctionDefinitionWriter::visit(AST::FunctionDecl& functionDefinition)
 void FunctionDefinitionWriter::visit(AST::StructDecl& structDecl)
 {
     // FIXME: visit struct attributes
+    m_structRole = { structDecl.role() };
     m_stringBuilder.append(m_indent, "struct ", structDecl.name(), " {\n");
     {
         IndentationScope scope(m_indent);
@@ -145,12 +150,14 @@ void FunctionDefinitionWriter::visit(AST::StructDecl& structDecl)
         }
     }
     m_stringBuilder.append(m_indent, "};\n\n");
+    m_structRole = std::nullopt;
 }
 
 void FunctionDefinitionWriter::visit(AST::VariableDecl& variableDecl)
 {
     ASSERT(variableDecl.maybeTypeDecl());
 
+    m_stringBuilder.append(m_indent);
     visit(*variableDecl.maybeTypeDecl());
     m_stringBuilder.append(" ", variableDecl.name());
     if (variableDecl.maybeInitializer()) {
@@ -198,6 +205,21 @@ void FunctionDefinitionWriter::visit(AST::StageAttribute& stage)
 
 void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
 {
+    if (m_structRole.has_value()) {
+        auto role = *m_structRole;
+        switch (role) {
+        case AST::StructRole::UserDefined:
+            break;
+        case AST::StructRole::VertexOutput:
+        case AST::StructRole::FragmentInput:
+            m_stringBuilder.append("[[user(loc", location.location(), ")]]");
+            return;
+        case AST::StructRole::VertexInput:
+        case AST::StructRole::ComputeInput:
+            // FIXME: not sure if these should actually be attributes or not
+            break;
+        }
+    }
     m_stringBuilder.append("[[attribute(", location.location(), ")]]");
 }
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -264,7 +264,7 @@ Expected<AST::StructDecl, Error> Parser<Lexer>::parseStructDecl(AST::Attribute::
 
     CONSUME_TYPE(BraceRight);
 
-    RETURN_NODE(StructDecl, name.m_ident, WTFMove(members), WTFMove(attributes));
+    RETURN_NODE(StructDecl, name.m_ident, WTFMove(members), WTFMove(attributes), AST::StructRole::UserDefined);
 }
 
 template<typename Lexer>
@@ -512,7 +512,7 @@ Expected<AST::Parameter, Error> Parser<Lexer>::parseParameter()
     CONSUME_TYPE(Colon);
     PARSE(type, TypeDecl);
 
-    RETURN_NODE(Parameter, name.m_ident, WTFMove(type), WTFMove(attributes));
+    RETURN_NODE(Parameter, name.m_ident, WTFMove(type), WTFMove(attributes), AST::ParameterRole::UserDefined);
 }
 
 template<typename Lexer>


### PR DESCRIPTION
#### 80357a24d696b3f75ff143d2bb790b7dc37c38a9
<pre>
[WGSL] Add `role`s to structs and parameters to aid codegen
<a href="https://bugs.webkit.org/show_bug.cgi?id=251089">https://bugs.webkit.org/show_bug.cgi?id=251089</a>
&lt;rdar://problem/104602741&gt;

Reviewed by Myles C. Maxfield.

Add a field to indicate what is the role of structs and parameters. That
helps with codegen as we can identify as if a struct or parameter was generated
for a specific purposed, e.g. to receive stage_in parameters. This extra information
helps when choosing the right metal attributes during codegen.

* Source/WebGPU/WGSL/AST/ASTFunctionDecl.h:
* Source/WebGPU/WGSL/AST/ASTStructureDecl.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::appendBuiltins):
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStructDecl):
(WGSL::Parser&lt;Lexer&gt;::parseParameter):

Canonical link: <a href="https://commits.webkit.org/259345@main">https://commits.webkit.org/259345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97053921c5216f4188ad87fc32201b85aa851431

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113834 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174062 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4561 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112791 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38957 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108034 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80621 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27394 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92446 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4774 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3965 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30033 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103394 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46950 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101132 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6442 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8899 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25098 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->