### PR TITLE
Amortized behaviors of iterators and hasNullReferences should be consistent between WeakHashSet and WeakHashMap

### DIFF
--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -321,7 +321,7 @@ public:
             return !iterator.key.get();
         });
         if (result)
-            amortizedCleanupIfNeeded(count);
+            increaseOperationCountSinceLastCleanup(count);
         else
             m_operationCountSinceLastCleanup = 0;
         return result;

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -47,8 +47,10 @@ public:
         using reference = const value_type&;
 
     private:
-        WeakHashSetConstIterator(const WeakPtrImplSet& set, typename WeakPtrImplSet::const_iterator position)
-            : m_position(position), m_endPosition(set.end())
+        WeakHashSetConstIterator(const WeakHashSet& set, typename WeakPtrImplSet::const_iterator position)
+            : m_set(set)
+            , m_position(position)
+            , m_endPosition(set.m_set.end())
         {
             skipEmptyBuckets();
         }
@@ -63,6 +65,7 @@ public:
             ASSERT(m_position != m_endPosition);
             ++m_position;
             skipEmptyBuckets();
+            m_set.increaseOperationCountSinceLastCleanup();
             return *this;
         }
 
@@ -85,6 +88,7 @@ public:
     private:
         template <typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
 
+        const WeakHashSet& m_set;
         typename WeakPtrImplSet::const_iterator m_position;
         typename WeakPtrImplSet::const_iterator m_endPosition;
     };
@@ -92,17 +96,8 @@ public:
 
     WeakHashSet() { }
 
-    const_iterator begin() const
-    {
-        increaseOperationCountSinceLastCleanup();
-        return WeakHashSetConstIterator(m_set, m_set.begin());
-    }
-
-    const_iterator end() const
-    {
-        increaseOperationCountSinceLastCleanup();
-        return WeakHashSetConstIterator(m_set, m_set.end());
-    }
+    const_iterator begin() const { return WeakHashSetConstIterator(*this, m_set.begin()); }
+    const_iterator end() const { return WeakHashSetConstIterator(*this, m_set.end()); }
 
     template <typename U>
     AddResult add(const U& value)
@@ -148,7 +143,16 @@ public:
 
     bool hasNullReferences() const
     {
-        return WTF::anyOf(m_set, [] (auto& value) { return !value.get(); });
+        unsigned count = 0;
+        auto result = WTF::anyOf(m_set, [&](auto& value) {
+            ++count;
+            return !value.get();
+        });
+        if (result)
+            increaseOperationCountSinceLastCleanup(count);
+        else
+            m_operationCountSinceLastCleanup = 0;
+        return result;
     }
 
     unsigned computeSize() const
@@ -159,7 +163,6 @@ public:
 
     void forEach(const Function<void(T&)>& callback)
     {
-        increaseOperationCountSinceLastCleanup();
         auto items = map(m_set, [](const Ref<WeakPtrImpl>& item) {
             auto* pointer = static_cast<T*>(item->template get<T>());
             return WeakPtr<T, WeakPtrImpl> { pointer };
@@ -185,9 +188,9 @@ private:
         m_operationCountSinceLastCleanup = 0;
     }
 
-    ALWAYS_INLINE unsigned increaseOperationCountSinceLastCleanup() const
+    ALWAYS_INLINE unsigned increaseOperationCountSinceLastCleanup(unsigned count = 1) const
     {
-        unsigned currentCount = m_operationCountSinceLastCleanup++;
+        unsigned currentCount = m_operationCountSinceLastCleanup += count;
         return currentCount;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -909,6 +909,75 @@ TEST(WTF_WeakPtr, WeakHashSetComputeSize)
     }
 }
 
+TEST(WTF_WeakPtr, WeakHashSetAmortizedCleanup)
+{
+    {
+        WeakHashSet<Base> weakHashSet;
+        Vector<std::unique_ptr<Base>> objects;
+        EXPECT_EQ(s_baseWeakReferences, 0u);
+        for (unsigned i = 0; i < 50; ++i) {
+            objects.append(makeUnique<Base>());
+            weakHashSet.add(*objects[i]);
+        }
+        EXPECT_EQ(s_baseWeakReferences, 50u);
+        EXPECT_EQ(weakHashSet.computeSize(), 50u);
+        EXPECT_FALSE(weakHashSet.hasNullReferences());
+        for (unsigned i = 0; i < objects.size(); ++i) {
+            if (!(i % 8))
+                objects[i] = nullptr;
+        }
+        EXPECT_EQ(s_baseWeakReferences, 50u);
+        EXPECT_TRUE(weakHashSet.hasNullReferences());
+        for (unsigned i = 0; i < 3; ++i) {
+            unsigned count = 0;
+            for (auto& item : weakHashSet) {
+                UNUSED_PARAM(item);
+                count++;
+            } 
+            EXPECT_EQ(count, 43u);
+        }
+        EXPECT_EQ(s_baseWeakReferences, 50u);
+        EXPECT_TRUE(weakHashSet.hasNullReferences());
+        Base object;
+        weakHashSet.add(object);
+        EXPECT_EQ(s_baseWeakReferences, 44u);
+        EXPECT_FALSE(weakHashSet.hasNullReferences());
+    }
+
+    {
+        WeakHashSet<Base> weakHashSet;
+        Vector<std::unique_ptr<Base>> objects;
+        EXPECT_EQ(s_baseWeakReferences, 0u);
+        for (unsigned i = 0; i < 50; ++i) {
+            objects.append(makeUnique<Base>());
+            weakHashSet.add(*objects[i]);
+        }
+        EXPECT_EQ(s_baseWeakReferences, 50u);
+        EXPECT_EQ(weakHashSet.computeSize(), 50u);
+        EXPECT_FALSE(weakHashSet.hasNullReferences());
+        Vector<Base*> objectsInIterationOrder;
+        for (auto& item : weakHashSet)
+            objectsInIterationOrder.append(&item);
+        for (unsigned i = 0; i < 50; ++i) {
+            if (i < 40)
+                continue;
+            auto* objectToRemove = objectsInIterationOrder[i];
+            for (unsigned j = 0; j < 50; ++j) {
+                if (objects[j].get() == objectToRemove)
+                    objects[j] = nullptr;
+            }
+        }
+        EXPECT_EQ(s_baseWeakReferences, 50u);
+        for (unsigned i = 0; i < 5; ++i)
+            EXPECT_TRUE(weakHashSet.hasNullReferences());
+        EXPECT_EQ(s_baseWeakReferences, 50u);
+        Base object;
+        weakHashSet.add(object);
+        EXPECT_EQ(s_baseWeakReferences, 41u);
+        EXPECT_FALSE(weakHashSet.hasNullReferences());
+    }
+}
+
 template <typename T, typename U>
 unsigned computeSizeOfWeakHashMap(const WeakHashMap<T, U>& map)
 {
@@ -1785,14 +1854,14 @@ TEST(WTF_WeakPtr, WeakHashMapAmortizedCleanup)
             }
 
             weakHashMap.checkConsistency();
-            EXPECT_EQ(s_baseWeakReferences, 40u);
+            EXPECT_EQ(s_baseWeakReferences, 50u);
             EXPECT_TRUE(weakHashMap.hasNullReferences());
 
             for (unsigned i = 0; i < 4; ++i)
                 collectKeyValuePairsUsingIterators<Base*, int>(weakHashMap);
 
             weakHashMap.checkConsistency();
-            EXPECT_EQ(s_baseWeakReferences, 40u);
+            EXPECT_EQ(s_baseWeakReferences, 50u);
             EXPECT_TRUE(weakHashMap.hasNullReferences());
         }
     }
@@ -1838,8 +1907,8 @@ TEST(WTF_WeakPtr, WeakHashMapAmortizedCleanup)
                     objects[i] = nullptr;
             }
             weakHashMap.checkConsistency();
-            EXPECT_EQ(s_baseWeakReferences, 42u);
-            EXPECT_EQ(ValueObject::s_count, 42u);
+            EXPECT_EQ(s_baseWeakReferences, 50u);
+            EXPECT_EQ(ValueObject::s_count, 50u);
             EXPECT_TRUE(weakHashMap.hasNullReferences());
 
             for (unsigned i = 0; i < 4; ++i) {


### PR DESCRIPTION
#### 58e8ab36fc7d9b1cb93e6d8b49668546679f5e6a
<pre>
Amortized behaviors of iterators and hasNullReferences should be consistent between WeakHashSet and WeakHashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=251116">https://bugs.webkit.org/show_bug.cgi?id=251116</a>

Reviewed by Chris Dumez.

Made const_iterator and hasNullReferences of WeakHashSet trigger amortized cleanup as in WeakHashMap for consistency.

* Source/WTF/wtf/WeakHashMap.h:
(WeakHashMap::hasNullReferences): Just increment the operation count and don&apos;t do amortized cleanup here.

* Source/WTF/wtf/WeakHashSet.h:
(WeakHashSet::WeakHashSetConstIterator::WeakHashSetConstIterator):
(WeakHashSet::WeakHashSetConstIterator::operator++): Increment the operation count.
(WeakHashSet::begin):
(WeakHashSet::end):
(WeakHashSet::hasNullReferences): Increase the operation count.
(WeakHashSet::forEach): Don&apos;t increment the operation count here given the iterator does it now.
(WeakHashSet::increaseOperationCountSinceLastCleanup): Now takes the increment as an argument.

* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(WTF_WeakPtr.WeakHashSetAmortizedCleanup): Added.
(WTF_WeakPtr.WeakHashMapAmortizedCleanup):

Canonical link: <a href="https://commits.webkit.org/259341@main">https://commits.webkit.org/259341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9531a0ca4cada3148efb2bb54e652f0bc0b77a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113921 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4651 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112860 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94483 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108118 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80680 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7078 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27453 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92538 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4845 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4033 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30107 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103475 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47009 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101224 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8974 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3416 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->