### PR TITLE
[JSC] Update Intl.DurationFormat based on Jan ECMA402 consensus

### DIFF
--- a/JSTests/stress/intl-durationformat-format-to-parts.js
+++ b/JSTests/stress/intl-durationformat-format-to-parts.js
@@ -1,4 +1,5 @@
 //@ requireOptions("--useIntlDurationFormat=1")
+//@ skip if $hostOS != "darwin" # We are testing Intl features based on Darwin's ICU. The other port owners can extend it by testing it in their platforms and removing this condition.
 
 function shouldBe(actual, expected) {
     if (actual !== expected)
@@ -43,7 +44,7 @@ if (Intl.DurationFormat) {
             hours: 22,
             minutes: 30,
             seconds: 34,
-        })), `[{"type":"years","value":"1 yr"},{"type":"literal","value":", "},{"type":"hours","value":"22 hr"},{"type":"literal","value":", "},{"type":"minutes","value":"30 min"},{"type":"literal","value":", "},{"type":"seconds","value":"34 sec"}]`);
+        })), `[{"type":"integer","value":"1","unit":"year"},{"type":"literal","value":" ","unit":"year"},{"type":"unit","value":"yr","unit":"year"},{"type":"literal","value":", "},{"type":"integer","value":"22","unit":"hour"},{"type":"literal","value":" ","unit":"hour"},{"type":"unit","value":"hr","unit":"hour"},{"type":"literal","value":", "},{"type":"integer","value":"30","unit":"minute"},{"type":"literal","value":" ","unit":"minute"},{"type":"unit","value":"min","unit":"minute"},{"type":"literal","value":", "},{"type":"integer","value":"34","unit":"second"},{"type":"literal","value":" ","unit":"second"},{"type":"unit","value":"sec","unit":"second"}]`);
     }
     {
         var fmt = new Intl.DurationFormat('en', {
@@ -54,8 +55,13 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(JSON.stringify(fmt.formatToParts({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 })), [
-            `[{"type":"years","value":"1y"},{"type":"literal","value":", "},{"type":"months","value":"2mo"},{"type":"literal","value":", "},{"type":"weeks","value":"3w"},{"type":"literal","value":", "},{"type":"days","value":"4d"},{"type":"literal","value":", "},{"type":"hours","value":"10"},{"type":"literal","value":":"},{"type":"minutes","value":"34"},{"type":"literal","value":":"},{"type":"seconds","value":"33.03"}]`,
-            `[{"type":"years","value":"1y"},{"type":"literal","value":", "},{"type":"months","value":"2m"},{"type":"literal","value":", "},{"type":"weeks","value":"3w"},{"type":"literal","value":", "},{"type":"days","value":"4d"},{"type":"literal","value":", "},{"type":"hours","value":"10"},{"type":"literal","value":":"},{"type":"minutes","value":"34"},{"type":"literal","value":":"},{"type":"seconds","value":"33.03"}]`,
+            `[{"type":"integer","value":"1","unit":"year"},{"type":"unit","value":"y","unit":"year"},{"type":"literal","value":", "},{"type":"integer","value":"2","unit":"month"},{"type":"unit","value":"mo","unit":"month"},{"type":"literal","value":", "},{"type":"integer","value":"3","unit":"week"},{"type":"unit","value":"w","unit":"week"},{"type":"literal","value":", "},{"type":"integer","value":"4","unit":"day"},{"type":"unit","value":"d","unit":"day"},{"type":"literal","value":", "},{"type":"integer","value":"10","unit":"hour"},{"type":"literal","value":":"},{"type":"integer","value":"34","unit":"minute"},{"type":"literal","value":":"},{"type":"integer","value":"33","unit":"second"},{"type":"decimal","value":".","unit":"second"},{"type":"fraction","value":"03","unit":"second"}]`,
+        ]);
+    }
+    {
+        var fmt = new Intl.DurationFormat('en-US', { style: 'digital', fractionalDigits: 9, millseconds: 'numeric' });
+        shouldBeOneOf(JSON.stringify(fmt.formatToParts({ hours: 7, minutes: 8, seconds: 9, milliseconds: 123, microseconds: 456, nanoseconds: 789 })), [
+            `[{"type":"integer","value":"7","unit":"hour"},{"type":"literal","value":":"},{"type":"integer","value":"08","unit":"minute"},{"type":"literal","value":":"},{"type":"integer","value":"09","unit":"second"},{"type":"decimal","value":".","unit":"second"},{"type":"fraction","value":"123456789","unit":"second"}]`,
         ]);
     }
 }

--- a/JSTests/stress/intl-durationformat.js
+++ b/JSTests/stress/intl-durationformat.js
@@ -166,7 +166,7 @@ function test() {
         shouldThrow(() => df.format({}), TypeError);
         shouldThrow(() => df.format([]), TypeError);
         shouldThrow(() => df.format(42), TypeError);
-        shouldThrow(() => df.format("Apple"), TypeError);
+        shouldThrow(() => df.format("Apple"), RangeError);
         shouldThrow(() => df.format(null), TypeError);
         shouldThrow(() => df.format(undefined), TypeError);
         shouldThrow(() => df.format([null]), TypeError);
@@ -194,11 +194,17 @@ function test() {
     {
         const duration = { hours: 1, minutes: 2, seconds: 3 };
         const expected = [
-            {"type":"hours","value":"1 hour"},
+            {"type":"integer","value":"1","unit":"hour"},
+            {"type":"literal","value":" ","unit":"hour"},
+            {"type":"unit","value":"hour","unit":"hour"},
             {"type":"literal","value":", "},
-            {"type":"minutes","value":"2 minutes"},
+            {"type":"integer","value":"2","unit":"minute"},
+            {"type":"literal","value":" ","unit":"minute"},
+            {"type":"unit","value":"minutes","unit":"minute"},
             {"type":"literal","value":", "},
-            {"type":"seconds","value":"3 seconds"}
+            {"type":"integer","value":"3","unit":"second"},
+            {"type":"literal","value":" ","unit":"second"},
+            {"type":"unit","value":"seconds","unit":"second"}
         ];
 
         const df = new Intl.DurationFormat('en-GB', { style: 'long' });
@@ -211,7 +217,7 @@ function test() {
 
         shouldThrow(() => df.formatToParts(), TypeError);
         shouldThrow(() => df.formatToParts([]), TypeError);
-        shouldThrow(() => df.formatToParts("Apple"), TypeError);
+        shouldThrow(() => df.formatToParts("Apple"), RangeError);
         shouldThrow(() => df.formatToParts(42), TypeError);
         shouldThrow(() => df.formatToParts(null), TypeError);
         shouldThrow(() => df.formatToParts(undefined), TypeError);

--- a/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
@@ -86,11 +86,11 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormat, (JSGlobalObject*
     if (!durationFormat)
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format called on value that's not a DurationFormat"_s);
 
-    auto* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
-    if (UNLIKELY(!object))
-        return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format argument needs to be an object"_s);
+    JSValue argument = callFrame->argument(0);
+    if (UNLIKELY(!argument.isObject() && !argument.isString()))
+        return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format argument needs to be an object or a string"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, object);
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, argument);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(durationFormat->format(globalObject, WTFMove(duration))));
@@ -106,11 +106,11 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormatToParts, (JSGlobal
     if (!durationFormat)
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts called on value that's not a DurationFormat"_s);
 
-    auto* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
-    if (UNLIKELY(!object))
-        return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts argument needs to be an object"_s);
+    JSValue argument = callFrame->argument(0);
+    if (UNLIKELY(!argument.isObject() && !argument.isString()))
+        return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts argument needs to be an object or a string"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, object);
+    auto duration = TemporalDuration::toISO8601Duration(globalObject, argument);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(durationFormat->formatToParts(globalObject, WTFMove(duration))));


### PR DESCRIPTION
#### 4bfba24bc18e04141df7181b750dcebea75e3845
<pre>
[JSC] Update Intl.DurationFormat based on Jan ECMA402 consensus
<a href="https://bugs.webkit.org/show_bug.cgi?id=251115">https://bugs.webkit.org/show_bug.cgi?id=251115</a>
rdar://104582024

Reviewed by Mark Lam.

This patch upgrades Intl.DurationFormat implementation to align it to Jan ECMA402 meeting consensus.
The changes are three-fold.

1. format and formatToParts should accept String too. And throwing a range error when string is not valid[1].
2. formatToParts should use singular form of unit names instead of plural form.
3. formatToParts should split each unit&apos;s representation to make numeric part and unit part accessible[3]. Previously,
   we just grouped &quot;1 hour&quot; as &quot;hour&quot; part. But after this, we split it into &quot;1&quot; integer, &quot; &quot; literal, and &quot;hour&quot; unit,
   with unit = &quot;hour&quot;.

[1]: <a href="https://github.com/tc39/proposal-intl-duration-format/issues/128">https://github.com/tc39/proposal-intl-duration-format/issues/128</a>
[2]: <a href="https://github.com/tc39/proposal-intl-duration-format/issues/44">https://github.com/tc39/proposal-intl-duration-format/issues/44</a>
[3]: <a href="https://github.com/tc39/proposal-intl-duration-format/issues/55">https://github.com/tc39/proposal-intl-duration-format/issues/55</a>

* JSTests/stress/intl-durationformat-format-to-parts.js:
(Intl.DurationFormat.shouldBe.JSON.stringify.fmt.formatToParts):
(Intl.DurationFormat.shouldBeOneOf):
* JSTests/stress/intl-durationformat.js:
(test):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):
(JSC::IntlDurationFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/259317@main">https://commits.webkit.org/259317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ede2b518ffc846257ae09b411390cbb9e7837d5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113893 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4621 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110380 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/96949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108090 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/96949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7049 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92508 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30082 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103448 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13204 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/46990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101194 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3410 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->