### PR TITLE
REGRESSION (257227@main): initial whitespace breaks the query in window.matchMedia()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/match-media-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/match-media-parsing-expected.txt
@@ -1,0 +1,23 @@
+
+PASS Test parsing '' with matchMedia
+PASS Test parsing ' ' with matchMedia
+PASS Test parsing 'all' with matchMedia
+PASS Test parsing ' all' with matchMedia
+PASS Test parsing '   all   ' with matchMedia
+PASS Test parsing 'all,all' with matchMedia
+PASS Test parsing ' all , all ' with matchMedia
+PASS Test parsing '(color)' with matchMedia
+PASS Test parsing '(color' with matchMedia
+PASS Test parsing ' (color)' with matchMedia
+PASS Test parsing ' ( color  )  ' with matchMedia
+PASS Test parsing ' ( color   ' with matchMedia
+PASS Test parsing 'color)' with matchMedia
+PASS Test parsing '  color)' with matchMedia
+PASS Test parsing '  color ), ( color' with matchMedia
+PASS Test parsing ' foo ' with matchMedia
+PASS Test parsing ',' with matchMedia
+PASS Test parsing ' , ' with matchMedia
+PASS Test parsing ',,' with matchMedia
+PASS Test parsing '  ,  ,  ' with matchMedia
+PASS Test parsing ' foo,' with matchMedia
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/match-media-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/match-media-parsing.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/#parse-comma-separated-list-of-component-values">
+<script type="text/javascript" src="/resources/testharness.js"></script>
+<script type="text/javascript" src="/resources/testharnessreport.js"></script>
+
+<script>
+function test_parsing(query, expected) {
+    test(() => {
+        const match = window.matchMedia(query);
+        assert_equals(match.media, expected)
+    }, "Test parsing '" + query + "' with matchMedia");
+}
+test_parsing("", "");
+test_parsing(" ", "");
+test_parsing("all", "all");
+test_parsing(" all", "all");
+test_parsing("   all   ", "all");
+test_parsing("all,all", "all, all");
+test_parsing(" all , all ", "all, all");
+test_parsing("(color)", "(color)");
+test_parsing("(color", "(color)");
+test_parsing(" (color)", "(color)");
+test_parsing(" ( color  )  ", "(color)");
+test_parsing(" ( color   ", "(color)");
+test_parsing("color)", "not all");
+test_parsing("  color)", "not all");
+test_parsing("  color ), ( color", "not all, (color)");
+test_parsing(" foo ", "foo");
+test_parsing(",", "not all, not all");
+test_parsing(" , ", "not all, not all");
+test_parsing(",,", "not all, not all, not all");
+test_parsing("  ,  ,  ", "not all, not all, not all");
+test_parsing(" foo,", "foo, not all");
+</script>

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -79,17 +79,19 @@ std::optional<MediaQuery> MediaQueryParser::parseCondition(CSSParserTokenRange r
 
 MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& range)
 {
+    range.consumeWhitespace();
+
+    if (range.atEnd())
+        return { };
+
     MediaQueryList list;
 
-    while (!range.atEnd()) {
+    while (true) {
         auto begin = range.begin();
         while (!range.atEnd() && range.peek().type() != CommaToken)
             range.consumeComponentValue();
 
         auto subrange = range.makeSubRange(begin, &range.peek());
-
-        if (!range.atEnd())
-            range.consumeIncludingWhitespace();
 
         auto consumeMediaQueryOrNotAll = [&] {
             if (auto query = consumeMediaQuery(subrange))
@@ -99,6 +101,10 @@ MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& rang
         };
 
         list.append(consumeMediaQueryOrNotAll());
+
+        if (range.atEnd())
+            break;
+        range.consumeIncludingWhitespace();
     }
 
     return list;


### PR DESCRIPTION
#### 738835521b50d28d1409c9c0e86fe3c2c695ffec
<pre>
REGRESSION (257227@main): initial whitespace breaks the query in window.matchMedia()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251147">https://bugs.webkit.org/show_bug.cgi?id=251147</a>
rdar://104104606

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/match-media-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/match-media-parsing.html: Added.
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::MediaQueryParser::consumeMediaQueryList):

Consume initial whitespace. Parsing functions expect to start with a non-whitespace token.
This was not an issue with the regular media queries because stylesheet parsing had already
consumed any initial whitespace.

Also fix the loop so that commas generate &quot;not all&quot; list items even for empty strings &quot;foo,&quot; -&gt; &quot;foo, not all&quot;.

Canonical link: <a href="https://commits.webkit.org/259357@main">https://commits.webkit.org/259357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ea1946ebd851f2680b106092dd8ce920295b65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113984 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174188 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4717 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112912 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110470 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94538 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108179 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80730 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27508 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92602 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7247 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30161 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103532 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47067 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101288 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6449 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9034 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->