### PR TITLE
Gamepad.vibrationActuator: Add support for "trigger-rumble" effect type

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2405,6 +2405,20 @@ GStreamerEnabled:
     WebKit:
       default: true
 
+GamepadTriggerRumbleEnabled:
+  type: bool
+  status: testable
+  humanReadableName: "Gamepad trigger vibration support"
+  humanReadableDescription: "Support for Gamepad trigger vibration"
+  condition: ENABLE(GAMEPAD)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GamepadVibrationActuatorEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.h
@@ -37,6 +37,9 @@ struct GamepadEffectParameters {
     double strongMagnitude = 0.0;
     double weakMagnitude = 0.0;
 
+    double leftTrigger = 0.0;
+    double rightTrigger = 0.0;
+
     // A maximum duration of 5 seconds is recommended by the specification:
     // - https://w3c.github.io/gamepad/extensions.html#gamepadeffectparameters-dictionary
     static constexpr Seconds maximumDuration = 5_s;

--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
@@ -31,4 +31,9 @@
     double startDelay = 0.0;
     double strongMagnitude = 0.0;
     double weakMagnitude = 0.0;
+
+    // Not in the specification but supported by Blink:
+    // https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md
+    double leftTrigger = 0.0;
+    double rightTrigger = 0.0;
 };

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.h
@@ -59,7 +59,10 @@ private:
     GamepadHapticActuator(Document*, Type, Gamepad&);
 
     Document* document();
+    const Document* document() const;
+
     void stopEffects(CompletionHandler<void()>&&);
+    RefPtr<DeferredPromise>& promiseForEffectType(EffectType);
 
     // ActiveDOMObject.
     const char* activeDOMObjectName() const final;
@@ -71,7 +74,8 @@ private:
 
     Type m_type;
     WeakPtr<Gamepad> m_gamepad;
-    RefPtr<DeferredPromise> m_playingEffectPromise;
+    RefPtr<DeferredPromise> m_dualRumbleEffectPromise;
+    RefPtr<DeferredPromise> m_triggerRumbleEffectPromise;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl
@@ -27,5 +27,7 @@
     Conditional=GAMEPAD
 ] enum GamepadHapticEffectType {
     "dual-rumble",
-    "trigger-rumble", // Not in the specification but supported by Blink.
+    // Not in the specification but supported by Blink:
+    // https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md
+    "trigger-rumble",
 };

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -76,6 +76,10 @@ void GameControllerGamepad::setupElements()
             if ([haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityLeftHandle()] && [haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityRightHandle()])
                 m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
         }
+        if (canLoad_GameController_GCHapticsLocalityLeftTrigger() && canLoad_GameController_GCHapticsLocalityRightTrigger()) {
+            if ([haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityLeftTrigger()] && [haptics.supportedLocalities containsObject:get_GameController_GCHapticsLocalityRightTrigger()])
+                m_supportedEffectTypes.add(GamepadHapticEffectType::TriggerRumble);
+        }
     }
 #endif
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h
@@ -29,29 +29,31 @@
 
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class GameControllerHapticEngines;
 struct GamepadEffectParameters;
+enum class GamepadHapticEffectType : uint8_t;
 
-class GameControllerHapticEffect {
+class GameControllerHapticEffect : public CanMakeWeakPtr<GameControllerHapticEffect> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<GameControllerHapticEffect> create(GameControllerHapticEngines&, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&);
+    static std::unique_ptr<GameControllerHapticEffect> create(GameControllerHapticEngines&, GamepadHapticEffectType, const GamepadEffectParameters&);
     ~GameControllerHapticEffect();
 
-    bool start();
+    void start(CompletionHandler<void(bool)>&&);
     void stop();
 
-    void strongEffectFinishedPlaying();
-    void weakEffectFinishedPlaying();
+    void leftEffectFinishedPlaying();
+    void rightEffectFinishedPlaying();
 
 private:
-    GameControllerHapticEffect(RetainPtr<id>&& strongPlayer, RetainPtr<id>&& weakPlayer, CompletionHandler<void(bool)>&&);
+    GameControllerHapticEffect(RetainPtr<id>&& leftPlayer, RetainPtr<id>&& rightPlayer);
 
-    RetainPtr<id> m_strongPlayer;
-    RetainPtr<id> m_weakPlayer;
+    RetainPtr<id> m_leftPlayer;
+    RetainPtr<id> m_rightPlayer;
     CompletionHandler<void(bool)> m_completionHandler;
 };
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h
@@ -51,19 +51,27 @@ public:
 
     void stop(CompletionHandler<void()>&&);
 
-    CHHapticEngine *strongEngine() { return m_strongEngine.get(); }
-    CHHapticEngine *weakEngine() { return m_weakEngine.get(); }
+    CHHapticEngine *leftHandleEngine() { return m_leftHandleEngine.get(); }
+    CHHapticEngine *rightHandleEngine() { return m_rightHandleEngine.get(); }
+    CHHapticEngine *leftTriggerEngine() { return m_leftTriggerEngine.get(); }
+    CHHapticEngine *rightTriggerEngine() { return m_rightTriggerEngine.get(); }
 
 private:
     explicit GameControllerHapticEngines(GCController *);
 
-    void ensureStarted(CompletionHandler<void(bool)>&&);
+    void ensureStarted(GamepadHapticEffectType, CompletionHandler<void(bool)>&&);
+    std::unique_ptr<GameControllerHapticEffect>& currentEffectForType(GamepadHapticEffectType);
 
-    RetainPtr<CHHapticEngine> m_strongEngine;
-    RetainPtr<CHHapticEngine> m_weakEngine;
-    bool m_failedToStartStrongEngine { false };
-    bool m_failedToStartWeakEngine { false };
-    std::unique_ptr<GameControllerHapticEffect> m_currentEffect;
+    RetainPtr<CHHapticEngine> m_leftHandleEngine;
+    RetainPtr<CHHapticEngine> m_rightHandleEngine;
+    RetainPtr<CHHapticEngine> m_leftTriggerEngine;
+    RetainPtr<CHHapticEngine> m_rightTriggerEngine;
+    bool m_failedToStartLeftHandleEngine { false };
+    bool m_failedToStartRightHandleEngine { false };
+    bool m_failedToStartLeftTriggerEngine { false };
+    bool m_failedToStartRightTriggerEngine { false };
+    std::unique_ptr<GameControllerHapticEffect> m_currentDualRumbleEffect;
+    std::unique_ptr<GameControllerHapticEffect> m_currentTriggerRumbleEffect;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm
@@ -48,52 +48,92 @@ std::unique_ptr<GameControllerHapticEngines> GameControllerHapticEngines::create
 }
 
 GameControllerHapticEngines::GameControllerHapticEngines(GCController *gamepad)
-    : m_strongEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityLeftHandle()])
-    , m_weakEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityRightHandle()])
+    : m_leftHandleEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityLeftHandle()])
+    , m_rightHandleEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityRightHandle()])
+    , m_leftTriggerEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityLeftTrigger()])
+    , m_rightTriggerEngine([gamepad.haptics createEngineWithLocality:get_GameController_GCHapticsLocalityRightTrigger()])
 {
 }
 
 GameControllerHapticEngines::~GameControllerHapticEngines() = default;
 
+std::unique_ptr<GameControllerHapticEffect>& GameControllerHapticEngines::currentEffectForType(GamepadHapticEffectType type)
+{
+    switch (type) {
+    case GamepadHapticEffectType::DualRumble:
+        return m_currentDualRumbleEffect;
+    case GamepadHapticEffectType::TriggerRumble:
+        return m_currentTriggerRumbleEffect;
+    }
+    ASSERT_NOT_REACHED();
+    return m_currentDualRumbleEffect;
+}
+
 void GameControllerHapticEngines::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
-    ASSERT_UNUSED(type, type == GamepadHapticEffectType::DualRumble);
+    auto& currentEffect = currentEffectForType(type);
 
     // Trying to create pattern players with a 0 duration will fail. However, Games on XBox seem to use such
     // requests to stop vibrating.
     if (!parameters.duration) {
-        if (auto currentEffect = std::exchange(m_currentEffect, nullptr))
-            currentEffect->stop();
+        if (auto effect = std::exchange(currentEffect, nullptr))
+            effect->stop();
         return completionHandler(true);
     }
 
-    auto currentEffect = GameControllerHapticEffect::create(*this, parameters, WTFMove(completionHandler));
-    if (!currentEffect)
-        return;
+    auto newEffect = GameControllerHapticEffect::create(*this, type, parameters);
+    if (!newEffect)
+        return completionHandler(false);
 
-    if (m_currentEffect)
-        m_currentEffect->stop();
+    if (currentEffect)
+        currentEffect->stop();
 
-    m_currentEffect = WTFMove(currentEffect);
-    ensureStarted([weakThis = WeakPtr { *this }](bool success) mutable {
-        if (!success || !weakThis || !weakThis->m_currentEffect)
-            return;
+    currentEffect = WTFMove(newEffect);
+    ensureStarted(type, [weakThis = WeakPtr { *this }, type, effect = WeakPtr { *currentEffect }, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+        if (!weakThis)
+            return completionHandler(false);
 
-        if (!weakThis->m_currentEffect->start())
-            weakThis->m_currentEffect = nullptr;
+        auto& currentEffect = weakThis->currentEffectForType(type);
+        if (!currentEffect || currentEffect.get() != effect.get())
+            return completionHandler(false);
+
+        if (!success) {
+            currentEffect = nullptr;
+            return completionHandler(false);
+        }
+
+        currentEffect->start([weakThis = WTFMove(weakThis), effect = WTFMove(effect), type, completionHandler = WTFMove(completionHandler)](bool success) mutable {
+            completionHandler(success);
+            if (!weakThis)
+                return;
+            auto& currentEffect = weakThis->currentEffectForType(type);
+            if (currentEffect.get() == effect.get())
+                currentEffect = nullptr;
+        });
     });
 }
 
 void GameControllerHapticEngines::stopEffects()
 {
-    if (auto currentEffect = std::exchange(m_currentEffect, nullptr))
+    if (auto currentEffect = std::exchange(m_currentDualRumbleEffect, nullptr))
+        currentEffect->stop();
+    if (auto currentEffect = std::exchange(m_currentTriggerRumbleEffect, nullptr))
         currentEffect->stop();
 }
 
-void GameControllerHapticEngines::ensureStarted(CompletionHandler<void(bool)>&& completionHandler)
+void GameControllerHapticEngines::ensureStarted(GamepadHapticEffectType effectType, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
-        completionHandler(weakThis && !weakThis->m_failedToStartStrongEngine && !weakThis->m_failedToStartWeakEngine);
+    auto callbackAggregator = MainRunLoopCallbackAggregator::create([weakThis = WeakPtr { *this }, effectType, completionHandler = WTFMove(completionHandler)]() mutable {
+        bool success = false;
+        switch (effectType) {
+        case GamepadHapticEffectType::DualRumble:
+            success = weakThis && !weakThis->m_failedToStartLeftHandleEngine && !weakThis->m_failedToStartRightHandleEngine;
+            break;
+        case GamepadHapticEffectType::TriggerRumble:
+            success = weakThis && !weakThis->m_failedToStartLeftTriggerEngine && !weakThis->m_failedToStartRightTriggerEngine;
+            break;
+        }
+        completionHandler(success);
     });
     auto startEngine = [weakThis = WeakPtr { *this }](CHHapticEngine *engine, CompletionHandler<void(bool)>&& completionHandler, std::function<void()>&& playersFinished) mutable {
         [engine startWithCompletionHandler:makeBlockPtr([weakThis = WTFMove(weakThis), engine, completionHandler = WTFMove(completionHandler), playersFinished](NSError* error) mutable {
@@ -110,32 +150,60 @@ void GameControllerHapticEngines::ensureStarted(CompletionHandler<void(bool)>&& 
             }).get()];
         }).get()];
     };
-    startEngine(m_strongEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-        if (weakThis)
-            weakThis->m_failedToStartStrongEngine = !success;
-    }, [weakThis = WeakPtr { *this }] {
-        if (weakThis && weakThis->m_currentEffect)
-            weakThis->m_currentEffect->strongEffectFinishedPlaying();
-    });
-    startEngine(m_weakEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
-        if (weakThis)
-            weakThis->m_failedToStartWeakEngine = !success;
-    }, [weakThis = WeakPtr { *this }] {
-        if (weakThis && weakThis->m_currentEffect)
-            weakThis->m_currentEffect->weakEffectFinishedPlaying();
-    });
+    switch (effectType) {
+    case GamepadHapticEffectType::DualRumble:
+        startEngine(m_leftHandleEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+            if (weakThis)
+                weakThis->m_failedToStartLeftHandleEngine = !success;
+        }, [weakThis = WeakPtr { *this }] {
+            if (weakThis && weakThis->m_currentDualRumbleEffect)
+                weakThis->m_currentDualRumbleEffect->leftEffectFinishedPlaying();
+        });
+        startEngine(m_rightHandleEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+            if (weakThis)
+                weakThis->m_failedToStartRightHandleEngine = !success;
+        }, [weakThis = WeakPtr { *this }] {
+            if (weakThis && weakThis->m_currentDualRumbleEffect)
+                weakThis->m_currentDualRumbleEffect->rightEffectFinishedPlaying();
+        });
+        break;
+    case GamepadHapticEffectType::TriggerRumble:
+        startEngine(m_leftTriggerEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+            if (weakThis)
+                weakThis->m_failedToStartLeftTriggerEngine = !success;
+        }, [weakThis = WeakPtr { *this }] {
+            if (weakThis && weakThis->m_currentTriggerRumbleEffect)
+                weakThis->m_currentTriggerRumbleEffect->leftEffectFinishedPlaying();
+        });
+        startEngine(m_rightTriggerEngine.get(), [weakThis = WeakPtr { *this }, callbackAggregator](bool success) {
+            if (weakThis)
+                weakThis->m_failedToStartRightTriggerEngine = !success;
+        }, [weakThis = WeakPtr { *this }] {
+            if (weakThis && weakThis->m_currentTriggerRumbleEffect)
+                weakThis->m_currentTriggerRumbleEffect->rightEffectFinishedPlaying();
+        });
+        break;
+    }
 }
 
 void GameControllerHapticEngines::stop(CompletionHandler<void()>&& completionHandler)
 {
     auto callbackAggregator = MainRunLoopCallbackAggregator::create(WTFMove(completionHandler));
-    [m_strongEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
+    [m_leftHandleEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
         if (error)
-            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the strong haptic engine");
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the left handle haptic engine");
     }).get()];
-    [m_weakEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
+    [m_rightHandleEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
         if (error)
-            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the weak haptic engine");
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the right handle haptic engine");
+    }).get()];
+    [m_leftTriggerEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
+        if (error)
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the left trigger haptic engine");
+    }).get()];
+    [m_rightTriggerEngine stopWithCompletionHandler:makeBlockPtr([callbackAggregator](NSError *error) {
+        if (error)
+            RELEASE_LOG_ERROR(Gamepad, "GameControllerHapticEngines::stop: Failed to stop the right trigger haptic engine");
     }).get()];
 }
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
@@ -72,6 +72,8 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCControllerDidD
 
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityLeftHandle, NSString *)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityRightHandle, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityLeftTrigger, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(WebCore, GameController, GCHapticsLocalityRightTrigger, NSString *)
 
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, GameController, ControllerClassForService, Class, (IOHIDServiceClientRef service), (service))

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
@@ -56,6 +56,8 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCControllerDidD
 
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityLeftHandle, NSString *)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityRightHandle, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityLeftTrigger, NSString *)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE(WebCore, GameController, GCHapticsLocalityRightTrigger, NSString *)
 
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, GameController, ControllerClassForService, Class, (IOHIDServiceClientRef service), (service))

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2549,6 +2549,8 @@ struct WebCore::GamepadEffectParameters {
     double startDelay;
     double strongMagnitude;
     double weakMagnitude;
+    double leftTrigger;
+    double rightTrigger;
 };
 
 header: <WebCore/GamepadHapticEffectType.h>


### PR DESCRIPTION
#### 2dca512b491e5f7024d1013d651f77124f154d99
<pre>
Gamepad.vibrationActuator: Add support for &quot;trigger-rumble&quot; effect type
<a href="https://bugs.webkit.org/show_bug.cgi?id=250352">https://bugs.webkit.org/show_bug.cgi?id=250352</a>
rdar://104315486

Reviewed by Brent Fulgham and Geoffrey Garen.

Gamepad.vibrationActuator: Add support for &quot;trigger-rumble&quot; effect type:
-  <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md">https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/GamepadHapticsActuatorTriggerRumble/explainer.md</a>

It allows vibrating the triggers (which the XBox controller supports), while the
existing &quot;dual-rumble&quot; only makes the handles vibrate.

This isn&apos;t yet part of the specification at:
- <a href="https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticeffecttype">https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticeffecttype</a>

However, it is supported by Blink and used by XBox cloud games.

I am adding support behind an experimental feature flag, off by default.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/gamepad/GamepadEffectParameters.h:
* Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::canPlayEffectType const):
(WebCore::GamepadHapticActuator::playEffect):
(WebCore::GamepadHapticActuator::stopEffects):
(WebCore::GamepadHapticActuator::document const):
(WebCore::GamepadHapticActuator::promiseForEffectType):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.h:
* Source/WebCore/Modules/gamepad/GamepadHapticEffectType.idl:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::GameControllerHapticEffect::create):
(WebCore::GameControllerHapticEffect::GameControllerHapticEffect):
(WebCore::GameControllerHapticEffect::start):
(WebCore::GameControllerHapticEffect::stop):
(WebCore::GameControllerHapticEffect::leftEffectFinishedPlaying):
(WebCore::GameControllerHapticEffect::rightEffectFinishedPlaying):
(WebCore::GameControllerHapticEffect::strongEffectFinishedPlaying): Deleted.
(WebCore::GameControllerHapticEffect::weakEffectFinishedPlaying): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.h:
(WebCore::GameControllerHapticEngines::leftHandleEngine):
(WebCore::GameControllerHapticEngines::rightHandleEngine):
(WebCore::GameControllerHapticEngines::leftTriggerEngine):
(WebCore::GameControllerHapticEngines::rightTriggerEngine):
(WebCore::GameControllerHapticEngines::strongEngine): Deleted.
(WebCore::GameControllerHapticEngines::weakEngine): Deleted.
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEngines.mm:
(WebCore::GameControllerHapticEngines::GameControllerHapticEngines):
(WebCore::GameControllerHapticEngines::currentEffectForType):
(WebCore::GameControllerHapticEngines::playEffect):
(WebCore::GameControllerHapticEngines::stopEffects):
(WebCore::GameControllerHapticEngines::ensureStarted):
(WebCore::GameControllerHapticEngines::stop):
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259507@main">https://commits.webkit.org/259507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24bea121c18c508ca5354ff535c595fa06222e82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113992 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174194 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4725 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112918 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39076 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108186 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80743 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94647 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27524 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92609 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4897 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4096 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30168 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103538 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47084 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101296 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6552 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9041 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25238 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->