### PR TITLE
Rename WeakHashSet::computesEmpty to WeakHashSet::isEmptyIgnoringNullReferences

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -69,7 +69,7 @@ public:
         return m_set.contains(value.m_controlBlock);
     }
 
-    bool computesEmpty() const
+    bool isEmptyIgnoringNullReferences() const
     {
         Locker locker { m_lock };
         amortizedCleanupIfNeeded();

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -139,7 +139,12 @@ public:
 
     unsigned capacity() const { return m_set.capacity(); }
 
-    bool computesEmpty() const { return begin() == end(); }
+    bool isEmptyIgnoringNullReferences() const
+    {
+        if (m_set.isEmpty())
+            return true;
+        return begin() == end();
+    }
 
     bool hasNullReferences() const
     {

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -149,7 +149,7 @@ void RunLoop::observe(const RunLoop::Observer& observer)
 
 void RunLoop::notify(RunLoop::Event event, const char* name)
 {
-    if (m_observers.computesEmpty())
+    if (m_observers.isEmptyIgnoringNullReferences())
         return;
 
     m_observers.forEach([event, name = String::fromUTF8(name)](auto& observer) {

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -117,7 +117,7 @@ void GamepadManager::platformGamepadInputActivity(EventMakesGamepadsVisible even
     if (eventVisibility == EventMakesGamepadsVisible::No)
         return;
 
-    if (m_gamepadBlindNavigators.computesEmpty() && m_gamepadBlindDOMWindows.computesEmpty())
+    if (m_gamepadBlindNavigators.isEmptyIgnoringNullReferences() && m_gamepadBlindDOMWindows.isEmptyIgnoringNullReferences())
         return;
 
     for (auto* gamepad : GamepadProvider::singleton().platformGamepads()) {
@@ -133,7 +133,7 @@ void GamepadManager::makeGamepadVisible(PlatformGamepad& platformGamepad, WeakHa
 {
     LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - New gamepad '%s' is visible", (unsigned)getpid(), platformGamepad.id().utf8().data());
 
-    if (navigatorSet.computesEmpty() && domWindowSet.computesEmpty())
+    if (navigatorSet.isEmptyIgnoringNullReferences() && domWindowSet.isEmptyIgnoringNullReferences())
         return;
 
     for (auto& navigator : navigatorSet)
@@ -218,7 +218,7 @@ void GamepadManager::maybeStartMonitoringGamepads()
     if (m_isMonitoringGamepads)
         return;
 
-    if (!m_navigators.computesEmpty() || !m_domWindows.computesEmpty()) {
+    if (!m_navigators.isEmptyIgnoringNullReferences() || !m_domWindows.isEmptyIgnoringNullReferences()) {
         LOG(Gamepad, "(%u) GamepadManager has %i NavigatorGamepads and %i DOMWindows registered, is starting gamepad monitoring", (unsigned)getpid(), m_navigators.computeSize(), m_domWindows.computeSize());
         m_isMonitoringGamepads = true;
         GamepadProvider::singleton().startMonitoringGamepads(*this);
@@ -230,7 +230,7 @@ void GamepadManager::maybeStopMonitoringGamepads()
     if (!m_isMonitoringGamepads)
         return;
 
-    if (m_navigators.computesEmpty() && m_domWindows.computesEmpty()) {
+    if (m_navigators.isEmptyIgnoringNullReferences() && m_domWindows.isEmptyIgnoringNullReferences()) {
         LOG(Gamepad, "(%u) GamepadManager has no NavigatorGamepads or DOMWindows registered, is stopping gamepad monitoring", (unsigned)getpid());
         m_isMonitoringGamepads = false;
         GamepadProvider::singleton().stopMonitoringGamepads(*this);

--- a/Source/WebCore/animation/DocumentTimelinesController.cpp
+++ b/Source/WebCore/animation/DocumentTimelinesController.cpp
@@ -73,7 +73,7 @@ void DocumentTimelinesController::detachFromDocument()
 {
     m_currentTimeClearingTaskCancellationGroup.cancel();
 
-    while (!m_timelines.computesEmpty())
+    while (!m_timelines.isEmptyIgnoringNullReferences())
         m_timelines.begin()->detachFromDocument();
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7042,7 +7042,7 @@ void Document::removeMediaCanStartListener(MediaCanStartListener& listener)
 
 MediaCanStartListener* Document::takeAnyMediaCanStartListener()
 {
-    if (m_mediaCanStartListeners.computesEmpty())
+    if (m_mediaCanStartListeners.isEmptyIgnoringNullReferences())
         return nullptr;
 
     MediaCanStartListener* listener = m_mediaCanStartListeners.begin().get();

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -67,7 +67,7 @@ MutationObserver::MutationObserver(Ref<MutationCallback>&& callback)
 
 MutationObserver::~MutationObserver()
 {
-    ASSERT(m_registrations.computesEmpty());
+    ASSERT(m_registrations.isEmptyIgnoringNullReferences());
 }
 
 bool MutationObserver::validateOptions(MutationObserverOptions options)

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 class RadioButtonGroup {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    bool isEmpty() const { return m_members.computesEmpty(); }
+    bool isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
     bool isRequired() const { return m_requiredCount; }
     RefPtr<HTMLInputElement> checkedButton() const { return m_checkedButton.get(); }
     void add(HTMLInputElement&);
@@ -153,7 +153,7 @@ void RadioButtonGroup::remove(HTMLInputElement& button)
         }
     }
 
-    if (m_members.computesEmpty()) {
+    if (m_members.isEmptyIgnoringNullReferences()) {
         ASSERT(!m_requiredCount);
         ASSERT(!m_checkedButton);
     } else if (wasValid != isValid())

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -69,7 +69,7 @@ CanvasBase::CanvasBase(IntSize size)
 CanvasBase::~CanvasBase()
 {
     ASSERT(m_didNotifyObserversCanvasDestroyed);
-    ASSERT(m_observers.computesEmpty());
+    ASSERT(m_observers.isEmptyIgnoringNullReferences());
     ASSERT(!m_imageBuffer);
 }
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -97,7 +97,7 @@ public:
     void addDisplayBufferObserver(CanvasDisplayBufferObserver&);
     void removeDisplayBufferObserver(CanvasDisplayBufferObserver&);
     void notifyObserversCanvasDisplayBufferPrepared();
-    bool hasDisplayBufferObservers() const { return !m_displayBufferObservers.computesEmpty(); }
+    bool hasDisplayBufferObservers() const { return !m_displayBufferObservers.isEmptyIgnoringNullReferences(); }
 
     HashSet<Element*> cssCanvasClients() const;
 

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -144,12 +144,12 @@ void HTMLFieldSetElement::didMoveToNewDocument(Document& oldDocument, Document& 
 
 bool HTMLFieldSetElement::matchesValidPseudoClass() const
 {
-    return m_invalidDescendants.computesEmpty();
+    return m_invalidDescendants.isEmptyIgnoringNullReferences();
 }
 
 bool HTMLFieldSetElement::matchesInvalidPseudoClass() const
 {
-    return !m_invalidDescendants.computesEmpty();
+    return !m_invalidDescendants.isEmptyIgnoringNullReferences();
 }
 
 bool HTMLFieldSetElement::supportsFocus() const
@@ -186,7 +186,7 @@ void HTMLFieldSetElement::addInvalidDescendant(const HTMLElement& invalidFormCon
     ASSERT_WITH_MESSAGE(!m_invalidDescendants.contains(invalidFormControlElement), "Updating the fieldset on validity change is not an efficient operation, it should only be done when necessary.");
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (m_invalidDescendants.computesEmpty())
+    if (m_invalidDescendants.isEmptyIgnoringNullReferences())
         emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassValid, false }, { CSSSelector::PseudoClassInvalid, true } });
 
     m_invalidDescendants.add(invalidFormControlElement);

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -653,7 +653,7 @@ void HTMLFormElement::addInvalidFormControl(const HTMLElement& formControlElemen
     ASSERT(static_cast<const Element&>(formControlElement).matchesInvalidPseudoClass());
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (m_invalidFormControls.computesEmpty())
+    if (m_invalidFormControls.isEmptyIgnoringNullReferences())
         emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassValid, false }, { CSSSelector::PseudoClassInvalid, true } });
 
     m_invalidFormControls.add(formControlElement);
@@ -899,7 +899,7 @@ void HTMLFormElement::removeFromPastNamesMap(FormAssociatedElement& item)
 
 bool HTMLFormElement::matchesValidPseudoClass() const
 {
-    return m_invalidFormControls.computesEmpty();
+    return m_invalidFormControls.isEmptyIgnoringNullReferences();
 }
 
 bool HTMLFormElement::matchesInvalidPseudoClass() const

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1700,7 +1700,7 @@ void FrameLoader::clearProvisionalLoadForPolicyCheck()
 
 bool FrameLoader::hasOpenedFrames() const
 {
-    return !m_openedFrames.computesEmpty();
+    return !m_openedFrames.isEmptyIgnoringNullReferences();
 }
 
 void FrameLoader::reportLocalLoadFailed(Frame* frame, const String& url)

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -560,8 +560,8 @@ void FrameView::didDestroyRenderTree()
     // Everything else should have removed itself as the tree was felled.
     ASSERT(!m_embeddedObjectsToUpdate || m_embeddedObjectsToUpdate->isEmpty() || (m_embeddedObjectsToUpdate->size() == 1 && m_embeddedObjectsToUpdate->first() == nullptr));
 
-    ASSERT(!m_viewportConstrainedObjects || m_viewportConstrainedObjects->computesEmpty());
-    ASSERT(!m_slowRepaintObjects || m_slowRepaintObjects->computesEmpty());
+    ASSERT(!m_viewportConstrainedObjects || m_viewportConstrainedObjects->isEmptyIgnoringNullReferences());
+    ASSERT(!m_slowRepaintObjects || m_slowRepaintObjects->isEmptyIgnoringNullReferences());
 }
 
 void FrameView::setContentsSize(const IntSize& size)
@@ -1598,7 +1598,7 @@ void FrameView::removeSlowRepaintObject(RenderElement& renderer)
             layer->setNeedsScrollingTreeUpdate();
     }
 
-    if (!m_slowRepaintObjects->computesEmpty())
+    if (!m_slowRepaintObjects->isEmptyIgnoringNullReferences())
         return;
 
     m_slowRepaintObjects = nullptr;
@@ -2164,7 +2164,7 @@ OptionSet<StyleColorOptions> FrameView::styleColorOptions() const
 
 bool FrameView::scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect)
 {
-    if (!m_viewportConstrainedObjects || m_viewportConstrainedObjects->computesEmpty()) {
+    if (!m_viewportConstrainedObjects || m_viewportConstrainedObjects->isEmptyIgnoringNullReferences()) {
         m_frame->page()->chrome().scroll(scrollDelta, rectToScroll, clipRect);
         return true;
     }

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -344,14 +344,14 @@ public:
     void addSlowRepaintObject(RenderElement&);
     void removeSlowRepaintObject(RenderElement&);
     bool hasSlowRepaintObject(const RenderElement& renderer) const { return m_slowRepaintObjects && m_slowRepaintObjects->contains(renderer); }
-    bool hasSlowRepaintObjects() const { return m_slowRepaintObjects && !m_slowRepaintObjects->computesEmpty(); }
+    bool hasSlowRepaintObjects() const { return m_slowRepaintObjects && !m_slowRepaintObjects->isEmptyIgnoringNullReferences(); }
     WeakHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
 
     // Includes fixed- and sticky-position objects.
     void addViewportConstrainedObject(RenderLayerModelObject&);
     void removeViewportConstrainedObject(RenderLayerModelObject&);
     const WeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
-    bool hasViewportConstrainedObjects() const { return m_viewportConstrainedObjects && !m_viewportConstrainedObjects->computesEmpty(); }
+    bool hasViewportConstrainedObjects() const { return m_viewportConstrainedObjects && !m_viewportConstrainedObjects->isEmptyIgnoringNullReferences(); }
     
     float frameScaleFactor() const;
 

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -49,7 +49,7 @@ UserContentProvider::UserContentProvider()
 
 UserContentProvider::~UserContentProvider()
 {
-    ASSERT(m_pages.computesEmpty());
+    ASSERT(m_pages.isEmptyIgnoringNullReferences());
 }
 
 void UserContentProvider::addPage(Page& page)

--- a/Source/WebCore/page/VisitedLinkStore.cpp
+++ b/Source/WebCore/page/VisitedLinkStore.cpp
@@ -36,7 +36,7 @@ VisitedLinkStore::VisitedLinkStore()
 
 VisitedLinkStore::~VisitedLinkStore()
 {
-    ASSERT(m_pages.computesEmpty());
+    ASSERT(m_pages.isEmptyIgnoringNullReferences());
 }
 
 void VisitedLinkStore::addPage(Page& page)

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -375,7 +375,7 @@ bool ContentChangeObserver::containsObservedDOMTimer(const DOMTimer& timer) cons
 
 bool ContentChangeObserver::hasObservedDOMTimer() const
 {
-    return !m_DOMTimerList.computesEmpty();
+    return !m_DOMTimerList.isEmptyIgnoringNullReferences();
 }
 
 void ContentChangeObserver::styleRecalcDidStart()
@@ -469,7 +469,7 @@ void ContentChangeObserver::elementDidBecomeHidden(const Element& element)
     if (!m_visibilityCandidateList.remove(element))
         return;
 //    ASSERT(hasVisibleChangeState());
-    if (m_visibilityCandidateList.computesEmpty())
+    if (m_visibilityCandidateList.isEmptyIgnoringNullReferences())
         setHasIndeterminateState();
 }
 

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -163,7 +163,7 @@ private:
 
     bool hasVisibleChangeState() const { return observedContentChange() == WKContentVisibilityChange; }
     bool hasObservedDOMTimer() const;
-    bool hasObservedTransition() const { return !m_elementsWithTransition.computesEmpty(); }
+    bool hasObservedTransition() const { return !m_elementsWithTransition.isEmptyIgnoringNullReferences(); }
 
     void setIsBetweenTouchEndAndMouseMoved(bool isBetween) { m_isBetweenTouchEndAndMouseMoved = isBetween; }
     bool isBetweenTouchEndAndMouseMoved() const { return m_isBetweenTouchEndAndMouseMoved; }

--- a/Source/WebCore/platform/ScreenOrientationProvider.cpp
+++ b/Source/WebCore/platform/ScreenOrientationProvider.cpp
@@ -44,7 +44,7 @@ ScreenOrientationProvider::~ScreenOrientationProvider()
 
 void ScreenOrientationProvider::addObserver(Observer& observer)
 {
-    bool wasEmpty = m_observers.computesEmpty();
+    bool wasEmpty = m_observers.isEmptyIgnoringNullReferences();
     m_observers.add(observer);
     if (wasEmpty)
         platformStartListeningForChanges();
@@ -53,7 +53,7 @@ void ScreenOrientationProvider::addObserver(Observer& observer)
 void ScreenOrientationProvider::removeObserver(Observer& observer)
 {
     m_observers.remove(observer);
-    if (m_observers.computesEmpty()) {
+    if (m_observers.isEmptyIgnoringNullReferences()) {
         m_currentOrientation = std::nullopt;
         platformStopListeningForChanges();
     }
@@ -76,7 +76,7 @@ ScreenOrientationType ScreenOrientationProvider::currentOrientation()
         return *m_currentOrientation;
 
     auto orientation = platformCurrentOrientation();
-    if (!m_observers.computesEmpty())
+    if (!m_observers.isEmptyIgnoringNullReferences())
         m_currentOrientation = orientation;
     return orientation;
 }

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
@@ -122,7 +122,7 @@ void SharedRoutingArbitrator::endRoutingArbitrationForToken(const Token& token)
 {
     m_tokens.remove(token);
 
-    if (!m_tokens.computesEmpty())
+    if (!m_tokens.isEmptyIgnoringNullReferences())
         return;
 
     for (auto& callback : m_enqueuedCallbacks)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -131,7 +131,7 @@ void RealtimeMediaSource::removeObserver(Observer& observer)
 {
     ASSERT(isMainThread());
     m_observers.remove(observer);
-    if (m_observers.computesEmpty())
+    if (m_observers.isEmptyIgnoringNullReferences())
         stopBeingObserved();
 }
 

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm
@@ -112,7 +112,7 @@ void CoreAudioCaptureSourceFactoryIOS::addExtensiveObserver(ExtensiveObserver& o
 void CoreAudioCaptureSourceFactoryIOS::removeExtensiveObserver(ExtensiveObserver& observer)
 {
     m_observers.remove(observer);
-    if (m_observers.computesEmpty())
+    if (m_observers.isEmptyIgnoringNullReferences())
         AVAudioSessionCaptureDeviceManager::singleton().disableAllDevicesQuery();
 }
 
@@ -120,7 +120,7 @@ CaptureSourceOrError CoreAudioCaptureSourceFactoryIOS::createAudioCaptureSource(
 {
     // We enable exhaustive query to be sure to start capture with the right device.
     // FIXME: We should stop the auxiliary session after starting capture.
-    if (m_observers.computesEmpty())
+    if (m_observers.isEmptyIgnoringNullReferences())
         AVAudioSessionCaptureDeviceManager::singleton().enableAllDevicesQuery();
     return CoreAudioCaptureSource::create(String { device.persistentId() }, WTFMove(hashSalts), constraints, pageIdentifier);
 }

--- a/Source/WebCore/plugins/PluginInfoProvider.cpp
+++ b/Source/WebCore/plugins/PluginInfoProvider.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 PluginInfoProvider::~PluginInfoProvider()
 {
-    ASSERT(m_pages.computesEmpty());
+    ASSERT(m_pages.isEmptyIgnoringNullReferences());
 }
 
 void PluginInfoProvider::clearPagesPluginData()

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -538,7 +538,7 @@ WeakHashSet<RenderElement>& SVGHitTestCycleDetectionScope::visitedElements()
 
 bool SVGHitTestCycleDetectionScope::isEmpty()
 {
-    return visitedElements().computesEmpty();
+    return visitedElements().isEmptyIgnoringNullReferences();
 }
 
 bool SVGHitTestCycleDetectionScope::isVisiting(const RenderElement& element)

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -268,17 +268,17 @@ void Scope::removePendingSheet(const ProcessingInstruction& processingInstructio
 
 bool Scope::hasPendingSheets() const
 {
-    return hasPendingSheetsBeforeBody() || !m_elementsInBodyWithPendingSheets.computesEmpty();
+    return hasPendingSheetsBeforeBody() || !m_elementsInBodyWithPendingSheets.isEmptyIgnoringNullReferences();
 }
 
 bool Scope::hasPendingSheetsBeforeBody() const
 {
-    return !m_elementsInHeadWithPendingSheets.computesEmpty() || !m_processingInstructionsWithPendingSheets.computesEmpty();
+    return !m_elementsInHeadWithPendingSheets.isEmptyIgnoringNullReferences() || !m_processingInstructionsWithPendingSheets.isEmptyIgnoringNullReferences();
 }
 
 bool Scope::hasPendingSheetsInBody() const
 {
-    return !m_elementsInBodyWithPendingSheets.computesEmpty();
+    return !m_elementsInBodyWithPendingSheets.isEmptyIgnoringNullReferences();
 }
 
 void Scope::didRemovePendingStylesheet()

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -207,7 +207,7 @@ void SVGDocumentExtensions::removeElementFromPendingResources(SVGElement& elemen
         for (auto& resource : m_pendingResources) {
             auto& elements = resource.value;
             elements.remove(element);
-            if (elements.computesEmpty())
+            if (elements.isEmptyIgnoringNullReferences())
                 toBeRemoved.append(resource.key);
         }
 
@@ -224,7 +224,7 @@ void SVGDocumentExtensions::removeElementFromPendingResources(SVGElement& elemen
         for (auto& resource : m_pendingResourcesForRemoval) {
             auto& elements = resource.value;
             elements.remove(element);
-            if (elements.computesEmpty())
+            if (elements.isEmptyIgnoringNullReferences())
                 toBeRemoved.append(resource.key);
         }
 
@@ -242,7 +242,7 @@ void SVGDocumentExtensions::markPendingResourcesForRemoval(const AtomString& id)
     ASSERT(!m_pendingResourcesForRemoval.contains(id));
 
     auto existing = m_pendingResources.take(id);
-    if (!existing.computesEmpty())
+    if (!existing.isEmptyIgnoringNullReferences())
         m_pendingResourcesForRemoval.add(id, WTFMove(existing));
 }
 
@@ -262,7 +262,7 @@ RefPtr<SVGElement> SVGDocumentExtensions::takeElementFromPendingResourcesForRemo
 
     resourceSet.remove(*firstElement);
 
-    if (resourceSet.computesEmpty())
+    if (resourceSet.isEmptyIgnoringNullReferences())
         m_pendingResourcesForRemoval.remove(id);
 
     return firstElement;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -174,7 +174,7 @@ SVGElement::SVGElement(const QualifiedName& tagName, Document& document, UniqueR
 SVGElement::~SVGElement()
 {
     if (m_svgRareData) {
-        RELEASE_ASSERT(m_svgRareData->referencingElements().computesEmpty());
+        RELEASE_ASSERT(m_svgRareData->referencingElements().isEmptyIgnoringNullReferences());
         for (SVGElement& instance : copyToVectorOf<Ref<SVGElement>>(instances()))
             instance.m_svgRareData->setCorrespondingElement(nullptr);
         RELEASE_ASSERT(!m_svgRareData->correspondingElement());
@@ -276,7 +276,7 @@ void SVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& old
                 extensions.addElementToRebuild(element);
                 Ref { element }->clearTarget();
             }
-            RELEASE_ASSERT(m_svgRareData->referencingElements().computesEmpty());
+            RELEASE_ASSERT(m_svgRareData->referencingElements().isEmptyIgnoringNullReferences());
         }
         extensions.removeElementToRebuild(*this);
     }

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -60,7 +60,7 @@ public:
 
     String title() const override;
     virtual bool supportsMarkers() const { return false; }
-    bool hasRelativeLengths() const { return !m_elementsWithRelativeLengths.computesEmpty(); }
+    bool hasRelativeLengths() const { return !m_elementsWithRelativeLengths.isEmptyIgnoringNullReferences(); }
     virtual bool needsPendingResourceHandling() const { return true; }
     bool instanceUpdatesBlocked() const;
     void setInstanceUpdatesBlocked(bool);

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.h
@@ -53,7 +53,7 @@ public:
     virtual std::optional<String> synchronize() { return std::nullopt; }
     
     // Control the animation life cycle.
-    bool isAnimating() const { return !m_animators.computesEmpty(); }
+    bool isAnimating() const { return !m_animators.isEmptyIgnoringNullReferences(); }
     virtual void startAnimation(SVGAttributeAnimator& animator) { m_animators.add(animator); }
     virtual void stopAnimation(SVGAttributeAnimator& animator) { m_animators.remove(animator); }
     

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -71,7 +71,7 @@ static NetworkManagerWrapper& networkManager()
 
 void NetworkManagerWrapper::addListener(NetworkRTCMonitor& monitor)
 {
-    bool shouldStart = m_observers.computesEmpty();
+    bool shouldStart = m_observers.isEmptyIgnoringNullReferences();
     m_observers.add(monitor);
     if (!shouldStart) {
         if (m_didReceiveResults)
@@ -93,7 +93,7 @@ void NetworkManagerWrapper::addListener(NetworkRTCMonitor& monitor)
 void NetworkManagerWrapper::removeListener(NetworkRTCMonitor& monitor)
 {
     m_observers.remove(monitor);
-    if (!m_observers.computesEmpty())
+    if (!m_observers.isEmptyIgnoringNullReferences())
         return;
 
     monitor.rtcProvider().callOnRTCNetworkThread([this]() {

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -54,7 +54,7 @@ HTTPCookieStore::HTTPCookieStore(WebKit::WebsiteDataStore& websiteDataStore)
 
 HTTPCookieStore::~HTTPCookieStore()
 {
-    ASSERT(m_observers.computesEmpty());
+    ASSERT(m_observers.isEmptyIgnoringNullReferences());
 }
 
 void HTTPCookieStore::filterAppBoundCookies(Vector<WebCore::Cookie>&& cookies, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
@@ -167,7 +167,7 @@ void HTTPCookieStore::flushCookies(CompletionHandler<void()>&& completionHandler
 
 void HTTPCookieStore::registerObserver(Observer& observer)
 {
-    bool wasObserving = !m_observers.computesEmpty();
+    bool wasObserving = !m_observers.isEmptyIgnoringNullReferences();
     m_observers.add(observer);
     if (wasObserving)
         return;
@@ -179,7 +179,7 @@ void HTTPCookieStore::registerObserver(Observer& observer)
 void HTTPCookieStore::unregisterObserver(Observer& observer)
 {
     m_observers.remove(observer);
-    if (!m_observers.computesEmpty())
+    if (!m_observers.isEmptyIgnoringNullReferences())
         return;
 
     if (auto* networkProcess = networkProcessIfExists())

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -169,7 +169,7 @@ static bool processHasActiveRunTimeLimitation()
 
 - (void)_updateBackgroundTask
 {
-    if (!_assertionsNeedingBackgroundTask.computesEmpty() && (![self _hasBackgroundTask] || _backgroundTaskWasInvalidated)) {
+    if (!_assertionsNeedingBackgroundTask.isEmptyIgnoringNullReferences() && (![self _hasBackgroundTask] || _backgroundTaskWasInvalidated)) {
         if (processHasActiveRunTimeLimitation()) {
             RELEASE_LOG(ProcessSuspension, "%p - WKProcessAssertionBackgroundTaskManager: Ignored request to start a new background task because RunningBoard has already started the expiration timer", self);
             return;
@@ -183,11 +183,11 @@ static bool processHasActiveRunTimeLimitation()
         _backgroundTaskWasInvalidated = false;
         [_backgroundTask acquireWithInvalidationHandler:nil];
         RELEASE_LOG(ProcessSuspension, "WKProcessAssertionBackgroundTaskManager: Took a FinishTaskInterruptable assertion for own process");
-    } else if (_assertionsNeedingBackgroundTask.computesEmpty()) {
+    } else if (_assertionsNeedingBackgroundTask.isEmptyIgnoringNullReferences()) {
         // Release the background task asynchronously because releasing the background task may destroy the ProcessThrottler and we don't
         // want it to get destroyed while in the middle of updating its assertion.
         RunLoop::main().dispatch([self, strongSelf = retainPtr(self)] {
-            if (_assertionsNeedingBackgroundTask.computesEmpty())
+            if (_assertionsNeedingBackgroundTask.isEmptyIgnoringNullReferences())
                 [self _releaseBackgroundTask];
         });
     }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1433,7 +1433,7 @@ void NetworkProcessProxy::removeSession(WebsiteDataStore& websiteDataStore)
     if (canSendMessage())
         send(Messages::NetworkProcess::DestroySession { websiteDataStore.sessionID() }, 0);
 
-    if (m_websiteDataStores.computesEmpty())
+    if (m_websiteDataStores.isEmptyIgnoringNullReferences())
         defaultNetworkProcess() = nullptr;
 }
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -43,7 +43,7 @@ Ref<VisitedLinkStore> VisitedLinkStore::create()
 
 VisitedLinkStore::~VisitedLinkStore()
 {
-    RELEASE_ASSERT(m_processes.computesEmpty());
+    RELEASE_ASSERT(m_processes.isEmptyIgnoringNullReferences());
 }
 
 VisitedLinkStore::VisitedLinkStore()

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -188,7 +188,7 @@ void WebGeolocationManagerProxy::stopUpdatingWithProxy(WebProcessProxy& proxy, c
             providerSetEnabledHighAccuracy(perDomainData, highAccuracyShouldBeEnabled);
     }
 
-    if (perDomainData.watchers.computesEmpty() && perDomainData.watchersNeedingHighAccuracy.computesEmpty())
+    if (perDomainData.watchers.isEmptyIgnoringNullReferences() && perDomainData.watchersNeedingHighAccuracy.isEmptyIgnoringNullReferences())
         m_perDomainData.remove(it);
 }
 
@@ -220,13 +220,13 @@ bool WebGeolocationManagerProxy::isUpdating(const PerDomainData& perDomainData) 
 {
 #if PLATFORM(IOS_FAMILY)
     if (!m_clientProvider)
-        return !perDomainData.watchers.computesEmpty();
+        return !perDomainData.watchers.isEmptyIgnoringNullReferences();
 #else
     UNUSED_PARAM(perDomainData);
 #endif
 
     for (auto& perDomainData : m_perDomainData.values()) {
-        if (!perDomainData->watchers.computesEmpty())
+        if (!perDomainData->watchers.isEmptyIgnoringNullReferences())
             return true;
     }
     return false;
@@ -237,13 +237,13 @@ bool WebGeolocationManagerProxy::isHighAccuracyEnabled(const PerDomainData& perD
 {
 #if PLATFORM(IOS_FAMILY)
     if (!m_clientProvider)
-        return !perDomainData.watchersNeedingHighAccuracy.computesEmpty();
+        return !perDomainData.watchersNeedingHighAccuracy.isEmptyIgnoringNullReferences();
 #else
     UNUSED_PARAM(perDomainData);
 #endif
 
     for (auto& data : m_perDomainData.values()) {
-        if (!data->watchersNeedingHighAccuracy.computesEmpty())
+        if (!data->watchersNeedingHighAccuracy.isEmptyIgnoringNullReferences())
             return true;
     }
     return false;
@@ -255,7 +255,7 @@ void WebGeolocationManagerProxy::providerStartUpdating(PerDomainData& perDomainD
     if (!m_clientProvider) {
         ASSERT(!perDomainData.provider);
         perDomainData.provider = makeUnique<WebCore::CoreLocationGeolocationProvider>(registrableDomain, *this);
-        perDomainData.provider->setEnableHighAccuracy(!perDomainData.watchersNeedingHighAccuracy.computesEmpty());
+        perDomainData.provider->setEnableHighAccuracy(!perDomainData.watchersNeedingHighAccuracy.isEmptyIgnoringNullReferences());
         return;
     }
 #else

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -74,7 +74,7 @@ WebPreferences::WebPreferences(const WebPreferences& other)
 
 WebPreferences::~WebPreferences()
 {
-    ASSERT(m_pages.computesEmpty());
+    ASSERT(m_pages.isEmptyIgnoringNullReferences());
 }
 
 const Vector<RefPtr<API::Object>>& WebPreferences::experimentalFeatures()

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -301,7 +301,7 @@ WebProcessPool::~WebProcessPool()
 #endif
 
 #if ENABLE(GAMEPAD)
-    if (!m_processesUsingGamepads.computesEmpty())
+    if (!m_processesUsingGamepads.isEmptyIgnoringNullReferences())
         UIGamepadProvider::singleton().processPoolStoppedUsingGamepads(*this);
 #endif
 
@@ -1599,7 +1599,7 @@ void WebProcessPool::startedUsingGamepads(IPC::Connection& connection)
     if (!proxy)
         return;
 
-    bool wereAnyProcessesUsingGamepads = !m_processesUsingGamepads.computesEmpty();
+    bool wereAnyProcessesUsingGamepads = !m_processesUsingGamepads.isEmptyIgnoringNullReferences();
 
     ASSERT(!m_processesUsingGamepads.contains(*proxy));
     m_processesUsingGamepads.add(*proxy);
@@ -1633,12 +1633,12 @@ void WebProcessPool::stopGamepadEffects(unsigned gamepadIndex, const String& gam
 
 void WebProcessPool::processStoppedUsingGamepads(WebProcessProxy& process)
 {
-    bool wereAnyProcessesUsingGamepads = !m_processesUsingGamepads.computesEmpty();
+    bool wereAnyProcessesUsingGamepads = !m_processesUsingGamepads.isEmptyIgnoringNullReferences();
 
     ASSERT(m_processesUsingGamepads.contains(process));
     m_processesUsingGamepads.remove(process);
 
-    if (wereAnyProcessesUsingGamepads && m_processesUsingGamepads.computesEmpty())
+    if (wereAnyProcessesUsingGamepads && m_processesUsingGamepads.isEmptyIgnoringNullReferences())
         UIGamepadProvider::singleton().processPoolStoppedUsingGamepads(*this);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -372,7 +372,7 @@ void WebProcessProxy::setIsInProcessCache(bool value, WillShutDown willShutDown)
     if (value) {
         RELEASE_ASSERT(m_pageMap.isEmpty());
         RELEASE_ASSERT(!m_suspendedPageCount);
-        RELEASE_ASSERT(m_provisionalPages.computesEmpty());
+        RELEASE_ASSERT(m_provisionalPages.isEmptyIgnoringNullReferences());
         m_previouslyApprovedFilePaths.clear();
     }
 
@@ -442,7 +442,7 @@ void WebProcessProxy::removeProvisionalPageProxy(ProvisionalPageProxy& provision
     ASSERT(m_provisionalPages.contains(provisionalPage));
     m_provisionalPages.remove(provisionalPage);
     updateRegistrationWithDataStore();
-    if (m_provisionalPages.computesEmpty())
+    if (m_provisionalPages.isEmptyIgnoringNullReferences())
         maybeShutDown();
 }
 
@@ -464,7 +464,7 @@ void WebProcessProxy::removeProvisionalFrameProxy(ProvisionalFrameProxy& provisi
     ASSERT(m_provisionalFrames.contains(provisionalFrame));
     m_provisionalFrames.remove(provisionalFrame);
     updateRegistrationWithDataStore();
-    if (m_provisionalFrames.computesEmpty())
+    if (m_provisionalFrames.isEmptyIgnoringNullReferences())
         maybeShutDown();
 }
 
@@ -1305,8 +1305,8 @@ bool WebProcessProxy::canTerminateAuxiliaryProcess()
     if (!m_pageMap.isEmpty()
         || !m_frameMap.isEmpty()
         || m_suspendedPageCount
-        || !m_provisionalPages.computesEmpty()
-        || !m_provisionalFrames.computesEmpty()
+        || !m_provisionalPages.isEmptyIgnoringNullReferences()
+        || !m_provisionalFrames.isEmptyIgnoringNullReferences()
         || m_isInProcessCache
         || m_shutdownPreventingScopeCounter.value()) {
         WEBPROCESSPROXY_RELEASE_LOG(Process, "canTerminateAuxiliaryProcess: returns false (pageCount=%u, provisionalPageCount=%u, m_suspendedPageCount=%u, m_isInProcessCache=%d, m_shutdownPreventingScopeCounter=%lu)", m_pageMap.size(), m_provisionalPages.computeSize(), m_suspendedPageCount, m_isInProcessCache, m_shutdownPreventingScopeCounter.value());

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -110,7 +110,7 @@ void WebGeolocationManager::unregisterWebPage(WebPage& page)
             m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
     }
 
-    if (pageSets.pageSet.computesEmpty() && pageSets.highAccuracyPageSet.computesEmpty())
+    if (pageSets.pageSet.isEmptyIgnoringNullReferences() && pageSets.highAccuracyPageSet.isEmptyIgnoringNullReferences())
         m_pageSets.remove(it);
 }
 
@@ -173,12 +173,12 @@ void WebGeolocationManager::didFailToDeterminePosition(const WebCore::Registrabl
 
 bool WebGeolocationManager::isUpdating(const PageSets& pageSets) const
 {
-    return !pageSets.pageSet.computesEmpty();
+    return !pageSets.pageSet.isEmptyIgnoringNullReferences();
 }
 
 bool WebGeolocationManager::isHighAccuracyEnabled(const PageSets& pageSets) const
 {
-    return !pageSets.highAccuracyPageSet.computesEmpty();
+    return !pageSets.highAccuracyPageSet.isEmptyIgnoringNullReferences();
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp
@@ -51,33 +51,33 @@ WebDeviceOrientationUpdateProvider::~WebDeviceOrientationUpdateProvider()
 
 void WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation(WebCore::MotionManagerClient& client)
 {
-    if (m_deviceOrientationClients.computesEmpty() && m_page)
+    if (m_deviceOrientationClients.isEmptyIgnoringNullReferences() && m_page)
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceOrientation());
     m_deviceOrientationClients.add(client);
 }
 
 void WebDeviceOrientationUpdateProvider::stopUpdatingDeviceOrientation(WebCore::MotionManagerClient& client)
 {
-    if (m_deviceOrientationClients.computesEmpty())
+    if (m_deviceOrientationClients.isEmptyIgnoringNullReferences())
         return;
     m_deviceOrientationClients.remove(client);
-    if (m_deviceOrientationClients.computesEmpty() && m_page)
+    if (m_deviceOrientationClients.isEmptyIgnoringNullReferences() && m_page)
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StopUpdatingDeviceOrientation());
 }
 
 void WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion(WebCore::MotionManagerClient& client)
 {
-    if (m_deviceMotionClients.computesEmpty() && m_page)
+    if (m_deviceMotionClients.isEmptyIgnoringNullReferences() && m_page)
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StartUpdatingDeviceMotion());
     m_deviceMotionClients.add(client);
 }
 
 void WebDeviceOrientationUpdateProvider::stopUpdatingDeviceMotion(WebCore::MotionManagerClient& client)
 {
-    if (m_deviceMotionClients.computesEmpty())
+    if (m_deviceMotionClients.isEmptyIgnoringNullReferences())
         return;
     m_deviceMotionClients.remove(client);
-    if (m_deviceMotionClients.computesEmpty() && m_page)
+    if (m_deviceMotionClients.isEmptyIgnoringNullReferences() && m_page)
         m_page->send(Messages::WebDeviceOrientationUpdateProviderProxy::StopUpdatingDeviceMotion());
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -51,7 +51,7 @@ WebCore::ScreenOrientationType WebScreenOrientationManager::currentOrientation()
 
     auto sendResult = m_page.sendSync(Messages::WebScreenOrientationManagerProxy::CurrentOrientation { });
     auto [currentOrientation] = sendResult.takeReplyOr(WebCore::ScreenOrientationType::PortraitPrimary);
-    if (!m_observers.computesEmpty())
+    if (!m_observers.isEmptyIgnoringNullReferences())
         m_currentOrientation = currentOrientation;
     return currentOrientation;
 }
@@ -75,7 +75,7 @@ void WebScreenOrientationManager::unlock()
 
 void WebScreenOrientationManager::addObserver(Observer& observer)
 {
-    bool wasEmpty = m_observers.computesEmpty();
+    bool wasEmpty = m_observers.isEmptyIgnoringNullReferences();
     m_observers.add(observer);
     if (wasEmpty)
         m_page.send(Messages::WebScreenOrientationManagerProxy::SetShouldSendChangeNotification { true });
@@ -84,7 +84,7 @@ void WebScreenOrientationManager::addObserver(Observer& observer)
 void WebScreenOrientationManager::removeObserver(Observer& observer)
 {
     m_observers.remove(observer);
-    if (m_observers.computesEmpty()) {
+    if (m_observers.isEmptyIgnoringNullReferences()) {
         m_currentOrientation = std::nullopt;
         m_page.send(Messages::WebScreenOrientationManagerProxy::SetShouldSendChangeNotification { false });
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -759,7 +759,7 @@ TEST(WTF_WeakPtr, WeakHashSetExpansion)
     }
 }
 
-TEST(WTF_WeakPtr, WeakHashSetComputesEmpty)
+TEST(WTF_WeakPtr, WeakHashSetisEmptyIgnoringNullReferences)
 {
     {
         WeakHashSet<Base> weakHashSet;
@@ -767,10 +767,10 @@ TEST(WTF_WeakPtr, WeakHashSetComputesEmpty)
             Base object;
             EXPECT_EQ(s_baseWeakReferences, 0u);
             weakHashSet.add(object);
-            EXPECT_FALSE(weakHashSet.computesEmpty());
+            EXPECT_FALSE(weakHashSet.isEmptyIgnoringNullReferences());
         }
         EXPECT_EQ(s_baseWeakReferences, 1u);
-        EXPECT_TRUE(weakHashSet.computesEmpty());
+        EXPECT_TRUE(weakHashSet.isEmptyIgnoringNullReferences());
     }
 
     {
@@ -782,12 +782,12 @@ TEST(WTF_WeakPtr, WeakHashSetComputesEmpty)
         {
             Base object2;
             weakHashSet.add(object2);
-            EXPECT_FALSE(weakHashSet.computesEmpty());
+            EXPECT_FALSE(weakHashSet.isEmptyIgnoringNullReferences());
         }
         EXPECT_EQ(s_baseWeakReferences, 2u);
-        EXPECT_FALSE(weakHashSet.computesEmpty());
+        EXPECT_FALSE(weakHashSet.isEmptyIgnoringNullReferences());
         weakHashSet.remove(object1);
-        EXPECT_TRUE(weakHashSet.computesEmpty());
+        EXPECT_TRUE(weakHashSet.isEmptyIgnoringNullReferences());
     }
 
     {
@@ -803,9 +803,9 @@ TEST(WTF_WeakPtr, WeakHashSetComputesEmpty)
 
         EXPECT_EQ(s_baseWeakReferences, objects.size() + 1);
         EXPECT_EQ(computeSizeOfWeakHashSet(weakHashSet), objects.size() + 1);
-        EXPECT_FALSE(weakHashSet.computesEmpty());
+        EXPECT_FALSE(weakHashSet.isEmptyIgnoringNullReferences());
         firstObject = nullptr;
-        EXPECT_FALSE(weakHashSet.computesEmpty());
+        EXPECT_FALSE(weakHashSet.isEmptyIgnoringNullReferences());
         EXPECT_EQ(s_baseWeakReferences, objects.size() + 1);
         EXPECT_EQ(computeSizeOfWeakHashSet(weakHashSet), objects.size());
     }
@@ -823,10 +823,10 @@ TEST(WTF_WeakPtr, WeakHashSetComputeSize)
             EXPECT_EQ(weakHashSet.computeSize(), 1u);
             weakHashSet.checkConsistency();
         }
-        EXPECT_TRUE(weakHashSet.computesEmpty());
+        EXPECT_TRUE(weakHashSet.isEmptyIgnoringNullReferences());
         EXPECT_EQ(weakHashSet.computeSize(), 0u);
         EXPECT_EQ(s_baseWeakReferences, 0u);
-        EXPECT_TRUE(weakHashSet.computesEmpty());
+        EXPECT_TRUE(weakHashSet.isEmptyIgnoringNullReferences());
         weakHashSet.checkConsistency();
     }
 
@@ -1950,8 +1950,8 @@ TEST(WTF_WeakPtr, MultipleInheritance)
         EXPECT_TRUE(derived.meowCalled());
         EXPECT_TRUE(derived.woofCalled());
     }
-    EXPECT_TRUE(base1Set.computesEmpty());
-    EXPECT_TRUE(base2Set.computesEmpty());
+    EXPECT_TRUE(base1Set.isEmptyIgnoringNullReferences());
+    EXPECT_TRUE(base2Set.isEmptyIgnoringNullReferences());
 }
 
 struct ThreadSafeInstanceCounter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ThreadSafeInstanceCounter> {
@@ -2091,10 +2091,10 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSet)
 
     EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 1u);
     EXPECT_TRUE(set.contains(*first));
-    EXPECT_FALSE(set.computesEmpty());
+    EXPECT_FALSE(set.isEmptyIgnoringNullReferences());
     set.clear();
     EXPECT_FALSE(set.contains(*first));
-    EXPECT_TRUE(set.computesEmpty());
+    EXPECT_TRUE(set.isEmptyIgnoringNullReferences());
     first = nullptr;
     EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
 }


### PR DESCRIPTION
#### eeb55349e8337dfaff7af0c091e1a246b4ac556f
<pre>
Rename WeakHashSet::computesEmpty to WeakHashSet::isEmptyIgnoringNullReferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=251108">https://bugs.webkit.org/show_bug.cgi?id=251108</a>

Reviewed by Chris Dumez.

Renamed WeakHashSet&apos;s computesEmpty to isEmptyIgnoringNullReferences to match WeakHashMap.

* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::notify):
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadInputActivity):
(WebCore::GamepadManager::makeGamepadVisible):
(WebCore::GamepadManager::maybeStartMonitoringGamepads):
(WebCore::GamepadManager::maybeStopMonitoringGamepads):
* Source/WebCore/animation/DocumentTimelinesController.cpp:
(WebCore::DocumentTimelinesController::detachFromDocument):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::takeAnyMediaCanStartListener):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::~MutationObserver):
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::isEmpty const):
(WebCore::RadioButtonGroup::remove):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::~CanvasBase):
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::hasDisplayBufferObservers const):
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::matchesValidPseudoClass const):
(WebCore::HTMLFieldSetElement::matchesInvalidPseudoClass const):
(WebCore::HTMLFieldSetElement::addInvalidDescendant):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::addInvalidFormControl):
(WebCore::HTMLFormElement::matchesValidPseudoClass const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::hasOpenedFrames const):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::didDestroyRenderTree):
(WebCore::FrameView::removeSlowRepaintObject):
(WebCore::FrameView::scrollContentsFastPath):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::UserContentProvider::~UserContentProvider):
* Source/WebCore/page/VisitedLinkStore.cpp:
(WebCore::VisitedLinkStore::~VisitedLinkStore):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::hasObservedDOMTimer const):
(WebCore::ContentChangeObserver::elementDidBecomeHidden):
* Source/WebCore/page/ios/ContentChangeObserver.h:
(WebCore::ContentChangeObserver::hasObservedTransition const):
* Source/WebCore/platform/ScreenOrientationProvider.cpp:
(WebCore::ScreenOrientationProvider::addObserver):
(WebCore::ScreenOrientationProvider::removeObserver):
(WebCore::ScreenOrientationProvider::currentOrientation):
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
(WebCore::SharedRoutingArbitrator::endRoutingArbitrationForToken):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::removeObserver):
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm:
(WebCore::CoreAudioCaptureSourceFactoryIOS::removeExtensiveObserver):
(WebCore::CoreAudioCaptureSourceFactoryIOS::createAudioCaptureSource):
* Source/WebCore/plugins/PluginInfoProvider.cpp:
(WebCore::PluginInfoProvider::~PluginInfoProvider):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGHitTestCycleDetectionScope::isEmpty):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::hasPendingSheets const):
(WebCore::Style::Scope::hasPendingSheetsBeforeBody const):
(WebCore::Style::Scope::hasPendingSheetsInBody const):
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::removeElementFromPendingResources):
(WebCore::SVGDocumentExtensions::markPendingResourcesForRemoval):
(WebCore::SVGDocumentExtensions::takeElementFromPendingResourcesForRemovalMap):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::~SVGElement):
(WebCore::SVGElement::removedFromAncestor):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::hasRelativeLengths const):
* Source/WebCore/svg/properties/SVGAnimatedProperty.h:
(WebCore::SVGAnimatedProperty::isAnimating const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkManagerWrapper::addListener):
(WebKit::NetworkManagerWrapper::removeListener):
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::~HTTPCookieStore):
(API::HTTPCookieStore::registerObserver):
(API::HTTPCookieStore::unregisterObserver):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(-[WKProcessAssertionBackgroundTaskManager _updateBackgroundTask]):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::removeSession):
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::~VisitedLinkStore):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::stopUpdatingWithProxy):
(WebKit::WebGeolocationManagerProxy::isUpdating const):
(WebKit::WebGeolocationManagerProxy::isHighAccuracyEnabled const):
(WebKit::WebGeolocationManagerProxy::providerStartUpdating):
* Source/WebKit/UIProcess/WebPreferences.cpp:
(WebKit::WebPreferences::~WebPreferences):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::~WebProcessPool):
(WebKit::WebProcessPool::startedUsingGamepads):
(WebKit::WebProcessPool::processStoppedUsingGamepads):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setIsInProcessCache):
(WebKit::WebProcessProxy::removeProvisionalPageProxy):
(WebKit::WebProcessProxy::removeProvisionalFrameProxy):
(WebKit::WebProcessProxy::canTerminateAuxiliaryProcess):
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::unregisterWebPage):
(WebKit::WebGeolocationManager::isUpdating const):
(WebKit::WebGeolocationManager::isHighAccuracyEnabled const):
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.cpp:
(WebKit::WebDeviceOrientationUpdateProvider::startUpdatingDeviceOrientation):
(WebKit::WebDeviceOrientationUpdateProvider::stopUpdatingDeviceOrientation):
(WebKit::WebDeviceOrientationUpdateProvider::startUpdatingDeviceMotion):
(WebKit::WebDeviceOrientationUpdateProvider::stopUpdatingDeviceMotion):
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
(WebKit::WebScreenOrientationManager::currentOrientation):
(WebKit::WebScreenOrientationManager::addObserver):
(WebKit::WebScreenOrientationManager::removeObserver):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/259339@main">https://commits.webkit.org/259339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c67a6dfd28ba9c1ceb0ded4b42ae70af962a18a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113892 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174110 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4620 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112836 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38999 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108089 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80663 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7048 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27433 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92507 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4820 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7159 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4008 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30081 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103447 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46989 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101193 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8948 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25148 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3415 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->