### PR TITLE
REGRESSION (STP 161): cache-storage 100+ test failures on WPT

### DIFF
--- a/LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any-expected.txt
+++ b/LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any-expected.txt
@@ -1,0 +1,18 @@
+
+PASS Cache.matchAll with no matching entries
+PASS Cache.matchAll with URL
+PASS Cache.matchAll with Request
+PASS Cache.matchAll with new Request
+PASS Cache.matchAll with HEAD
+PASS Cache.matchAll with ignoreSearch option (request with no search parameters)
+PASS Cache.matchAll with ignoreSearch option (request with search parameters)
+PASS Cache.matchAll supports ignoreMethod
+PASS Cache.matchAll supports ignoreVary
+PASS Cache.matchAll with URL containing fragment
+PASS Cache.matchAll with string fragment "http" as query
+PASS Cache.matchAll without parameters
+PASS Cache.matchAll with explicitly undefined request
+PASS Cache.matchAll with explicitly undefined request and empty options
+PASS Cache.matchAll with responses containing "Vary" header
+PASS Cache.matchAll with multiple vary pairs
+

--- a/LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any.html
+++ b/LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any.html
@@ -1,0 +1,2 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any.js
+++ b/LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any.js
@@ -1,0 +1,244 @@
+// META: title=Cache.matchAll
+// META: global=window,worker
+// META: script=/service-workers/cache-storage/resources/test-helpers.js
+// META: timeout=long
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll('not-present-in-the-cache')
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [],
+            'Cache.matchAll should resolve with an empty array on failure.');
+        });
+  }, 'Cache.matchAll with no matching entries');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(entries.a.request.url)
+      .then(function(result) {
+          assert_response_array_equals(result, [entries.a.response],
+                                       'Cache.matchAll should match by URL.');
+        });
+  }, 'Cache.matchAll with URL');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(entries.a.request)
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [entries.a.response],
+            'Cache.matchAll should match by Request.');
+        });
+  }, 'Cache.matchAll with Request');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(new Request(entries.a.request.url))
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [entries.a.response],
+            'Cache.matchAll should match by Request.');
+        });
+  }, 'Cache.matchAll with new Request');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(new Request(entries.a.request.url, {method: 'HEAD'}),
+                          {ignoreSearch: true})
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [],
+            'Cache.matchAll should not match HEAD Request.');
+        });
+  }, 'Cache.matchAll with HEAD');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(entries.a.request,
+                          {ignoreSearch: true})
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [
+              entries.a.response,
+              entries.a_with_query.response
+            ],
+            'Cache.matchAll with ignoreSearch should ignore the ' +
+            'search parameters of cached request.');
+        });
+  },
+  'Cache.matchAll with ignoreSearch option (request with no search ' +
+  'parameters)');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(entries.a_with_query.request,
+                          {ignoreSearch: true})
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [
+              entries.a.response,
+              entries.a_with_query.response
+            ],
+            'Cache.matchAll with ignoreSearch should ignore the ' +
+            'search parameters of request.');
+        });
+  },
+  'Cache.matchAll with ignoreSearch option (request with search parameters)');
+
+cache_test(function(cache) {
+    var request = new Request('http://example.com/');
+    var head_request = new Request('http://example.com/', {method: 'HEAD'});
+    var response = new Response('foo');
+    return cache.put(request.clone(), response.clone())
+      .then(function() {
+          return cache.matchAll(head_request.clone());
+        })
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [],
+            'Cache.matchAll should resolve with empty array for a ' +
+            'mismatched method.');
+          return cache.matchAll(head_request.clone(),
+                                {ignoreMethod: true});
+        })
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [response],
+            'Cache.matchAll with ignoreMethod should ignore the ' +
+            'method of request.');
+        });
+  }, 'Cache.matchAll supports ignoreMethod');
+
+cache_test(function(cache) {
+    var vary_request = new Request('http://example.com/c',
+                                   {headers: {'Cookies': 'is-for-cookie'}});
+    var vary_response = new Response('', {headers: {'Vary': 'Cookies'}});
+    var mismatched_vary_request = new Request('http://example.com/c');
+
+    return cache.put(vary_request.clone(), vary_response.clone())
+      .then(function() {
+          return cache.matchAll(mismatched_vary_request.clone());
+        })
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [],
+            'Cache.matchAll should resolve as undefined with a ' +
+            'mismatched vary.');
+          return cache.matchAll(mismatched_vary_request.clone(),
+                              {ignoreVary: true});
+        })
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [vary_response],
+            'Cache.matchAll with ignoreVary should ignore the ' +
+            'vary of request.');
+        });
+  }, 'Cache.matchAll supports ignoreVary');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(entries.cat.request.url + '#mouse')
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [
+              entries.cat.response,
+            ],
+            'Cache.matchAll should ignore URL fragment.');
+        });
+  }, 'Cache.matchAll with URL containing fragment');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll('http')
+      .then(function(result) {
+          assert_response_array_equals(
+            result, [],
+            'Cache.matchAll should treat query as a URL and not ' +
+            'just a string fragment.');
+        });
+  }, 'Cache.matchAll with string fragment "http" as query');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll()
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            simple_entries.map(entry => entry.response),
+            'Cache.matchAll without parameters should match all entries.');
+        });
+  }, 'Cache.matchAll without parameters');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    return cache.matchAll(undefined)
+      .then(result => {
+          assert_response_array_equals(
+            result,
+            simple_entries.map(entry => entry.response),
+            'Cache.matchAll with undefined request should match all entries.');
+        });
+  }, 'Cache.matchAll with explicitly undefined request');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+  return cache.matchAll(undefined, {})
+      .then(result => {
+          assert_response_array_equals(
+            result,
+            simple_entries.map(entry => entry.response),
+            'Cache.matchAll with undefined request should match all entries.');
+        });
+  }, 'Cache.matchAll with explicitly undefined request and empty options');
+
+prepopulated_cache_test(vary_entries, function(cache, entries) {
+    return cache.matchAll('http://example.com/c')
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [
+              entries.vary_cookie_absent.response
+            ],
+            'Cache.matchAll should exclude matches if a vary header is ' +
+            'missing in the query request, but is present in the cached ' +
+            'request.');
+        })
+
+      .then(function() {
+          return cache.matchAll(
+            new Request('http://example.com/c',
+                        {headers: {'Cookies': 'none-of-the-above'}}));
+        })
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [
+            ],
+            'Cache.matchAll should exclude matches if a vary header is ' +
+            'missing in the cached request, but is present in the query ' +
+            'request.');
+        })
+
+      .then(function() {
+          return cache.matchAll(
+            new Request('http://example.com/c',
+                        {headers: {'Cookies': 'is-for-cookie'}}));
+        })
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [entries.vary_cookie_is_cookie.response],
+            'Cache.matchAll should match the entire header if a vary header ' +
+            'is present in both the query and cached requests.');
+        });
+  }, 'Cache.matchAll with responses containing "Vary" header');
+
+prepopulated_cache_test(vary_entries, function(cache, entries) {
+    return cache.matchAll('http://example.com/c',
+                          {ignoreVary: true})
+      .then(function(result) {
+          assert_response_array_equals(
+            result,
+            [
+              entries.vary_cookie_is_cookie.response,
+              entries.vary_cookie_is_good.response,
+              entries.vary_cookie_absent.response
+            ],
+            'Cache.matchAll should support multiple vary request/response ' +
+            'pairs.');
+        });
+  }, 'Cache.matchAll with multiple vary pairs');
+
+done();

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -84,17 +84,19 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseBase::R
 {
 }
 
-ResourceResponseBase::CrossThreadData ResourceResponseBase::CrossThreadData::copy() const
+ResourceResponseBase::CrossThreadData ResourceResponseBase::CrossThreadData::isolatedCopy() const
 {
     ResourceResponseBase::CrossThreadData result;
-    result.url = url;
-    result.mimeType = mimeType;
+    result.url = url.isolatedCopy();
+    result.mimeType = mimeType.isolatedCopy();
     result.expectedContentLength = expectedContentLength;
-    result.textEncodingName = textEncodingName;
+    result.textEncodingName = textEncodingName.isolatedCopy();
     result.httpStatusCode = httpStatusCode;
-    result.httpVersion = httpVersion;
-    result.httpHeaderFields = httpHeaderFields;
-    result.networkLoadMetrics = networkLoadMetrics;
+    result.httpStatusText = httpStatusText.isolatedCopy();
+    result.httpVersion = httpVersion.isolatedCopy();
+    result.httpHeaderFields = httpHeaderFields.isolatedCopy();
+    if (networkLoadMetrics)
+        result.networkLoadMetrics = networkLoadMetrics->isolatedCopy();
     result.type = type;
     result.tainting = tainting;
     result.isRedirected = isRedirected;
@@ -131,13 +133,13 @@ ResourceResponse ResourceResponseBase::fromCrossThreadData(CrossThreadData&& dat
     ResourceResponse response;
 
     response.setURL(data.url);
-    response.setMimeType(AtomString { data.mimeType });
+    response.setMimeType(AtomString { WTFMove(data.mimeType) });
     response.setExpectedContentLength(data.expectedContentLength);
     response.setTextEncodingName(AtomString { WTFMove(data.textEncodingName) });
 
     response.setHTTPStatusCode(data.httpStatusCode);
-    response.setHTTPStatusText(AtomString { data.httpStatusText });
-    response.setHTTPVersion(AtomString { data.httpVersion });
+    response.setHTTPStatusText(AtomString { WTFMove(data.httpStatusText) });
+    response.setHTTPVersion(AtomString { WTFMove(data.httpVersion) });
 
     response.m_httpHeaderFields = WTFMove(data.httpHeaderFields);
     if (data.networkLoadMetrics)

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -76,7 +76,8 @@ public:
         CrossThreadData() = default;
         CrossThreadData(CrossThreadData&&) = default;
         CrossThreadData& operator=(CrossThreadData&&) = default;
-        WEBCORE_EXPORT CrossThreadData copy() const;
+
+        WEBCORE_EXPORT CrossThreadData isolatedCopy() const;
 
         URL url;
         String mimeType;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
@@ -35,11 +35,16 @@ Ref<CacheStorageMemoryStore> CacheStorageMemoryStore::create()
     return adoptRef(*new CacheStorageMemoryStore);
 }
 
+static CacheStorageRecord copyCacheStorageRecord(const CacheStorageRecord& record)
+{
+    return { record.info, record.requestHeadersGuard, record.request, record.options, record.referrer, record.responseHeadersGuard, record.responseData.isolatedCopy(), record.responseBodySize, WebCore::DOMCacheEngine::copyResponseBody(record.responseBody) };
+}
+
 void CacheStorageMemoryStore::readAllRecords(ReadAllRecordsCallback&& callback)
 {
     callback(WTF::map(m_records.values(), [](const auto& record) {
         RELEASE_ASSERT(record);
-        return record->copy();
+        return copyCacheStorageRecord(*record);
     }));
 }
 
@@ -49,7 +54,7 @@ void CacheStorageMemoryStore::readRecords(const Vector<CacheStorageRecordInforma
         auto iterator = m_records.find(recordInfo.identifier);
         if (iterator == m_records.end())
             return std::nullopt;
-        return { iterator->value->copy() };
+        return copyCacheStorageRecord(*iterator->value);
     });
     return callback(WTFMove(result));
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -79,11 +79,6 @@ struct CacheStorageRecord {
     {
     }
 
-    CacheStorageRecord copy() const
-    {
-        return CacheStorageRecord { info, requestHeadersGuard, request, options, referrer, responseHeadersGuard, responseData.copy(), responseBodySize, WebCore::DOMCacheEngine::copyResponseBody(responseBody) };
-    }
-
     CacheStorageRecordInformation info;
     WebCore::FetchHeaders::Guard requestHeadersGuard;
     WebCore::ResourceRequest request;


### PR DESCRIPTION
#### 7fa5066e9d64de34b5fa1c46bf3b8fecf3957fc2
<pre>
REGRESSION (STP 161): cache-storage 100+ test failures on WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=250590">https://bugs.webkit.org/show_bug.cgi?id=250590</a>
rdar://problem/104237218

Reviewed by Chris Dumez.

This is a regression of switching to the new CacheStorage backend in ephemeral sessions.
WPT is using ephemeral sessions which is the only code path to store ResponseResourceBase::CrossThreadData in CacheStorageMemoryStore.
It is manipulated in a WorkQueue where several threads might be involved, which is not working well with AtomString that are bound by thread.
In particular, when we create a ResponseResourceBase from a CacheStorageMemoryStore record CrossThreadData, the CrossThreadData String will be change to an AtomString.
To prevent this, we make sure to isolate copy all Strings inside ResponseResourceBase::CrossThreadData::isolatedCopy() and create a new CrossThreadData from CacheStorageMemoryStore records.

We isolate copy all strings as it is safer in general, the result of ResponseResourceBase::CrossThreadData::copy() could be sent to another thread for instance.
There should be no perf impact except on CacheStorage in ephemeral sessions since ResponseResourceBase::CrossThreadData::isolatedCopy() is only used there.

We also fix ResourceResponseBase::CrossThreadData copy as it was missing statusText copy.
And we also add a bunch of WTFMove as a small improvement in ResourceResponseBase::fromCrossThreadData.

We remove CacheStorageRecord::copy and put it as a static function in CacheStorageMemoryStore as it is only used there and is very specific in that it isolate copy the ResponseResourceBase::CrossThreadData but not other fields.

To cover this patch, we copy WPT cache-matchAll.https.any.html in http/wpt to run it with an ephemeral session.

* LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any-expected.txt: Added.
* LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any.html: Added.
* LayoutTests/http/wpt/cache-storage/cache-matchAll.https.any.js: Added.
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::CrossThreadData::copy const):
(WebCore::ResourceResponseBase::fromCrossThreadData):
* Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp:
(WebKit::copyCacheStorageRecord):
(WebKit::CacheStorageMemoryStore::readAllRecords):
(WebKit::CacheStorageMemoryStore::readRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
(WebKit::CacheStorageRecord::copy const): Deleted.

Canonical link: <a href="https://commits.webkit.org/259418@main">https://commits.webkit.org/259418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e534ebd5897c3fa0fbc1f7d2c220ee267930be1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114131 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174322 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4866 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113156 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110622 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94651 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26269 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27630 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4220 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47180 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6497 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9171 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->