### PR TITLE
[content-visibility] Add support for css content-visibility: auto

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4925,16 +4925,15 @@ webanimations/translate-property-and-translate-animation-with-delay-on-forced-la
 imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-bfc-floats-001.html [ ImageOnlyFailure ]
 # forced layout
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html [ Skip ]
-# c-v: auto
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-nested-scroll.html [ Skip ]
+# off-screen selection
+imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071.html [ Skip ]
+# c-v: auto contentvisibilityautostatechanged event
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-first-observation.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-fieldset-size.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-in-auto-subtree-removal.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -1261,6 +1261,8 @@
         "web-platform-tests/css/css-contain/content-visibility/content-visibility-fieldset-size-ref.html",
         "web-platform-tests/css/css-contain/content-visibility/content-visibility-resize-observer-no-error-ref.html",
         "web-platform-tests/css/css-contain/content-visibility/content-visibility-video-ref.html",
+        "web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html",
+        "web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html",
         "web-platform-tests/css/css-contain/content-visibility/content-with-popover-top-layer-ref.html",
         "web-platform-tests/css/css-contain/content-visibility/content-with-top-layer-ref.html",
         "web-platform-tests/css/css-contain/content-visibility/crashtests/content-visibility-transition-finished-001.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Fragment navigation with content-visibility; single text assert_equals: expected "text" but got "undefined"
-FAIL Fragment navigation with content-visibility; range across blocks assert_equals: expected "text2" but got "unknown"
+FAIL Fragment navigation with content-visibility; single text assert_equals: expected "text" but got "top"
+FAIL Fragment navigation with content-visibility; range across blocks assert_equals: expected "text2" but got "top"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-068-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-068-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Content Visibility: off-screen focus assert_equals: step1 height expected 100 but got 10
+FAIL Content Visibility: off-screen focus assert_equals: step5 height expected 10 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070-expected.txt
@@ -1,4 +1,3 @@
-hello
 
-FAIL Content Visibility: off-screen selection assert_equals: step1 height expected 100 but got 10
+FAIL Content Visibility: off-screen selection assert_equals: step3 height expected 10 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071-expected.txt
@@ -1,13 +1,8 @@
-hello
-hello
-hello
-hello
-hello
 
-FAIL One elements selected:  assert_true: expected true got false
-FAIL Range extended to cover more elements:  assert_true: expected true got false
-FAIL Range shrunk to cover fewer elements:  assert_true: expected true got false
-FAIL Range flipped from back to front:  assert_true: expected true got false
-FAIL Range flipped from front to back:  assert_true: expected true got false
-FAIL Range goes back and forth:  assert_true: expected true got false
+FAIL One elements selected:  assert_false: 2 expected false got true
+FAIL Range extended to cover more elements:  assert_false: 2 expected false got true
+FAIL Range shrunk to cover fewer elements:  assert_false: 2 expected false got true
+FAIL Range flipped from back to front:  assert_false: 2 expected false got true
+FAIL Range flipped from front to back:  assert_false: 3 expected false got true
+FAIL Range goes back and forth:  assert_false: test_0, container_1 expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-072-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-072-expected.txt
@@ -1,7 +1,7 @@
 
 PASS one.getBoundingClientRect():
-FAIL two.getBoundingClientRect():  assert_equals: y expected 3007 but got 3041
-FAIL three.getBoundingClientRect():  assert_equals: y expected 3007 but got 3041
-FAIL four.getBoundingClientRect():  assert_equals: y expected 3007 but got 3041
-FAIL five.getBoundingClientRect():  assert_equals: y expected 3007 but got 3041
+PASS two.getBoundingClientRect():
+PASS three.getBoundingClientRect():
+PASS four.getBoundingClientRect():
+PASS five.getBoundingClientRect():
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-006-expected.txt
@@ -1,4 +1,3 @@
-content
 
-FAIL CSS Content Visibility: offscreen c-v auto content is relevant when in top layer assert_equals: expected 100 but got 200
+PASS CSS Content Visibility: offscreen c-v auto content is relevant when in top layer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-expected.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in popover is shown on showPopover"</title>
+<meta name="assert" content="content-visibility: auto descendant in popover is shown on showPopover">
+
+<div id="spacer" style="height: 100vh"></div>
+<div popover="manual" style="display: block; position: static;" id="popover">
+  <span>Test passes if this is visible</span>
+</div>
+
+<script>
+  popover.showPopover();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in popover is shown on showPopover"</title>
+<meta name="assert" content="content-visibility: auto descendant in popover is shown on showPopover">
+
+<div id="spacer" style="height: 100vh"></div>
+<div popover="manual" style="display: block; position: static;" id="popover">
+  <span>Test passes if this is visible</span>
+</div>
+
+<script>
+  popover.showPopover();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html class="reftest-wait">
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in popover is shown on showPopover</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="content-visibility-with-popover-top-layer-and-auto-descendant-ref.html">
+<meta name="assert" content="content-visibility: auto descendant in popover is shown on showPopover">
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+#inner {
+  content-visibility: auto;
+  contain-intrinsic-size: 100px 100px;
+}
+</style>
+
+<div id="spacer" style="height: 100vh"></div>
+<div popover="manual" style="display: block; position: static;" id="popover">
+  <span id="inner">Test passes if this is visible</span>
+</div>
+
+<script>
+function runTest() {
+  popover.showPopover();
+  requestAnimationFrame(takeScreenshot);
+}
+
+window.onload = runTest;
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-006-expected.txt
@@ -1,4 +1,3 @@
-content
 
-FAIL CSS Content Visibility: offscreen c-v auto content is relevant when in top layer assert_equals: expected 100 but got 200
+PASS CSS Content Visibility: offscreen c-v auto content is relevant when in top layer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-expected.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in dialog is shown on showModal"</title>
+<meta name="assert" content="content-visibility: auto descendant in dialog is shown on showModal">
+
+<div id="spacer" style="height: 100vh"></div>
+<dialog id="dialog" style="display: block; position: static;">
+  <span>Test passes if this is visible</span>
+</dialog>
+
+<script>
+  dialog.showModal();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in dialog is shown on showModal"</title>
+<meta name="assert" content="content-visibility: auto descendant in dialog is shown on showModal">
+
+<div id="spacer" style="height: 100vh"></div>
+<dialog id="dialog" style="display: block; position: static;">
+  <span>Test passes if this is visible</span>
+</dialog>
+
+<script>
+  dialog.showModal();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html class="reftest-wait">
+<meta charset="utf8">
+<title>CSS Content Visibility: content-visibility: auto descendant in dialog is shown on showModal</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="content-visibility-with-top-layer-and-auto-descendant-ref.html">
+<meta name="assert" content="content-visibility: auto descendant in dialog is shown on showModal">
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+#inner {
+  content-visibility: auto;
+  contain-intrinsic-size: 100px 100px;
+}
+</style>
+
+<div id="spacer" style="height: 100vh"></div>
+<dialog id="dialog" style="display: block; position: static;">
+  <span id="inner">Test passes if this is visible</span>
+</dialog>
+
+<script>
+function runTest() {
+  dialog.showModal();
+  requestAnimationFrame(takeScreenshot);
+}
+
+window.onload = runTest;
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/w3c-import.log
@@ -232,6 +232,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-005-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-005.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-006.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-hide-after-addition-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-hide-after-addition.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-000-expected.html
@@ -247,6 +250,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-005-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-005.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-006.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-hide-after-addition-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-hide-after-addition.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-in-auto-subtree-removal-expected.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL contain-intrinsic-size: auto assert_equals: expected 50 but got 1
+PASS contain-intrinsic-size: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt
@@ -1,9 +1,9 @@
 
-PASS Sizing normally
+FAIL Sizing normally assert_equals: clientWidth expected 50 but got 100
 PASS Sizing with c-i-s fallback
 PASS Still sizing with c-i-s fallback
 PASS Sizing with last remembered size
-FAIL Still sizing with last remembered size assert_equals: clientWidth expected 100 but got 150
+PASS Still sizing with last remembered size
 PASS Sizing with new c-i-s fallback
-FAIL Sizing with new last remembered size assert_equals: clientWidth expected 150 but got 200
+PASS Sizing with new last remembered size
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3559,8 +3559,6 @@ imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html [ P
 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-001.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-002.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-content/quotes-006.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-content/quotes-007.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-content/quotes-012.html [ Pass ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2573,3 +2573,9 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-eleme
 
 # rdar://111704637 - 'mousemove' not emitted from 'eventSender.moveMouseTo()'
 fast/html/transient-activation.html [ Skip ]
+
+webkit.org/b/259075 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-079.html [ ImageOnlyFailure ]
+webkit.org/b/259075 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-in-iframe.html [ ImageOnlyFailure ]
+webkit.org/b/259075 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-intrinsic-width.html [ ImageOnlyFailure ]
+webkit.org/b/259075 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-nested.html [ ImageOnlyFailure  ]
+webkit.org/b/259075 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-resize-observer-no-error.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1349,8 +1349,6 @@ webkit.org/b/228713 [ BigSur Debug arm64 ] compositing/video/video-object-fit.ht
 
 webkit.org/b/224698 [ BigSur Release arm64 ] inspector/console/console-oom.html [ Pass Crash ]
 
-webkit.org/b/238033 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-050.html [ Pass Failure ]
-
 webkit.org/b/224963 [ BigSur arm64 ] webrtc/captureCanvas-webrtc.html [ Pass Timeout ]
 
 webkit.org/b/225430 [ BigSur arm64 ] http/tests/inspector/network/resource-sizes-network.html [ Pass Failure ]

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1032,6 +1032,7 @@ dom/CompositionEvent.cpp
 dom/ConstantPropertyMap.cpp
 dom/ContainerNode.cpp
 dom/ContainerNodeAlgorithms.cpp
+dom/ContentVisibilityDocumentState.cpp
 dom/ContextDestructionObserver.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/CustomElementReactionQueue.cpp

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ContentVisibilityDocumentState.h"
+
+#include "Element.h"
+#include "IntersectionObserverCallback.h"
+#include "IntersectionObserverEntry.h"
+#include "NodeRenderStyle.h"
+#include "RenderElement.h"
+#include "RenderStyle.h"
+
+namespace WebCore {
+
+class ContentVisibilityIntersectionObserverCallback final : public IntersectionObserverCallback {
+public:
+    static Ref<ContentVisibilityIntersectionObserverCallback> create(Document& document)
+    {
+        return adoptRef(*new ContentVisibilityIntersectionObserverCallback(document));
+    }
+
+private:
+    bool hasCallback() const final { return true; }
+
+    CallbackResult<void> handleEvent(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    {
+        ASSERT(!entries.isEmpty());
+
+        for (auto& entry : entries) {
+            if (auto* element = entry->target()) {
+                element->contentVisibilityViewportChange(entry->isIntersecting());
+                element->document().contentVisibilityDocumentState().updateOnScreenObservationTarget(*element, entry->isIntersecting());
+            }
+        }
+        return { };
+    }
+
+    ContentVisibilityIntersectionObserverCallback(Document& document)
+        : IntersectionObserverCallback(&document)
+    {
+    }
+};
+
+void ContentVisibilityDocumentState::observe(Element& element)
+{
+    auto& state = element.document().contentVisibilityDocumentState();
+    if (auto* intersectionObserver = state.intersectionObserver(element.document()))
+        intersectionObserver->observe(element);
+}
+
+void ContentVisibilityDocumentState::unobserve(Element& element)
+{
+    auto& state = element.document().contentVisibilityDocumentState();
+    if (auto& intersectionObserver = state.m_observer) {
+        intersectionObserver->unobserve(element);
+        state.updateOnScreenObservationTarget(element, false);
+    }
+    element.setContentRelevancyStatus({ });
+}
+
+IntersectionObserver* ContentVisibilityDocumentState::intersectionObserver(Document& document)
+{
+    if (!m_observer) {
+        auto callback = ContentVisibilityIntersectionObserverCallback::create(document);
+        IntersectionObserver::Init options { &document, { }, { } };
+        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
+        if (observer.hasException())
+            return nullptr;
+        m_observer = observer.returnValue().ptr();
+    }
+    return m_observer.get();
+}
+
+bool ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements(const OptionSet<ContentRelevancyStatus>& relevancyToCheck)
+{
+    bool didUpdateAnyContentRelevancy = false;
+    for (auto target : m_observer->observationTargets()) {
+        if (target) {
+            auto oldRelevancy = target->contentRelevancyStatus();
+            auto newRelevancy = oldRelevancy;
+            auto setRelevancyValue = [&](ContentRelevancyStatus reason, bool value) {
+                if (value)
+                    newRelevancy.add(reason);
+                else
+                    newRelevancy.remove(reason);
+            };
+            if (relevancyToCheck.contains(ContentRelevancyStatus::OnScreen))
+                setRelevancyValue(ContentRelevancyStatus::OnScreen, m_onScreenObservationTargets.contains(*target));
+
+            if (relevancyToCheck.contains(ContentRelevancyStatus::Focused))
+                setRelevancyValue(ContentRelevancyStatus::Focused, target->hasFocusWithin());
+
+            auto hasTopLayerinSubtree = [](const Element& target) {
+                for (auto& element : target.document().topLayerElements()) {
+                    if (element->isDescendantOf(target))
+                        return true;
+                }
+                return false;
+            };
+            if (relevancyToCheck.contains(ContentRelevancyStatus::IsInTopLayer))
+                setRelevancyValue(ContentRelevancyStatus::IsInTopLayer, hasTopLayerinSubtree(*target));
+
+            if (oldRelevancy == newRelevancy)
+                continue;
+            target->setContentRelevancyStatus(newRelevancy);
+            target->invalidateStyle();
+            didUpdateAnyContentRelevancy = true;
+        }
+    }
+    return didUpdateAnyContentRelevancy;
+}
+
+// Workaround for lack of support for scroll anchoring. We make sure any content-visibility: auto elements
+// above the one to be scrolled to are already hidden, so the scroll position will not need to be adjusted
+// later.
+// FIXME: remove when scroll anchoring is implemented.
+void ContentVisibilityDocumentState::updateContentRelevancyStatusForScrollIfNeeded(const Element& scrollAnchor)
+{
+    if (!m_observer)
+        return;
+    auto findSkippedContentRoot = [](const Element& element) -> const Element* {
+        const Element* found = nullptr;
+        if (element.renderer() && element.renderer()->isSkippedContent()) {
+            for (auto candidate = &element; candidate; candidate = candidate->parentElementInComposedTree()) {
+                if (candidate->renderer() && candidate->renderStyle()->contentVisibility() == ContentVisibility::Auto)
+                    found = candidate;
+            }
+        }
+        return found;
+    };
+
+    if (auto* scrollAnchorRoot = findSkippedContentRoot(scrollAnchor)) {
+        for (auto target : m_observer->observationTargets()) {
+            if (target) {
+                ASSERT(target->renderer() && target->renderStyle()->contentVisibility() == ContentVisibility::Auto);
+                updateOnScreenObservationTarget(*target, false);
+            }
+        }
+        updateOnScreenObservationTarget(*scrollAnchorRoot, true);
+        scrollAnchorRoot->document().scheduleContentRelevancyUpdate(ContentRelevancyStatus::OnScreen);
+        scrollAnchorRoot->document().updateRelevancyOfContentVisibilityElements();
+    }
+}
+
+void ContentVisibilityDocumentState::updateOnScreenObservationTarget(const Element& element, bool onScreen)
+{
+    if (onScreen)
+        m_onScreenObservationTargets.add(element);
+    else
+        m_onScreenObservationTargets.remove(element);
+}
+
+}

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.h
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IntersectionObserver.h"
+#include <wtf/WeakHashSet.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+
+class ContentVisibilityDocumentState {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static void observe(Element&);
+    static void unobserve(Element&);
+
+    void updateContentRelevancyStatusForScrollIfNeeded(const Element& scrollAnchor);
+
+    bool hasObservationTargets() const { return m_observer && m_observer->hasObservationTargets(); }
+
+    bool updateRelevancyOfContentVisibilityElements(const OptionSet<ContentRelevancyStatus>&);
+
+    void updateOnScreenObservationTarget(const Element&, bool);
+
+private:
+    IntersectionObserver* intersectionObserver(Document&);
+
+    RefPtr<IntersectionObserver> m_observer;
+
+    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_onScreenObservationTargets;
+};
+
+} // namespace

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -99,6 +99,7 @@ class CanvasRenderingContext2D;
 class CharacterData;
 class Comment;
 class ConstantPropertyMap;
+class ContentVisibilityDocumentState;
 class DOMImplementation;
 class DOMSelection;
 class LocalDOMWindow;
@@ -266,6 +267,7 @@ enum class CollectionType : uint8_t;
 enum CSSPropertyID : uint16_t;
 
 enum class CompositeOperator : uint8_t;
+enum class ContentRelevancyStatus : uint8_t;
 enum class DOMAudioSessionType : uint8_t;
 enum class DisabledAdaptations : uint8_t;
 enum class FireEvents : bool;
@@ -1726,6 +1728,8 @@ public:
 
     LazyLoadImageObserver& lazyLoadImageObserver();
 
+    ContentVisibilityDocumentState& contentVisibilityDocumentState();
+
     void setHasVisuallyNonEmptyCustomContent() { m_hasVisuallyNonEmptyCustomContent = true; }
     bool hasVisuallyNonEmptyCustomContent() const { return m_hasVisuallyNonEmptyCustomContent; }
     void enqueuePaintTimingEntryIfNeeded();
@@ -1776,6 +1780,9 @@ public:
 #endif
 
     virtual void didChangeViewSize() { }
+
+    void updateRelevancyOfContentVisibilityElements();
+    void scheduleContentRelevancyUpdate(ContentRelevancyStatus);
 
 protected:
     enum class ConstructionFlag : uint8_t {
@@ -1910,6 +1917,8 @@ private:
     RefPtr<ResizeObserver> ensureResizeObserverForContainIntrinsicSize();
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 
+    bool isObservingContentVisibilityTargets() const;
+
     const Ref<const Settings> m_settings;
 
     UniqueRef<Quirks> m_quirks;
@@ -1995,6 +2004,8 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_cssTarget;
 
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
+
+    std::unique_ptr<ContentVisibilityDocumentState> m_contentVisibilityDocumentState;
 
 #if !LOG_DISABLED
     MonotonicTime m_documentCreationTime;
@@ -2287,6 +2298,8 @@ private:
 #if ENABLE(DOM_AUDIO_SESSION)
     DOMAudioSessionType m_audioSessionType { };
 #endif
+
+    OptionSet<ContentRelevancyStatus> m_contentRelevancyStatusUpdate;
 
     StandaloneStatus m_xmlStandalone { StandaloneStatus::Unspecified };
     bool m_hasXMLDeclaration { false };

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -105,6 +105,14 @@ struct ShadowRootInit;
 using ElementName = NodeName;
 using ExplicitlySetAttrElementsMap = HashMap<QualifiedName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>>;
 
+// https://drafts.csswg.org/css-contain/#relevant-to-the-user
+enum class ContentRelevancyStatus : uint8_t {
+    OnScreen = 1 << 0,
+    Focused = 1 << 1,
+    IsInTopLayer = 1 << 2,
+    // FIXME: add Selected (see https://bugs.webkit.org/show_bug.cgi?id=258194).
+};
+
 namespace Style {
 class Resolver;
 enum class Change : uint8_t;
@@ -726,6 +734,13 @@ public:
 
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
     ExplicitlySetAttrElementsMap* explicitlySetAttrElementsMapIfExists() const;
+
+    bool isRelevantToUser() const;
+
+    void contentVisibilityViewportChange(bool);
+
+    OptionSet<ContentRelevancyStatus> contentRelevancyStatus() const;
+    void setContentRelevancyStatus(OptionSet<ContentRelevancyStatus>);
 
 protected:
     Element(const QualifiedName&, Document&, ConstructionType);

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -36,6 +36,7 @@ namespace WebCore {
 struct SameSizeAsElementRareData : NodeRareData {
     unsigned short m_childIndex;
     int m_tabIndex;
+    uint32_t contentRelevancy;
     IntPoint savedLayerScrollPosition;
     Vector<std::unique_ptr<ElementAnimationRareData>> animationRareData;
     void* pointers[16];

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -145,6 +145,9 @@ public:
     PopoverData* popoverData() { return m_popoverData.get(); }
     void setPopoverData(std::unique_ptr<PopoverData>&& popoverData) { m_popoverData = WTFMove(popoverData); }
 
+    const OptionSet<ContentRelevancyStatus>& contentRelevancyStatus() const { return m_contentRelevancyStatus; }
+    void setContentRelevancyStatus(OptionSet<ContentRelevancyStatus>& contentRelevancyStatus) { m_contentRelevancyStatus = contentRelevancyStatus; }
+
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
     {
@@ -202,6 +205,8 @@ public:
 private:
     unsigned short m_childIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
     int m_unusualTabIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
+
+    OptionSet<ContentRelevancyStatus> m_contentRelevancyStatus;
 
     IntPoint m_savedLayerScrollPosition;
     std::unique_ptr<RenderStyle> m_computedStyle;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -36,6 +36,7 @@
 #include "ChromeClient.h"
 #include "ColorBlending.h"
 #include "ContainerNode.h"
+#include "ContentVisibilityDocumentState.h"
 #include "DebugPageOverlays.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
@@ -2406,6 +2407,9 @@ void LocalFrameView::maintainScrollPositionAtAnchor(ContainerNode* anchorNode)
         return;
 
     cancelScheduledScrolls();
+
+    if (is<Element>(anchorNode))
+        m_frame->document()->contentVisibilityDocumentState().updateContentRelevancyStatusForScrollIfNeeded(downcast<Element>(*anchorNode));
 
     // We need to update the layout before scrolling, otherwise we could
     // really mess things up if an anchor scroll comes at a bad moment.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1823,6 +1823,10 @@ void Page::updateRendering()
         }
     });
 
+    runProcessingStep(RenderingUpdateStep::UpdateContentRelevancy, [] (Document& document) {
+        document.updateRelevancyOfContentVisibilityElements();
+    });
+
     runProcessingStep(RenderingUpdateStep::IntersectionObservations, [] (Document& document) {
         document.updateIntersectionObservations();
     });
@@ -4188,6 +4192,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
     case RenderingUpdateStep::Fullscreen: ts << "Fullscreen"; break;
     case RenderingUpdateStep::AnimationFrameCallbacks: ts << "AnimationFrameCallbacks"; break;
     case RenderingUpdateStep::IntersectionObservations: ts << "IntersectionObservations"; break;
+    case RenderingUpdateStep::UpdateContentRelevancy: ts << "UpdateContentRelevancy"; break;
     case RenderingUpdateStep::ResizeObservations: ts << "ResizeObservations"; break;
     case RenderingUpdateStep::Images: ts << "Images"; break;
     case RenderingUpdateStep::WheelEventMonitorCallbacks: ts << "WheelEventMonitorCallbacks"; break;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -243,6 +243,7 @@ enum class RenderingUpdateStep : uint32_t {
     AccessibilityRegionUpdate       = 1 << 20,
 #endif
     RestoreScrollPositionAndViewState = 1 << 21,
+    UpdateContentRelevancy          = 1 << 22,
 };
 
 enum class LinkDecorationFilteringTrigger : uint8_t {
@@ -271,6 +272,7 @@ constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
 #endif
     RenderingUpdateStep::PrepareCanvasesForDisplay,
     RenderingUpdateStep::CaretAnimation,
+    RenderingUpdateStep::UpdateContentRelevancy,
 };
 
 constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<RenderingUpdateStep> {

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -287,6 +287,8 @@ public:
     virtual bool establishesIndependentFormattingContext() const;
     bool createsNewFormattingContext() const;
 
+    bool isSkippedContentRoot() const;
+
 protected:
     enum BaseTypeFlag {
         RenderLayerModelObjectFlag  = 1 << 0,
@@ -539,6 +541,13 @@ inline RenderObject* RenderElement::lastInFlowChild() const
         return lastChild->previousInFlowSibling();
     }
     return nullptr;
+}
+
+inline bool RenderObject::isSkippedContentRoot() const
+{
+    if (isText())
+        return false;
+    return downcast<RenderElement>(*this).isSkippedContentRoot();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -73,7 +73,7 @@ inline bool RenderElement::shouldApplyAnyContainment() const
 
 inline bool RenderElement::shouldApplyInlineSizeContainment() const
 {
-    return shouldApplySizeOrStyleContainment(style().containsInlineSize());
+    return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsInlineSize());
 }
 
 inline bool RenderElement::shouldApplyLayoutContainment() const
@@ -98,12 +98,12 @@ inline bool RenderElement::shouldApplyPaintContainment() const
 
 inline bool RenderElement::shouldApplySizeContainment() const
 {
-    return shouldApplySizeOrStyleContainment(style().containsSize() || style().contentVisibility() == ContentVisibility::Hidden);
+    return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsSize());
 }
 
 inline bool RenderElement::shouldApplySizeOrInlineSizeContainment() const
 {
-    return shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize() || style().contentVisibility() == ContentVisibility::Hidden);
+    return isSkippedContentRoot() || shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize());
 }
 
 inline bool RenderElement::shouldApplySizeOrStyleContainment(bool containsAccordingToStyle) const

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2676,11 +2676,6 @@ bool RenderObject::isSkippedContent() const
     return parent() && parent()->style().effectiveSkippedContent();
 }
 
-bool RenderObject::isSkippedContentRoot() const
-{
-    return style().contentVisibility() == ContentVisibility::Hidden;
-}
-
 TextStream& operator<<(TextStream& ts, const RenderObject& renderer)
 {
     ts << renderer.debugDescription();

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -912,6 +912,7 @@ static bool rareInheritedDataChangeRequiresLayout(const StyleRareInheritedData& 
         || first.lineSnap != second.lineSnap
         || first.lineAlign != second.lineAlign
         || first.hangingPunctuation != second.hangingPunctuation
+        || first.effectiveSkippedContent != second.effectiveSkippedContent
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
         || first.useTouchOverflowScrolling != second.useTouchOverflowScrolling
 #endif

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -40,6 +40,7 @@ class Color;
 class ContentData;
 class CounterContent;
 class CursorList;
+class Element;
 class FillLayer;
 class FilterOperations;
 class FloatPoint;
@@ -2262,5 +2263,7 @@ constexpr BorderStyle collapsedBorderStyle(BorderStyle);
 inline bool pseudoElementRendererIsNeeded(const RenderStyle*);
 inline bool generatesBox(const RenderStyle&);
 inline bool isNonVisibleOverflow(Overflow);
+
+inline bool isSkippedContentRoot(const RenderStyle&, const Element*);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -26,6 +26,7 @@
 
 #include "AnimationList.h"
 #include "CSSLineBoxContainValue.h"
+#include "Element.h"
 #include "FontCascadeDescription.h"
 #include "GraphicsTypes.h"
 #include "ImageOrientation.h"
@@ -965,6 +966,21 @@ constexpr bool RenderStyle::preserveNewline(WhiteSpace mode)
 {
     // Normal and nowrap do not preserve newlines.
     return mode != WhiteSpace::Normal && mode != WhiteSpace::NoWrap;
+}
+
+inline bool isSkippedContentRoot(const RenderStyle& style, const Element* element)
+{
+    switch (style.contentVisibility()) {
+    case ContentVisibility::Visible:
+        return false;
+    case ContentVisibility::Hidden:
+        return true;
+    case ContentVisibility::Auto:
+        return element && !element->isRelevantToUser();
+    };
+
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 inline float adjustFloatForAbsoluteZoom(float value, const RenderStyle& style)

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -605,7 +605,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
 #endif
     }
 
-    if (style.contentVisibility() == ContentVisibility::Hidden)
+    if (isSkippedContentRoot(style, m_element))
         style.setEffectiveSkippedContent(true);
 
     adjustForSiteSpecificQuirks(style);

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -258,6 +258,9 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
     if (elementHasDirectionAuto(candidateElement))
         return false;
 
+    if (candidateElement.isRelevantToUser() != element.isRelevantToUser())
+        return false;
+
     if (candidateElement.isLink() && context.elementLinkState != style->insideLink())
         return false;
 


### PR DESCRIPTION
#### b39fee5ba22e0f62398d7e869e271415f3d6ec84
<pre>
[content-visibility] Add support for css content-visibility: auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=236711">https://bugs.webkit.org/show_bug.cgi?id=236711</a>

Reviewed by Tim Nguyen.

This patch implements support for content-visibility: auto [1].

To keep track of whether an element is relevant to the user [2] and
decide to whether it should skip contents [3] the following is done:
- state is kept using ContentRelevancyStatus enum class whether the
  content-visibility: auto subtree contains any visible, focused or
  selected elements, since that means it is relevant to the user.
- an IntersectionObserver is installed as soon as content-visibility: auto
  is set on an Element. This keeps track whether the Element is in the
  viewport or not and thus if it is relevant to the user.
- updating of c-v: auto elements relevancy and its effect on its subtree
  is done as part of &quot;Update the Rendering&quot;, see [4].

The methods focus() [4.3.6] and scrollIntoView() [4.3.5] treat any previously
skipped content as becoming relevant to the user before doing any scrolling.

Handling selected elements will be done in a future patch.

[1] <a href="https://drafts.csswg.org/css-contain/#valdef-content-visibility-auto">https://drafts.csswg.org/css-contain/#valdef-content-visibility-auto</a>
[2] <a href="https://drafts.csswg.org/css-contain/#relevant-to-the-user">https://drafts.csswg.org/css-contain/#relevant-to-the-user</a>
[3] <a href="https://drafts.csswg.org/css-contain/#skips-its-contents">https://drafts.csswg.org/css-contain/#skips-its-contents</a>
[4] <a href="https://drafts.csswg.org/css-contain/#cv-notes">https://drafts.csswg.org/css-contain/#cv-notes</a> (point 3)

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-068-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-072-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-and-auto-descendant.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-and-auto-descendant.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp: Added.
(WebCore::ContentVisibilityDocumentState::observe):
(WebCore::ContentVisibilityDocumentState::unobserve):
(WebCore::ContentVisibilityDocumentState::intersectionObserver):
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements): integration into &quot;Update the Rendering&quot;, see [4]
(WebCore::ContentVisibilityDocumentState::updateContentRelevancyStatusForScrollIfNeeded): helper around lack of scroll anchoring.
(WebCore::ContentVisibilityDocumentState::updateOnScreenObservationTarget):
* Source/WebCore/dom/ContentVisibilityDocumentState.h: Added.
(WebCore::ContentVisibilityDocumentState::hasObservationTargets const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement): handle all focus changes.
(WebCore::Document::contentVisibilityDocumentState): keep track of observers for content-visibility: auto elements.
(WebCore::Document::isObservingContentVisibilityTargets const):
(WebCore::Document::updateRelevancyOfContentVisibilityElements): integration into &quot;Update the Rendering&quot;, see [4]
(WebCore::Document::scheduleContentRelevancyUpdate): integration into &quot;Update the Rendering&quot;, see [4]
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focus): make sure scrolled to element is in visible subtree.
(WebCore::Element::hasFocusableStyle const): only test focus for c-v: hidden subtrees.
(WebCore::Element::scrollIntoView): make sure scrolled to element is in visible subtree.
(WebCore::Element::scrollIntoViewIfNeeded): make sure scrolled to element is in visible subtree.
(WebCore::Element::focus): make sure scrolled to element is in visible subtree.
(WebCore::Element::addToTopLayer): make sure element is in visible subtree.
(WebCore::Element::removeFromTopLayer): make sure element is not in visible subtree anymore.
(WebCore::Element::isRelevantToUser const): see [2].
(WebCore::Element::contentRelevancyStatus const):
(WebCore::Element::setContentRelevancyStatus):
(WebCore::Element::contentVisibilityViewportChange): handle changed visibility in viewport status.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::contentRelevancyStatus):
(WebCore::ElementRareData::setContentRelevancyStatus):
* Source/WebCore/dom/NodeRareData.h: keep track of whether content is relevant to the user.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::FrameView::maintainScrollPositionAtAnchor): handle anchor scrolls.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering): integration into &quot;Update the Rendering&quot;, see <a href="https://drafts.csswg.org/css-contain/#cv-notes">https://drafts.csswg.org/css-contain/#cv-notes</a>
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange): add/remove observation for content-visibility: auto element.
(WebCore::RenderElement::willBeDestroyed): remove observation for content-visibility: auto element.
(WebCore::RenderElement::isSkippedContentRoot const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderObject::isSkippedContentRoot const):
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::shouldApplyInlineSizeContainment const): take into account current value of effectiveSkippedContent.
(WebCore::RenderElement::shouldApplySizeContainment const): take into account current value of effectiveSkippedContent.
(WebCore::RenderElement::shouldApplySizeOrInlineSizeContainment const): take into account current value of effectiveSkippedContent.
(WebCore::RenderObject::isSkippedContentRoot const):
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::shouldApplyInlineSizeContainment const):
(WebCore::RenderElement::shouldApplySizeOrInlineSizeContainment const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::shouldSkipContent const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareInheritedDataChangeRequiresLayout): a change in effectiveSkippedContent requires a layout.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::isSkippedContentRoot):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const): take content-visibility: auto into account.
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::canShareStyleWithElement const): do not share styles with different isRelevantToUser values.

Canonical link: <a href="https://commits.webkit.org/266084@main">https://commits.webkit.org/266084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98ef53ef1ac0c303f854d57f37c82ee4f0273d2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14949 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15014 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18674 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14974 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11476 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3141 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->