### PR TITLE
Cherry-pick 252432.841@safari-7614-branch (a47510d4bcf4). rdar://104609847

### DIFF
--- a/LayoutTests/fast/dom/lazy-loading-iframe-destruction-crash-expected.txt
+++ b/LayoutTests/fast/dom/lazy-loading-iframe-destruction-crash-expected.txt
@@ -1,0 +1,9 @@
+This test passes if it doesn't crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/lazy-loading-iframe-destruction-crash.html
+++ b/LayoutTests/fast/dom/lazy-loading-iframe-destruction-crash.html
@@ -1,0 +1,24 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+
+function runTest() {
+    description("This test passes if it doesn't crash.");
+
+    inputElement.selectionDirection = "forward";
+    inputElement.setRangeText("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    setTimeout(finishJSTest, 100);
+}
+
+function inputSelectHandler() {
+    outputElement.innerHTML = rpElement.innerHTML;;
+    gc();
+}
+</script>
+<body onload="runTest()">
+<rp id="rpElement" onfocusin="f3()" onfocusout="f2()">
+<iframe inputmode="numeric" loading="lazy" 1px" scrolling="yes">
+</iframe>
+</rp>
+<input id="inputElement" contextmenu="x26" onselect="inputSelectHandler()" height="1024">
+<output id="outputElement" dir="auto">

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -822,14 +822,14 @@ void Document::commonTeardown()
     m_documentFragmentForInnerOuterHTML = nullptr;
 
     auto intersectionObservers = m_intersectionObservers;
-    for (auto& intersectionObserver : intersectionObservers) {
-        if (intersectionObserver)
+    for (auto& weakIntersectionObserver : intersectionObservers) {
+        if (RefPtr intersectionObserver = weakIntersectionObserver.get())
             intersectionObserver->disconnect();
     }
 
     auto resizeObservers = m_resizeObservers;
-    for (auto& resizeObserver : resizeObservers) {
-        if (resizeObserver)
+    for (auto& weakResizeObserver : resizeObservers) {
+        if (RefPtr resizeObserver = weakResizeObserver.get())
             resizeObserver->disconnect();
     }
 


### PR DESCRIPTION
#### 574c3859cc0c99c8947c785c44f8b76a45c1fd17
<pre>
Cherry-pick 252432.841@safari-7614-branch (a47510d4bcf4). rdar://104609847

    Fix potential crash under IntersectionObserver::disconnect()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248111">https://bugs.webkit.org/show_bug.cgi?id=248111</a>
    rdar://100355921

    Reviewed by Jonathan Bedard and Ryosuke Niwa.

    Make sure we protect the intersection observers and resize observers before
    calling disconnect() on them in Document::commonTeardown().

    This is a speculative fix to address the crash in the radar, which I was
    unable to reproduce.

    * LayoutTests/fast/dom/lazy-loading-iframe-destruction-crash-expected.txt: Added.
    * LayoutTests/fast/dom/lazy-loading-iframe-destruction-crash.html: Added.
    Include test from the radar, even though it didn&apos;t reproduce the issue for me.

    * Source/WebCore/dom/Document.cpp:
    (WebCore::Document::commonTeardown):

    Canonical link: <a href="https://commits.webkit.org/252432.841@safari-7614-branch">https://commits.webkit.org/252432.841@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259332@main">https://commits.webkit.org/259332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29acefdf79db5487a974e5a40a46f1f3484b1ce2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113855 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174080 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4581 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96914 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112807 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38974 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108054 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80638 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94555 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27407 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92467 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4791 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3984 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30051 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103414 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46963 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101153 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6436 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8918 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25117 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->