### PR TITLE
Trim collapsed margins at block-start and block-end when specified by margin-trim

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-collapsed-margins-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-collapsed-margins-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-end-collapsed-margins</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="collapsed block-end margins should be trimmed but not affect container margins">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-collapsed-margins.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-collapsed-margins.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-end-collapsed-margins</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="block-container-collapsed-margins-ref.html">
+<meta name="assert" content="collapsed block-end margins should be trimmed but not affect container margins">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    margin-block-end: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-end-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-block-end-self-collapsing-item-has-larger-block-end</title>
+<meta name="assert" content="self-collapsing margin at block-end has its block-end margin trimmed which would normally be used in collapsing with container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-end.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-end-self-collapsing-item-has-larger-block-end</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="block-container-collapsed-margins-ref.html">
+<meta name="assert" content="self-collapsing margin at block-end has its block-end margin trimmed which would normally be used in collapsing with container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    margin-block-end: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 100px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-start-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-end-self-collapsing-item-has-larger-block-start</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="self-collapsing margin at block-end has its block-start margin trimmed which would normally be used in collapsing with container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-start.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-end-self-collapsing-item-has-larger-block-start</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="block-container-collapsed-margins-ref.html">
+<meta name="assert" content="self-collapsing margin at block-end has its block-end margin trimmed which would normally be used in collapsing with container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    margin-block-end: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 100px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-collapsed-margins-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-collapsed-margins-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-collapsed-margins</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="collapsed block-start margins should be trimmed but not affect container margins">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<item style="margin-block-start: 0px;"></item>
+<container>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-collapsed-margins.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-collapsed-margins.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-collapsed-margins</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="block-container-collapsed-margins-ref.html">
+<meta name="assert" content="second item propagates block-start margin through self collapsing item and gets trimmed">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    margin-block-start: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<item style="margin-block-start: 0px;"></item>
+<container>
+    <item class="collapsed"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-has-larger-block-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-has-larger-block-end-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-self-collapsing-item-has-larger-block-end</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="self-collapsing margin at block-start has its block-end margin trimmed which would normally be used in collapsing with container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+
+</body>
+</html>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-has-larger-block-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-has-larger-block-end.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-self-collapsing-item-has-larger-block-end</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="block-container-collapsed-margins-ref.html">
+<meta name="assert" content="self-collapsing margin at block-start has its block-end margin trimmed which would normally be used in collapsing with container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    margin-block-start: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 100px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<item style="margin-block-start: 0px;"></item>
+<container>
+    <item class="collapsed"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-larger-block-start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-larger-block-start-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-self-collapsing-item-has-larger-block-start</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="collapsed block-end margins should be trimmed but not affect container margins">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 0px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+    <item class="collapsed"></item>
+</container>
+<item></item>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-larger-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-larger-block-start.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>margin-trim: block-container-block-start-self-collapsing-item-has-larger-block-start</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="block-container-collapsed-margins-ref.html">
+<meta name="assert" content="self-collapsing margin at block-start has its block-start margin trimmed which would normally be used in collapsing with container"">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    margin-block-start: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 100px;
+    height: 0px;
+}
+</style>
+</head>
+<body>
+<item style="margin-block-start: 0px;"></item>
+<container>
+    <item class="collapsed"></item>
+    <item></item>
+</container>
+</body>
+</html>


### PR DESCRIPTION
#### 82ef68207e2f4b6c16b642e5df3a2e79d0e62355
<pre>
Trim collapsed margins at block-start and block-end when specified by margin-trim
<a href="https://bugs.webkit.org/show_bug.cgi?id=249781">https://bugs.webkit.org/show_bug.cgi?id=249781</a>
rdar://103640784

Reviewed by Alan Baradlay.

When collapsed margins at propagated to the block-start or block-end of
a block container and the appropriate margin-trim values are specified,
those margins should also be trimmed.

This can be done by keeping track of whether we are at the block start
or block end of the box as specified by the MarginInfo structure. If
we are currently at the block start of the container, then we should
trim the before margin of the child. If the child is self collapsing,
we should also trim its after margin.

By the time we are in setCollapsedBottomMargin, we are at the block
end of the block container. That means we should be able to trim the
values inside of MarginInfo if margin-trim: block/block-end is
specified.

Here is an example to demonstrate this logic:

container {
    display: block;
    margin-trim: block;
    margin-block-start: 10px;
}
item {
    display: block;
    margin-block-start: 40px;
    width: 50px;
    height: 50px;
    background-color: green;
}
.collapsed {
    margin-block-start: 0px;
    height: 0px;
}
&lt;item style=&quot;margin-block-start: 0px;&quot;&gt;&lt;/item&gt;
&lt;container&gt;
    &lt;item class=&quot;collapsed&quot;&gt;&lt;/item&gt;
    &lt;item&gt;&lt;/item&gt;
&lt;/container&gt;

- The container will begin layout of its block children and will iterate
over them. Each iteration will take in and update a MarginInfo structure
that is used to handle any sort of collapsing. Initially this structure
will just hold the margin information for the container itself.

- RenderBlockFlow::layoutBlockChild will call RenderBlockFlow::collapseMargins
with the child as an argument, and that method will call
RenderBlockFlow::collapseMarginsWithChildInfo to perform the actual
collapsing.

- Since we are at the before side of the block, which is a part of the
MarginInfo state, and block-start trimming is specified, we will then
trim the block-start margin of the child. We will also trim the block-end
margin of the child since it is self-collapsing.

- Once we are done with this item and we are back in RenderBlockFlow::layoutBlockChild
we will check to see if we need to update the MarginInfo state that keeps
track of us being at the before side of the block container. Since
1.) We were at the before side of the block container
2.) The child we just laid out is self collapsing
We will not update our MarginInfo state and we will continue to be at the
before side of the block. This means that this trimming logic will continue
on with the next item in the container. If the first item was not
self collapsing, however, then we would update our MarginInfo state so
that we are no longer at the before side and we would not trim the
block-start margins of the future children.

- After we layout and trim the margins of the second item,
RenderBlockFlow::layoutBlockChildren will call handleAfterSideOfBlock
with the MarginInfo structure that has been modified this whole time.
This should contain any margins that have collapsed through to the
after side of the block.

- Once in RenderBlockFlow::setCollapsedBottomMargin, we will check to
see if block-end margin trimming has been specified. If it has, then
we will use 0 (trimmed) for the margin from MarginInfo that is supposed
to collapse with the container&apos;s margin.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-collapsed-margins-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-collapsed-margins.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-end-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-start-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-item-has-larger-block-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-collapsed-margins-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-collapsed-margins.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-has-larger-block-end-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-has-larger-block-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-larger-block-start-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-start-self-collapsing-item-larger-block-start.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::collapseMarginsWithChildInfo):
(WebCore::RenderBlockFlow::setCollapsedBottomMargin):

Canonical link: <a href="https://commits.webkit.org/259734@main">https://commits.webkit.org/259734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6216aaec8f1224888b34a29c14b25fc6cb689026

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114910 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175051 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5973 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97949 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111436 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12309 "Found 1 new test failure: fast/dynamic/create-renderer-for-whitespace-only-text.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39790 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28284 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8537 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4869 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47831 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6733 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10090 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->