### PR TITLE
[JSC] Fix misc wasm bugs to expand V8 test coverage

### DIFF
--- a/JSTests/wasm/function-references/ref_types.js
+++ b/JSTests/wasm/function-references/ref_types.js
@@ -92,12 +92,12 @@ async function testRefTypeParamCheck() {
     // Trigger the ic path
     assert.throws(
       () => instance2.exports.f(null),
-      WebAssembly.RuntimeError,
+      TypeError,
       "Funcref must be an exported wasm function"
     );
     assert.throws(
       () => instance2.exports.f(instance1.exports.f),
-      WebAssembly.RuntimeError,
+      TypeError,
       "Argument function did not match the reference type"
     );
     instance3.exports.f(null);
@@ -129,7 +129,7 @@ async function testRefGlobalCheck() {
   const instance1 = new WebAssembly.Instance(m1);
   assert.throws(
     () => (instance1.exports.g.value = null),
-    WebAssembly.RuntimeError,
+    TypeError,
     "Funcref must be an exported wasm function"
   );
 
@@ -145,12 +145,12 @@ async function testRefGlobalCheck() {
   const instance2 = new WebAssembly.Instance(m2);
   assert.throws(
     () => (instance2.exports.g.value = null),
-    WebAssembly.RuntimeError,
+    TypeError,
     "Funcref must be an exported wasm function"
   );
   assert.throws(
     () => (instance2.exports.g.value = providerInstance.exports.f),
-    WebAssembly.RuntimeError,
+    TypeError,
     "Argument function did not match the reference type"
   );
 
@@ -237,12 +237,12 @@ async function testExternFuncrefNonNullCheck() {
     // Trigger the ic path
     assert.throws(
       () => instance1.exports.f(null),
-      WebAssembly.RuntimeError,
+      TypeError,
       "Non-null Externref cannot be null"
     );
     assert.throws(
       () => instance2.exports.f(null),
-      WebAssembly.RuntimeError,
+      TypeError,
       "Funcref must be an exported wasm function"
     );
   }
@@ -326,8 +326,8 @@ async function testWasmJSGlobals() {
 
   assert.throws(
     () => wasmGlobalFuncref.value = console.log,
-    WebAssembly.RuntimeError,
-    "Funcref must be an exported wasm function (evaluating 'wasmGlobalFuncref.value = console.log')"
+    TypeError,
+    "Funcref must be an exported wasm function"
   );
 
   const wasmGlobalExtern = new WebAssembly.Global({value:'externref', mutable:true});

--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -99,7 +99,7 @@ function testArrayJS() {
       `);
       m.exports.f();
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -113,7 +113,7 @@ function testArrayJS() {
       `);
       m.exports.f(null);
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -128,7 +128,7 @@ function testArrayJS() {
       `, { m: { f: (x) => { return; } } });
       m.exports.g();
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -143,7 +143,7 @@ function testArrayJS() {
       `, { m: { f: (x) => { return null; } } });
       m.exports.g();
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -158,7 +158,7 @@ function testArrayJS() {
       `);
       m.exports.g.value = 42;
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 }

--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -200,7 +200,7 @@ function testI31JS() {
       `);
       m.exports.f(42);
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "I31ref import from JS currently unsupported"
   )
 
@@ -221,7 +221,7 @@ function testI31JS() {
       `);
       m.exports.g.value = 42;
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "I31ref import from JS currently unsupported"
   )
 }

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -137,7 +137,7 @@ function testStructJS() {
       `);
       m.exports.f();
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -151,7 +151,7 @@ function testStructJS() {
       `);
       m.exports.f(null);
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -166,7 +166,7 @@ function testStructJS() {
       `, { m: { f: (x) => { return; } } });
       m.exports.g();
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -181,7 +181,7 @@ function testStructJS() {
       `, { m: { f: (x) => { return null; } } });
       m.exports.g();
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 
@@ -196,7 +196,7 @@ function testStructJS() {
       `);
       m.exports.g.value = 42;
     },
-    WebAssembly.RuntimeError,
+    TypeError,
     "Unsupported use of struct or array type"
   )
 }

--- a/JSTests/wasm/references/func_ref.js
+++ b/JSTests/wasm/references/func_ref.js
@@ -124,13 +124,13 @@ function makeFuncrefIdent() {
 
     assert.eq(instance.exports.i(null), null)
     assert.eq(instance.exports.i(myfun), myfun)
-    assert.throws(() => instance.exports.i(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
-    assert.throws(() => instance.exports.i(5), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => instance.exports.i(fun), TypeError, "Funcref must be an exported wasm function")
+    assert.throws(() => instance.exports.i(5), TypeError, "Funcref must be an exported wasm function")
 
-    assert.throws(() => instance.exports.get_i()(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => instance.exports.get_i()(fun), TypeError, "Funcref must be an exported wasm function")
     assert.eq(instance.exports.get_i()(null), null)
     assert.eq(instance.exports.get_i()(myfun), myfun)
-    assert.throws(() => instance.exports.get_i()(5), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => instance.exports.get_i()(5), TypeError, "Funcref must be an exported wasm function")
 
     assert.eq(instance.exports.fix()(), instance.exports.fix());
     assert.eq(instance.exports.fix(), instance.exports.fix);
@@ -226,7 +226,7 @@ function makeFuncrefIdent() {
     $1.exports.set_glob(null); assert.eq($1.exports.get_glob(), null)
     $1.exports.set_glob(myfun); assert.eq($1.exports.get_glob()(), 42);
 
-    assert.throws(() => $1.exports.set_glob(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => $1.exports.set_glob(fun), TypeError, "Funcref must be an exported wasm function")
 
     assert.eq($1.exports.glob_is_null(), 0)
     $1.exports.set_glob_null(); assert.eq($1.exports.get_glob(), null)
@@ -317,11 +317,11 @@ assert.throws(() => new WebAssembly.Module((new Builder())
     $1.exports.set_glob(null); assert.eq($1.exports.get_glob(), null); assert.throws(() => $1.exports.call_glob(42), Error, "call_indirect to a null table entry (evaluating 'func(...args)')")
     $1.exports.set_glob(ident); assert.eq($1.exports.get_glob(), ident); assert.eq($1.exports.call_glob(42), 42)
 
-    assert.throws(() => $1.exports.set_glob(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => $1.exports.set_glob(fun), TypeError, "Funcref must be an exported wasm function")
     $1.exports.set_glob(myfun); assert.eq($1.exports.get_glob(), myfun); assert.throws(() => $1.exports.call_glob(42), Error, "call_indirect to a signature that does not match (evaluating 'func(...args)')")
 
     for (let i=0; i<1000; ++i) {
-        assert.throws(() => $1.exports.set_glob(function() {}), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')");
+        assert.throws(() => $1.exports.set_glob(function() {}), TypeError, "Funcref must be an exported wasm function");
     }
 }
 
@@ -436,20 +436,20 @@ for (let importedFun of [function(i) { return i; }, makeFuncrefIdent()]) {
     for (let test of [$1.exports.test1, $1.exports.test3]) {
         assert.eq(test(myfun), myfun)
         assert.eq(test(myfun)(), 1337)
-        assert.throws(() => test(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+        assert.throws(() => test(fun), TypeError, "Funcref must be an exported wasm function")
 
         for (let i=0; i<1000; ++i) {
-            assert.throws(() => test(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+            assert.throws(() => test(fun), TypeError, "Funcref must be an exported wasm function")
         }
     }
 
     for (let test of [$1.exports.test2, $1.exports.test4]) {
         assert.eq(test(), $1.exports.test1)
         assert.eq(test()(myfun), myfun)
-        assert.throws(() => test()(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+        assert.throws(() => test()(fun), TypeError, "Funcref must be an exported wasm function")
 
         for (let i=0; i<1000; ++i) {
-            assert.throws(() => test()(fun), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+            assert.throws(() => test()(fun), TypeError, "Funcref must be an exported wasm function")
         }
     }
 }
@@ -471,7 +471,7 @@ for (let importedFun of [function(i) { return i; }, makeFuncrefIdent()]) {
     const myfun = makeExportedFunction(1337);
     assert.eq(myfun(), 1337)
     assert.eq(42, $1.exports.test(42, myfun))
-    assert.throws(() => $1.exports.test(42, () => 5), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => $1.exports.test(42, () => 5), TypeError, "Funcref must be an exported wasm function")
 }
 
 {
@@ -508,7 +508,7 @@ for (let importedFun of [function(i) { return i; }, makeFuncrefIdent()]) {
     for (let i = 0; i < 100; ++i)
         foo(0);
 
-    assert.throws(() => $1.exports.test(42, () => 5), Error, "Funcref must be an exported wasm function (evaluating 'func(...args)')")
+    assert.throws(() => $1.exports.test(42, () => 5), TypeError, "Funcref must be an exported wasm function")
     assert.throws(() => $1.exports.test(42, myfun), RangeError, "Maximum call stack size exceeded.")
     assert.throws(() => foo(1), RangeError, "Maximum call stack size exceeded.")
 }

--- a/JSTests/wasm/references/globals.js
+++ b/JSTests/wasm/references/globals.js
@@ -36,10 +36,10 @@ async function testGlobalConstructorForFuncref() {
   {
       let global = new WebAssembly.Global({ value: "anyfunc", mutable: true }, instance.exports.foo);
       assert.eq(global.value, instance.exports.foo);
-      assert.throws(() => global.value = new Pelmen(calories), WebAssembly.RuntimeError, "Funcref must be an exported wasm function (evaluating 'global.value = new Pelmen(calories)')");
+      assert.throws(() => global.value = new Pelmen(calories), TypeError, "Funcref must be an exported wasm function");
   }
 
-  assert.throws(() => new WebAssembly.Global({ value: "anyfunc", mutable: true }, new Pelmen(calories)), WebAssembly.RuntimeError, "Funcref must be an exported wasm function (evaluating 'new WebAssembly.Global({ value: \"anyfunc\", mutable: true }, new Pelmen(calories))')");
+  assert.throws(() => new WebAssembly.Global({ value: "anyfunc", mutable: true }, new Pelmen(calories)), TypeError, "Funcref must be an exported wasm function");
 }
 
 testGlobalConstructorForExternref();

--- a/JSTests/wasm/stress/global-wrong-type.js
+++ b/JSTests/wasm/stress/global-wrong-type.js
@@ -10,4 +10,4 @@ assert.throws(() => {
     new WebAssembly.Global({
         value: 'anyfunc'
     }, {});
-}, WebAssembly.RuntimeError, `Funcref must be an exported wasm function`);
+}, TypeError, `Funcref must be an exported wasm function`);

--- a/JSTests/wasm/stress/mutable-globals.js
+++ b/JSTests/wasm/stress/mutable-globals.js
@@ -187,12 +187,12 @@ import * as assert from '../assert.js'
                 false,
             ];
             for (let value of list) {
-                assert.throws(() => binding.value = value, WebAssembly.RuntimeError, `Funcref must be an exported wasm function (evaluating 'binding.value = value')`);
+                assert.throws(() => binding.value = value, TypeError, `Funcref must be an exported wasm function`);
                 assert.eq(binding.value, null);
                 assert.eq(instance.exports.getFuncref(), null);
                 instance.exports.setFuncref(null);
                 assert.eq(instance.exports.getFuncref(), null);
-                assert.throws(() => instance.exports.setFuncref(value), WebAssembly.RuntimeError, `Funcref must be an exported wasm function (evaluating 'func(...args)')`);
+                assert.throws(() => instance.exports.setFuncref(value), TypeError, `Funcref must be an exported wasm function`);
                 assert.eq(instance.exports.getFuncref(), null);
             }
             binding.value = instance.exports.setFuncref;

--- a/JSTests/wasm/v8/atomics.js
+++ b/JSTests/wasm/v8/atomics.js
@@ -1,7 +1,7 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
-i// Exception: Failure (Error message):
+// Exception: Failure (Error message):
 //  expected:
 //  should match '/(\/Out of bounds memory access\/|operation does not support unaligned accesses)/'
 //  found:
@@ -489,5 +489,5 @@ function CmpExchgLoop(opcode, alignment) {
   assertEquals(false, WebAssembly.validate(builder.toBuffer()));
   assertThrows(
       () => builder.toModule(), WebAssembly.CompileError,
-      /invalid atomic opcode: 0xfe790/);
+      /WebAssembly.Module doesn't parse at byte 4: invalid extended atomic op 1936, in function at index 0/);
 })();

--- a/JSTests/wasm/v8/bit-shift-right.js
+++ b/JSTests/wasm/v8/bit-shift-right.js
@@ -124,8 +124,4 @@ let testFct = () => {
   assertEquals(-123, wasm.i32_shr_s_by_negative_22((-123 << 10) + 456));
 };
 
-for (let i = 0; i < 20; i++) testFct();
-for (let fct of fcts) {
-  %WasmTierUpFunction(instance, fct.index);
-}
-testFct();
+for (let i = 0; i < 10000; i++) testFct();

--- a/JSTests/wasm/v8/divrem-trap.js
+++ b/JSTests/wasm/v8/divrem-trap.js
@@ -1,12 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  "divide result unrepresentable"
-//  found:
-//  "Integer overflow (evaluating 'divs(0x80000000, -1)')"
-
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/export-global.js
+++ b/JSTests/wasm/v8/export-global.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/Duplicate export name 'g' for global 0 and global 1/'
-//  found:
-//  "WebAssembly.Module doesn't parse at byte 30: duplicate export: 'g' (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')"
-// Probably need to translate exception strings.
-
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -20,7 +11,7 @@ load("wasm-module-builder.js");
   builder.addGlobal(kWasmI64, false).exportAs('g');
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
-      /Duplicate export name 'g' for global 0 and global 1/);
+      /duplicate export: 'g'/);
 })();
 
 (function exportNameClashWithFunction() {
@@ -29,7 +20,7 @@ load("wasm-module-builder.js");
   builder.addFunction('f', kSig_v_v).addBody([]).exportAs('foo');
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
-      /Duplicate export name 'foo' for global 0 and function 0/);
+      /duplicate export: 'foo'/);
 })();
 
 (function veryLongExportName() {
@@ -43,7 +34,7 @@ load("wasm-module-builder.js");
   global.exportAs(export_name);
   global.exportAs(export_name);
   var error_msg =
-      'Duplicate export name \'(abc){10,20}ab?c?\.\.\.\' for global 0 and global 0';
+      'duplicate export: ';
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
       new RegExp(error_msg));

--- a/JSTests/wasm/v8/export-table.js
+++ b/JSTests/wasm/v8/export-table.js
@@ -1,29 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/Duplicate export name 'main' for function 0 and function 2/'
-//  found:
-//  "WebAssembly.Module doesn't parse at byte 49: duplicate export: 'main' (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')"
-//
-//  Stack: MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  fail@mjsunit.js:343:27
-//  assertMatches@mjsunit.js:599:11
-//  checkException@mjsunit.js:501:20
-//  assertThrows@mjsunit.js:518:21
-//  testExportNameClash@export-table.js:134:15
-//  global code@export-table.js:136:3
-//  MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  fail@mjsunit.js:343:27
-//  assertMatches@mjsunit.js:599:11
-//  checkException@mjsunit.js:501:20
-//  assertThrows@mjsunit.js:518:21
-//  testExportNameClash@export-table.js:134:15
-//  global code@export-table.js:136:3
-
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -132,7 +107,7 @@ load("wasm-module-builder.js");
   builder.addFunction("three", kSig_v_v).addBody([kExprNop]).exportAs("main");
 
   assertThrows(() => builder.instantiate(), WebAssembly.CompileError,
-    /Duplicate export name 'main' for function 0 and function 2/);
+    /duplicate export/);
 })();
 
 

--- a/JSTests/wasm/v8/externref-table.js
+++ b/JSTests/wasm/v8/externref-table.js
@@ -3,7 +3,7 @@
 // Failure:
 // Exception: Failure (Error message):
 //  expected:
-//  should match '/imported table does not match the expected type/'
+//  should match '/Table import /'
 //  found:
 //  "Table import imp:table provided a 'type' that is wrong (evaluating 'new WebAssembly.Instance(module, ffi)')"
 // Looks like we need to update the exception strings.
@@ -56,7 +56,7 @@ load("wasm-module-builder.js");
   let table_func = new WebAssembly.Table(
       { element: "anyfunc", initial: 3, maximum: 10 });
   assertThrows(() => builder.instantiate({ imp: { table: table_func } }),
-    WebAssembly.LinkError, /imported table does not match the expected type/);
+    WebAssembly.LinkError, /Table import /);
 })();
 
 (function TestExternRefDropDeclarativeElementSegment() {

--- a/JSTests/wasm/v8/externref.js
+++ b/JSTests/wasm/v8/externref.js
@@ -1,8 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Skipping this test due to the following issues:
-// call to %ScheduleGCInStackCheck()
-
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -285,7 +281,7 @@ load("wasm-module-builder.js");
 
   const instance = builder.instantiate({
     q: {
-      triggerGC: () => %ScheduleGCInStackCheck(),
+      triggerGC: () => fullGC(),
       func: (ref) => assertEquals(ref.hello, 4)
     }
   });
@@ -330,7 +326,7 @@ load("wasm-module-builder.js");
 
   const instance = builder.instantiate({
     q: {
-      triggerGC: () => %ScheduleGCInStackCheck(),
+      triggerGC: () => fullGC(),
       func: (ref) => assertEquals(ref.hello, 4)
     }
   });

--- a/JSTests/wasm/v8/indirect-call-non-zero-table.js
+++ b/JSTests/wasm/v8/indirect-call-non-zero-table.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Fails with:
-// Exception: CompileError: WebAssembly.Module doesn't parse at byte 4: invalid opcode 19, in function at index 7 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')
-// Module@[native code]
-// toModule@.tests/wasm.yaml/wasm/v8/wasm-module-builder.js:2082:34
-// instantiate@.tests/wasm.yaml/wasm/v8/wasm-module-builder.js:2071:31
-// IndirectCallToNonZeroTable@indirect-call-non-zero-table.js:88:39
-// global code@indirect-call-non-zero-table.js:110:3
-
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/indirect-calls.js
+++ b/JSTests/wasm/v8/indirect-calls.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/null function or function signature mismatch/'
-//  found:
-//  "call_indirect to a signature that does not match (evaluating 'module.exports.main(2, 12, 33)')"
-// Looks like we need to update the exception strings.
-
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/indirect-tables.js
+++ b/JSTests/wasm/v8/indirect-tables.js
@@ -614,7 +614,7 @@ function js_div(a, b) { return (a / b) | 0; }
   // the added function does not match.
   assertThrows(
       () => instance0.exports.main(0), WebAssembly.RuntimeError,
-      /signature mismatch/);
+      /signature that does not match/);
 })();
 
 (function IndirectCallIntoOtherInstance() {
@@ -932,5 +932,5 @@ function js_div(a, b) { return (a / b) | 0; }
 
   assertThrows(
     () => builder.instantiate(), WebAssembly.CompileError,
-    /non-imported globals cannot be used in constant expressions/);
+    /opcode for exp in element section/);
 })();

--- a/JSTests/wasm/v8/js-api.js
+++ b/JSTests/wasm/v8/js-api.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/must be invoked with 'new'/'
-//  found:
-//  "calling WebAssembly.Module constructor without new is invalid"
-// Looks like we need to update the exception strings.
-
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -155,24 +146,24 @@ assertEq(Module.length, 1);
 assertEq(Module.name, 'Module');
 assertTrue(isConstructor(Module));
 assertThrows(
-    () => Module(), TypeError, /must be invoked with 'new'/);
+    () => Module(), TypeError, /constructor without new is invalid/);
 assertThrows(
-    () => new Module(), TypeError, /Argument 0 must be a buffer source/);
+    () => new Module(), TypeError, /first argument must be an ArrayBufferView or an ArrayBuffer/);
 assertThrows(
     () => new Module(undefined), TypeError,
-    'WebAssembly.Module(): Argument 0 must be a buffer source');
+    /first argument must be an ArrayBufferView or an ArrayBuffer/);
 assertThrows(
     () => new Module(1), TypeError,
-    'WebAssembly.Module(): Argument 0 must be a buffer source');
+    /first argument must be an ArrayBufferView or an ArrayBuffer/);
 assertThrows(
     () => new Module({}), TypeError,
-    'WebAssembly.Module(): Argument 0 must be a buffer source');
+    /first argument must be an ArrayBufferView or an ArrayBuffer/);
 assertThrows(
     () => new Module(new Uint8Array()), CompileError,
-    /BufferSource argument is empty/);
+    /WebAssembly.Module doesn't parse at byte 0/);
 assertThrows(
     () => new Module(new ArrayBuffer()), CompileError,
-    /BufferSource argument is empty/);
+    /WebAssembly.Module doesn't parse at byte 0/);
 assertTrue(new Module(emptyModuleBinary) instanceof Module);
 assertTrue(new Module(emptyModuleBinary.buffer) instanceof Module);
 
@@ -209,13 +200,13 @@ let moduleImports = moduleImportsDesc.value;
 assertEq(moduleImports.length, 1);
 assertFalse(isConstructor(moduleImports));
 assertThrows(
-    () => moduleImports(), TypeError, /Argument 0 must be a WebAssembly.Module/);
+    () => moduleImports(), TypeError, /WebAssembly.Module.imports called with non WebAssembly.Module argument/);
 assertThrows(
     () => moduleImports(undefined), TypeError,
-    /Argument 0 must be a WebAssembly.Module/);
+    /WebAssembly.Module.imports called with non WebAssembly.Module argument/);
 assertThrows(
     () => moduleImports({}), TypeError,
-    /Argument 0 must be a WebAssembly.Module/);
+    /WebAssembly.Module.imports called with non WebAssembly.Module argument/);
 var arr = moduleImports(new Module(emptyModuleBinary));
 assertTrue(arr instanceof Array);
 assertEq(arr.length, 0);
@@ -257,13 +248,13 @@ let moduleExports = moduleExportsDesc.value;
 assertEq(moduleExports.length, 1);
 assertFalse(isConstructor(moduleExports));
 assertThrows(
-    () => moduleExports(), TypeError, /Argument 0 must be a WebAssembly.Module/);
+    () => moduleExports(), TypeError, /WebAssembly.Module.exports called with non WebAssembly.Module argument/);
 assertThrows(
     () => moduleExports(undefined), TypeError,
-    /Argument 0 must be a WebAssembly.Module/);
+    /WebAssembly.Module.exports called with non WebAssembly.Module argument/);
 assertThrows(
     () => moduleExports({}), TypeError,
-    /Argument 0 must be a WebAssembly.Module/);
+    /WebAssembly.Module.exports called with non WebAssembly.Module argument/);
 var arr = moduleExports(emptyModule);
 assertTrue(arr instanceof Array);
 assertEq(arr.length, 0);
@@ -304,20 +295,20 @@ let moduleCustomSections = moduleCustomSectionsDesc.value;
 assertEq(moduleCustomSections.length, 2);
 assertFalse(isConstructor(moduleCustomSections));
 assertThrows(
-    () => moduleCustomSections(), TypeError, /Argument 0 must be a WebAssembly.Module/);
+    () => moduleCustomSections(), TypeError, /Not enough arguments/);
 assertThrows(
     () => moduleCustomSections(undefined), TypeError,
-    /Argument 0 must be a WebAssembly.Module/);
+    /Not enough arguments/);
 assertThrows(
     () => moduleCustomSections({}), TypeError,
-    /Argument 0 must be a WebAssembly.Module/);
+    /Not enough arguments/);
 var arr = moduleCustomSections(emptyModule, 'x');
 assertEq(arr instanceof Array, true);
 assertEq(arr.length, 0);
 
 assertThrows(
     () => moduleCustomSections(1), TypeError,
-    'WebAssembly.Module.customSections(): Argument 0 must be a WebAssembly.Module');
+    'Not enough arguments');
 
 let customSectionModuleBinary2 = (() => {
   let builder = new WasmModuleBuilder();
@@ -363,16 +354,16 @@ assertEq(Instance.length, 1);
 assertEq(Instance.name, 'Instance');
 assertTrue(isConstructor(Instance));
 assertThrows(
-    () => Instance(), TypeError, /must be invoked with 'new'/);
+    () => Instance(), TypeError, /constructor without new is invalid/);
 assertThrows(
     () => new Instance(1), TypeError,
-    'WebAssembly.Instance(): Argument 0 must be a WebAssembly.Module');
+    /first argument to WebAssembly.Instance must be a WebAssembly.Module/);
 assertThrows(
     () => new Instance({}), TypeError,
-    'WebAssembly.Instance(): Argument 0 must be a WebAssembly.Module');
+    /first argument to WebAssembly.Instance must be a WebAssembly.Module/);
 assertThrows(
     () => new Instance(emptyModule, null), TypeError,
-    'WebAssembly.Instance(): Argument 1 must be an object');
+    /second argument to WebAssembly.Instance must be undefined or an Object/);
 assertThrows(() => new Instance(importingModule, null), TypeError);
 assertThrows(
     () => new Instance(importingModule, undefined), TypeError);
@@ -443,26 +434,26 @@ assertEq(Memory.length, 1);
 assertEq(Memory.name, 'Memory');
 assertTrue(isConstructor(Memory));
 assertThrows(
-    () => Memory(), TypeError, /must be invoked with 'new'/);
+    () => Memory(), TypeError, /constructor without new is invalid/);
 assertThrows(
     () => new Memory(1), TypeError,
-    'WebAssembly.Memory(): Argument 0 must be a memory descriptor');
+    /WebAssembly.Memory expects its first argument to be an object/);
 assertThrows(
     () => new Memory({initial: {valueOf() { throw new Error('here') }}}), Error,
     'here');
 assertThrows(
-    () => new Memory({initial: -1}), TypeError, /must be non-negative/);
+    () => new Memory({initial: -1}), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => new Memory({initial: Math.pow(2, 32)}), TypeError,
-    /must be in the unsigned long range/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => new Memory({initial: 1, maximum: Math.pow(2, 32) / Math.pow(2, 14)}),
-    RangeError, /is above the upper bound/);
+    RangeError, /WebAssembly.Memory 'maximum' page count is too large/);
 assertThrows(
     () => new Memory({initial: 2, maximum: 1}), RangeError,
-    /is below the lower bound/);
+    /'maximum' page count must be than greater than or equal to the 'initial' page count/);
 assertThrows(
-    () => new Memory({maximum: -1}), TypeError, /'initial' is required/);
+    () => new Memory({maximum: -1}), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertTrue(new Memory({initial: 1}) instanceof Memory);
 assertEq(new Memory({initial: 1.5}).buffer.byteLength, kPageSize);
 
@@ -499,9 +490,9 @@ assertTrue(bufferDesc.configurable);
 // 'WebAssembly.Memory.prototype.buffer' getter
 let bufferGetter = bufferDesc.get;
 assertThrows(
-    () => bufferGetter.call(), TypeError, /Receiver is not a WebAssembly.Memory/);
+    () => bufferGetter.call(), TypeError, /WebAssembly.Memory.prototype.buffer getter called with non WebAssembly.Memory |this| value/);
 assertThrows(
-    () => bufferGetter.call({}), TypeError, /Receiver is not a WebAssembly.Memory/);
+    () => bufferGetter.call({}), TypeError, /WebAssembly.Memory.prototype.buffer getter called with non WebAssembly.Memory |this| value/);
 assertTrue(bufferGetter.call(mem1) instanceof ArrayBuffer);
 assertEq(bufferGetter.call(mem1).byteLength, kPageSize);
 
@@ -516,14 +507,14 @@ let memGrow = memGrowDesc.value;
 assertEq(memGrow.length, 1);
 assertFalse(isConstructor(memGrow));
 assertThrows(
-    () => memGrow.call(), TypeError, /Receiver is not a WebAssembly.Memory/);
+    () => memGrow.call(), TypeError, /WebAssembly.Memory.prototype.buffer getter called with non WebAssembly.Memory |this| value/);
 assertThrows(
-    () => memGrow.call({}), TypeError, /Receiver is not a WebAssembly.Memory/);
+    () => memGrow.call({}), TypeError, /WebAssembly.Memory.prototype.buffer getter called with non WebAssembly.Memory |this| value/);
 assertThrows(
-    () => memGrow.call(mem1, -1), TypeError, /must be non-negative/);
+    () => memGrow.call(mem1, -1), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => memGrow.call(mem1, Math.pow(2, 32)), TypeError,
-    /must be in the unsigned long range/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 var mem = new Memory({initial: 1, maximum: 2});
 var buf = mem.buffer;
 assertEq(buf.byteLength, kPageSize);
@@ -542,9 +533,9 @@ assertTrue(buf !== mem.buffer);
 assertEq(buf.byteLength, 0);
 buf = mem.buffer;
 assertEq(buf.byteLength, 2 * kPageSize);
-assertThrows(() => mem.grow(1), Error, /Maximum memory size exceeded/);
-assertThrows(() => mem.grow(Infinity), Error, /must be convertible to a valid number/);
-assertThrows(() => mem.grow(-Infinity), Error, /must be convertible to a valid number/);
+assertThrows(() => mem.grow(1), Error, /WebAssembly.Memory.grow would exceed the memory's declared maximum size/);
+assertThrows(() => mem.grow(Infinity), Error, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
+assertThrows(() => mem.grow(-Infinity), Error, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertEq(buf, mem.buffer);
 let throwOnValueOf = {
   valueOf: function() {
@@ -588,33 +579,33 @@ assertEq(Table.length, 1);
 assertEq(Table.name, 'Table');
 assertTrue(isConstructor(Table));
 assertThrows(
-    () => Table(), TypeError, /must be invoked with 'new'/);
+    () => Table(), TypeError, /constructor without new is invalid/);
 assertThrows(
-    () => new Table(1), TypeError, 'WebAssembly.Table(): Argument 0 must be a table descriptor');
+    () => new Table(1), TypeError, /WebAssembly.Table expects its first argument to be an object/);
 assertThrows(
-    () => new Table({initial: 1, element: 1}), TypeError, /must be a WebAssembly reference type/);
+    () => new Table({initial: 1, element: 1}), TypeError, /WebAssembly.Table expects its 'element' field to be the string 'funcref' or 'externref'/);
 assertThrows(
     () => new Table({initial: 1, element: 'any'}), TypeError,
-    /must be a WebAssembly reference type/);
+    /WebAssembly.Table expects its 'element' field to be the string 'funcref' or 'externref'/);
 assertThrows(
     () => new Table({initial: 1, element: {valueOf() { return 'anyfunc' }}}),
-    TypeError, /must be a WebAssembly reference type/);
+    TypeError, /WebAssembly.Table expects its 'element' field to be the string 'funcref' or 'externref'/);
 assertThrows(
     () => new Table(
         {initial: {valueOf() { throw new Error('here') }}, element: 'anyfunc'}),
     Error, 'here');
 assertThrows(
     () => new Table({initial: -1, element: 'anyfunc'}), TypeError,
-    /must be non-negative/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => new Table({initial: Math.pow(2, 32), element: 'anyfunc'}), TypeError,
-    /must be in the unsigned long range/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => new Table({initial: 2, maximum: 1, element: 'anyfunc'}), RangeError,
-    /is below the lower bound/);
+    /'maximum' property must be greater than or equal to the 'initial' property/);
 assertThrows(
     () => new Table({initial: 2, maximum: Math.pow(2, 32), element: 'anyfunc'}),
-    TypeError, /must be in the unsigned long range/);
+    TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertTrue(new Table({initial: 1, element: 'anyfunc'}) instanceof Table);
 assertTrue(new Table({initial: 1.5, element: 'anyfunc'}) instanceof Table);
 assertTrue(
@@ -657,9 +648,9 @@ assertTrue(lengthDesc.configurable);
 let lengthGetter = lengthDesc.get;
 assertEq(lengthGetter.length, 0);
 assertThrows(
-    () => lengthGetter.call(), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => lengthGetter.call(), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
-    () => lengthGetter.call({}), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => lengthGetter.call({}), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertEq(typeof lengthGetter.call(tbl1), 'number');
 assertEq(lengthGetter.call(tbl1), 2);
 
@@ -674,22 +665,22 @@ let get = getDesc.value;
 assertEq(get.length, 1);
 assertFalse(isConstructor(get));
 assertThrows(
-    () => get.call(), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => get.call(), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
-    () => get.call({}), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => get.call({}), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
-    () => get.call(tbl1), TypeError, /must be convertible to a valid number/);
+    () => get.call(tbl1), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertEq(get.call(tbl1, 0), null);
 assertEq(get.call(tbl1, 0, Infinity), null);
 assertEq(get.call(tbl1, 1), null);
 assertEq(get.call(tbl1, 1.5), null);
-assertThrows(() => get.call(tbl1, 2), RangeError, /invalid index \d+ into function table/);
+assertThrows(() => get.call(tbl1, 2), RangeError, /WebAssembly.Table.prototype.get expects an integer less than the length of the table/);
 assertThrows(
-    () => get.call(tbl1, 2.5), RangeError, /invalid index \d+ into function table/);
-assertThrows(() => get.call(tbl1, -1), TypeError, /must be non-negative/);
+    () => get.call(tbl1, 2.5), RangeError, /WebAssembly.Table.prototype.get expects an integer less than the length of the table/);
+assertThrows(() => get.call(tbl1, -1), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => get.call(tbl1, Math.pow(2, 33)), TypeError,
-  /must be in the unsigned long range/);
+  /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => get.call(tbl1, {valueOf() { throw new Error('hi') }}), Error, 'hi');
 
@@ -704,40 +695,40 @@ let set = setDesc.value;
 assertEq(set.length, 1);
 assertFalse(isConstructor(set));
 assertThrows(
-    () => set.call(), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => set.call(), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
-    () => set.call({}), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => set.call({}), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
     () => set.call(tbl1, undefined), TypeError,
-    /must be convertible to a valid number/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
-    () => set.call(tbl1, 2, null), RangeError, /invalid index \d+ into function table/);
+    () => set.call(tbl1, 2, null), RangeError, /WebAssembly.Table.prototype.set expects an integer less than the length of the table/);
 assertThrows(
-    () => set.call(tbl1, -1, null), TypeError, /must be non-negative/);
+    () => set.call(tbl1, -1, null), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, Math.pow(2, 33), null), TypeError,
-    /must be in the unsigned long range/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, Infinity, null), TypeError,
-  /must be convertible to a valid number/);
+  /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, -Infinity, null), TypeError,
-  /must be convertible to a valid number/);
+  /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, 0, undefined), TypeError,
-    /Argument 1 is invalid for table: /);
+    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
 assertThrows(
     () => set.call(tbl1, undefined, undefined), TypeError,
-    /must be convertible to a valid number/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => set.call(tbl1, 0, {}), TypeError,
-    /Argument 1 is invalid for table:.*null.*or a Wasm function object/);
+    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
 assertThrows(
     () => set.call(tbl1, 0, function() {}), TypeError,
-    /Argument 1 is invalid for table:.*null.*or a Wasm function object/);
+    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
 assertThrows(
     () => set.call(tbl1, 0, Math.sin), TypeError,
-    /Argument 1 is invalid for table:.*null.*or a Wasm function object/);
+    /WebAssembly.Table.prototype.set expects the second argument to be null or an instance of WebAssembly.Function/);
 assertThrows(
     () => set.call(tbl1, {valueOf() { throw Error('hai') }}, null), Error,
     'hai');
@@ -745,7 +736,7 @@ assertEq(set.call(tbl1, 0, null), undefined);
 assertEq(set.call(tbl1, 1, null), undefined);
 assertThrows(
     () => set.call(tbl1, undefined, null), TypeError,
-    /must be convertible to a valid number/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 
 // 'WebAssembly.Table.prototype.grow' data property
 let tblGrowDesc = Object.getOwnPropertyDescriptor(tableProto, 'grow');
@@ -758,30 +749,30 @@ let tblGrow = tblGrowDesc.value;
 assertEq(tblGrow.length, 1);
 assertFalse(isConstructor(tblGrow));
 assertThrows(
-    () => tblGrow.call(), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => tblGrow.call(), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
-    () => tblGrow.call({}), TypeError, /Receiver is not a WebAssembly.Table/);
+    () => tblGrow.call({}), TypeError, /expected |this| value to be an instance of WebAssembly.Table/);
 assertThrows(
-    () => tblGrow.call(tbl1, -1), TypeError, /must be non-negative/);
+    () => tblGrow.call(tbl1, -1), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
     () => tblGrow.call(tbl1, Math.pow(2, 32)), TypeError,
-    /must be in the unsigned long range/);
+    /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 var tbl = new Table({element: 'anyfunc', initial: 1, maximum: 2});
 assertEq(tbl.length, 1);
 assertThrows(
-    () => tbl.grow(Infinity), TypeError, /must be convertible to a valid number/);
+    () => tbl.grow(Infinity), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
-    () => tbl.grow(-Infinity), TypeError, /must be convertible to a valid number/);
+    () => tbl.grow(-Infinity), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertEq(tbl.grow(0), 1);
 assertEq(tbl.length, 1);
 assertEq(tbl.grow(1, null, 4), 1);
 assertEq(tbl.length, 2);
 assertEq(tbl.length, 2);
-assertThrows(() => tbl.grow(1), Error, /failed to grow table by \d+/);
+assertThrows(() => tbl.grow(1), Error, /WebAssembly.Table.prototype.grow could not grow the table/);
 assertThrows(
-    () => tbl.grow(Infinity), TypeError, /must be convertible to a valid number/);
+    () => tbl.grow(Infinity), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 assertThrows(
-    () => tbl.grow(-Infinity), TypeError, /must be convertible to a valid number/);
+    () => tbl.grow(-Infinity), TypeError, /Expect an integer argument in the range[\s\S]*2\^32 - 1/);
 
 // 'WebAssembly.validate' function
 assertThrows(() => WebAssembly.validate(), TypeError);

--- a/JSTests/wasm/v8/reference-tables.js
+++ b/JSTests/wasm/v8/reference-tables.js
@@ -42,14 +42,14 @@ load("wasm-module-builder.js");
     builder.addImportedTable(
         'imports', 'table', 1, 100, wasmRefNullType(unary_type));
     builder.instantiate({imports: {table: exporting_instance.exports.table}})
-  }, WebAssembly.LinkError, /imported table does not match the expected type/);
+  }, WebAssembly.LinkError, /Table import /);
 
   // Type for imported table must match exactly.
   assertThrows(() => {
     var builder = new WasmModuleBuilder();
     builder.addImportedTable('imports', 'table', 1, 100, kWasmFuncRef);
     builder.instantiate({imports: {table: exporting_instance.exports.table}})
-  }, WebAssembly.LinkError, /imported table does not match the expected type/);
+  }, WebAssembly.LinkError, /Table import /);
 
   var instance = (function() {
     var builder = new WasmModuleBuilder();
@@ -423,7 +423,7 @@ load("wasm-module-builder.js");
     builder.addImportedTable(
         'imports', 'table', 1, 100, wasmRefNullType(struct_type));
     builder.instantiate({imports: {table: exporting_instance.exports.table}})
-  }, WebAssembly.LinkError, /imported table does not match the expected type/);
+  }, WebAssembly.LinkError, /Table import /);
 
   // Mismatching nullability.
   assertThrows(() => {
@@ -432,7 +432,7 @@ load("wasm-module-builder.js");
     builder.addImportedTable(
         'imports', 'table', 1, 100, wasmRefType(struct_type));
     builder.instantiate({imports: {table: exporting_instance.exports.table}})
-  }, WebAssembly.LinkError, /imported table does not match the expected type/);
+  }, WebAssembly.LinkError, /Table import /);
 
   // Equivalent struct type.
   let builder = new WasmModuleBuilder();

--- a/JSTests/wasm/v8/resources/wasm-module-builder.js
+++ b/JSTests/wasm/v8/resources/wasm-module-builder.js
@@ -932,14 +932,14 @@ let kTrapMsgs = [
   /Unreachable/,                                    // --
   /Out of bounds memory access/,                    // --
   /Division by zero/,                               // --
-  'divide result unrepresentable',                  // --
-  'remainder by zero',                              // --
+  /Integer overflow/,                  // --
+  /Division by zero|remainder by zero/,                              // --
   'float unrepresentable in integer range',         // --
-  'table index is out of bounds',                   // --
-  'null function or function signature mismatch',   // --
-  'operation does not support unaligned accesses',  // --
+  /Out of bounds call_indirect|Out of bounds table access/, // --
+  /null table entry|signature that does not match/,   // --
+  /operation does not support unaligned accesses|Out of bounds memory access/,  // --
   'data segment out of bounds',                     // --
-  'element segment out of bounds',                  // --
+  'Out of bounds table access',                  // --
   'rethrowing null value',                          // --
   'requested new array is too large',               // --
   'array element access out of bounds',             // --
@@ -954,7 +954,12 @@ function assertTraps(trap, code) {
 
 function assertTrapsOneOf(traps, code) {
   const errorChecker = new RegExp(
-    '(' + traps.map(trap => kTrapMsgs[trap]).join('|') + ')'
+    '(' + traps.map(trap => {
+        let message = kTrapMsgs[trap];
+        if (typeof message == 'string')
+            return message;
+        return message.source;
+    }).join('|') + ')'
   );
   assertThrows(code, WebAssembly.RuntimeError, errorChecker);
 }

--- a/JSTests/wasm/v8/start-function.js
+++ b/JSTests/wasm/v8/start-function.js
@@ -1,23 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-//  Stack: MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  fail@mjsunit.js:343:27
-//  assertEquals@mjsunit.js:413:11 
-//  checkException@mjsunit.js:503:19
-//  assertThrows@mjsunit.js:518:21
-//  testInvalidIndex@start-function.js:47:15
-//  global code@start-function.js:51:3
-//  MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  fail@mjsunit.js:343:27
-//  assertEquals@mjsunit.js:413:11
-//  checkException@mjsunit.js:503:19
-//  assertThrows@mjsunit.js:518:21
-//  testInvalidIndex@start-function.js:66:15
-//  global code@start-function.js:70:3
-
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -65,8 +46,7 @@ assertThrows(() => {instantiate(kSig_i_v, [kExprI32Const, 0]);});
 
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
-      'WebAssembly.Module(): ' +
-          'function index 1 out of bounds (1 entry) @+20');
+      /WebAssembly.Module doesn't parse at byte/);
 })();
 
 
@@ -82,7 +62,7 @@ assertThrows(() => {instantiate(kSig_i_v, [kExprI32Const, 0]);});
 
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
-      'WebAssembly.Module(): unexpected section <Start> @+27');
+      /WebAssembly.Module doesn't parse at byte/);
 })();
 
 
@@ -170,7 +150,7 @@ assertThrows(() => {instantiate(kSig_i_v, [kExprI32Const, 0]);});
   builder.addStart(func.index);
 
   assertThrows(
-      () => builder.instantiate(), WebAssembly.RuntimeError, /unreachable/);
+      () => builder.instantiate(), WebAssembly.RuntimeError, /unreachable/i);
   assertThrowsAsync(builder.asyncInstantiate(), WebAssembly.RuntimeError);
   assertThrowsAsync(
       WebAssembly.instantiate(builder.toModule()), WebAssembly.RuntimeError);

--- a/JSTests/wasm/v8/table-access.js
+++ b/JSTests/wasm/v8/table-access.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/table index is out of bounds/'
-//  found:
-//  "Out of bounds table access (evaluating 'exports.get_table_func1(11)')"
-// Looks like we need to update the exception strings.
-
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-copy-externref.js
+++ b/JSTests/wasm/v8/table-copy-externref.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/table index is out of bounds/'
-//  found:
-//  "Out of bounds table access (evaluating 'instance.exports.copy(3, 0, 3)')"
-// Looks like we need to update the exception strings.
-
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-fill.js
+++ b/JSTests/wasm/v8/table-fill.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/table index is out of bounds/'
-//  found:
-//  "Out of bounds table access (evaluating 'instance.exports[`fill${import_ref}`](start, value, count)')"
-// Looks like we need to change the exception expectation.
-
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-grow-from-wasm.js
+++ b/JSTests/wasm/v8/table-grow-from-wasm.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/table index is out of bounds/'
-//  found:
-//  "Out of bounds table access (evaluating 'instance.exports.get(size)')"
-// Looks like we need to update the exception strings.
-
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-grow.js
+++ b/JSTests/wasm/v8/table-grow.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  "table index is out of bounds"
-//  found:
-//  "Out of bounds call_indirect (evaluating 'instances[i].exports.main(s)')"
-// Looks like we need to update exception types
-
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table.js
+++ b/JSTests/wasm/v8/table.js
@@ -1,25 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message): expected <should match '/above the upper bound/'> found <"couldn't create Table">
-//
-//  Stack: MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  fail@mjsunit.js:343:27
-//  assertMatches@mjsunit.js:599:11
-//  checkException@mjsunit.js:501:20
-//  assertThrows@mjsunit.js:518:21
-//  TestConstructor@table.js:107:15
-//  global code@table.js:121:3
-//  MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  fail@mjsunit.js:343:27
-//  assertMatches@mjsunit.js:599:11
-//  checkException@mjsunit.js:501:20
-//  assertThrows@mjsunit.js:518:21
-//  TestConstructor@table.js:107:15
-//  global code@table.js:121:3
-
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -33,7 +12,7 @@ load("wasm-module-builder.js");
 // Basic tests.
 
 const outOfUint32RangeValue = 1e12;
-const kV8MaxWasmTableSize = 10000000;
+const kV8MaxWasmTableSize = 9999999;
 
 function assertTableIsValid(table, length) {
   assertSame(WebAssembly.Table.prototype, table.__proto__);
@@ -117,7 +96,7 @@ function assertTableIsValid(table, length) {
   assertThrows(
     () => new WebAssembly.Table(
       {element: "anyfunc", initial: kV8MaxWasmTableSize + 1}),
-    RangeError, /above the upper bound/);
+    RangeError, /couldn't create Table/);
 })();
 
 (function TestMaximumIsReadOnce() {

--- a/JSTests/wasm/v8/unicode.js
+++ b/JSTests/wasm/v8/unicode.js
@@ -1,12 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure (Error message):
-//  expected:
-//  should match '/Compiling function #0:"three snowmen: ☃☃☃" failed: /'
-//  found:
-//  "WebAssembly.Module doesn't validate:  block with type: () -> [I32] returns: 1 but stack has: 0 values, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')"
-
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -60,7 +52,7 @@ checkExports('☺☺mul☺☺', '☺☺mul☺☺', '☺☺add☺☺', '☺☺add
   builder.addFunction('three snowmen: ☃☃☃', kSig_i_v).addBody([]).exportFunc();
   assertThrows(
       () => builder.instantiate(), WebAssembly.CompileError,
-      /Compiling function #0:"three snowmen: ☃☃☃" failed: /);
+      /doesn't validate/);
 })();
 
 (function errorMessageUnicodeInImportModuleName() {
@@ -68,7 +60,7 @@ checkExports('☺☺mul☺☺', '☺☺mul☺☺', '☺☺add☺☺', '☺☺add
   builder.addImport('three snowmen: ☃☃☃', 'foo', kSig_i_v);
   assertThrows(
       () => builder.instantiate({}), TypeError,
-      /WebAssembly.Instance\(\): Import #0 module="three snowmen: ☃☃☃" error: /);
+      /import three snowmen: ☃☃☃:foo must be an object/);
 })();
 
 (function errorMessageUnicodeInImportElemName() {
@@ -76,8 +68,7 @@ checkExports('☺☺mul☺☺', '☺☺mul☺☺', '☺☺add☺☺', '☺☺add
   builder.addImport('mod', 'three snowmen: ☃☃☃', kSig_i_v);
   assertThrows(
       () => builder.instantiate({mod: {}}), WebAssembly.LinkError,
-      'WebAssembly.Instance\(\): Import #0 module="mod" function="three ' +
-          'snowmen: ☃☃☃" error: function import requires a callable');
+      /import function mod:three snowmen: ☃☃☃ must be callable/);
 })();
 
 (function errorMessageUnicodeInImportModAndElemName() {
@@ -87,7 +78,5 @@ checkExports('☺☺mul☺☺', '☺☺mul☺☺', '☺☺add☺☺', '☺☺add
   builder.addImport(mod_name, func_name, kSig_i_v);
   assertThrows(
       () => builder.instantiate({[mod_name]: {}}), WebAssembly.LinkError,
-      'WebAssembly.Instance(): Import #0 module="' + mod_name +
-          '" function="' + func_name +
-          '" error: function import requires a callable');
+      /import function ☮▁▂▃▄☾ ♛ ◡ ♛ ☽▄▃▂▁☮:☾˙❀‿❀˙☽ must be callable/);
 })();

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -76,7 +76,31 @@ ALWAYS_INLINE ASCIILiteral errorMessageForExceptionType(ExceptionType type)
 
 ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
 {
-    return type == ExceptionType::TypeErrorInvalidV128Use;
+    switch (type) {
+    case ExceptionType::OutOfBoundsMemoryAccess:
+    case ExceptionType::OutOfBoundsTableAccess:
+    case ExceptionType::OutOfBoundsCallIndirect:
+    case ExceptionType::NullTableEntry:
+    case ExceptionType::NullReference:
+    case ExceptionType::NullI31Get:
+    case ExceptionType::BadSignature:
+    case ExceptionType::OutOfBoundsTrunc:
+    case ExceptionType::Unreachable:
+    case ExceptionType::DivisionByZero:
+    case ExceptionType::IntegerOverflow:
+    case ExceptionType::StackOverflow:
+    case ExceptionType::OutOfBoundsArrayGet:
+    case ExceptionType::OutOfBoundsArraySet:
+    case ExceptionType::NullArrayGet:
+    case ExceptionType::NullArraySet:
+    case ExceptionType::NullArrayLen:
+        return false;
+    case ExceptionType::FuncrefNotWasm:
+    case ExceptionType::InvalidGCTypeUse:
+    case ExceptionType::TypeErrorInvalidV128Use:
+        return true;
+    }
+    return false;
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.cpp
@@ -95,14 +95,14 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
         break;
     }
     case TypeKind::V128: {
-        throwException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Cannot set value of v128 global"_s));
+        throwTypeError(globalObject, throwScope, "Cannot set value of v128 global"_s);
         return;
     }
     default: {
         if (isExternref(m_type)) {
             RELEASE_ASSERT(m_owner);
             if (!m_type.isNullable() && argument.isNull()) {
-                throwException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Non-null Externref cannot be null"_s));
+                throwTypeError(globalObject, throwScope, "Non-null Externref cannot be null"_s);
                 return;
             }
             m_value.m_externref.set(m_owner->vm(), m_owner, argument);
@@ -111,7 +111,7 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
             WebAssemblyFunction* wasmFunction = nullptr;
             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
             if (!isWebAssemblyHostFunction(argument, wasmFunction, wasmWrapperFunction) && (!m_type.isNullable() || !argument.isNull())) {
-                throwException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Funcref must be an exported wasm function"_s));
+                throwTypeError(globalObject, throwScope, "Funcref must be an exported wasm function"_s);
                 return;
             }
 
@@ -119,16 +119,16 @@ void Global::set(JSGlobalObject* globalObject, JSValue argument)
                 Wasm::TypeIndex paramIndex = m_type.index;
                 Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                 if (paramIndex != argIndex) {
-                    throwException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Argument function did not match the reference type"_s));
+                    throwTypeError(globalObject, throwScope, "Argument function did not match the reference type"_s);
                     return;
                 }
             }
             m_value.m_externref.set(m_owner->vm(), m_owner, argument);
         } else if (isRefWithTypeIndex(m_type)) {
-            throwVMException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Unsupported use of struct or array type"_s));
+            throwTypeError(globalObject, throwScope, "Unsupported use of struct or array type"_s);
             return;
         } else if (Wasm::isI31ref(m_type)) {
-            throwVMException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "I31ref import from JS currently unsupported"_s));
+            throwTypeError(globalObject, throwScope, "I31ref import from JS currently unsupported"_s);
             return;
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmInstance.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInstance.cpp
@@ -259,7 +259,7 @@ void Instance::initElementSegment(uint32_t tableIndex, const Element& segment, u
             globalObject,
             globalObject->webAssemblyFunctionStructure(),
             signature.argumentCount(),
-            String(),
+            WTF::makeString(functionIndex),
             jsInstance,
             embedderEntrypointCallee,
             entrypointLoadLocation,

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -204,20 +204,20 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
     default: {
         if (Wasm::isExternref(type)) {
             if (!type.isNullable() && value.isNull())
-                return throwVMException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, "Non-null Externref cannot be null"_s));
+                return throwVMTypeError(globalObject, scope, "Non-null Externref cannot be null"_s);
         } else if (Wasm::isFuncref(type) || isRefWithTypeIndex(type)) {
             WebAssemblyFunction* wasmFunction = nullptr;
             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
             if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && (!type.isNullable() || !value.isNull()))
-                return throwVMException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, "Funcref must be an exported wasm function"_s));
+                return throwVMTypeError(globalObject, scope, "Funcref must be an exported wasm function"_s);
             if (isRefWithTypeIndex(type) && !value.isNull()) {
                 Wasm::TypeIndex paramIndex = type.index;
                 Wasm::TypeIndex argIndex = wasmFunction ? wasmFunction->typeIndex() : wasmWrapperFunction->typeIndex();
                 if (paramIndex != argIndex)
-                    return throwVMException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, "Argument function did not match the reference type"_s));
+                    return throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
             }
         } else if (Wasm::isI31ref(type))
-            return throwVMException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, "I31ref import from JS currently unsupported"_s));
+            return throwVMTypeError(globalObject, scope, "I31ref import from JS currently unsupported"_s);
         else
             RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -62,7 +62,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
     {
         JSValue argument = callFrame->argument(0);
         if (!argument.isObject())
-            return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Global expects its first argument to be an object"_s)));
+            return throwVMTypeError(globalObject, throwScope, "WebAssembly.Global expects its first argument to be an object"_s);
         globalDescriptor = jsCast<JSObject*>(argument);
     }
 
@@ -99,7 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
         else if (valueString == "externref"_s)
             type = Wasm::externrefType();
         else
-            return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Global expects its 'value' field to be the string 'i32', 'i64', 'f32', 'f64', 'anyfunc', 'funcref', or 'externref'"_s)));
+            return throwVMTypeError(globalObject, throwScope, "WebAssembly.Global expects its 'value' field to be the string 'i32', 'i64', 'f32', 'f64', 'anyfunc', 'funcref', or 'externref'"_s);
     }
 
     uint64_t initialValue = 0;
@@ -141,17 +141,15 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
         if (Wasm::isFuncref(type)) {
             if (argument.isUndefined())
                 argument = defaultValueForReferenceType(type);
-            if (!isWebAssemblyHostFunction(argument) && !argument.isNull()) {
-                throwException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "Funcref must be an exported wasm function"_s));
-                return { };
-            }
+            if (!isWebAssemblyHostFunction(argument) && !argument.isNull())
+                return throwVMTypeError(globalObject, throwScope, "Funcref must be an exported wasm function"_s);
             initialValue = JSValue::encode(argument);
         } else if (Wasm::isExternref(type)) {
             if (argument.isUndefined())
                 argument = defaultValueForReferenceType(type);
             initialValue = JSValue::encode(argument);
         } else if (Wasm::isExternref(type))
-            return throwVMException(globalObject, throwScope, createJSWebAssemblyRuntimeError(globalObject, vm, "I31ref import from JS currently unsupported"_s));
+            return throwVMTypeError(globalObject, throwScope, "I31ref import from JS currently unsupported"_s);
         else
             RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleCustomSections, (JSGlobalObject* globa
     if (!module)
         return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Module.customSections called with non WebAssembly.Module argument"_s)));
 
-    const String sectionNameString = callFrame->uncheckedArgument(1).getString(globalObject);
+    String sectionNameString = callFrame->uncheckedArgument(1).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, { });
 
     JSArray* result = constructEmptyArray(globalObject, nullptr);


### PR DESCRIPTION
#### 50d7b35052eb1791708bb5bab76fdcd2558cf12c
<pre>
[JSC] Fix misc wasm bugs to expand V8 test coverage
<a href="https://bugs.webkit.org/show_bug.cgi?id=251122">https://bugs.webkit.org/show_bug.cgi?id=251122</a>
rdar://104623519

Reviewed by Mark Lam and Justin Michaud.

This patch fixes misc wasm issues to unlock some of V8 wasm tests.
This expands V8 wasm test coverage and defends against the future bug introduction.

* JSTests/wasm/function-references/ref_types.js:
(async testRefTypeParamCheck):
(async testRefGlobalCheck):
(async testExternFuncrefNonNullCheck):
(async testWasmJSGlobals):
* JSTests/wasm/gc/arrays.js:
* JSTests/wasm/gc/i31.js:
* JSTests/wasm/gc/structs.js:
* JSTests/wasm/references/func_ref.js:
(assert.throws):
(GetLocal.0.I32Const.0.TableSet.0.End.End.WebAssembly.assert.throws):
(GetLocal.0.I32Const.0.TableSet.0.End.End.WebAssembly):
(makeFuncrefIdent):
* JSTests/wasm/references/globals.js:
(async testGlobalConstructorForFuncref):
* JSTests/wasm/stress/global-wrong-type.js:
(assert.throws):
* JSTests/wasm/stress/mutable-globals.js:
* JSTests/wasm/v8/atomics.js:
(TestIllegalAtomicOp):
* JSTests/wasm/v8/bit-shift-right.js:
* JSTests/wasm/v8/divrem-trap.js:
* JSTests/wasm/v8/export-global.js:
(duplicateGlobalExportName):
* JSTests/wasm/v8/export-table.js:
(testExportNameClash):
* JSTests/wasm/v8/externref-table.js:
* JSTests/wasm/v8/externref.js:
(testGCInStackCheck):
* JSTests/wasm/v8/ffi-error.js:
(checkFailingInstantiation):
(testInvalidFFIs):
* JSTests/wasm/v8/indirect-call-non-zero-table.js:
* JSTests/wasm/v8/indirect-calls.js:
* JSTests/wasm/v8/indirect-tables.js:
(InitImportedTableSignatureMismatch):
(TestNonImportedGlobalInElementSegment):
* JSTests/wasm/v8/js-api.js:
(get assertThrows):
(set assertThrows):
(set let):
* JSTests/wasm/v8/reference-tables.js:
* JSTests/wasm/v8/resources/wasm-module-builder.js:
(assertTrapsOneOf):
* JSTests/wasm/v8/start-function.js:
(testInvalidIndex):
(testRun2): Deleted.
(testStartFFI.ffi.gak.foo): Deleted.
(testStartFFI): Deleted.
(testStartFunctionThrowsExplicitly.ffi.foo.throw_fn): Deleted.
(testStartFunctionThrowsExplicitly): Deleted.
* JSTests/wasm/v8/table-access.js:
* JSTests/wasm/v8/table-copy-externref.js:
* JSTests/wasm/v8/table-fill.js:
* JSTests/wasm/v8/table-grow-from-wasm.js:
* JSTests/wasm/v8/table-grow.js:
* JSTests/wasm/v8/table.js:
(TestConstructor):
(TestMaximumIsReadOnce.): Deleted.
(TestMaximumDoesHasProperty.): Deleted.
(TestMaximumDoesHasProperty): Deleted.
(TestLength): Deleted.
(TestGrow.init): Deleted.
(TestGrow.check): Deleted.
(TestGrow): Deleted.
(TestGrowWithInit.getDummy): Deleted.
(TestGrowWithInit): Deleted.
* JSTests/wasm/v8/unicode.js:
(errorMessageUnicodeInFuncName):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmGlobal.cpp:
(JSC::Wasm::Global::set):
* Source/JavaScriptCore/wasm/WasmInstance.cpp:
(JSC::Wasm::Instance::initElementSegment):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::fromJSValue):
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/259327@main">https://commits.webkit.org/259327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b29a8b17f7bf69b6025a81054526a5f30d0031dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113908 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4638 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96963 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94474 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108105 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26086 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27444 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92525 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30096 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103462 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47000 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101211 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/8961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3412 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->