### PR TITLE
[Wasm-GC] Fix null checks for struct operations

### DIFF
--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -766,6 +766,19 @@ function testStructGet() {
     WebAssembly.CompileError,
     "WebAssembly.Module doesn't validate: struct.get invalid index: Structref, in function at index 1 (evaluating 'new WebAssembly.Module(binary)')"
   );
+
+  // Test null checks.
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (struct (field i32)))
+        (func (export "f") (result i32)
+          (struct.get 0 0 (ref.null 0)))
+      )
+    `).exports.f(),
+    WebAssembly.RuntimeError,
+    "struct.get to a null reference"
+  );
 }
 
 function testStructSet() {
@@ -1164,6 +1177,19 @@ function testStructSet() {
       `),
     WebAssembly.CompileError,
     "WebAssembly.Module doesn't validate: struct.set index 5 is out of bound, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+  );
+
+  // Test null checks.
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (struct (field (mut i32))))
+        (func (export "f") (result)
+          (struct.set 0 0 (ref.null 0) (i32.const 42)))
+      )
+    `).exports.f(),
+    WebAssembly.RuntimeError,
+    "struct.set to a null reference"
   );
 }
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -2638,6 +2638,8 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addStructNewDefault(uint32_t t
 template <typename Derived, typename ExpressionType>
 auto AirIRGeneratorBase<Derived, ExpressionType>::addStructGet(ExpressionType structReference, const StructType& structType, uint32_t fieldIndex, ExpressionType& result) -> PartialResult
 {
+    emitThrowOnNullReference(structReference, ExceptionType::NullStructGet);
+
     auto payload = self().gPtr();
     auto structBase = self().extractJSValuePointer(structReference);
     self().emitLoad(structBase, JSWebAssemblyStruct::offsetOfPayload(), payload);
@@ -2654,6 +2656,8 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addStructGet(ExpressionType st
 template <typename Derived, typename ExpressionType>
 auto AirIRGeneratorBase<Derived, ExpressionType>::addStructSet(ExpressionType structReference, const StructType& structType, uint32_t fieldIndex, ExpressionType value) -> PartialResult
 {
+    emitThrowOnNullReference(structReference, ExceptionType::NullStructSet);
+
     auto payload = self().gPtr();
     auto structBase = self().extractJSValuePointer(structReference);
     self().emitLoad(structBase, JSWebAssemblyStruct::offsetOfPayload(), payload);

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -2914,6 +2914,14 @@ auto B3IRGenerator::addStructNewDefault(uint32_t typeIndex, ExpressionType& resu
 
 auto B3IRGenerator::addStructGet(ExpressionType structReference, const StructType& structType, uint32_t fieldIndex, ExpressionType& result) -> PartialResult
 {
+    {
+        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), get(structReference), m_currentBlock->appendNew<Const64Value>(m_proc, origin(), JSValue::encode(jsNull()))));
+        check->setGenerator([=, this] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, ExceptionType::NullStructGet);
+        });
+    }
+
     Value* payloadBase = m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Load), pointerType(), origin(), get(structReference), JSWebAssemblyStruct::offsetOfPayload());
     int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.getFieldOffset(fieldIndex));
 
@@ -2947,6 +2955,14 @@ auto B3IRGenerator::addStructGet(ExpressionType structReference, const StructTyp
 
 auto B3IRGenerator::addStructSet(ExpressionType structReference, const StructType& structType, uint32_t fieldIndex, ExpressionType value) -> PartialResult
 {
+    {
+        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), get(structReference), m_currentBlock->appendNew<Const64Value>(m_proc, origin(), JSValue::encode(jsNull()))));
+        check->setGenerator([=, this] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, ExceptionType::NullStructSet);
+        });
+    }
+
     emitStructSet(get(structReference), fieldIndex, structType, get(value));
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -53,6 +53,8 @@ namespace Wasm {
     macro(NullArrayGet, "array.get to a null reference"_s) \
     macro(NullArraySet, "array.set to a null reference"_s) \
     macro(NullArrayLen, "array.len to a null reference"_s) \
+    macro(NullStructGet, "struct.get to a null reference"_s) \
+    macro(NullStructSet, "struct.set to a null reference"_s) \
     macro(TypeErrorInvalidV128Use, "an exported wasm function cannot contain a v128 parameter or return value"_s) \
     macro(NullRefAsNonNull, "ref.as_non_null to a null reference"_s)
 
@@ -95,6 +97,8 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::NullArrayGet:
     case ExceptionType::NullArraySet:
     case ExceptionType::NullArrayLen:
+    case ExceptionType::NullStructGet:
+    case ExceptionType::NullStructSet:
     case ExceptionType::NullRefAsNonNull:
         return false;
     case ExceptionType::FuncrefNotWasm:

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -480,6 +480,8 @@ WASM_SLOW_PATH_DECL(struct_get)
     UNUSED_PARAM(instance);
     auto instruction = pc->as<WasmStructGet>();
     auto structReference = READ(instruction.m_structReference).encodedJSValue();
+    if (JSValue::decode(structReference).isNull())
+        WASM_THROW(Wasm::ExceptionType::NullStructGet);
     WASM_RETURN(Wasm::structGet(structReference, instruction.m_fieldIndex));
 }
 
@@ -489,6 +491,8 @@ WASM_SLOW_PATH_DECL(struct_set)
 
     auto instruction = pc->as<WasmStructSet>();
     auto structReference = READ(instruction.m_structReference).encodedJSValue();
+    if (JSValue::decode(structReference).isNull())
+        WASM_THROW(Wasm::ExceptionType::NullStructSet);
     auto value = READ(instruction.m_value).encodedJSValue();
     Wasm::structSet(instance, structReference, instruction.m_fieldIndex, value);
     WASM_END();


### PR DESCRIPTION
#### a5a87681d68f0e9b9def72c33858a176b45d2248
<pre>
[Wasm-GC] Fix null checks for struct operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=251133">https://bugs.webkit.org/show_bug.cgi?id=251133</a>

Reviewed by Justin Michaud.

Adds in missing null checks for struct instructions.

* JSTests/wasm/gc/structs.js:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addStructGet):
(JSC::Wasm::ExpressionType&gt;::addStructSet):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addStructGet):
(JSC::Wasm::B3IRGenerator::addStructSet):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):

Canonical link: <a href="https://commits.webkit.org/259449@main">https://commits.webkit.org/259449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21ed12c78b94fab524c75c8cde7399e88ad67558

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114149 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174340 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4885 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97208 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113171 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94667 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39179 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80841 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94749 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27646 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92771 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5036 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4237 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30242 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47196 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101462 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6517 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9190 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25316 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->