### PR TITLE
Cherry-pick 252432.840@safari-7614-branch (56f36c096a15). rdar://104609397

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -35,6 +35,7 @@
 #import <pal/spi/mac/QuarantineSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Scope.h>
+#import <wtf/SoftLinking.h>
 #import <wtf/UUID.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WorkQueue.h>
@@ -42,6 +43,7 @@
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPI.h"
 #import "WKContentViewInteraction.h"
+#import <LinkPresentation/LPLinkMetadata.h>
 #else
 #import <pal/spi/mac/NSSharingServicePickerSPI.h>
 #endif
@@ -51,6 +53,13 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+
+SOFT_LINK_FRAMEWORK(LinkPresentation)
+SOFT_LINK_CLASS(LinkPresentation, LPLinkMetadata)
+
+@interface LPLinkMetadata (Staging_102382126)
+- (void)_setIncomplete:(BOOL)incomplete;
+@end
 
 @interface WKShareSheetFileItemProvider : UIActivityItemProvider
 - (instancetype)initWithURL:(NSURL *)url;
@@ -77,6 +86,45 @@
 - (id)item
 {
     return _url.get();
+}
+
+@end
+
+@interface WKShareSheetURLItemProvider : UIActivityItemProvider
+- (instancetype)initWithURL:(NSURL *)url;
+@end
+
+@implementation WKShareSheetURLItemProvider {
+    RetainPtr<NSURL> _url;
+    RetainPtr<LPLinkMetadata> _metadata;
+}
+
+- (instancetype)initWithURL:(NSURL *)url
+{
+    if (!(self = [super initWithPlaceholderItem:url]))
+        return nil;
+
+    _metadata = adoptNS([allocLPLinkMetadataInstance() init]);
+    [_metadata setOriginalURL:url];
+    [_metadata setURL:url];
+    [_metadata setTitle:url._title];
+
+    if ([_metadata respondsToSelector:@selector(_setIncomplete:)])
+        [_metadata _setIncomplete:YES];
+
+    _url = url;
+
+    return self;
+}
+
+- (id)item
+{
+    return _url.get();
+}
+
+- (LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController
+{
+    return _metadata.get();
 }
 
 @end
@@ -178,8 +226,16 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
 #if PLATFORM(IOS_FAMILY)
         if (!data.shareData.title.isEmpty())
             url._title = data.shareData.title;
-#endif
+
+        if (data.originator == WebCore::ShareDataOriginator::Web) {
+            auto itemProvider = adoptNS([[WKShareSheetURLItemProvider alloc] initWithURL:url]);
+            if (itemProvider)
+                [shareDataArray addObject:itemProvider.get()];
+        } else
+            [shareDataArray addObject:url];
+#else
         [shareDataArray addObject:url];
+#endif
     }
     
     if (!data.shareData.title.isEmpty() && ![shareDataArray count])


### PR DESCRIPTION
#### 3c089e68eb066333c057a99dd3a511fd3495e5bf
<pre>
Cherry-pick 252432.840@safari-7614-branch (56f36c096a15). rdar://104609397

    Share Sheet may parse complex image formats
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248097">https://bugs.webkit.org/show_bug.cgi?id=248097</a>
    rdar://99294213

    Reviewed by Jonathan Bedard and Tim Horton.

    When a URL is given to the Share Sheet, the Share Sheet displays a thumbnail
    defined by the URL, in the UIProcess. The Web Share API allows the URL to be
    handed to the UIProcess from the WebProcess, via IPC. Consequently, there
    exists a way to trigger image decoding in the UIProcess from a compromised
    WebProcess, or one-click from a user.

    To fix, display a placeholder icon rather than showing a thumbnail defined by
    the URL in the Share Sheet. This behavior is achieved by specifying partial
    `LPLinkMetadata`.

    * Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
    (-[WKShareSheetURLItemProvider initWithURL:]):

    Mark the metadata as incomplete so that it may be refetched when the URL is
    actually shared.

    (-[WKShareSheetURLItemProvider item]):
    (-[WKShareSheetURLItemProvider activityViewControllerLinkMetadata:]):
    (-[WKShareSheet presentWithParameters:inRect:completionHandler:]):

    Only apply this mitigation when the Share Sheet is invoked using the Web Share
    API. Other contexts require more significant user interaction and are not done
    through IPC from the WebProcess.

    Canonical link: <a href="https://commits.webkit.org/252432.840@safari-7614-branch">https://commits.webkit.org/252432.840@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259328@main">https://commits.webkit.org/259328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64b6d40610444294389739799ee0f1345b21af37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113852 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174077 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4578 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112804 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38986 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108051 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80650 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7008 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27403 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92464 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4788 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3980 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30048 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103411 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46959 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101150 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6432 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8915 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25114 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->