### PR TITLE
Cherry-pick 252432.845@safari-7614-branch (2fc9fcfb0857). rdar://104611648

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -58,8 +58,9 @@ void RemoteImageDecoderAVFProxy::createDecoder(const IPC::SharedBufferReference&
     auto identifier = ImageDecoderIdentifier::generate();
     m_imageDecoders.add(identifier, imageDecoder.copyRef());
 
-    imageDecoder->setEncodedDataStatusChangeCallback([this, identifier](auto) mutable {
-        encodedDataStatusChanged(identifier);
+    imageDecoder->setEncodedDataStatusChangeCallback([proxy = WeakPtr<MessageReceiver> { *this },  identifier](auto) mutable {
+        if (proxy)
+            static_cast<RemoteImageDecoderAVFProxy*>(proxy.get())->encodedDataStatusChanged(identifier);
     });
 
     imageDecoderIdentifier = identifier;


### PR DESCRIPTION
#### 4b1a0c93dadf031285667d2d3fc09ecbca5001d1
<pre>
Cherry-pick 252432.845@safari-7614-branch (2fc9fcfb0857). rdar://104611648

    Use-after-free in RemoteImageDecoderAVFProxy::createDecoder.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248317">https://bugs.webkit.org/show_bug.cgi?id=248317</a>
    &lt;rdar://101576935&gt;

    Reviewed by Jonathan Bedard and David Kilzer.

    Passes a WeakPtr into the lambda instead, so that we can check if it&apos;s still
    alive before accessing it.

    * Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
    (WebKit::RemoteImageDecoderAVFProxy::createDecoder):

    Canonical link: <a href="https://commits.webkit.org/252432.845@safari-7614-branch">https://commits.webkit.org/252432.845@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259335@main">https://commits.webkit.org/259335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95217065509567693694b12df895832d156e5faf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113865 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174088 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4590 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112815 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38979 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108063 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80643 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94563 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7020 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27412 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92476 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4799 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3989 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30057 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103423 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46968 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101162 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6437 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8926 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25124 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->