### PR TITLE
Expose the inspected web view from _WKInspectorWindow

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindow.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindow.mm
@@ -24,16 +24,11 @@
  */
 
 #import "config.h"
-#import "_WKInspectorWindow.h"
+#import "_WKInspectorWindowInternal.h"
 
 #if PLATFORM(MAC)
 
 @implementation _WKInspectorWindow
-
-- (BOOL)isForRemoteTarget
-{
-    return _forRemoteTarget;
-}
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindowInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindowInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKInspectorWindow.h>
 
 #if !TARGET_OS_IPHONE
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class WKWebView;
+@interface _WKInspectorWindow ()
 
-WK_CLASS_AVAILABLE(macos(10.15))
-@interface _WKInspectorWindow : NSWindow
-
-@property (nonatomic, readonly, getter=isForRemoteTarget) BOOL forRemoteTarget;
-@property (nonatomic, nullable, readonly, weak) WKWebView *inspectedWebView WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readwrite, getter=isForRemoteTarget) BOOL forRemoteTarget;
+@property (nonatomic, nullable, readwrite, weak) WKWebView *inspectedWebView;
 
 @end
 
 NS_ASSUME_NONNULL_END
 
-#endif
+#endif // !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -131,7 +131,7 @@ public:
 
 #if PLATFORM(MAC)
     enum class InspectionTargetType { Local, Remote };
-    static RetainPtr<NSWindow> createFrontendWindow(NSRect savedWindowFrame, InspectionTargetType);
+    static RetainPtr<NSWindow> createFrontendWindow(NSRect savedWindowFrame, InspectionTargetType, WebPageProxy* inspectedPage = nullptr);
     static void showSavePanel(NSWindow *, NSURL *, Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool forceSaveAs, CompletionHandler<void(NSURL *)>&&);
 
     void didBecomeActive();
@@ -140,7 +140,6 @@ public:
     void inspectedViewFrameDidChange(CGFloat = 0);
     void windowFrameDidChange();
     void windowFullScreenDidChange();
-    NSWindow *inspectorWindow() const { return m_inspectorWindow.get(); }
 
     void closeFrontendPage();
     void closeFrontendAfterInactivityTimerFired();

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5745,6 +5745,7 @@
 		63C32C231E9810D900699BD0 /* _WKGeolocationPosition.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKGeolocationPosition.mm; sourceTree = "<group>"; };
 		63C32C241E9810D900699BD0 /* _WKGeolocationPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKGeolocationPosition.h; sourceTree = "<group>"; };
 		63C32C271E98119000699BD0 /* _WKGeolocationPositionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKGeolocationPositionInternal.h; sourceTree = "<group>"; };
+		63DCF6AF2980C0E50016E213 /* _WKInspectorWindowInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKInspectorWindowInternal.h; sourceTree = "<group>"; };
 		63FABE191E970D65003011D5 /* _WKGeolocationCoreLocationProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKGeolocationCoreLocationProvider.h; sourceTree = "<group>"; };
 		650994DF28C942B7006EE6DB /* com.apple.WebKit.WebContent.Crashy.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = com.apple.WebKit.WebContent.Crashy.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		6546A82913000164000CEB1C /* InjectedBundlePageResourceLoadClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InjectedBundlePageResourceLoadClient.cpp; sourceTree = "<group>"; };
@@ -10270,6 +10271,7 @@
 				99996A9E25004BCB004F7559 /* _WKInspectorTesting.mm */,
 				A5C0F0AA2000656E00536536 /* _WKInspectorWindow.h */,
 				A5C0F0A92000656E00536536 /* _WKInspectorWindow.mm */,
+				63DCF6AF2980C0E50016E213 /* _WKInspectorWindowInternal.h */,
 				31B362942141EBAD007BFA53 /* _WKInternalDebugFeature.h */,
 				31B362922141EBAC007BFA53 /* _WKInternalDebugFeature.mm */,
 				2D790A9C1AD7050D00AB90B3 /* _WKLayoutMode.h */,


### PR DESCRIPTION
#### 5bb44c8b1c3b4f3d3c289625412e57a0f6037f50
<pre>
Expose the inspected web view from _WKInspectorWindow
<a href="https://bugs.webkit.org/show_bug.cgi?id=251140">https://bugs.webkit.org/show_bug.cgi?id=251140</a>
rdar://104628163

Reviewed by Patrick Angle.

Introduce _WKInspectorWindow.inspectedWebView to read the web view inspected by the
inspector hosted in a _WKInspectorWindow.

* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindow.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindow.mm:
    Let the compiler automatically synthesize the properties. Manually implementing them
    doesn&apos;t provide any benefit.
(-[_WKInspectorWindow isForRemoteTarget]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindowInternal.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKInspectorWindow.h.
    As minor cleanup, add an internal header to redeclare the SPI as readwrite instead
    of exposing the properties as writable to WebKit clients who import the main header.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
    Add an optional parameter to createFrontendWindow() to specify a WebPageProxy being
    inspected. This will be used to populate the new `inspectedWebView` property.
(WebKit::WebInspectorUIProxy::inspectorWindow const): Deleted.
    Remove this method. It wasn&apos;t being used anywhere.
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::createFrontendWindow):
    If an inspected WebPageProxy was provided, look up the WKWebView to assign to
    _WKInspectorWindow.inspectedWebView.
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
    Pass the inspected page to createFrontendWindow().
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
    Add reference to _WKInspectorWindowInternal.h.

Canonical link: <a href="https://commits.webkit.org/259393@main">https://commits.webkit.org/259393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b105df938ce9896326c0aa182f8c5647b36525b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114034 "Built successfully") | 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4766 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97098 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94595 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108222 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26208 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27566 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92649 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7292 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30206 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47118 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101338 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6480 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9078 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->