### PR TITLE
HLS videos sometimes fail to reach "ended" state & cannot be restarted

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-ended-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-ended-expected.txt
@@ -1,0 +1,9 @@
+
+RUN(video.src = "../resources/hls/test-vod.m3u8")
+EVENT(canplay)
+RUN(video.currentTime = video.duration - 0.5)
+EVENT(seeked)
+RUN(video.play())
+EVENT(ended)
+END OF TEST
+

--- a/LayoutTests/http/tests/media/hls/hls-ended.html
+++ b/LayoutTests/http/tests/media/hls/hls-ended.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>hls-ended</title>
+    <script src=../../media-resources/video-test.js></script>
+    <script>
+    window.addEventListener('load', async event => {
+        video = document.getElementById('video');
+        run('video.src = "../resources/hls/test-vod.m3u8"');
+        await waitFor(video, 'canplay');
+        run('video.currentTime = video.duration - 0.5');
+        await waitFor(video, 'seeked');
+        run('video.play()');
+        await waitFor(video, 'ended');
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video id="video"></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -687,6 +687,7 @@ void MediaPlayerPrivateAVFoundation::didEnd()
     // Hang onto the current time and use it as duration from now on since we are definitely at
     // the end of the movie. Do this because the initial duration is sometimes an estimate.
     MediaTime now = currentMediaTime();
+    ALWAYS_LOG(LOGIDENTIFIER, "currentTime: ", now, ", seeking: ", m_seeking);
     if (now > MediaTime::zeroTime() && !m_seeking)
         m_cachedDuration = now;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1388,6 +1388,8 @@ String MediaPlayerPrivateAVFoundationObjC::errorLog() const
 void MediaPlayerPrivateAVFoundationObjC::didEnd()
 {
     m_requestedPlaying = false;
+    m_timeControlStatusAtCachedCurrentTime = AVPlayerTimeControlStatusPaused;
+    m_wallClockAtCachedCurrentTime = std::nullopt;
     MediaPlayerPrivateAVFoundation::didEnd();
 }
 


### PR DESCRIPTION
#### e03ce8335437dcc2601003936a6977d0e90937a7
<pre>
HLS videos sometimes fail to reach &quot;ended&quot; state &amp; cannot be restarted
<a href="https://bugs.webkit.org/show_bug.cgi?id=251119">https://bugs.webkit.org/show_bug.cgi?id=251119</a>
rdar://102114139

Reviewed by NOBODY (OOPS!).

When WebKit receives the AVPlayerItemDidPlayToEndTimeNotification notification, it still
attempts to estimate the current time because it believes it is still playing, as it hasn&apos;t
yet received the -timeControlStatus KVO. Reset the values for currentTime estimation when
receiving this notification so that the values returned are consistent.

* LayoutTests/http/tests/media/hls/hls-ended-expected.txt: Added.
* LayoutTests/http/tests/media/hls/hls-ended.html: Added.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::didEnd):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::didEnd):
</pre>