### PR TITLE
Update webkit.org trac source code links to GitHub

### DIFF
--- a/Websites/webkit.org/commit-review.md
+++ b/Websites/webkit.org/commit-review.md
@@ -10,7 +10,7 @@ A candidate for WebKit Committer or WebKit Reviewer should initially be nominate
 
 Once someone is successfully nominated for WebKit Committer status, Apple will take care of sending the committer agreement and granting read-write access once signed and received.
 
-Once someone is successfully nominated for WebKit Reviewer status, the nominating Reviewer or another responsible party should inform the candidate and ask for indication of acceptance from the potential new reviewer. If the candidate accepts, [contributors.json](http://trac.webkit.org/browser/trunk/metadata/contributors.json) will be updated.
+Once someone is successfully nominated for WebKit Reviewer status, the nominating Reviewer or another responsible party should inform the candidate and ask for indication of acceptance from the potential new reviewer. If the candidate accepts, [contributors.json](https://github.com/WebKit/WebKit/tree/main/metadata/contributors.json) will be updated.
 
 ## Criteria for Committers
 

--- a/Websites/webkit.org/docs/b3/assembly-intermediate-representation.html
+++ b/Websites/webkit.org/docs/b3/assembly-intermediate-representation.html
@@ -21,19 +21,19 @@
       Air (Assembly Intermediate Representation).</p>
     
     <p>Air programs are represented using a
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirCode.h"><code>Air::Code</code></a>
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirCode.h"><code>Air::Code</code></a>
       object. <code>Code</code> comprises an array of
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirBasicBlock.h">basic
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirBasicBlock.h">basic
         blocks</a>. Each basic block comprises an array of
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirInst.h"><code>Inst</code></a>s.
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirInst.h"><code>Inst</code></a>s.
       Air has an explicit control flow graph: each basic block has predecessor and successor blocks.
       Execution always begins at the first basic block (<code>code[0]</code>). The <code>Inst</code>s
       in each block are executed in order. Each <code>Inst</code> has an opcode, some flags, an
       array of arguments
-      (<a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirArg.h"><code>Arg</code></a>s),
+      (<a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirArg.h"><code>Arg</code></a>s),
       and an origin. The opcode and flags are wrapped in a <code>Kind</code>, to make it
       convenient to carry them around together. The origin is simply a B3 IR
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/B3Value.h"><code>Value</code></a>.
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/B3Value.h"><code>Value</code></a>.
       Some opcodes use the origin for additional meta-data. This works because Air code always
       coexists with the B3 procedure from which it was generated.</p>
     
@@ -57,9 +57,9 @@
       instruction sequence, and this includes CPU concepts like registers and direct accesses to the
       stack. Air also has a higher-level form in which the assembly has not yet undergone register
       or stack allocation. Therefore, Air also supports abstract registers (called
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirTmp.h"><code>Tmp</code></a>s)
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirTmp.h"><code>Tmp</code></a>s)
       and abstract
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirStackSlot.h">stack
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirStackSlot.h">stack
         slots</a>. A <code>Tmp</code> object can either hold an unallocated temporary or a
       register.</p>
     
@@ -349,13 +349,13 @@ Foo32 %tmp</code></pre></li>
       <code>Tmp</code>s or any abstract stack slots. If we wrote the
       code for validating, iterating, and generating each form by hand, we would have a bad time.
       For this reason, Air comes with an
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/opcode_generator.rb">opcode code generator</a>
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/opcode_generator.rb">opcode code generator</a>
       that uses a
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirOpcode.opcodes">opcode definition file</a>
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirOpcode.opcodes">opcode definition file</a>
       as input. The opcode definition file use a simple and concise syntax that lets us define many
       opcodes at once and constrain them to the CPU kinds that support them. Additionally, Air
       supports <i>custom</i> opcodes, where the code generator emits calls to
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirCustom.h">hand-written
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirCustom.h">hand-written
         C++ code</a>. This section describes the opcode definition language.</p>
     
     <p>It's easiest to understand the opcode definitions with an example. Let's use the two-argument
@@ -390,7 +390,7 @@ Foo32 %tmp</code></pre></li>
       <code>MacroAssembler::add32</code>, for example.</p>
     
     <p>See the header of
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirOpcode.opcodes">AirOpcode.opcodes</a>
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirOpcode.opcodes">AirOpcode.opcodes</a>
       for a complete list of shorthand used by Air's opcode definition language.</p>
     
     <h2>Summary</h2>
@@ -399,7 +399,7 @@ Foo32 %tmp</code></pre></li>
       which method name to use and its args indicate the arguments to pass to that method. We
       use code generation to create a massive switch statement that turns the reflective Insts
       into actual calls to MacroAssembler. Consequently, we can "add" new instructions to Air
-      usually by just editing the <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/air/AirOpcode.opcodes">AirOpcode.opcodes</a>
+      usually by just editing the <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/air/AirOpcode.opcodes">AirOpcode.opcodes</a>
       file.</p>
   </div>
 </body>

--- a/Websites/webkit.org/docs/b3/intermediate-representation.html
+++ b/Websites/webkit.org/docs/b3/intermediate-representation.html
@@ -34,9 +34,9 @@
     <ol>
       <li>Create the Procedure.</li>
       <li>Populate the Procedure with code.</li>
-      <li>Use either the <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/B3Compilation.h">high-level
+      <li>Use either the <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/B3Compilation.h">high-level
           Compilation API</a> or the
-        <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/B3Generate.h">low-level
+        <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/B3Generate.h">low-level
           generation API</a>.</li>
     </ol>
 
@@ -768,7 +768,7 @@ root->appendSuccessor(thirdEntrypoint);</code></pre>
     <h2>Flags</h2>
     
     <p>This section describes flags. These may be set in
-      <a href="http://trac.webkit.org/browser/trunk/Source/JavaScriptCore/b3/B3Kind.h"><code>Kind</code></a>.</p>
+      <a href="https://github.com/WebKit/WebKit/tree/main/Source/JavaScriptCore/b3/B3Kind.h"><code>Kind</code></a>.</p>
     
     <dl>
       <dt>Chill</dt>


### PR DESCRIPTION
#### 0ab19d727b810ae14cb6b3559c4c199411d594e7
<pre>
Update webkit.org trac source code links to GitHub
<a href="https://bugs.webkit.org/show_bug.cgi?id=251128">https://bugs.webkit.org/show_bug.cgi?id=251128</a>

Reviewed by Jonathan Bedard.

Update the source code links from trac to github on webkit.org.
We have moved over our development to posting patches on GitHub, so it seems nicer
to point at the GitHub repo instead.

* Websites/webkit.org/commit-review.md:
* Websites/webkit.org/docs/b3/assembly-intermediate-representation.html:
* Websites/webkit.org/docs/b3/intermediate-representation.html:

Canonical link: <a href="https://commits.webkit.org/259362@main">https://commits.webkit.org/259362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e74d593a3d66c4b96e2e8b4ec5c459356492a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113930 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174142 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4661 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112866 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11464 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94490 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMaximum2, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMaximum1, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialRequestOptionsMaximum (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39023 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108127 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80687 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7088 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27460 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92548 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4851 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4042 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30116 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103484 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47016 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101234 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8982 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25184 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3424 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->