### PR TITLE
Fix traversal for moved out elements by mapping placeholders

### DIFF
--- a/LayoutTests/fast/rendering/render-multi-column-set-invalidate-crash-expected.txt
+++ b/LayoutTests/fast/rendering/render-multi-column-set-invalidate-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/rendering/render-multi-column-set-invalidate-crash.html
+++ b/LayoutTests/fast/rendering/render-multi-column-set-invalidate-crash.html
@@ -1,0 +1,63 @@
+<head>
+<style>
+*:not(head):not(script):not(style) {
+    column-rule: solid;
+    column-span: all;
+    column-count: 44;
+}
+#elementID2 {
+    display: flex;
+    float: right;
+    -webkit-user-modify: read-write;
+}
+</style>
+<script>
+let selectSubtreeChangedCount = 0;
+
+function test() {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    elementID3.hidden = true;
+    elementID4.addEventListener("DOMSubtreeModified", selectSubtreeChanged);
+    mutateSubtree();
+}
+
+function mutateSubtree() {
+    getSelection().setBaseAndExtent(document.createElement("div"), 1, elementID6, 81);
+    elementID4.options.add(elementID5);
+    document.execCommand("subscript", false);
+    document.execCommand("insertText", false, "1");
+}
+
+function selectSubtreeChanged() {
+    selectSubtreeChangedCount++;
+
+    if (selectSubtreeChangedCount > 1) {
+        requestAnimationFrame(finish);
+        return;
+    }
+
+    requestAnimationFrame(mutateSubtree);
+    elementID2.prepend(String.fromCodePoint(0));
+    elementID4.length = 99;
+    elementID4.lastChild.appendChild(elementID6);
+}
+
+function finish() {
+    document.body.innerHTML = 'PASS if no crash.'
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<body onload="test()">
+    <embed id="elementID1"></embed>
+    <div id="elementID2">
+        <div id="elementID3"></div>
+        <select id="elementID4">
+            <optgroup id="elementID5" tabindex="0"></optgroup>
+        </select>
+    </div>
+    <div id="elementID6"></div>
+</body>

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -31,6 +31,7 @@
 #include "RenderLayerBacking.h"
 #include "RenderLayerCompositor.h"
 #include "RenderLayerScrollableArea.h"
+#include "RenderMultiColumnSet.h"
 #include "RenderSVGBlock.h"
 #include "RenderSVGModelObject.h"
 #include "RenderSVGText.h"
@@ -84,7 +85,8 @@ void RenderLayerModelObject::willBeDestroyed()
 
 void RenderLayerModelObject::willBeRemovedFromTree(IsInternalMove isInternalMove)
 {
-    if (auto* layer = this->layer(); layer && layer->needsFullRepaint() && isInternalMove == IsInternalMove::No)
+    bool shouldNotRepaint = is<RenderMultiColumnSet>(this->previousSibling());
+    if (auto* layer = this->layer(); layer && layer->needsFullRepaint() && isInternalMove == IsInternalMove::No && !shouldNotRepaint)
         issueRepaint(std::nullopt, ClipRepaintToLayer::No, ForceRepaint::Yes);
 
     RenderElement::willBeRemovedFromTree(isInternalMove);

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -101,7 +101,7 @@ RenderBox* RenderMultiColumnFlow::previousColumnSetOrSpannerSiblingOf(const Rend
     return nullptr;
 }
 
-RenderMultiColumnSpannerPlaceholder* RenderMultiColumnFlow::findColumnSpannerPlaceholder(RenderBox* spanner) const
+RenderMultiColumnSpannerPlaceholder* RenderMultiColumnFlow::findColumnSpannerPlaceholder(const RenderBox* spanner) const
 {
     return m_spannerMap->get(spanner).get();
 }

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -48,7 +48,7 @@ public:
     static RenderBox* nextColumnSetOrSpannerSiblingOf(const RenderBox*);
     static RenderBox* previousColumnSetOrSpannerSiblingOf(const RenderBox*);
 
-    RenderMultiColumnSpannerPlaceholder* findColumnSpannerPlaceholder(RenderBox* spanner) const;
+    RenderMultiColumnSpannerPlaceholder* findColumnSpannerPlaceholder(const RenderBox* spanner) const;
 
     void layout() override;
 
@@ -95,7 +95,7 @@ public:
     // FIXME: Eventually as column and fragment flow threads start nesting, this will end up changing.
     bool shouldCheckColumnBreaks() const override;
 
-    typedef HashMap<RenderBox*, WeakPtr<RenderMultiColumnSpannerPlaceholder>> SpannerMap;
+    typedef HashMap<const RenderBox*, WeakPtr<RenderMultiColumnSpannerPlaceholder>> SpannerMap;
     SpannerMap& spannerMap() { return *m_spannerMap; }
 
 private:

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -915,6 +915,15 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
     bool repaintRectNeedsConverting = false;
     // Issue repaint on the renderer with outline: auto.
     for (const auto* renderer = this; renderer; renderer = renderer->parent()) {
+        if (is<RenderMultiColumnSet>(renderer->previousSibling())) {
+            auto previousMultiColumnSet = downcast<RenderMultiColumnSet>(renderer->previousSibling());
+            auto enclosingMultiColumnFlow = previousMultiColumnSet->multiColumnFlow();
+            auto& previousMultiColumnSetBox = downcast<RenderBox>(*renderer);
+            auto renderMultiColumnPlaceholder = enclosingMultiColumnFlow->findColumnSpannerPlaceholder(&previousMultiColumnSetBox);
+            ASSERT(renderMultiColumnPlaceholder);
+            renderer = renderMultiColumnPlaceholder;
+        }
+
         bool rendererHasOutlineAutoAncestor = renderer->hasOutlineAutoAncestor();
         ASSERT(rendererHasOutlineAutoAncestor
             || renderer->outlineStyleForRepaint().outlineStyleIsAuto() == OutlineIsAuto::On

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -43,6 +43,7 @@
 #include "RenderMathMLFenced.h"
 #include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
+#include "RenderMultiColumnSet.h"
 #include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderReplaced.h"
 #include "RenderRuby.h"
@@ -932,7 +933,6 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderGrid(RenderGrid& pare
 RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed willBeDestroyed)
 {
     RELEASE_ASSERT_WITH_MESSAGE(!parent.view().frameView().layoutContext().layoutState(), "Layout must not mutate render tree");
-
     ASSERT(parent.canHaveChildren() || parent.canHaveGeneratedChildren());
     ASSERT(child.parent() == &parent);
 
@@ -943,9 +943,10 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
     // that a positioned child got yanked). We also repaint, so that the area exposed when the child
     // disappears gets repainted properly.
     if (!parent.renderTreeBeingDestroyed() && child.everHadLayout()) {
-        if (child.isBody())
+        bool shouldNotRepaint = is<RenderMultiColumnSet>(child.previousSibling());
+        if (child.isBody() && !shouldNotRepaint)
             parent.view().repaintRootContents();
-        else
+        else if (!shouldNotRepaint)
             child.repaint();
         child.setNeedsLayoutAndPrefWidthsRecalc();
     }


### PR DESCRIPTION
#### 0ff58f04d04d4c6b1aa1e2635dce38903db82f9a
<pre>
Fix traversal for moved out elements by mapping placeholders
<a href="https://bugs.webkit.org/show_bug.cgi?id=251126">https://bugs.webkit.org/show_bug.cgi?id=251126</a>
rdar://94017781

Reviewed by Alan Baradlay.

Before this change, when we used to traverse the ancestor chain for
autoinline validation in
propagateRepaintToParentWithOutlineAutoIfNeeded, we just looked at the
direct parent of the moved out element. That was incorrect, because the
moved out elements have a placeholder inserted in their original
position and hence we need to look it up in the enclosing scope. This
change fixes that.

* LayoutTests/fast/rendering/render-multi-column-set-invalidate-crash-expected.txt: Added.
* LayoutTests/fast/rendering/render-multi-column-set-invalidate-crash.html: Added.
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::willBeRemovedFromTree):
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::findColumnSpannerPlaceholder const):
* Source/WebCore/rendering/RenderMultiColumnFlow.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded const):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::detachFromRenderElement):

Canonical link: <a href="https://commits.webkit.org/259412@main">https://commits.webkit.org/259412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31381c434efec626b9439aad18c372fb96b589d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114066 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174268 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4799 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112980 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39123 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26221 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27581 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4174 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6490 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9108 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->