### PR TITLE
Change code order in HTMLMetaElement::process()

### DIFF
--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -2,7 +2,8 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -160,32 +161,41 @@ void HTMLMetaElement::process()
     if (!isInDocumentTree())
         return;
 
+    // https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element
+    // All below situations require a content attribute (which can be the empty string).
     const AtomString& contentValue = attributeWithoutSynchronization(contentAttr);
     if (contentValue.isNull())
         return;
-
-    if (equalLettersIgnoringASCIICase(name(), "viewport"_s))
-        document().processViewport(contentValue, ViewportArguments::ViewportMeta);
-    else if (document().settings().disabledAdaptationsMetaTagEnabled() && equalLettersIgnoringASCIICase(name(), "disabled-adaptations"_s))
-        document().processDisabledAdaptations(contentValue);
-#if ENABLE(DARK_MODE_CSS)
-    else if (equalLettersIgnoringASCIICase(name(), "color-scheme"_s) || equalLettersIgnoringASCIICase(name(), "supported-color-schemes"_s))
-        document().processColorScheme(contentValue);
-#endif
-    else if (equalLettersIgnoringASCIICase(name(), "theme-color"_s))
-        document().metaElementThemeColorChanged(*this);
-#if PLATFORM(IOS_FAMILY)
-    else if (equalLettersIgnoringASCIICase(name(), "format-detection"_s))
-        document().processFormatDetection(contentValue);
-    else if (equalLettersIgnoringASCIICase(name(), "apple-mobile-web-app-orientations"_s))
-        document().processWebAppOrientations();
-#endif
-    else if (equalLettersIgnoringASCIICase(name(), "referrer"_s))
-        document().processReferrerPolicy(contentValue, ReferrerPolicySource::MetaTag);
-
+    
     const AtomString& httpEquivValue = attributeWithoutSynchronization(http_equivAttr);
+    // Get the document to process the tag, but only if we're actually part of DOM
+    // tree (changing a meta tag while it's not in the tree shouldn't have any effect
+    // on the document)
     if (!httpEquivValue.isNull())
         document().processMetaHttpEquiv(httpEquivValue, contentValue, isDescendantOf(document().head()));
+    
+    const AtomString& nameValue = attributeWithoutSynchronization(nameAttr);
+    if (nameValue.isNull())
+        return;
+
+    if (equalLettersIgnoringASCIICase(nameValue, "viewport"_s))
+        document().processViewport(contentValue, ViewportArguments::ViewportMeta);
+    else if (document().settings().disabledAdaptationsMetaTagEnabled() && equalLettersIgnoringASCIICase(nameValue, "disabled-adaptations"_s))
+        document().processDisabledAdaptations(contentValue);
+#if ENABLE(DARK_MODE_CSS)
+    else if (equalLettersIgnoringASCIICase(nameValue, "color-scheme"_s) || equalLettersIgnoringASCIICase(nameValue, "supported-color-schemes"_s))
+        document().processColorScheme(contentValue);
+#endif
+    else if (equalLettersIgnoringASCIICase(nameValue, "theme-color"_s))
+        document().metaElementThemeColorChanged(*this);
+#if PLATFORM(IOS_FAMILY)
+    else if (equalLettersIgnoringASCIICase(nameValue, "format-detection"_s))
+        document().processFormatDetection(contentValue);
+    else if (equalLettersIgnoringASCIICase(nameValue, "apple-mobile-web-app-orientations"_s))
+        document().processWebAppOrientations();
+#endif
+    else if (equalLettersIgnoringASCIICase(nameValue, "referrer"_s))
+        document().processReferrerPolicy(contentValue, ReferrerPolicySource::MetaTag);
 }
 
 const AtomString& HTMLMetaElement::content() const


### PR DESCRIPTION
#### b66d5e5ea816cde25864cad0e14941127e725181
<pre>
Change code order in HTMLMetaElement::process()

Change code order in HTMLMetaElement::process()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251046">https://bugs.webkit.org/show_bug.cgi?id=251046</a>

Reviewed by Tim Nguyen.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/d905ef4a93adf27fc8f72cc333e28acf0e912cf6">https://chromium.googlesource.com/chromium/blink/+/d905ef4a93adf27fc8f72cc333e28acf0e912cf6</a>

This patch is to refactor &apos;process&apos; function to check &apos;name&apos; attribute earlier and
avoid any unnecessary comparisons.

* Source/WebCore/html/HTMLMetaElement.cpp:
(HTMLMetaElement::process): Refactoring

Canonical link: <a href="https://commits.webkit.org/259413@main">https://commits.webkit.org/259413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35f49c876531d9879f82685532b5339dd42b4d08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114074 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174276 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4808 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112988 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39133 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26228 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7230 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4179 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47138 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6492 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9116 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->