### PR TITLE
formDisabledCallback() sometimes fires even when disabled-ness hasn't changed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback-expected.txt
@@ -2,10 +2,14 @@
 
 
 
+
+
 PASS Adding/removing disabled content attribute
 PASS Relationship with FIELDSET
 PASS A disabled form-associated custom element should not provide an entry for it
 PASS A disabled form-associated custom element should not submit an entry for it
 PASS Disabled attribute affects focus-capability
 PASS Upgrading an element with disabled content attribute
+PASS Toggling "disabled" attribute on a custom element inside disabled <fieldset> does not trigger a callback
+PASS Toggling "disabled" attribute on a <fieldset> does not trigger a callback on disabled custom element descendant
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback.html
@@ -110,5 +110,27 @@ test(() => {
   container.innerHTML = '<fieldset disabled><my-control>';
   assert_array_equals(container.querySelector('my-control').disabledHistory(), [true]);
 }, 'Upgrading an element with disabled content attribute');
+
+test(() => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  container.innerHTML = '<fieldset disabled><my-control></my-control></fieldset>';
+
+  const control = container.querySelector('my-control');
+  control.setAttribute('disabled', '');
+  control.removeAttribute('disabled');
+  assert_array_equals(control.disabledHistory(), [true]);
+}, 'Toggling "disabled" attribute on a custom element inside disabled <fieldset> does not trigger a callback');
+
+test(() => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  container.innerHTML = '<fieldset><my-control disabled></my-control></fieldset>';
+
+  const fieldset = container.firstElementChild;
+  fieldset.disabled = true;
+  fieldset.disabled = false;
+  assert_array_equals(container.querySelector('my-control').disabledHistory(), [true]);
+}, 'Toggling "disabled" attribute on a <fieldset> does not trigger a callback on disabled custom element descendant');
 </script>
 </body>

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -52,7 +52,7 @@ inline HTMLFieldSetElement::HTMLFieldSetElement(const QualifiedName& tagName, Do
 
 HTMLFieldSetElement::~HTMLFieldSetElement()
 {
-    if (m_hasDisabledAttribute)
+    if (hasDisabledAttribute())
         document().removeDisabledFieldsetElement();
 }
 
@@ -82,18 +82,16 @@ static void updateFromControlElementsAncestorDisabledStateUnder(HTMLElement& sta
     }
 }
 
-void HTMLFieldSetElement::disabledAttributeChanged()
+void HTMLFieldSetElement::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
-    bool hasDisabledAttribute = hasAttributeWithoutSynchronization(disabledAttr);
-    if (m_hasDisabledAttribute != hasDisabledAttribute) {
-        m_hasDisabledAttribute = hasDisabledAttribute;
-        if (hasDisabledAttribute)
+    HTMLFormControlElement::parseAttribute(name, value);
+
+    if (name == disabledAttr) {
+        if (hasDisabledAttribute())
             document().addDisabledFieldsetElement();
         else
             document().removeDisabledFieldsetElement();
     }
-
-    HTMLFormControlElement::disabledAttributeChanged();
 }
 
 void HTMLFieldSetElement::disabledStateChanged()
@@ -136,7 +134,7 @@ void HTMLFieldSetElement::didMoveToNewDocument(Document& oldDocument, Document& 
 {
     ASSERT_WITH_SECURITY_IMPLICATION(&document() == &newDocument);
     HTMLFormControlElement::didMoveToNewDocument(oldDocument, newDocument);
-    if (m_hasDisabledAttribute) {
+    if (hasDisabledAttribute()) {
         oldDocument.removeDisabledFieldsetElement();
         newDocument.addDisabledFieldsetElement();
     }

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -49,7 +49,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     const AtomString& formControlType() const final;
     bool computeWillValidate() const final { return false; }
-    void disabledAttributeChanged() final;
+    void parseAttribute(const QualifiedName&, const AtomString&) final;
     void disabledStateChanged() final;
     void childrenChanged(const ChildChange&) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
@@ -58,7 +58,6 @@ private:
     bool matchesInvalidPseudoClass() const final;
 
     WeakHashSet<HTMLElement, WeakPtrImplWithEventTargetData> m_invalidDescendants;
-    bool m_hasDisabledAttribute { false };
 };
 
 } // namespace

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -91,6 +91,7 @@ public:
     virtual const AtomString& formControlType() const = 0;
 
 protected:
+    bool hasDisabledAttribute() const { return m_disabled; }
     virtual bool computeWillValidate() const;
     virtual bool readOnlyBarsFromConstraintValidation() const { return false; }
     void updateWillValidateAndValidity();
@@ -105,7 +106,6 @@ protected:
     void parseDisabledAttribute(const AtomString&);
     void parseReadOnlyAttribute(const AtomString&);
 
-    virtual void disabledAttributeChanged();
     virtual void disabledStateChanged();
     virtual void readOnlyStateChanged();
 
@@ -118,6 +118,7 @@ protected:
 
 private:
     bool computeIsDisabledByFieldsetAncestor() const;
+    void setDisabledInternal(bool disabled, bool disabledByAncestorFieldset);
     virtual HTMLElement* validationAnchorElement() = 0;
 
     void startDelayingUpdateValidity() { ++m_delayedUpdateValidityCount; }


### PR DESCRIPTION
#### b391993e41c59f2bd93750700eee8e8d9b157d15
<pre>
formDisabledCallback() sometimes fires even when disabled-ness hasn&apos;t changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=251097">https://bugs.webkit.org/show_bug.cgi?id=251097</a>

Reviewed by Ryosuke Niwa.

This change:

1. Replaces disabledAttributeChanged() hook, which was only used by &lt;fieldset&gt;,
   with hasDisabledAttribute() protected method, removing a virtual call
   and reducing sizeof(HTMLFieldSetElement) by 8.
2. Extracts setDisabledInternal() so that disabledStateChanged() hook is called
   only when disabled-ness is actually changed, always taking into account
   m_disabledByAncestorFieldset.

The latter wasn&apos;t a huge issue before form-associated custom elements were introduced,
whose disabledAttributeChanged() calls into userland JS code, yet even apart from that,
this change eliminates redundant work for native controls and even makes psedo-class
invalidation more precise, reducing matches{Valid,Invalid}PseudoClass() calls.

Also, moving the pseudo-class invalidation into a single function paves the way for
a follow-up patch that will invalidate a few more selectors to match the spec.

Aligns WebKit with Blink and Gecko.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback.html:
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::~HTMLFieldSetElement):
(WebCore::HTMLFieldSetElement::parseAttribute):
(WebCore::HTMLFieldSetElement::didMoveToNewDocument):
(WebCore::HTMLFieldSetElement::disabledAttributeChanged): Deleted.
* Source/WebCore/html/HTMLFieldSetElement.h:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::setDisabledByAncestorFieldset):
(WebCore::ValidatedFormListedElement::setDisabledInternal):
(WebCore::ValidatedFormListedElement::parseDisabledAttribute):
(WebCore::ValidatedFormListedElement::syncWithFieldsetAncestors):
(WebCore::ValidatedFormListedElement::removedFromAncestor):
(WebCore::ValidatedFormListedElement::disabledAttributeChanged): Deleted.
* Source/WebCore/html/ValidatedFormListedElement.h:
(WebCore::ValidatedFormListedElement::hasDisabledAttribute const):

Canonical link: <a href="https://commits.webkit.org/259372@main">https://commits.webkit.org/259372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77f935fbb0e8ded431082c5350dc3c2216f45154

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114007 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174206 "Failed to checkout and rebase branch from PR 9056") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4741 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97062 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110492 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94558 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/108199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26172 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27528 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92623 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7268 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30181 "Passed tests") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/103550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47088 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101311 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6458 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9055 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->