### PR TITLE
Expose "hybrid" transport enum value

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -61,7 +61,11 @@ typedef NS_ENUM(NSInteger, _WKWebAuthenticationResult) {
 typedef NS_ENUM(NSInteger, _WKWebAuthenticationTransport) {
     _WKWebAuthenticationTransportUSB,
     _WKWebAuthenticationTransportNFC,
+    _WKWebAuthenticationTransportBLE,
     _WKWebAuthenticationTransportInternal,
+    _WKWebAuthenticationTransportCaBLE,
+    _WKWebAuthenticationTransportHybrid,
+    _WKWebAuthenticationTransportSmartCard,
 } WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 
 typedef NS_ENUM(NSInteger, _WKWebAuthenticationType) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -182,11 +182,16 @@ static _WKWebAuthenticationTransport wkWebAuthenticationTransport(WebCore::Authe
         return _WKWebAuthenticationTransportUSB;
     case WebCore::AuthenticatorTransport::Nfc:
         return _WKWebAuthenticationTransportNFC;
+    case WebCore::AuthenticatorTransport::Ble:
+        return _WKWebAuthenticationTransportBLE;
     case WebCore::AuthenticatorTransport::Internal:
         return _WKWebAuthenticationTransportInternal;
-    default:
-        ASSERT_NOT_REACHED();
-        return _WKWebAuthenticationTransportUSB;
+    case WebCore::AuthenticatorTransport::Cable:
+        return _WKWebAuthenticationTransportCaBLE;
+    case WebCore::AuthenticatorTransport::Hybrid:
+        return _WKWebAuthenticationTransportHybrid;
+    case WebCore::AuthenticatorTransport::SmartCard:
+        return _WKWebAuthenticationTransportSmartCard;
     }
 }
 
@@ -783,11 +788,16 @@ static WebCore::AuthenticatorTransport authenticatorTransport(_WKWebAuthenticati
         return WebCore::AuthenticatorTransport::Usb;
     case _WKWebAuthenticationTransportNFC:
         return WebCore::AuthenticatorTransport::Nfc;
+    case _WKWebAuthenticationTransportBLE:
+        return WebCore::AuthenticatorTransport::Ble;
     case _WKWebAuthenticationTransportInternal:
         return WebCore::AuthenticatorTransport::Internal;
-    default:
-        ASSERT_NOT_REACHED();
-        return WebCore::AuthenticatorTransport::Usb;
+    case _WKWebAuthenticationTransportCaBLE:
+        return WebCore::AuthenticatorTransport::Cable;
+    case _WKWebAuthenticationTransportHybrid:
+        return WebCore::AuthenticatorTransport::Hybrid;
+    case _WKWebAuthenticationTransportSmartCard:
+        return WebCore::AuthenticatorTransport::SmartCard;
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1590,8 +1590,9 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     auto usb = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportUSB]);
     auto nfc = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportNFC]);
     auto internal = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportInternal]);
+    auto hybrid = adoptNS([NSNumber numberWithInt:_WKWebAuthenticationTransportHybrid]);
     auto credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
-    [credential setTransports:@[ usb.get(), nfc.get(), internal.get() ]];
+    [credential setTransports:@[ usb.get(), nfc.get(), internal.get(), hybrid.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
     auto authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
@@ -1626,10 +1627,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
-    EXPECT_EQ(result.excludeCredentials[0].transports.size(), 3lu);
+    EXPECT_EQ(result.excludeCredentials[0].transports.size(), 4lu);
     EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
     EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
     EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_EQ(result.excludeCredentials[0].transports[3], AuthenticatorTransport::Hybrid);
 
     EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::Platform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);


### PR DESCRIPTION
#### a2abb66f9942cd26df0c2cb40d7f683e7298dd6b
<pre>
Expose &quot;hybrid&quot; transport enum value
<a href="https://bugs.webkit.org/show_bug.cgi?id=251109">https://bugs.webkit.org/show_bug.cgi?id=251109</a>
rdar://104611530

Reviewed by J Pascoe.

Expose &quot;hybrid&quot; and other transport enums value via existing SPI.
The values of the WebCore version enums and _WK version must remain in sync.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(wkWebAuthenticationTransport):
(authenticatorTransport):

Canonical link: <a href="https://commits.webkit.org/259440@main">https://commits.webkit.org/259440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66887ea78a4e0cc458c5b3375a3908246c7a9541

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114152 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174343 "Found 1 new test failure: js/regress-148411.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4888 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97211 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113174 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39182 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80844 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7308 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27654 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7402 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47205 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6515 "Build was cancelled. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by J Pascoe; Validated commit message; Compiled WebKit (warnings); layout-tests (exception)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9193 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3460 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->