### PR TITLE
[WPE][GTK] Move network session APIs to a new WebKitNetworkSession class

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -182,6 +182,12 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitWebViewBase.h.in
 )
 
+if (ENABLE_2022_GLIB_API)
+    list(APPEND WebKitGTK_HEADER_TEMPLATES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitNetworkSession.h.in
+    )
+endif ()
+
 set(WebKitGTK_INSTALLED_HEADERS
     ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/WebKitEnumTypes.h
     ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/WebKitVersion.h

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -194,6 +194,12 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/webkit.h.in
 )
 
+if (ENABLE_2022_GLIB_API)
+    list(APPEND WPE_API_HEADER_TEMPLATES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitNetworkSession.h.in
+    )
+endif ()
+
 set(WPE_API_INSTALLED_HEADERS
     ${DERIVED_SOURCES_WPE_API_DIR}/WebKitEnumTypes.h
     ${DERIVED_SOURCES_WPE_API_DIR}/WebKitVersion.h

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -157,6 +157,7 @@ UIProcess/API/glib/WebKitNavigationAction.cpp @no-unify
 UIProcess/API/glib/WebKitNavigationClient.cpp @no-unify
 UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp @no-unify
 UIProcess/API/glib/WebKitNetworkProxySettings.cpp @no-unify
+UIProcess/API/glib/WebKitNetworkSession.cpp @no-unify
 UIProcess/API/glib/WebKitNotification.cpp @no-unify
 UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitNotificationProvider.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -149,6 +149,7 @@ UIProcess/API/glib/WebKitNavigationAction.cpp @no-unify
 UIProcess/API/glib/WebKitNavigationClient.cpp @no-unify
 UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp @no-unify
 UIProcess/API/glib/WebKitNetworkProxySettings.cpp @no-unify
+UIProcess/API/glib/WebKitNetworkSession.cpp @no-unify
 UIProcess/API/glib/WebKitNotification.cpp @no-unify
 UIProcess/API/glib/WebKitNotificationPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitNotificationProvider.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -56,7 +56,7 @@ IconDatabase::IconDatabase(const String& path, AllowDatabaseWrite allowDatabaseW
     // We initialize the database synchronously, it's hopefully fast enough because it makes
     // the implementation a lot simpler.
     m_workQueue->dispatchSync([&] {
-        if (allowDatabaseWrite == AllowDatabaseWrite::No && !FileSystem::fileExists(path))
+        if (allowDatabaseWrite == AllowDatabaseWrite::No && (path.isNull() || !FileSystem::fileExists(path)))
             return;
 
         auto databaseDirectory = FileSystem::parentPath(path);

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
@@ -45,6 +45,9 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitInputMethodContext, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitInstallMissingMediaPluginsPermissionRequest, g_object_unref)
 #endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNavigationPolicyDecision, g_object_unref)
+#if ENABLE(2022_GLIB_API)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNetworkSession, g_object_unref)
+#endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNotification, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitNotificationPermissionRequest, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPermissionRequest, g_object_unref)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
@@ -34,6 +34,10 @@
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 
+#if ENABLE(2022_GLIB_API)
+#include "WebKitNetworkSessionPrivate.h"
+#endif
+
 using namespace WebKit;
 using namespace WebCore;
 
@@ -158,19 +162,31 @@ private:
     void navigationActionDidBecomeDownload(WebPageProxy&, API::NavigationAction&, DownloadProxy& downloadProxy) override
     {
         auto download = webkitDownloadCreate(downloadProxy, m_webView);
+#if ENABLE(2022_GLIB_API)
+        webkitNetworkSessionDownloadStarted(webkit_web_view_get_network_session(m_webView), download.get());
+#else
         webkitWebContextDownloadStarted(webkit_web_view_get_context(m_webView), download.get());
+#endif
     }
 
     void navigationResponseDidBecomeDownload(WebPageProxy&, API::NavigationResponse&, DownloadProxy& downloadProxy) override
     {
         auto download = webkitDownloadCreate(downloadProxy, m_webView);
+#if ENABLE(2022_GLIB_API)
+        webkitNetworkSessionDownloadStarted(webkit_web_view_get_network_session(m_webView), download.get());
+#else
         webkitWebContextDownloadStarted(webkit_web_view_get_context(m_webView), download.get());
+#endif
     }
 
     void contextMenuDidCreateDownload(WebPageProxy&, DownloadProxy& downloadProxy) override
     {
         auto download = webkitDownloadCreate(downloadProxy, m_webView);
+#if ENABLE(2022_GLIB_API)
+        webkitNetworkSessionDownloadStarted(webkit_web_view_get_network_session(m_webView), download.get());
+#else
         webkitWebContextDownloadStarted(webkit_web_view_get_context(m_webView), download.get());
+#endif
     }
 
     WebKitWebView* m_webView;

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -1,0 +1,657 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#if ENABLE(2022_GLIB_API)
+
+#include "config.h"
+#include "WebKitNetworkSession.h"
+
+#include "APIDownloadClient.h"
+#include "FrameInfoData.h"
+#include "NetworkProcessMessages.h"
+#include "WebKitCookieManagerPrivate.h"
+#include "WebKitDownloadPrivate.h"
+#include "WebKitInitialize.h"
+#include "WebKitMemoryPressureSettings.h"
+#include "WebKitMemoryPressureSettingsPrivate.h"
+#include "WebKitNetworkProxySettingsPrivate.h"
+#include "WebKitPrivate.h"
+#include "WebKitWebsiteDataManagerPrivate.h"
+#include "WebProcessPool.h"
+#include <glib/gi18n-lib.h>
+#include <pal/HysteresisActivity.h>
+#include <wtf/HashSet.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+
+using namespace WebKit;
+
+/**
+ * WebKitNetworkSession:
+ * @see_also: #WebKitWebContext, #WebKitWebsiteData
+ *
+ * Manages network configuration.
+ *
+ *
+ * Since: 2.40
+ */
+
+using namespace WebKit;
+
+enum {
+    PROP_0,
+
+    PROP_DATA_DIRECTORY,
+    PROP_CACHE_DIRECTORY,
+    PROP_IS_EPHEMERAL,
+
+    N_PROPERTIES
+};
+
+static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+
+enum {
+    DOWNLOAD_STARTED,
+
+    LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0, };
+
+struct _WebKitNetworkSessionPrivate {
+    _WebKitNetworkSessionPrivate()
+        : dnsPrefetchHystereris([this](PAL::HysteresisState state) {
+            if (state == PAL::HysteresisState::Stopped)
+                dnsPrefetchedHosts.clear();
+        })
+    {
+    }
+
+    GRefPtr<WebKitWebsiteDataManager> websiteDataManager;
+    GRefPtr<WebKitCookieManager> cookieManager;
+    WebKitTLSErrorsPolicy tlsErrorsPolicy;
+
+    GUniquePtr<char> dataDirectory;
+    GUniquePtr<char> cacheDirectory;
+
+    HashSet<String> dnsPrefetchedHosts;
+    PAL::HysteresisActivity dnsPrefetchHystereris;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WebKitNetworkSession, webkit_network_session, G_TYPE_OBJECT)
+
+static void webkitNetworkSessionGetProperty(GObject* object, guint propID, GValue* value, GParamSpec* paramSpec)
+{
+    WebKitNetworkSession* session = WEBKIT_NETWORK_SESSION(object);
+
+    switch (propID) {
+    case PROP_IS_EPHEMERAL:
+        g_value_set_boolean(value, webkit_network_session_is_ephemeral(session));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
+    }
+}
+
+static void webkitNetworkSessionSetProperty(GObject* object, guint propID, const GValue* value, GParamSpec* paramSpec)
+{
+    WebKitNetworkSession* session = WEBKIT_NETWORK_SESSION(object);
+
+    switch (propID) {
+    case PROP_DATA_DIRECTORY:
+        session->priv->dataDirectory.reset(g_value_dup_string(value));
+        break;
+    case PROP_CACHE_DIRECTORY:
+        session->priv->cacheDirectory.reset(g_value_dup_string(value));
+        break;
+    case PROP_IS_EPHEMERAL:
+        if (g_value_get_boolean(value))
+            session->priv->websiteDataManager = adoptGRef(WEBKIT_WEBSITE_DATA_MANAGER(g_object_new(WEBKIT_TYPE_WEBSITE_DATA_MANAGER, "is-ephemeral", TRUE, nullptr)));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
+    }
+}
+
+static void webkitNetworkSessionConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(webkit_network_session_parent_class)->constructed(object);
+
+    WebKitNetworkSessionPrivate* priv = WEBKIT_NETWORK_SESSION(object)->priv;
+    if (!priv->websiteDataManager)
+        priv->websiteDataManager = adoptGRef(webkitWebsiteDataManagerCreate(WTFMove(priv->dataDirectory), WTFMove(priv->cacheDirectory)));
+
+    priv->tlsErrorsPolicy = WEBKIT_TLS_ERRORS_POLICY_FAIL;
+    webkitWebsiteDataManagerGetDataStore(priv->websiteDataManager.get()).setIgnoreTLSErrors(false);
+
+    // Enable favicons by default.
+    webkit_website_data_manager_set_favicons_enabled(priv->websiteDataManager.get(), TRUE);
+}
+
+static void webkit_network_session_class_init(WebKitNetworkSessionClass* sessionClass)
+{
+    webkitInitialize();
+
+    GObjectClass* gObjectClass = G_OBJECT_CLASS(sessionClass);
+    gObjectClass->get_property = webkitNetworkSessionGetProperty;
+    gObjectClass->set_property = webkitNetworkSessionSetProperty;
+    gObjectClass->constructed = webkitNetworkSessionConstructed;
+
+    /**
+     * WebKitNetworkSession:data-directory:
+     *
+     * The base data directory used to create the #WebKitWebsiteDataManager. If %NULL, a default location will be used.
+     *
+     * Since: 2.40
+     */
+    sObjProperties[PROP_DATA_DIRECTORY] =
+        g_param_spec_string(
+            "data-directory",
+            nullptr, nullptr,
+            nullptr,
+            static_cast<GParamFlags>(WEBKIT_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WebKitNetworkSession:cache-directory:
+     *
+     * The base caches directory used to create the #WebKitWebsiteDataManager. If %NULL, a default location will be used.
+     *
+     * Since: 2.40
+     */
+    sObjProperties[PROP_CACHE_DIRECTORY] =
+        g_param_spec_string(
+            "cache-directory",
+            nullptr, nullptr,
+            nullptr,
+            static_cast<GParamFlags>(WEBKIT_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WebKitNetworkSession:is-ephemeral:
+     *
+     * Whether to create an ephermeral #WebKitWebsiteDataManager for the session.
+     *
+     * Since: 2.40
+     */
+    sObjProperties[PROP_IS_EPHEMERAL] =
+        g_param_spec_boolean(
+            "is-ephemeral",
+            nullptr, nullptr,
+            FALSE,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    g_object_class_install_properties(gObjectClass, N_PROPERTIES, sObjProperties);
+
+    /**
+     * WebKitNetworkSession::download-started:
+     * @session: the #WebKitNetworkSession
+     * @download: the #WebKitDownload associated with this event
+     *
+     * This signal is emitted when a new download request is made.
+     *
+     * Since: 2.40
+     */
+    signals[DOWNLOAD_STARTED] =
+        g_signal_new("download-started",
+            G_TYPE_FROM_CLASS(gObjectClass),
+            G_SIGNAL_RUN_LAST,
+            0, nullptr, nullptr,
+            nullptr,
+            G_TYPE_NONE, 1,
+            WEBKIT_TYPE_DOWNLOAD);
+}
+
+void webkitNetworkSessionDownloadStarted(WebKitNetworkSession* session, WebKitDownload* download)
+{
+    g_signal_emit(session, signals[DOWNLOAD_STARTED], 0, download);
+}
+
+static gpointer createDefaultNetworkSession(gpointer)
+{
+    static GRefPtr<WebKitNetworkSession> session = adoptGRef(webkit_network_session_new(nullptr, nullptr));
+    return session.get();
+}
+
+/**
+ * webkit_network_session_get_default:
+ *
+ * Get the default network session.
+ * The default network session is created using webkit_network_session_new() and passing
+ * %NULL as data and cache directories.
+ *
+ * Returns: (transfer none): a #WebKitNetworkSession
+ *
+ * Since: 2.40
+ */
+WebKitNetworkSession* webkit_network_session_get_default()
+{
+    static GOnce onceInit = G_ONCE_INIT;
+    return WEBKIT_NETWORK_SESSION(g_once(&onceInit, createDefaultNetworkSession, nullptr));
+}
+
+/**
+ * webkit_network_session_new:
+ * @data_directory: (nullable): a base directory for data, or %NULL
+ * @cache_directrory: (nullable): a base direfctory for caches, or %NULL
+ *
+ * Creates a new #WebKitNetworkSession with a persistent #WebKitWebsiteDataManager.
+ *
+ * It must be passed as construction parameter of a #WebKitWebView.
+ *
+ * Returns: (transfer full): the newly created #WebKitNetworkSession
+ *
+ * Since: 2.40
+ */
+WebKitNetworkSession* webkit_network_session_new(const char* dataDirectory, const char* cacheDirectory)
+{
+    return WEBKIT_NETWORK_SESSION(g_object_new(WEBKIT_TYPE_NETWORK_SESSION, "data-directory", dataDirectory, "cache-directory", cacheDirectory, nullptr));
+}
+
+/**
+ * webkit_network_session_new_ephemeral:
+ *
+ * Creates a new #WebKitNetworkSession with an ephemeral #WebKitWebsiteDataManager.
+ *
+ *
+ * Returns: (transfer full): a new ephemeral #WebKitNetworkSession.
+ *
+ * Since: 2.40
+ */
+WebKitNetworkSession* webkit_network_session_new_ephemeral()
+{
+    return WEBKIT_NETWORK_SESSION(g_object_new(WEBKIT_TYPE_NETWORK_SESSION, "is-ephemeral", TRUE, nullptr));
+}
+
+/**
+ * webkit_network_session_is_ephemeral:
+ * @session: a #WebKitNetworkSession
+ *
+ * Get whether @session is ephemeral.
+ * A #WebKitNetworkSession is ephemeral when its #WebKitWebsiteDataManager is ephemeral.
+ * See #WebKitWebsiteDataManager:is-ephemeral for more details.
+ *
+ * Returns: %TRUE if @session is pehmeral, or %FALSE otherwise
+ *
+ * Since: 2.40
+ */
+gboolean webkit_network_session_is_ephemeral(WebKitNetworkSession* session)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), FALSE);
+
+    return webkit_website_data_manager_is_ephemeral(session->priv->websiteDataManager.get());
+}
+
+/**
+ * webkit_network_session_get_website_data_manager:
+ * @session: a #WebKitNetworkSession
+ *
+ * Get the #WebKitWebsiteDataManager of @session.
+ *
+ * Returns: (transfer none): a #WebKitWebsiteDataManager
+ *
+ * Since: 2.40
+ */
+WebKitWebsiteDataManager* webkit_network_session_get_website_data_manager(WebKitNetworkSession* session)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), nullptr);
+
+    return session->priv->websiteDataManager.get();
+}
+
+/**
+ * webkit_network_session_get_cookie_manager:
+ * @session: a #WebKitNetworkSession
+ *
+ * Get the #WebKitCookieManager of @session.
+ *
+ * Returns: (transfer none): a #WebKitCookieManager
+ *
+ * Since: 2.40
+ */
+WebKitCookieManager* webkit_network_session_get_cookie_manager(WebKitNetworkSession* session)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), nullptr);
+
+    if (!session->priv->cookieManager)
+        session->priv->cookieManager = adoptGRef(webkitCookieManagerCreate(session->priv->websiteDataManager.get()));
+
+    return session->priv->cookieManager.get();
+}
+
+/**
+ * webkit_network_session_set_itp_enabled:
+ * @session: a #WebKitNetworkSession
+ * @enabled: value to set
+ *
+ * Enable or disable Intelligent Tracking Prevention (ITP).
+ *
+ * When ITP is enabled resource load statistics
+ * are collected and used to decide whether to allow or block third-party cookies and prevent user tracking.
+ * Note that while ITP is enabled the accept policy %WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY is ignored and
+ * %WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS is used instead. See also webkit_cookie_session_set_accept_policy().
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_set_itp_enabled(WebKitNetworkSession* session, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore.setTrackingPreventionEnabled(enabled);
+}
+
+/**
+ * webkit_network_session_get_itp_enabled:
+ * @session: a #WebKitNetworkSession
+ *
+ * Get whether Intelligent Tracking Prevention (ITP) is enabled or not.
+ *
+ * Returns: %TRUE if ITP is enabled, or %FALSE otherwise.
+ *
+ * Since: 2.40
+ */
+gboolean webkit_network_session_get_itp_enabled(WebKitNetworkSession* session)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), FALSE);
+
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    return websiteDataStore.trackingPreventionEnabled();
+}
+
+/**
+ * webkit_network_session_set_persistent_credential_storage_enabled:
+ * @session: a #WebKitNetworkSession
+ * @enabled: value to set
+ *
+ * Enable or disable persistent credential storage.
+ *
+ * When enabled, which is the default for
+ * non-ephemeral sessions, the network process will try to read and write HTTP authentiacation
+ * credentials from persistent storage.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_set_persistent_credential_storage_enabled(WebKitNetworkSession* session, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore.setPersistentCredentialStorageEnabled(enabled);
+}
+
+/**
+ * webkit_network_session_get_persistent_credential_storage_enabled:
+ * @session: a #WebKitNetworkSession
+ *
+ * Get whether persistent credential storage is enabled or not.
+ *
+ * See also webkit_network_session_set_persistent_credential_storage_enabled().
+ *
+ * Returns: %TRUE if persistent credential storage is enabled, or %FALSE otherwise.
+ *
+ * Since: 2.40
+ */
+gboolean webkit_network_session_get_persistent_credential_storage_enabled(WebKitNetworkSession* session)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), FALSE);
+
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    return websiteDataStore.persistentCredentialStorageEnabled();
+}
+
+/**
+ * webkit_network_session_set_tls_errors_policy:
+ * @session: a #WebKitNetworkSession
+ * @policy: a #WebKitTLSErrorsPolicy
+ *
+ * Set the TLS errors policy of @session as @policy.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_set_tls_errors_policy(WebKitNetworkSession* session, WebKitTLSErrorsPolicy policy)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+
+    if (session->priv->tlsErrorsPolicy == policy)
+        return;
+
+    session->priv->tlsErrorsPolicy = policy;
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore.setIgnoreTLSErrors(policy == WEBKIT_TLS_ERRORS_POLICY_IGNORE);
+}
+
+/**
+ * webkit_network_session_get_tls_errors_policy:
+ * @session: a #WebKitNetworkSession
+ *
+ * Get the TLS errors policy of @session.
+ *
+ * Returns: a #WebKitTLSErrorsPolicy
+ *
+ * Since: 2.40
+ */
+WebKitTLSErrorsPolicy webkit_network_session_get_tls_errors_policy(WebKitNetworkSession* session)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), WEBKIT_TLS_ERRORS_POLICY_FAIL);
+
+    return session->priv->tlsErrorsPolicy;
+}
+
+/**
+ * webkit_network_session_allow_tls_certificate_for_host:
+ * @session: a #WebKitNetworkSession
+ * @certificate: a #GTlsCertificate
+ * @host: the host for which a certificate is to be allowed
+ *
+ * Ignore further TLS errors on the @host for the certificate present in @info.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_allow_tls_certificate_for_host(WebKitNetworkSession* session, GTlsCertificate* certificate, const char* host)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+    g_return_if_fail(G_IS_TLS_CERTIFICATE(certificate));
+    g_return_if_fail(host);
+
+    auto certificateInfo = WebCore::CertificateInfo(certificate, static_cast<GTlsCertificateFlags>(0));
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore.allowSpecificHTTPSCertificateForHost(certificateInfo, String::fromUTF8(host));
+}
+
+/**
+ * webkit_network_session_set_proxy_settings:
+ * @session: a #WebKitNetworkSession
+ * @proxy_mode: a #WebKitNetworkProxyMode
+ * @proxy_settings: (allow-none): a #WebKitNetworkProxySettings, or %NULL
+ *
+ * Set the network proxy settings to be used by connections started in @session session.
+ *
+ * By default %WEBKIT_NETWORK_PROXY_MODE_DEFAULT is used, which means that the
+ * system settings will be used (g_proxy_resolver_get_default()).
+ * If you want to override the system default settings, you can either use
+ * %WEBKIT_NETWORK_PROXY_MODE_NO_PROXY to make sure no proxies are used at all,
+ * or %WEBKIT_NETWORK_PROXY_MODE_CUSTOM to provide your own proxy settings.
+ * When @proxy_mode is %WEBKIT_NETWORK_PROXY_MODE_CUSTOM @proxy_settings must be
+ * a valid #WebKitNetworkProxySettings; otherwise, @proxy_settings must be %NULL.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_set_proxy_settings(WebKitNetworkSession* session, WebKitNetworkProxyMode proxyMode, WebKitNetworkProxySettings* proxySettings)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+    g_return_if_fail((proxyMode != WEBKIT_NETWORK_PROXY_MODE_CUSTOM && !proxySettings) || (proxyMode == WEBKIT_NETWORK_PROXY_MODE_CUSTOM && proxySettings));
+
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    switch (proxyMode) {
+    case WEBKIT_NETWORK_PROXY_MODE_DEFAULT:
+        websiteDataStore.setNetworkProxySettings({ });
+        break;
+    case WEBKIT_NETWORK_PROXY_MODE_NO_PROXY:
+        websiteDataStore.setNetworkProxySettings(WebCore::SoupNetworkProxySettings(WebCore::SoupNetworkProxySettings::Mode::NoProxy));
+        break;
+    case WEBKIT_NETWORK_PROXY_MODE_CUSTOM:
+        auto settings = webkitNetworkProxySettingsGetNetworkProxySettings(proxySettings);
+        if (settings.isEmpty()) {
+            g_warning("Invalid attempt to set custom network proxy settings with an empty WebKitNetworkProxySettings. Use "
+                "WEBKIT_NETWORK_PROXY_MODE_NO_PROXY to not use any proxy or WEBKIT_NETWORK_PROXY_MODE_DEFAULT to use the default system settings");
+        } else
+            websiteDataStore.setNetworkProxySettings(WTFMove(settings));
+        break;
+    }
+}
+
+/**
+ * webkit_network_session_set_memory_pressure_settings:
+ * @settings: a WebKitMemoryPressureSettings.
+ *
+ * Sets @settings as the #WebKitMemoryPressureSettings.
+ *
+ * Sets @settings as the #WebKitMemoryPressureSettings to be used by the network
+ * process created by any instance of #WebKitNetworkSession after this function
+ * is called.
+ *
+ * Be sure to call this function before creating any #WebKitNetworkSession.
+ *
+ * The periodic check for used memory is disabled by default on network processes. This will
+ * be enabled only if custom settings have been set using this function. After that, in order
+ * to remove the custom settings and disable the periodic check, this function must be called
+ * passing %NULL as the value of @settings.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_set_memory_pressure_settings(WebKitMemoryPressureSettings* settings)
+{
+    std::optional<MemoryPressureHandler::Configuration> config = settings ? std::make_optional(webkitMemoryPressureSettingsGetMemoryPressureHandlerConfiguration(settings)) : std::nullopt;
+    WebProcessPool::setNetworkProcessMemoryPressureHandlerConfiguration(config);
+}
+
+/**
+ * webkit_network_session_get_itp_summary:
+ * @session: a #WebKitNetworkSession
+ * @cancellable: (allow-none): a #GCancellable or %NULL to ignore
+ * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied
+ * @user_data: (closure): the data to pass to callback function
+ *
+ * Asynchronously get the list of #WebKitITPThirdParty seen for @session.
+ *
+ * Every #WebKitITPThirdParty
+ * contains the list of #WebKitITPFirstParty under which it has been seen.
+ *
+ * When the operation is finished, @callback will be called. You can then call
+ * webkit_network_session_get_itp_summary_finish() to get the result of the operation.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_get_itp_summary(WebKitNetworkSession* session, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    GRefPtr<GTask> task = adoptGRef(g_task_new(session, cancellable, callback, userData));
+    websiteDataStore.getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<WebResourceLoadStatisticsStore::ThirdPartyData>&& thirdPartyList) {
+        GList* result = nullptr;
+        while (!thirdPartyList.isEmpty())
+            result = g_list_prepend(result, webkitITPThirdPartyCreate(thirdPartyList.takeLast()));
+        g_task_return_pointer(task.get(), result, [](gpointer data) {
+            g_list_free_full(static_cast<GList*>(data), reinterpret_cast<GDestroyNotify>(webkit_itp_third_party_unref));
+        });
+    });
+}
+
+/**
+ * webkit_network_session_get_itp_summary_finish:
+ * @session: a #WebKitNetworkSession
+ * @result: a #GAsyncResult
+ * @error: return location for error or %NULL to ignore
+ *
+ * Finish an asynchronous operation started with webkit_network_session_get_itp_summary().
+ *
+ * Returns: (transfer full) (element-type WebKitITPThirdParty): a #GList of #WebKitITPThirdParty.
+ *    You must free the #GList with g_list_free() and unref the #WebKitITPThirdParty<!-- -->s with
+ *    webkit_itp_third_party_unref() when you're done with them.
+ *
+ * Since: 2.40
+ */
+GList* webkit_network_session_get_itp_summary_finish(WebKitNetworkSession* session, GAsyncResult* result, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), nullptr);
+    g_return_val_if_fail(g_task_is_valid(result, session), nullptr);
+
+    return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
+}
+
+/**
+ * webkit_network_session_prefetch_dns:
+ * @session: a #WebKitNetworkSession
+ * @hostname: a hostname to be resolved
+ *
+ * Resolve the domain name of the given @hostname in advance, so that if a URI
+ * of @hostname is requested the load will be performed more quickly.
+ *
+ * Since: 2.40
+ */
+void webkit_network_session_prefetch_dns(WebKitNetworkSession* session, const char* hostname)
+{
+    g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
+    g_return_if_fail(hostname);
+
+    if (session->priv->dnsPrefetchedHosts.add(String::fromUTF8(hostname)).isNewEntry) {
+        auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+        websiteDataStore.networkProcess().send(Messages::NetworkProcess::PrefetchDNS(String::fromUTF8(hostname)), 0);
+    }
+    session->priv->dnsPrefetchHystereris.impulse();
+}
+
+/**
+ * webkit_network_session_download_uri:
+ * @session: a #WebKitNetworkSession
+ * @uri: the URI to download
+ *
+ * Requests downloading of the specified URI string.
+ *
+ * The download operation will not be associated to any #WebKitWebView,
+ * if you are interested in starting a download from a particular #WebKitWebView use
+ * webkit_web_view_download_uri() instead.
+ *
+ * Returns: (transfer full): a new #WebKitDownload representing
+ *    the download operation.
+ *
+ * Since: 2.40
+ */
+WebKitDownload* webkit_network_session_download_uri(WebKitNetworkSession* session, const char* uri)
+{
+    g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), nullptr);
+    g_return_val_if_fail(uri, nullptr);
+
+    WebCore::ResourceRequest request(String::fromUTF8(uri));
+    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    auto& downloadProxy = websiteDataStore.createDownloadProxy(adoptRef(*new API::DownloadClient), request, nullptr, { });
+    auto download = webkitDownloadCreate(downloadProxy);
+    downloadProxy.setDidStartCallback([session = GRefPtr<WebKitNetworkSession> { session }, download = download.get()](auto* downloadProxy) {
+        if (!downloadProxy)
+            return;
+
+        webkitDownloadStarted(download);
+        webkitNetworkSessionDownloadStarted(session.get(), download);
+    });
+    websiteDataStore.download(downloadProxy, { });
+    return download.leakRef();
+}
+
+#endif // ENABLE(2022_GLIB_API)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitNetworkSession_h
+#define WebKitNetworkSession_h
+
+#include <gio/gio.h>
+#include <@API_INCLUDE_PREFIX@/WebKitCookieManager.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDownload.h>
+#include <@API_INCLUDE_PREFIX@/WebKitMemoryPressureSettings.h>
+#include <@API_INCLUDE_PREFIX@/WebKitNetworkProxySettings.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebsiteDataManager.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_NETWORK_SESSION            (webkit_network_session_get_type())
+#define WEBKIT_NETWORK_SESSION(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_NETWORK_SESSION, WebKitNetworkSession))
+#define WEBKIT_IS_NETWORK_SESSION(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_NETWORK_SESSION))
+#define WEBKIT_NETWORK_SESSION_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_NETWORK_SESSION, WebKitNetworkSessionClass))
+#define WEBKIT_IS_NETWORK_SESSION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_NETWORK_SESSION))
+#define WEBKIT_NETWORK_SESSION_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_NETWORK_SESSION, WebKitNetworkSessionClass))
+
+typedef struct _WebKitNetworkSession        WebKitNetworkSession;
+typedef struct _WebKitNetworkSessionClass   WebKitNetworkSessionClass;
+typedef struct _WebKitNetworkSessionPrivate WebKitNetworkSessionPrivate;
+
+struct _WebKitNetworkSession {
+    GObject parent;
+
+    /*< private >*/
+    WebKitNetworkSessionPrivate *priv;
+};
+
+struct _WebKitNetworkSessionClass {
+    GObjectClass parent_class;
+
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
+    void (*_webkit_reserved1) (void);
+    void (*_webkit_reserved2) (void);
+    void (*_webkit_reserved3) (void);
+};
+
+WEBKIT_API GType
+webkit_network_session_get_type                                  (void);
+
+WEBKIT_API WebKitNetworkSession *
+webkit_network_session_get_default                               (void);
+
+WEBKIT_API WebKitNetworkSession *
+webkit_network_session_new                                       (const char                   *data_directory,
+                                                                  const char                   *cache_directrory);
+WEBKIT_API WebKitNetworkSession *
+webkit_network_session_new_ephemeral                             (void);
+
+WEBKIT_API gboolean
+webkit_network_session_is_ephemeral                              (WebKitNetworkSession         *session);
+
+WEBKIT_API WebKitWebsiteDataManager *
+webkit_network_session_get_website_data_manager                  (WebKitNetworkSession         *session);
+
+WEBKIT_API WebKitCookieManager *
+webkit_network_session_get_cookie_manager                        (WebKitNetworkSession         *session);
+
+WEBKIT_API void
+webkit_network_session_set_itp_enabled                           (WebKitNetworkSession         *session,
+                                                                  gboolean                      enabled);
+
+WEBKIT_API gboolean
+webkit_network_session_get_itp_enabled                           (WebKitNetworkSession         *session);
+
+WEBKIT_API void
+webkit_network_session_set_persistent_credential_storage_enabled (WebKitNetworkSession         *session,
+                                                                  gboolean                      enabled);
+
+WEBKIT_API gboolean
+webkit_network_session_get_persistent_credential_storage_enabled (WebKitNetworkSession         *session);
+
+WEBKIT_API void
+webkit_network_session_set_tls_errors_policy                     (WebKitNetworkSession         *session,
+                                                                  WebKitTLSErrorsPolicy         policy);
+
+WEBKIT_API WebKitTLSErrorsPolicy
+webkit_network_session_get_tls_errors_policy                     (WebKitNetworkSession         *session);
+
+WEBKIT_API void
+webkit_network_session_allow_tls_certificate_for_host            (WebKitNetworkSession         *session,
+                                                                  GTlsCertificate              *certificate,
+                                                                  const char                   *host);
+
+WEBKIT_API void
+webkit_network_session_set_proxy_settings                        (WebKitNetworkSession         *session,
+                                                                  WebKitNetworkProxyMode        proxy_mode,
+                                                                  WebKitNetworkProxySettings   *proxy_settings);
+
+WEBKIT_API void
+webkit_network_session_set_memory_pressure_settings              (WebKitMemoryPressureSettings *settings);
+
+WEBKIT_API void
+webkit_network_session_get_itp_summary                           (WebKitNetworkSession         *session,
+                                                                  GCancellable                 *cancellable,
+                                                                  GAsyncReadyCallback           callback,
+                                                                  gpointer                      user_data);
+WEBKIT_API GList *
+webkit_network_session_get_itp_summary_finish                    (WebKitNetworkSession         *session,
+                                                                  GAsyncResult                 *result,
+                                                                  GError                      **error);
+WEBKIT_API WebKitDownload *
+webkit_network_session_download_uri                              (WebKitNetworkSession         *session,
+                                                                  const char                   *uri);
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSessionPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSessionPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Igalia S.L.
+ * Copyright (C) 2023 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -19,12 +19,7 @@
 
 #pragma once
 
-#include "WebResourceLoadStatisticsStore.h"
-#include "WebsiteDataStore.h"
-#include <wtf/glib/GUniquePtr.h>
+#include "WebKitDownload.h"
+#include "WebKitNetworkSession.h"
 
-#if ENABLE(2022_GLIB_API)
-WebKitWebsiteDataManager* webkitWebsiteDataManagerCreate(GUniquePtr<char>&&, GUniquePtr<char>&&);
-#endif
-WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteDataManager*);
-WebKitITPThirdParty* webkitITPThirdPartyCreate(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&&);
+void webkitNetworkSessionDownloadStarted(WebKitNetworkSession*, WebKitDownload*);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -27,7 +27,9 @@
 #include <@API_INCLUDE_PREFIX@/WebKitCookieManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDownload.h>
+#if !ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitGeolocationManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitNetworkProxySettings.h>
 #include <@API_INCLUDE_PREFIX@/WebKitSecurityManager.h>
@@ -140,6 +142,7 @@ webkit_web_context_get_default                      (void);
 WEBKIT_API WebKitWebContext *
 webkit_web_context_new                              (void);
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitWebContext *
 webkit_web_context_new_ephemeral                    (void);
 
@@ -151,6 +154,7 @@ webkit_web_context_get_website_data_manager         (WebKitWebContext           
 
 WEBKIT_API gboolean
 webkit_web_context_is_ephemeral                     (WebKitWebContext              *context);
+#endif
 
 WEBKIT_API gboolean
 webkit_web_context_is_automation_allowed            (WebKitWebContext              *context);
@@ -173,15 +177,14 @@ WEBKIT_DEPRECATED guint
 webkit_web_context_get_web_process_count_limit      (WebKitWebContext              *context);
 #endif
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_web_context_clear_cache                      (WebKitWebContext              *context);
 
-#if !ENABLE(2022_GLIB_API)
 WEBKIT_DEPRECATED_FOR(webkit_website_data_manager_set_network_proxy_settings) void
 webkit_web_context_set_network_proxy_settings       (WebKitWebContext              *context,
                                                      WebKitNetworkProxyMode         proxy_mode,
                                                      WebKitNetworkProxySettings    *proxy_settings);
-#endif
 
 WEBKIT_API WebKitDownload *
 webkit_web_context_download_uri                     (WebKitWebContext              *context,
@@ -189,10 +192,12 @@ webkit_web_context_download_uri                     (WebKitWebContext           
 
 WEBKIT_API WebKitCookieManager *
 webkit_web_context_get_cookie_manager               (WebKitWebContext              *context);
+#endif
 
 WEBKIT_API WebKitGeolocationManager *
 webkit_web_context_get_geolocation_manager          (WebKitWebContext              *context);
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitFaviconDatabase *
 webkit_web_context_get_favicon_database             (WebKitWebContext              *context);
 
@@ -201,6 +206,7 @@ webkit_web_context_set_favicon_database_directory   (WebKitWebContext           
                                                      const gchar                   *path);
 WEBKIT_API const gchar *
 webkit_web_context_get_favicon_database_directory   (WebKitWebContext              *context);
+#endif
 
 WEBKIT_API WebKitSecurityManager *
 webkit_web_context_get_security_manager             (WebKitWebContext              *context);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h
@@ -31,8 +31,14 @@
 #include "WebProcessPool.h"
 #include <WebCore/ResourceRequest.h>
 
+#if ENABLE(2022_GLIB_API)
+#include "WebKitNetworkSession.h"
+#endif
+
 WebKit::WebProcessPool& webkitWebContextGetProcessPool(WebKitWebContext*);
+#if !ENABLE(2022_GLIB_API)
 void webkitWebContextDownloadStarted(WebKitWebContext*, WebKitDownload*);
+#endif
 void webkitWebContextCreatePageForWebView(WebKitWebContext*, WebKitWebView*, WebKitUserContentManager*, WebKitWebView*, WebKitWebsitePolicies*);
 void webkitWebContextWebViewDestroyed(WebKitWebContext*, WebKitWebView*);
 WebKitWebView* webkitWebContextGetWebViewForPage(WebKitWebContext*, WebKit::WebPageProxy*);
@@ -40,4 +46,7 @@ GVariant* webkitWebContextInitializeWebExtensions(WebKitWebContext*);
 void webkitWebContextInitializeNotificationPermissions(WebKitWebContext*);
 #if ENABLE(REMOTE_INSPECTOR)
 void webkitWebContextWillCloseAutomationSession(WebKitWebContext*);
+#if ENABLE(2022_GLIB_API)
+WebKitNetworkSession* webkitWebContextGetNetworkSessionForAutomation(WebKitWebContext*);
+#endif
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -54,6 +54,10 @@
 #include <@API_INCLUDE_PREFIX@/WebKitWebsitePolicies.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWindowProperties.h>
 
+#if ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitNetworkSession.h>
+#endif
+
 #if PLATFORM(GTK)
 #include <JavaScriptCore/JSBase.h>
 #include <webkit/WebKitColorChooserRequest.h>
@@ -471,8 +475,10 @@ WEBKIT_API WebKitWebViewBackend *
 webkit_web_view_get_backend                          (WebKitWebView             *web_view);
 #endif
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API gboolean
 webkit_web_view_is_ephemeral                         (WebKitWebView             *web_view);
+#endif
 
 WEBKIT_API gboolean
 webkit_web_view_is_controlled_by_automation          (WebKitWebView             *web_view);
@@ -480,8 +486,13 @@ webkit_web_view_is_controlled_by_automation          (WebKitWebView             
 WEBKIT_API WebKitAutomationBrowsingContextPresentation
 webkit_web_view_get_automation_presentation_type     (WebKitWebView             *web_view);
 
+#if ENABLE(2022_GLIB_API)
+WEBKIT_API WebKitNetworkSession *
+webkit_web_view_get_network_session                  (WebKitWebView             *web_view);
+#else
 WEBKIT_API WebKitWebsiteDataManager *
 webkit_web_view_get_website_data_manager             (WebKitWebView             *web_view);
+#endif
 
 WEBKIT_API WebKitWebContext *
 webkit_web_view_get_context                          (WebKitWebView             *web_view);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
@@ -25,6 +25,9 @@
 #include <gio/gio.h>
 #include <@API_INCLUDE_PREFIX@/WebKitCookieManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+#if ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitMemoryPressureSettings.h>
 #include <@API_INCLUDE_PREFIX@/WebKitNetworkProxySettings.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebsiteData.h>
@@ -77,11 +80,13 @@ struct _WebKitWebsiteDataManagerClass {
 WEBKIT_API GType
 webkit_website_data_manager_get_type                                  (void);
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API WebKitWebsiteDataManager *
 webkit_website_data_manager_new                                       (const gchar              *first_option_name,
                                                                        ...);
 WEBKIT_API WebKitWebsiteDataManager *
 webkit_website_data_manager_new_ephemeral                             (void);
+#endif
 
 WEBKIT_API gboolean
 webkit_website_data_manager_is_ephemeral                              (WebKitWebsiteDataManager* manager);
@@ -91,6 +96,18 @@ webkit_website_data_manager_get_base_data_directory                   (WebKitWeb
 
 WEBKIT_API const gchar *
 webkit_website_data_manager_get_base_cache_directory                  (WebKitWebsiteDataManager *manager);
+
+#if ENABLE(2022_GLIB_API)
+WEBKIT_API void
+webkit_website_data_manager_set_favicons_enabled                      (WebKitWebsiteDataManager *manager,
+                                                                       gboolean                  enabled);
+
+WEBKIT_API gboolean
+webkit_website_data_manager_get_favicons_enabled                      (WebKitWebsiteDataManager *manager);
+
+WEBKIT_API WebKitFaviconDatabase *
+webkit_website_data_manager_get_favicon_database                      (WebKitWebsiteDataManager *manager);
+#endif
 
 #if !ENABLE(2022_GLIB_API)
 WEBKIT_DEPRECATED const gchar *
@@ -119,7 +136,6 @@ webkit_website_data_manager_get_service_worker_registrations_directory(WebKitWeb
 
 WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_dom_cache_directory                   (WebKitWebsiteDataManager *manager);
-#endif
 
 WEBKIT_API WebKitCookieManager *
 webkit_website_data_manager_get_cookie_manager                        (WebKitWebsiteDataManager *manager);
@@ -149,6 +165,7 @@ WEBKIT_API void
 webkit_website_data_manager_set_network_proxy_settings                (WebKitWebsiteDataManager *manager,
                                                                        WebKitNetworkProxyMode    proxy_mode,
                                                                        WebKitNetworkProxySettings *proxy_settings);
+#endif
 
 WEBKIT_API void
 webkit_website_data_manager_fetch                                     (WebKitWebsiteDataManager *manager,
@@ -186,8 +203,10 @@ webkit_website_data_manager_clear_finish                               (WebKitWe
                                                                         GAsyncResult             *result,
                                                                         GError                  **error);
 
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_website_data_manager_set_memory_pressure_settings               (WebKitMemoryPressureSettings *settings);
+#endif
 
 
 #define WEBKIT_TYPE_ITP_FIRST_PARTY   (webkit_itp_first_party_get_type())

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -76,6 +76,9 @@
 #include <@API_INCLUDE_PREFIX@/WebKitNavigationAction.h>
 #include <@API_INCLUDE_PREFIX@/WebKitNavigationPolicyDecision.h>
 #include <@API_INCLUDE_PREFIX@/WebKitNetworkProxySettings.h>
+#if ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitNetworkSession.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitNotification.h>
 #include <@API_INCLUDE_PREFIX@/WebKitNotificationPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitOptionMenu.h>

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -352,7 +352,9 @@ GtkWidget* webkit_web_view_new_with_context(WebKitWebContext* context)
     g_return_val_if_fail(WEBKIT_IS_WEB_CONTEXT(context), 0);
 
     return GTK_WIDGET(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if !ENABLE(2022_GLIB_API)
         "is-ephemeral", webkit_web_context_is_ephemeral(context),
+#endif
         "web-context", context,
         nullptr));
 }

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -110,7 +110,9 @@ WebKitWebView* webkit_web_view_new_with_context(WebKitWebViewBackend* backend, W
 
     return WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
         "backend", backend,
+#if !ENABLE(2022_GLIB_API)
         "is-ephemeral", webkit_web_context_is_ephemeral(context),
+#endif
         "web-context", context,
         nullptr));
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -253,7 +253,7 @@ SOAuthorizationCoordinator& WebsiteDataStore::soAuthorizationCoordinator(const W
 
 static Ref<NetworkProcessProxy> networkProcessForSession(PAL::SessionID sessionID)
 {
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if ((PLATFORM(GTK) || PLATFORM(WPE)) && !ENABLE(2022_GLIB_API))
     if (sessionID.isEphemeral()) {
         // Reuse a previous persistent session network process for ephemeral sessions.
         for (auto* dataStore : allDataStores().values()) {

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -66,3 +66,18 @@ accordingly.
 `webkit_web_view_new_with_user_content_manager()` have all been removed. You
 may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] and
 [ctor@WebKit.WebView.new_with_related_view] both remain.
+
+## Network session API
+
+WebKit now uses a single global network process for all web contexts, and different
+network sessions can be created and used in the same network process. All the networking
+APIs have been moved from [type@WebKit.WebContext] and [type@WebKit.WebsiteDataManager] to the new class
+[type@WebKit.NetworkSession]. There's a default global persistent session that you can get with
+[func@WebKit.NetworkSession.get_default]. You can also create new sessions with
+[ctor@WebKit.NetworkSession.new] for persistent sessions and [ctor@WebKit.NetworkSession.new_ephemeral]
+for ephemeral sessions. It's no longer possible to create a [type@WebKit.WebsiteDataManager], it's now
+created by the [type@WebKit.NetworkSession] automatically at construction time. The [type@WebKit.NetworkSession]
+to be used must be passed to the [type@WebKit.WebView] as a construct parameter. You can pass the
+same [type@WebKit.NetworkSession] object to several web views to use the same session. The only exception
+is automation mode, which uses its own ephemeral session that is configured by the automation
+session capabilities.

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -218,7 +218,11 @@ static void tlsErrorsDialogResponse(GtkWidget *dialog, gint response, BrowserTab
         GTlsCertificate *certificate = (GTlsCertificate *)g_object_get_data(G_OBJECT(dialog), "certificate");
 #if SOUP_CHECK_VERSION(2, 91, 0)
         GUri *uri = g_uri_parse(failingURI, SOUP_HTTP_URI_FLAGS, NULL);
+#if GTK_CHECK_VERSION(3, 98, 5)
+        webkit_network_session_allow_tls_certificate_for_host(webkit_web_view_get_network_session(tab->webView), certificate, g_uri_get_host(uri));
+#else
         webkit_web_context_allow_tls_certificate_for_host(webkit_web_view_get_context(tab->webView), certificate, g_uri_get_host(uri));
+#endif
         g_uri_unref(uri);
 #else
         SoupURI *uri = soup_uri_new(failingURI);

--- a/Tools/MiniBrowser/gtk/BrowserWindow.h
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.h
@@ -50,7 +50,12 @@ typedef struct _BrowserWindowClass   BrowserWindowClass;
 
 GType browser_window_get_type(void);
 
+#if GTK_CHECK_VERSION(3, 98, 0)
+GtkWidget* browser_window_new(GtkWindow*, WebKitWebContext*, WebKitNetworkSession*);
+WebKitNetworkSession* browser_window_get_network_session(BrowserWindow*);
+#else
 GtkWidget* browser_window_new(GtkWindow*, WebKitWebContext*);
+#endif
 WebKitWebContext* browser_window_get_web_context(BrowserWindow*);
 void browser_window_append_view(BrowserWindow*, WebKitWebView*);
 void browser_window_load_uri(BrowserWindow*, const char *uri);

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -76,8 +76,8 @@ static const GOptionEntry commandLineOptions[] =
 
 class InputClient final : public WPEToolingBackends::ViewBackend::InputClient {
 public:
-    InputClient(GMainLoop* loop, WebKitWebView* webView)
-        : m_loop(loop)
+    InputClient(GApplication* application, WebKitWebView* webView)
+        : m_application(application)
         , m_webView(webView)
     {
     }
@@ -88,7 +88,7 @@ public:
             return false;
 
         if (event->modifiers & wpe_input_keyboard_modifier_control && event->key_code == WPE_KEY_q) {
-            g_main_loop_quit(m_loop);
+            g_application_quit(m_application);
             return true;
         }
 
@@ -108,7 +108,7 @@ public:
     }
 
 private:
-    GMainLoop* m_loop { nullptr };
+    GApplication* m_application { nullptr };
     WebKitWebView* m_webView { nullptr };
 };
 
@@ -183,50 +183,42 @@ static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationActi
     return newWebView;
 }
 
-int main(int argc, char *argv[])
+static void activate(GApplication* application, WPEToolingBackends::ViewBackend* backend)
 {
-#if ENABLE_DEVELOPER_MODE
-    g_setenv("WEBKIT_INJECTED_BUNDLE_PATH", WEBKIT_INJECTED_BUNDLE_PATH, FALSE);
-#endif
+    g_application_hold(application);
+#if ENABLE_2022_GLIB_API
+    WebKitNetworkSession* networkSession = nullptr;
+    if (!automationMode) {
+        networkSession = privateMode ? webkit_network_session_new_ephemeral() : webkit_network_session_new(nullptr, nullptr);
+        webkit_network_session_set_itp_enabled(networkSession, enableITP);
 
-    GOptionContext* context = g_option_context_new(nullptr);
-    g_option_context_add_main_entries(context, commandLineOptions, nullptr);
+        if (proxy) {
+            auto* webkitProxySettings = webkit_network_proxy_settings_new(proxy, ignoreHosts);
+            webkit_network_session_set_proxy_settings(networkSession, WEBKIT_NETWORK_PROXY_MODE_CUSTOM, webkitProxySettings);
+            webkit_network_proxy_settings_free(webkitProxySettings);
+        }
 
-#if !USE_GSTREAMER_FULL && (ENABLE_WEB_AUDIO || ENABLE_VIDEO)
-    g_option_context_add_group(context, gst_init_get_option_group());
-#endif
+        if (ignoreTLSErrors)
+            webkit_network_session_set_tls_errors_policy(networkSession, WEBKIT_TLS_ERRORS_POLICY_IGNORE);
 
-    GError* error = nullptr;
-    if (!g_option_context_parse(context, &argc, &argv, &error)) {
-        g_printerr("Cannot parse arguments: %s\n", error->message);
-        g_error_free(error);
-        g_option_context_free(context);
+        if (cookiesPolicy) {
+            auto* cookieManager = webkit_network_session_get_cookie_manager(networkSession);
+            auto* enumClass = static_cast<GEnumClass*>(g_type_class_ref(WEBKIT_TYPE_COOKIE_ACCEPT_POLICY));
+            GEnumValue* enumValue = g_enum_get_value_by_nick(enumClass, cookiesPolicy);
+            if (enumValue)
+                webkit_cookie_manager_set_accept_policy(cookieManager, static_cast<WebKitCookieAcceptPolicy>(enumValue->value));
+            g_type_class_unref(enumClass);
+        }
 
-        return 1;
-    }
-    g_option_context_free(context);
-
-    if (printVersion) {
-        g_print("WPE WebKit %u.%u.%u",
-            webkit_get_major_version(),
-            webkit_get_minor_version(),
-            webkit_get_micro_version());
-        if (g_strcmp0(BUILD_REVISION, "tarball"))
-            g_print(" (%s)", BUILD_REVISION);
-        g_print("\n");
-        return 0;
-    }
-
-    auto* loop = g_main_loop_new(nullptr, FALSE);
-
-    auto backend = createViewBackend(1280, 720);
-    struct wpe_view_backend* wpeBackend = backend->backend();
-    if (!wpeBackend) {
-        g_warning("Failed to create WPE view backend");
-        g_main_loop_unref(loop);
-        return 1;
+        if (cookiesFile && !webkit_network_session_is_ephemeral(networkSession)) {
+            auto* cookieManager = webkit_network_session_get_cookie_manager(networkSession);
+            auto storageType = g_str_has_suffix(cookiesFile, ".txt") ? WEBKIT_COOKIE_PERSISTENT_STORAGE_TEXT : WEBKIT_COOKIE_PERSISTENT_STORAGE_SQLITE;
+            webkit_cookie_manager_set_persistent_storage(cookieManager, cookiesFile, storageType);
+        }
     }
 
+    auto* webContext = WEBKIT_WEB_CONTEXT(g_object_new(WEBKIT_TYPE_WEB_CONTEXT, "time-zone-override", timeZone, nullptr));
+#else
     auto* manager = (privateMode || automationMode) ? webkit_website_data_manager_new_ephemeral() : webkit_website_data_manager_new(nullptr);
     webkit_website_data_manager_set_itp_enabled(manager, enableITP);
 
@@ -256,6 +248,7 @@ int main(int argc, char *argv[])
         auto storageType = g_str_has_suffix(cookiesFile, ".txt") ? WEBKIT_COOKIE_PERSISTENT_STORAGE_TEXT : WEBKIT_COOKIE_PERSISTENT_STORAGE_SQLITE;
         webkit_cookie_manager_set_persistent_storage(cookieManager, cookiesFile, storageType);
     }
+#endif
 
     WebKitUserContentManager* userContentManager = nullptr;
     if (contentFilter) {
@@ -290,25 +283,27 @@ int main(int argc, char *argv[])
         "enable-encrypted-media", TRUE,
         nullptr);
 
-    auto* backendPtr = backend.get();
-    auto* viewBackend = webkit_web_view_backend_new(wpeBackend, [](gpointer data) {
+    auto* viewBackend = webkit_web_view_backend_new(backend->backend(), [](gpointer data) {
         delete static_cast<WPEToolingBackends::ViewBackend*>(data);
-    }, backend.release());
+    }, backend);
 
     auto* webView = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
         "backend", viewBackend,
         "web-context", webContext,
+#if ENABLE_2022_GLIB_API
+        "network-session", networkSession,
+#endif
         "settings", settings,
         "user-content-manager", userContentManager,
         "is-controlled-by-automation", automationMode,
         nullptr));
     g_object_unref(settings);
 
-    backendPtr->setInputClient(std::make_unique<InputClient>(loop, webView));
+    backend->setInputClient(std::make_unique<InputClient>(application, webView));
 #if defined(ENABLE_ACCESSIBILITY) && ENABLE_ACCESSIBILITY
-    auto* accessible = wpe_view_backend_dispatch_get_accessible(wpeBackend);
+    auto* accessible = wpe_view_backend_dispatch_get_accessible(backend->backend());
     if (ATK_IS_OBJECT(accessible))
-        backendPtr->setAccessibleChild(ATK_OBJECT(accessible));
+        backend->setAccessibleChild(ATK_OBJECT(accessible));
 #endif
 
     openViews = g_hash_table_new_full(nullptr, nullptr, g_object_unref, nullptr);
@@ -339,14 +334,59 @@ int main(int argc, char *argv[])
     else
         webkit_web_view_load_uri(webView, "https://wpewebkit.org");
 
-    g_main_loop_run(loop);
+    g_object_unref(webContext);
+#if ENABLE_2022_GLIB_API
+    g_clear_object(&networkSession);
+#endif
+}
+
+int main(int argc, char *argv[])
+{
+#if ENABLE_DEVELOPER_MODE
+    g_setenv("WEBKIT_INJECTED_BUNDLE_PATH", WEBKIT_INJECTED_BUNDLE_PATH, FALSE);
+#endif
+
+    GOptionContext* context = g_option_context_new(nullptr);
+    g_option_context_add_main_entries(context, commandLineOptions, nullptr);
+
+#if !USE_GSTREAMER_FULL && (ENABLE_WEB_AUDIO || ENABLE_VIDEO)
+    g_option_context_add_group(context, gst_init_get_option_group());
+#endif
+
+    GError* error = nullptr;
+    if (!g_option_context_parse(context, &argc, &argv, &error)) {
+        g_printerr("Cannot parse arguments: %s\n", error->message);
+        g_error_free(error);
+        g_option_context_free(context);
+
+        return 1;
+    }
+    g_option_context_free(context);
+
+    if (printVersion) {
+        g_print("WPE WebKit %u.%u.%u",
+            webkit_get_major_version(),
+            webkit_get_minor_version(),
+            webkit_get_micro_version());
+        if (g_strcmp0(BUILD_REVISION, "tarball"))
+            g_print(" (%s)", BUILD_REVISION);
+        g_print("\n");
+        return 0;
+    }
+
+    auto backend = createViewBackend(1280, 720);
+    struct wpe_view_backend* wpeBackend = backend->backend();
+    if (!wpeBackend) {
+        g_warning("Failed to create WPE view backend");
+        return 1;
+    }
+
+    GApplication* application = g_application_new("org.wpewebkit.MiniBrowser", G_APPLICATION_NON_UNIQUE);
+    g_signal_connect(application, "activate", G_CALLBACK(activate), backend.release());
+    g_application_run(application, 0, nullptr);
+    g_object_unref(application);
 
     g_hash_table_destroy(openViews);
-
-
-    if (privateMode || automationMode)
-        g_object_unref(webContext);
-    g_main_loop_unref(loop);
 
     return 0;
 }

--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -30,7 +30,7 @@ if (ENABLE_COG)
         set(WPE_COG_REPO "https://github.com/Igalia/cog.git")
     endif ()
     if ("${WPE_COG_TAG}" STREQUAL "")
-        set(WPE_COG_TAG "934728d982d95d440f494241506f6574bbe807bc")
+        set(WPE_COG_TAG "8f82f7e4287ee69a8375ca7e894f0981a32d7ac8")
     endif ()
     # TODO Use GIT_REMOTE_UPDATE_STRATEGY with 3.18 to allow switching between
     # conflicting branches without having to delete the repo

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
@@ -57,9 +57,17 @@ public:
 
     CookieManagerTest()
         : WebViewTest()
+#if ENABLE(2022_GLIB_API)
+        , m_cookieManager(webkit_network_session_get_cookie_manager(m_networkSession.get()))
+        , m_websiteDataManager(webkit_network_session_get_website_data_manager(m_networkSession.get()))
+#else
         , m_cookieManager(webkit_web_context_get_cookie_manager(m_webContext.get()))
+        , m_websiteDataManager(webkit_web_context_get_website_data_manager(m_webContext.get()))
+#endif
     {
-        g_assert_true(webkit_website_data_manager_get_cookie_manager(webkit_web_context_get_website_data_manager(m_webContext.get())) == m_cookieManager);
+#if !ENABLE(2022_GLIB_API)
+        g_assert_true(webkit_website_data_manager_get_cookie_manager(m_websiteDataManager) == m_cookieManager);
+#endif
         g_signal_connect(m_cookieManager, "changed", G_CALLBACK(cookiesChangedCallback), this);
     }
 
@@ -175,28 +183,37 @@ public:
         webkit_cookie_manager_set_accept_policy(m_cookieManager, policy);
     }
 
-    static void getDomainsReadyCallback(GObject* object, GAsyncResult* result, gpointer userData)
+    GUniquePtr<GList> fetch()
     {
-        GUniqueOutPtr<GError> error;
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-        char** domains = webkit_cookie_manager_get_domains_with_cookies_finish(WEBKIT_COOKIE_MANAGER(object), result, &error.outPtr());
-        G_GNUC_END_IGNORE_DEPRECATIONS;
-        g_assert_no_error(error.get());
+        struct TestData {
+            GUniquePtr<GList> dataList;
+            GMainLoop* mainLoop;
+        } data = { nullptr, m_mainLoop };
 
-        CookieManagerTest* test = static_cast<CookieManagerTest*>(userData);
-        test->m_domains = domains;
-        g_main_loop_quit(test->m_mainLoop);
+        webkit_website_data_manager_fetch(m_websiteDataManager, WEBKIT_WEBSITE_DATA_COOKIES, nullptr, [](GObject* object, GAsyncResult* result, gpointer userData) {
+            auto* data = static_cast<TestData*>(userData);
+            GUniqueOutPtr<GError> error;
+            data->dataList.reset(webkit_website_data_manager_fetch_finish(WEBKIT_WEBSITE_DATA_MANAGER(object), result, &error.outPtr()));
+            g_assert_no_error(error.get());
+            g_main_loop_quit(data->mainLoop);
+        }, &data);
+        g_main_loop_run(m_mainLoop);
+        return WTFMove(data.dataList);
     }
 
     char** getDomains()
     {
-        g_strfreev(m_domains);
-        m_domains = 0;
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-        webkit_cookie_manager_get_domains_with_cookies(m_cookieManager, 0, getDomainsReadyCallback, this);
-        G_GNUC_END_IGNORE_DEPRECATIONS;
-        g_main_loop_run(m_mainLoop);
+        g_clear_pointer(&m_domains, g_strfreev);
+        GUniquePtr<GList> dataList = fetch();
+        GPtrArray* domains = g_ptr_array_sized_new(g_list_length(dataList.get()));
+        for (GList* item = dataList.get(); item; item = g_list_next(item)) {
+            auto* data = static_cast<WebKitWebsiteData*>(item->data);
+            g_ptr_array_add(domains, g_strdup(webkit_website_data_get_name(data)));
+            webkit_website_data_unref(data);
+        }
+        g_ptr_array_add(domains, nullptr);
 
+        m_domains = reinterpret_cast<char**>(g_ptr_array_free(domains, FALSE));
         return m_domains;
     }
 
@@ -214,16 +231,23 @@ public:
 
     void deleteCookiesForDomain(const char* domain)
     {
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-        webkit_cookie_manager_delete_cookies_for_domain(m_cookieManager, domain);
-        G_GNUC_END_IGNORE_DEPRECATIONS;
+        GUniquePtr<GList> dataList = fetch();
+        GUniquePtr<GList> cookies;
+        for (GList* item = dataList.get(); item; item = g_list_next(item)) {
+            auto* data = static_cast<WebKitWebsiteData*>(item->data);
+            if (!g_strcmp0(webkit_website_data_get_name(data), domain))
+                cookies.reset(g_list_prepend(cookies.get(), webkit_website_data_ref(data)));
+            webkit_website_data_unref(data);
+        }
+        webkit_website_data_manager_remove(m_websiteDataManager, WEBKIT_WEBSITE_DATA_COOKIES, cookies.get(), nullptr, nullptr, nullptr);
+        g_list_foreach(cookies.get(), [](gpointer data, gpointer) {
+            webkit_website_data_unref(static_cast<WebKitWebsiteData*>(data));
+        }, nullptr);
     }
 
     void deleteAllCookies()
     {
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-        webkit_cookie_manager_delete_all_cookies(m_cookieManager);
-        G_GNUC_END_IGNORE_DEPRECATIONS;
+        webkit_website_data_manager_clear(m_websiteDataManager, WEBKIT_WEBSITE_DATA_COOKIES, 0, nullptr, nullptr, nullptr);
     }
 
     void waitUntilCookiesChanged(int cookiesExpectedToChangeCount = 1)
@@ -235,7 +259,17 @@ public:
         m_finishLoopWhenCookiesChange = false;
     }
 
+    void setITPEnable(bool enable)
+    {
+#if ENABLE(2022_GLIB_API)
+        webkit_network_session_set_itp_enabled(m_networkSession.get(), enable);
+#else
+        webkit_website_data_manager_set_itp_enabled(m_websiteDataManager, enable);
+#endif
+    }
+
     WebKitCookieManager* m_cookieManager { nullptr };
+    WebKitWebsiteDataManager* m_websiteDataManager { nullptr };
     WebKitCookieAcceptPolicy m_acceptPolicy { WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY };
     char** m_domains { nullptr };
     GList* m_cookies { nullptr };
@@ -278,23 +312,22 @@ static void testCookieManagerAcceptPolicy(CookieManagerTest* test, gconstpointer
     g_assert_cmpint(g_strv_length(domains), ==, 0);
 
     // ITP never uses NO_THIRD_PARTY.
-    auto* manager = webkit_web_context_get_website_data_manager(test->m_webContext.get());
-    webkit_website_data_manager_set_itp_enabled(manager, TRUE);
+    test->setITPEnable(true);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_NEVER);
     test->setAcceptPolicy(WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS);
-    webkit_website_data_manager_set_itp_enabled(manager, FALSE);
+    test->setITPEnable(false);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY);
-    webkit_website_data_manager_set_itp_enabled(manager, TRUE);
+    test->setITPEnable(true);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS);
-    webkit_website_data_manager_set_itp_enabled(manager, FALSE);
+    test->setITPEnable(false);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_NO_THIRD_PARTY);
     test->setAcceptPolicy(WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS);
-    webkit_website_data_manager_set_itp_enabled(manager, TRUE);
+    test->setITPEnable(true);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_ALWAYS);
     test->setAcceptPolicy(WEBKIT_COOKIE_POLICY_ACCEPT_NEVER);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_NEVER);
-    webkit_website_data_manager_set_itp_enabled(manager, FALSE);
+    test->setITPEnable(false);
     g_assert_cmpint(test->getAcceptPolicy(), ==, WEBKIT_COOKIE_POLICY_ACCEPT_NEVER);
 }
 
@@ -667,15 +700,26 @@ static void testCookieManagerEphemeral(CookieManagerTest* test, gconstpointer)
     g_assert_nonnull(domains);
     g_assert_cmpint(g_strv_length(domains), ==, 0);
 
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitNetworkSession> ephemeralSession = adoptGRef(webkit_network_session_new_ephemeral());
+#endif
     auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
 #if PLATFORM(WPE)
         "backend", Test::createWebViewBackend(),
 #endif
         "web-context", webkit_web_view_get_context(test->m_webView),
+#if ENABLE(2022_GLIB_API)
+        "network-session", ephemeralSession.get(),
+#else
         "is-ephemeral", TRUE,
+#endif
         nullptr));
+#if ENABLE(2022_GLIB_API)
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == ephemeralSession.get());
+#else
     g_assert_true(webkit_web_view_is_ephemeral(webView.get()));
     g_assert_false(webkit_web_context_is_ephemeral(webkit_web_view_get_context(webView.get())));
+#endif
 
     g_signal_connect(webView.get(), "load-changed", G_CALLBACK(ephemeralViewloadChanged), test);
     webkit_web_view_load_uri(webView.get(), kServer->getURIForPath("/index.html").data());
@@ -685,24 +729,32 @@ static void testCookieManagerEphemeral(CookieManagerTest* test, gconstpointer)
     g_assert_nonnull(domains);
     g_assert_cmpint(g_strv_length(domains), ==, 0);
 
+#if ENABLE(2022_GLIB_API)
+    auto* viewDataManager = webkit_network_session_get_website_data_manager(ephemeralSession.get());
+#else
     auto* viewDataManager = webkit_web_view_get_website_data_manager(webView.get());
+#endif
     g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(viewDataManager));
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(viewDataManager));
+#if ENABLE(2022_GLIB_API)
+    auto* cookieManager = webkit_network_session_get_cookie_manager(ephemeralSession.get());
+#else
     g_assert_true(viewDataManager != webkit_web_context_get_website_data_manager(webkit_web_view_get_context(test->m_webView)));
     auto* cookieManager = webkit_website_data_manager_get_cookie_manager(viewDataManager);
+#endif
     g_assert_true(WEBKIT_IS_COOKIE_MANAGER(cookieManager));
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(cookieManager));
     g_assert_true(cookieManager != test->m_cookieManager);
-    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-    webkit_cookie_manager_get_domains_with_cookies(cookieManager, nullptr, [](GObject* object, GAsyncResult* result, gpointer userData) {
+    webkit_website_data_manager_fetch(viewDataManager, WEBKIT_WEBSITE_DATA_COOKIES, nullptr, [](GObject* object, GAsyncResult* result, gpointer userData) {
         auto* test = static_cast<CookieManagerTest*>(userData);
-        GUniquePtr<char*> domains(webkit_cookie_manager_get_domains_with_cookies_finish(WEBKIT_COOKIE_MANAGER(object), result, nullptr));
+        GUniquePtr<GList> domains(webkit_website_data_manager_fetch_finish(WEBKIT_WEBSITE_DATA_MANAGER(object), result, nullptr));
         g_assert_nonnull(domains);
-        g_assert_cmpint(g_strv_length(domains.get()), ==, 1);
-        g_assert_cmpstr(domains.get()[0], ==, kFirstPartyDomain);
+        g_assert_cmpint(g_list_length(domains.get()), ==, 1);
+        auto* data = static_cast<WebKitWebsiteData*>(domains.get()->data);
+        g_assert_cmpstr(webkit_website_data_get_name(data), ==, kFirstPartyDomain);
+        webkit_website_data_unref(data);
         test->quitMainLoop();
     }, test);
-    G_GNUC_END_IGNORE_DEPRECATIONS;
     g_main_loop_run(test->m_mainLoop);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2012, 2017 Igalia S.L.
  *
@@ -35,11 +36,15 @@ public:
     MAKE_GLIB_TEST_FIXTURE(FaviconDatabaseTest);
 
     FaviconDatabaseTest()
+#if ENABLE(2022_GLIB_API)
+        : m_database(webkit_website_data_manager_get_favicon_database(webkit_network_session_get_website_data_manager(m_networkSession.get())))
+#else
         : m_database(webkit_web_context_get_favicon_database(m_webContext.get()))
+#endif
     {
-        g_assert_true(WEBKIT_IS_FAVICON_DATABASE(m_database));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_database));
-        g_signal_connect(m_database, "favicon-changed", G_CALLBACK(faviconChangedCallback), this);
+        g_assert_true(WEBKIT_IS_FAVICON_DATABASE(m_database.get()));
+        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_database.get()));
+        g_signal_connect(m_database.get(), "favicon-changed", G_CALLBACK(faviconChangedCallback), this);
     }
 
     ~FaviconDatabaseTest()
@@ -47,15 +52,36 @@ public:
         if (m_favicon)
             cairo_surface_destroy(m_favicon);
 
-        g_signal_handlers_disconnect_matched(m_database, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+        g_signal_handlers_disconnect_matched(m_database.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+#if ENABLE(2022_GLIB_API)
+        GUniquePtr<char> databaseDirectory(g_build_filename(Test::dataDirectory(), "icondatabase", nullptr));
+        if (GDir* directory = g_dir_open(databaseDirectory.get(), 0, nullptr)) {
+            const char* fileName;
+            while ((fileName = g_dir_read_name(directory))) {
+                GUniquePtr<char> filePath(g_build_filename(databaseDirectory.get(), fileName, nullptr));
+                g_unlink(filePath.get());
+            }
+            g_dir_close(directory);
+        }
+        g_rmdir(databaseDirectory.get());
+#endif
     }
 
+#if !ENABLE(2022_GLIB_API)
     void open(const char* directory)
     {
         GUniquePtr<char> databaseDirectory(g_build_filename(dataDirectory(), directory, nullptr));
         webkit_web_context_set_favicon_database_directory(m_webContext.get(), databaseDirectory.get());
         g_assert_cmpstr(databaseDirectory.get(), ==, webkit_web_context_get_favicon_database_directory(m_webContext.get()));
     }
+#else
+    void close()
+    {
+        auto* manager = webkit_network_session_get_website_data_manager(m_networkSession.get());
+        webkit_website_data_manager_set_favicons_enabled(manager, FALSE);
+        g_assert_null(webkit_website_data_manager_get_favicon_database(manager));
+    }
+#endif
 
     static void faviconChangedCallback(WebKitFaviconDatabase* database, const char* pageURI, const char* faviconURI, FaviconDatabaseTest* test)
     {
@@ -89,7 +115,7 @@ public:
     static void getFaviconCallback(GObject* sourceObject, GAsyncResult* result, void* data)
     {
         FaviconDatabaseTest* test = static_cast<FaviconDatabaseTest*>(data);
-        test->m_favicon = webkit_favicon_database_get_favicon_finish(test->m_database, result, &test->m_error.outPtr());
+        test->m_favicon = webkit_favicon_database_get_favicon_finish(test->m_database.get(), result, &test->m_error.outPtr());
         test->quitMainLoop();
     }
 
@@ -123,7 +149,7 @@ public:
             m_favicon = nullptr;
         }
 
-        webkit_favicon_database_get_favicon(m_database, pageURI, 0, getFaviconCallback, this);
+        webkit_favicon_database_get_favicon(m_database.get(), pageURI, 0, getFaviconCallback, this);
         g_main_loop_run(m_mainLoop);
     }
 
@@ -136,7 +162,7 @@ public:
         m_waitingForFaviconURI = false;
     }
 
-    WebKitFaviconDatabase* m_database { nullptr };
+    GRefPtr<WebKitFaviconDatabase> m_database;
     cairo_surface_t* m_favicon { nullptr };
     CString m_faviconURI;
     GUniqueOutPtr<GError> m_error;
@@ -184,18 +210,35 @@ static void serverCallback(SoupServer*, SoupServerMessage* message, const char* 
 
 static void testFaviconDatabaseInitialization(FaviconDatabaseTest* test, gconstpointer)
 {
+    // In 2022 API favicons are enabled by default.
+#if !ENABLE(2022_GLIB_API)
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/foo").data());
     g_assert_null(test->m_favicon);
     g_assert_error(test->m_error.get(), WEBKIT_FAVICON_DATABASE_ERROR, WEBKIT_FAVICON_DATABASE_ERROR_NOT_INITIALIZED);
 
     test->open("testFaviconDatabaseInitialization");
+#endif
+
+#if ENABLE(2022_GLIB_API)
+    GUniquePtr<char> databaseFile(g_build_filename(Test::dataDirectory(), "icondatabase", "WebpageIcons.db", nullptr));
+#else
     GUniquePtr<char> databaseFile(g_build_filename(webkit_web_context_get_favicon_database_directory(test->m_webContext.get()), "WebpageIcons.db", nullptr));
+#endif
     g_assert_true(g_file_test(databaseFile.get(), G_FILE_TEST_IS_REGULAR));
+
+#if ENABLE(2022_GLIB_API)
+    test->close();
+    test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/foo").data());
+    g_assert_null(test->m_favicon);
+    g_assert_error(test->m_error.get(), WEBKIT_FAVICON_DATABASE_ERROR, WEBKIT_FAVICON_DATABASE_ERROR_NOT_INITIALIZED);
+#endif
 }
 
 static void testFaviconDatabaseGetFavicon(FaviconDatabaseTest* test, gconstpointer)
 {
+#if !ENABLE(2022_GLIB_API)
     test->open("testFaviconDatabaseGetFavicon");
+#endif
 
     test->loadURI(kServer->getURIForPath("/foo").data());
     test->waitUntilLoadFinishedAndFaviconChanged();
@@ -249,7 +292,8 @@ static void ephemeralViewFaviconChanged(WebKitWebView* webView, GParamSpec*, Web
 
 static void testFaviconDatabaseEphemeral(FaviconDatabaseTest* test, gconstpointer)
 {
-    // If the context is ephemeral, the database is not created if it doesn't exist.
+#if !ENABLE(2022_GLIB_API)
+    // If the context is ephemeral, the database is not created.
     GRefPtr<WebKitWebContext> ephemeralContext = adoptGRef(webkit_web_context_new_ephemeral());
     GUniquePtr<char> databaseDirectory(g_build_filename(Test::dataDirectory(), "testFaviconDatabaseEphemeral", nullptr));
     webkit_web_context_set_favicon_database_directory(ephemeralContext.get(), databaseDirectory.get());
@@ -260,21 +304,40 @@ static void testFaviconDatabaseEphemeral(FaviconDatabaseTest* test, gconstpointe
 
     test->open("testFaviconDatabaseEphemeral");
     g_assert_true(g_file_test(databaseFile.get(), G_FILE_TEST_EXISTS));
+#endif
 
     test->loadURI(kServer->getURIForPath("/foo").data());
     test->waitUntilLoadFinishedAndFaviconChanged();
+    g_assert_nonnull(webkit_favicon_database_get_favicon_uri(test->m_database.get(), kServer->getURIForPath("/foo").data()));
 
     // An ephemeral web view doesn't write to the database.
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitNetworkSession> ephemeralSession = adoptGRef(webkit_network_session_new_ephemeral());
+#endif
     auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-        "web-context", test->m_webContext.get(), "is-ephemeral", TRUE, nullptr));
+        "web-context", test->m_webContext.get(),
+#if ENABLE(2022_GLIB_API)
+        "network-session", ephemeralSession.get(),
+#else
+        "is-ephemeral", TRUE,
+#endif
+        nullptr));
     g_signal_connect(webView.get(), "notify::favicon", G_CALLBACK(ephemeralViewFaviconChanged), test);
     webkit_web_view_load_uri(webView.get(), kServer->getURIForPath("/bar").data());
     g_main_loop_run(test->m_mainLoop);
 
+#if ENABLE(2022_GLIB_API)
+    auto* database = webkit_website_data_manager_get_favicon_database(webkit_network_session_get_website_data_manager(ephemeralSession.get()));
+    // Persistent session database is not modified by ephemeral web views.
+    g_assert_null(webkit_favicon_database_get_favicon_uri(test->m_database.get(), kServer->getURIForPath("/bar").data()));
+#else
+    auto* database = test->m_database.get();
+#endif
     // We get a favicon, but it's only in database memory cache.
-    g_assert_nonnull(webkit_favicon_database_get_favicon_uri(test->m_database, kServer->getURIForPath("/bar").data()));
+    g_assert_nonnull(webkit_favicon_database_get_favicon_uri(database, kServer->getURIForPath("/bar").data()));
 
-    // If the database exists, it's used in read only mode for epeheral contexts.
+#if !ENABLE(2022_GLIB_API)
+    // If the database exists, it's used in read only mode for ephemeral contexts.
     ephemeralContext = adoptGRef(webkit_web_context_new_ephemeral());
     webkit_web_context_set_favicon_database_directory(ephemeralContext.get(), databaseDirectory.get());
     auto* ephemeralDatabase = webkit_web_context_get_favicon_database(ephemeralContext.get());
@@ -283,22 +346,25 @@ static void testFaviconDatabaseEphemeral(FaviconDatabaseTest* test, gconstpointe
     // Page URL loaded in ephemeral web view is not in the database.
     g_assert_null(webkit_favicon_database_get_favicon_uri(ephemeralDatabase, kServer->getURIForPath("/bar").data()));
     ephemeralContext = nullptr;
+#endif
 }
 
 void testFaviconDatabaseClear(FaviconDatabaseTest* test, gconstpointer)
 {
+#if !ENABLE(2022_GLIB_API)
     test->open("testFaviconDatabaseClear");
+#endif
     test->loadURI(kServer->getURIForPath("/foo").data());
     test->waitUntilLoadFinishedAndFaviconChanged();
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/foo").data());
     g_assert_nonnull(test->m_favicon);
-    g_assert_nonnull(webkit_favicon_database_get_favicon_uri(test->m_database, kServer->getURIForPath("/foo").data()));
+    g_assert_nonnull(webkit_favicon_database_get_favicon_uri(test->m_database.get(), kServer->getURIForPath("/foo").data()));
 
-    webkit_favicon_database_clear(test->m_database);
+    webkit_favicon_database_clear(test->m_database.get());
 
     test->getFaviconForPageURIAndWaitUntilReady(kServer->getURIForPath("/foo").data());
     g_assert_null(test->m_favicon);
-    g_assert_null(webkit_favicon_database_get_favicon_uri(test->m_database, kServer->getURIForPath("/foo").data()));
+    g_assert_null(webkit_favicon_database_get_favicon_uri(test->m_database.get(), kServer->getURIForPath("/foo").data()));
 }
 
 void beforeAll()

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp
@@ -1,0 +1,278 @@
+
+
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "WebKitTestServer.h"
+#include "WebViewTest.h"
+#include <libsoup/soup.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+
+static WebKitTestServer* kServer;
+
+static void testNetworkSessionDefault(Test* test, gconstpointer)
+{
+    // Check there's a single instance of the default network session.
+    g_assert_true(webkit_network_session_get_default() == webkit_network_session_get_default());
+    g_assert_true(webkit_network_session_get_default() != test->m_networkSession.get());
+}
+
+static void testNetworkSessionEphemeral(Test* test, gconstpointer)
+{
+    // By default network sessions are not ephemeral.
+    g_assert_false(webkit_network_session_is_ephemeral(webkit_network_session_get_default()));
+    g_assert_false(webkit_network_session_is_ephemeral(test->m_networkSession.get()));
+
+    WebKitWebsiteDataManager* manager = webkit_network_session_get_website_data_manager(webkit_network_session_get_default());
+    g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
+    g_assert_false(webkit_website_data_manager_is_ephemeral(manager));
+    manager = webkit_network_session_get_website_data_manager(test->m_networkSession.get());
+    g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
+    g_assert_false(webkit_website_data_manager_is_ephemeral(manager));
+
+    auto webView = Test::adoptView(Test::createWebView());
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == webkit_network_session_get_default());
+
+    webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+        "backend", Test::createWebViewBackend(),
+#endif
+        "web-context", test->m_webContext.get(),
+        "network-session", test->m_networkSession.get(),
+        nullptr));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == test->m_networkSession.get());
+
+    GRefPtr<WebKitNetworkSession> session = adoptGRef(webkit_network_session_new_ephemeral());
+    g_assert_true(webkit_network_session_is_ephemeral(session.get()));
+    manager = webkit_network_session_get_website_data_manager(session.get());
+    g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
+    g_assert_true(webkit_website_data_manager_is_ephemeral(manager));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) != session.get());
+
+    webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+        "backend", Test::createWebViewBackend(),
+#endif
+        "web-context", test->m_webContext.get(),
+        "network-session", session.get(),
+        nullptr));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == session.get());
+}
+
+static void serverCallback(SoupServer* server, SoupServerMessage* message, const char* path, GHashTable*, gpointer)
+{
+    if (soup_server_message_get_method(message) != SOUP_METHOD_GET) {
+        soup_server_message_set_status(message, SOUP_STATUS_NOT_IMPLEMENTED, nullptr);
+        return;
+    }
+
+    auto* responseBody = soup_server_message_get_response_body(message);
+
+    if (g_str_equal(path, "/echoPort")) {
+        char* port = g_strdup_printf("%u", g_inet_socket_address_get_port(G_INET_SOCKET_ADDRESS(soup_server_message_get_local_address(message))));
+        soup_message_body_append(responseBody, SOUP_MEMORY_TAKE, port, strlen(port));
+        soup_message_body_complete(responseBody);
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+    } else
+        soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
+}
+
+class ProxyTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(ProxyTest);
+
+    enum class WebSocketServerType {
+        Unknown,
+        NoProxy,
+        Proxy
+    };
+
+    static void webSocketProxyServerCallback(SoupServer*, SoupServerMessage*, const char* path, SoupWebsocketConnection*, gpointer userData)
+    {
+        static_cast<ProxyTest*>(userData)->webSocketConnected(ProxyTest::WebSocketServerType::Proxy);
+    }
+
+    ProxyTest()
+    {
+        // This "proxy server" is actually just a different instance of the main
+        // test server (kServer), listening on a different port. Requests
+        // will not actually be proxied to kServer because proxyServer is not
+        // actually a proxy server. We're testing whether the proxy settings
+        // work, not whether we can write a soup proxy server.
+        m_proxyServer.run(serverCallback);
+        g_assert_false(m_proxyServer.baseURL().isNull());
+
+        m_proxyServer.addWebSocketHandler(webSocketProxyServerCallback, this);
+        g_assert_false(m_proxyServer.baseWebSocketURL().isNull());
+    }
+
+    CString loadURIAndGetMainResourceData(const char* uri)
+    {
+        loadURI(uri);
+        waitUntilLoadFinished();
+        size_t dataSize = 0;
+        const char* data = mainResourceData(dataSize);
+        return CString(data, dataSize);
+    }
+
+    GUniquePtr<char> proxyServerPortAsString()
+    {
+        GUniquePtr<char> port(g_strdup_printf("%u", m_proxyServer.port()));
+        return port;
+    }
+
+    void webSocketConnected(WebSocketServerType serverType)
+    {
+        m_webSocketRequestReceived = serverType;
+        quitMainLoop();
+    }
+
+    WebSocketServerType createWebSocketAndWaitUntilConnected()
+    {
+        m_webSocketRequestReceived = WebSocketServerType::Unknown;
+        GUniquePtr<char> createWebSocket(g_strdup_printf("var ws = new WebSocket('%s');", kServer->getWebSocketURIForPath("/foo").data()));
+        runJavaScriptAndWaitUntilFinished(createWebSocket.get(), nullptr);
+        if (m_webSocketRequestReceived == WebSocketServerType::Unknown)
+            g_main_loop_run(m_mainLoop);
+        return m_webSocketRequestReceived;
+    }
+
+    WebKitTestServer m_proxyServer;
+    WebSocketServerType m_webSocketRequestReceived { WebSocketServerType::Unknown };
+};
+
+static void webSocketServerCallback(SoupServer*, SoupServerMessage*, const char*, SoupWebsocketConnection*, gpointer userData)
+{
+    static_cast<ProxyTest*>(userData)->webSocketConnected(ProxyTest::WebSocketServerType::NoProxy);
+}
+
+static void ephemeralViewloadChanged(WebKitWebView* webView, WebKitLoadEvent loadEvent, ProxyTest* test)
+{
+    if (loadEvent != WEBKIT_LOAD_FINISHED)
+        return;
+    g_signal_handlers_disconnect_by_func(webView, reinterpret_cast<void*>(ephemeralViewloadChanged), test);
+    test->quitMainLoop();
+}
+
+static void testNetworkSessionProxySettings(ProxyTest* test, gconstpointer)
+{
+    // Proxy URI is unset by default. Requests to kServer should be received by kServer.
+    GUniquePtr<char> serverPortAsString(g_strdup_printf("%u", kServer->port()));
+    auto mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, serverPortAsString.get());
+
+    // WebSocket requests should also be received by kServer.
+    kServer->addWebSocketHandler(webSocketServerCallback, test);
+    auto serverType = test->createWebSocketAndWaitUntilConnected();
+    g_assert_true(serverType == ProxyTest::WebSocketServerType::NoProxy);
+
+    // Set default proxy URI to point to proxyServer. Requests to kServer should be received by proxyServer instead.
+    WebKitNetworkProxySettings* settings = webkit_network_proxy_settings_new(test->m_proxyServer.baseURL().string().utf8().data(), nullptr);
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, settings);
+    GUniquePtr<char> proxyServerPortAsString = test->proxyServerPortAsString();
+    mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, proxyServerPortAsString.get());
+
+    // WebSocket requests should also be received by proxyServer.
+    serverType = test->createWebSocketAndWaitUntilConnected();
+    g_assert_true(serverType == ProxyTest::WebSocketServerType::Proxy);
+
+    // Proxy settings also affect ephemeral web views.
+    GRefPtr<WebKitNetworkSession> ephemeralSession = adoptGRef(webkit_network_session_new_ephemeral());
+    webkit_network_session_set_proxy_settings(ephemeralSession.get(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, settings);
+    webkit_network_proxy_settings_free(settings);
+    auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+        "backend", Test::createWebViewBackend(),
+#endif
+        "web-context", test->m_webContext.get(),
+        "network-session", ephemeralSession.get(),
+        nullptr));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == ephemeralSession.get());
+
+    g_signal_connect(webView.get(), "load-changed", G_CALLBACK(ephemeralViewloadChanged), test);
+    webkit_web_view_load_uri(webView.get(), kServer->getURIForPath("/echoPort").data());
+    g_main_loop_run(test->m_mainLoop);
+    WebKitWebResource* resource = webkit_web_view_get_main_resource(webView.get());
+    g_assert_true(WEBKIT_IS_WEB_RESOURCE(resource));
+    webkit_web_resource_get_data(resource, nullptr, [](GObject* object, GAsyncResult* result, gpointer userData) {
+        size_t dataSize;
+        GUniquePtr<char> data(reinterpret_cast<char*>(webkit_web_resource_get_data_finish(WEBKIT_WEB_RESOURCE(object), result, &dataSize, nullptr)));
+        g_assert_nonnull(data);
+        auto* test = static_cast<ProxyTest*>(userData);
+        GUniquePtr<char> proxyServerPortAsString = test->proxyServerPortAsString();
+        ASSERT_CMP_CSTRING(CString(data.get(), dataSize), ==, proxyServerPortAsString.get());
+        test->quitMainLoop();
+        }, test);
+    g_main_loop_run(test->m_mainLoop);
+
+    // Remove the proxy. Requests to kServer should be received by kServer again.
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, nullptr);
+    mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, serverPortAsString.get());
+
+    // Use a default proxy uri, but ignoring requests to localhost.
+    static const char* ignoreHosts[] = { "localhost", nullptr };
+    settings = webkit_network_proxy_settings_new(test->m_proxyServer.baseURL().string().utf8().data(), ignoreHosts);
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, settings);
+    mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, proxyServerPortAsString.get());
+    GUniquePtr<char> localhostEchoPortURI(g_strdup_printf("http://localhost:%s/echoPort", serverPortAsString.get()));
+    mainResourceData = test->loadURIAndGetMainResourceData(localhostEchoPortURI.get());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, serverPortAsString.get());
+    webkit_network_proxy_settings_free(settings);
+
+    // Remove the proxy again to ensure next test is not using any previous values.
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, nullptr);
+    mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, serverPortAsString.get());
+
+    // Use scheme specific proxy instead of the default.
+    settings = webkit_network_proxy_settings_new(nullptr, nullptr);
+    webkit_network_proxy_settings_add_proxy_for_scheme(settings, "http", test->m_proxyServer.baseURL().string().utf8().data());
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, settings);
+    mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, proxyServerPortAsString.get());
+    webkit_network_proxy_settings_free(settings);
+
+    // Reset to use the default resolver.
+    webkit_network_session_set_proxy_settings(test->m_networkSession.get(), WEBKIT_NETWORK_PROXY_MODE_DEFAULT, nullptr);
+    mainResourceData = test->loadURIAndGetMainResourceData(kServer->getURIForPath("/echoPort").data());
+    ASSERT_CMP_CSTRING(mainResourceData, ==, serverPortAsString.get());
+
+    kServer->removeWebSocketHandler();
+}
+
+void beforeAll()
+{
+    kServer = new WebKitTestServer();
+    kServer->run(serverCallback);
+
+    Test::add("WebKitNetworkSession", "default-session", testNetworkSessionDefault);
+    Test::add("WebKitNetworkSession", "ephemeral", testNetworkSessionEphemeral);
+    ProxyTest::add("WebKitNetworkSession", "proxy", testNetworkSessionProxySettings);
+}
+
+void afterAll()
+{
+    delete kServer;
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
@@ -41,6 +41,7 @@ static void testWebContextDefault(Test* test, gconstpointer)
     g_assert_true(webkit_web_context_get_default() != test->m_webContext.get());
 }
 
+#if !ENABLE(2022_GLIB_API)
 static void testWebContextEphemeral(Test* test, gconstpointer)
 {
     // By default web contexts are not ephemeral.
@@ -78,6 +79,7 @@ static void testWebContextEphemeral(Test* test, gconstpointer)
     context = adoptGRef(webkit_web_context_new_with_website_data_manager(ephemeralManager.get()));
     g_assert_true(webkit_web_context_is_ephemeral(context.get()));
 }
+#endif
 
 static const char* kBarHTML = "<html><body>Bar</body></html>";
 static const char* kEchoHTMLFormat = "<html><body>%s</body></html>";
@@ -768,6 +770,7 @@ public:
 #endif
 };
 
+#if !ENABLE(2022_GLIB_API)
 #if SOUP_CHECK_VERSION(2, 61, 90)
 #if USE(SOUP2)
 static void webSocketServerCallback(SoupServer*, SoupWebsocketConnection*, const char*, SoupClientContext*, gpointer userData)
@@ -881,6 +884,7 @@ static void testWebContextProxySettings(ProxyTest* test, gconstpointer)
     kServer->removeWebSocketHandler();
 #endif
 }
+#endif
 
 class MemoryPressureTest : public WebViewTest {
 public:
@@ -1066,7 +1070,9 @@ void beforeAll()
     kServer->run(serverCallback);
 
     Test::add("WebKitWebContext", "default-context", testWebContextDefault);
+#if !ENABLE(2022_GLIB_API)
     Test::add("WebKitWebContext", "ephemeral", testWebContextEphemeral);
+#endif
     URISchemeTest::add("WebKitWebContext", "uri-scheme", testWebContextURIScheme);
     // FIXME: implement spellchecker in WPE.
 #if PLATFORM(GTK)
@@ -1075,7 +1081,9 @@ void beforeAll()
     WebViewTest::add("WebKitWebContext", "languages", testWebContextLanguages);
     SecurityPolicyTest::add("WebKitSecurityManager", "security-policy", testWebContextSecurityPolicy);
     WebViewTest::add("WebKitSecurityManager", "file-xhr", testWebContextSecurityFileXHR);
+#if !ENABLE(2022_GLIB_API)
     ProxyTest::add("WebKitWebContext", "proxy", testWebContextProxySettings);
+#endif
     MemoryPressureTest::add("WebKitWebContext", "memory-pressure", testMemoryPressureSettings);
     WebViewTest::add("WebKitWebContext", "timezone", testWebContextTimeZoneOverride);
     WebViewTest::add("WebKitWebContext", "timezone-worker", testWebContextTimeZoneOverrideInWorker);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -104,9 +104,12 @@ class WebsiteDataTest : public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(WebsiteDataTest);
 
-
     WebsiteDataTest()
+#if ENABLE(2022_GLIB_API)
+        : m_manager(webkit_network_session_get_website_data_manager(webkit_web_view_get_network_session(m_webView)))
+#else
         : m_manager(webkit_web_context_get_website_data_manager(webkit_web_view_get_context(m_webView)))
+#endif
     {
         g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(m_manager));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_manager));
@@ -160,10 +163,11 @@ public:
     GList* m_dataList { nullptr };
 };
 
-#if !ENABLE(2022_GLIB_API)
 static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
 {
+#if !ENABLE(2022_GLIB_API)
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+#endif
 
     g_assert_cmpstr(webkit_website_data_manager_get_base_data_directory(test->m_manager), ==, Test::dataDirectory());
     g_assert_cmpstr(webkit_website_data_manager_get_base_cache_directory(test->m_manager), ==, Test::dataDirectory());
@@ -172,7 +176,9 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     test->waitUntilLoadFinished();
     test->runJavaScriptAndWaitUntilFinished("window.localStorage.myproperty = 42;", nullptr);
     GUniquePtr<char> localStorageDirectory(g_build_filename(Test::dataDirectory(), "localstorage", nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(localStorageDirectory.get(), ==, webkit_website_data_manager_get_local_storage_directory(test->m_manager));
+#endif
     test->assertFileIsCreated(localStorageDirectory.get());
     g_assert_true(g_file_test(localStorageDirectory.get(), G_FILE_TEST_IS_DIR));
     test->runJavaScriptAndWaitUntilFinished("window.localStorage.clear();", nullptr);
@@ -181,37 +187,51 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     test->waitUntilLoadFinished();
     test->runJavaScriptAndWaitUntilFinished("window.indexedDB.open('TestDatabase');", nullptr);
     GUniquePtr<char> indexedDBDirectory(g_build_filename(Test::dataDirectory(), "databases", "indexeddb", nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(indexedDBDirectory.get(), ==, webkit_website_data_manager_get_indexeddb_directory(test->m_manager));
+#endif
     test->assertFileIsCreated(indexedDBDirectory.get());
     g_assert_true(g_file_test(indexedDBDirectory.get(), G_FILE_TEST_IS_DIR));
 
     test->loadURI(kServer->getURIForPath("/appcache").data());
     test->waitUntilLoadFinished();
     GUniquePtr<char> applicationCacheDirectory(g_build_filename(Test::dataDirectory(), "applications", nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(applicationCacheDirectory.get(), ==, webkit_website_data_manager_get_offline_application_cache_directory(test->m_manager));
+#endif
     GUniquePtr<char> applicationCacheDatabase(g_build_filename(applicationCacheDirectory.get(), "ApplicationCache.db", nullptr));
     test->assertFileIsCreated(applicationCacheDatabase.get());
 
     GUniquePtr<char> diskCacheDirectory(g_build_filename(Test::dataDirectory(), nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(diskCacheDirectory.get(), ==, webkit_website_data_manager_get_disk_cache_directory(test->m_manager));
+#endif
     g_assert_true(g_file_test(diskCacheDirectory.get(), G_FILE_TEST_IS_DIR));
 
     GUniquePtr<char> hstsCacheDirectory(g_build_filename(Test::dataDirectory(), nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(hstsCacheDirectory.get(), ==, webkit_website_data_manager_get_hsts_cache_directory(test->m_manager));
+#endif
     g_assert_true(g_file_test(hstsCacheDirectory.get(), G_FILE_TEST_IS_DIR));
 
+#if !ENABLE(2022_GLIB_API)
     GUniquePtr<char> itpDirectory(g_build_filename(Test::dataDirectory(), "itp", nullptr));
     g_assert_cmpstr(itpDirectory.get(), ==, webkit_website_data_manager_get_itp_directory(test->m_manager));
+#endif
 
     test->runJavaScriptAndWaitUntilFinished("navigator.serviceWorker.register('./some-dummy.js');", nullptr);
     GUniquePtr<char> swRegistrationsDirectory(g_build_filename(Test::dataDirectory(), "serviceworkers", nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(swRegistrationsDirectory.get(), ==, webkit_website_data_manager_get_service_worker_registrations_directory(test->m_manager));
+#endif
     test->assertFileIsCreated(swRegistrationsDirectory.get());
     g_assert_true(g_file_test(swRegistrationsDirectory.get(), G_FILE_TEST_IS_DIR));
 
     test->runJavaScriptAndWaitUntilFinished("let domCacheOpened = false; caches.open('my-cache').then(() => { domCacheOpened = true});", nullptr);
     GUniquePtr<char> domCacheDirectory(g_build_filename(Test::dataDirectory(), "CacheStorage", nullptr));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(domCacheDirectory.get(), ==, webkit_website_data_manager_get_dom_cache_directory(test->m_manager));
+#endif
     test->assertFileIsCreated(domCacheDirectory.get());
     g_assert_true(g_file_test(domCacheDirectory.get(), G_FILE_TEST_IS_DIR));
 
@@ -226,10 +246,17 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     test->clear(persistentCaches, 0);
     g_assert_null(test->fetch(persistentCaches));
 
-    // The default context should have a different manager with different configuration.
-    WebKitWebsiteDataManager* defaultManager = webkit_web_context_get_website_data_manager(webkit_web_context_get_default());
+    // The default context or session should have a different manager with different configuration.
+#if ENABLE(2022_GLIB_API)
+    auto* defaultManager = webkit_network_session_get_website_data_manager(webkit_network_session_get_default());
+#else
+    auto* defaultManager = webkit_web_context_get_website_data_manager(webkit_web_context_get_default());
+#endif
     g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(defaultManager));
     g_assert_true(test->m_manager != defaultManager);
+    g_assert_cmpstr(webkit_website_data_manager_get_base_data_directory(test->m_manager), !=, webkit_website_data_manager_get_base_data_directory(defaultManager));
+    g_assert_cmpstr(webkit_website_data_manager_get_base_cache_directory(test->m_manager), !=, webkit_website_data_manager_get_base_cache_directory(defaultManager));
+#if !ENABLE(2022_GLIB_API)
     g_assert_cmpstr(webkit_website_data_manager_get_local_storage_directory(test->m_manager), !=, webkit_website_data_manager_get_local_storage_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_indexeddb_directory(test->m_manager), !=, webkit_website_data_manager_get_indexeddb_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_disk_cache_directory(test->m_manager), !=, webkit_website_data_manager_get_disk_cache_directory(defaultManager));
@@ -238,7 +265,9 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_manager_get_itp_directory(test->m_manager), !=, webkit_website_data_manager_get_itp_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_service_worker_registrations_directory(test->m_manager), !=, webkit_website_data_manager_get_service_worker_registrations_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_dom_cache_directory(test->m_manager), !=, webkit_website_data_manager_get_dom_cache_directory(defaultManager));
+#endif
 
+#if !ENABLE(2022_GLIB_API)
     // Any specific configuration provided takes precedence over base dirs.
     indexedDBDirectory.reset(g_build_filename(Test::dataDirectory(), "mycustomindexeddb", nullptr));
     applicationCacheDirectory.reset(g_build_filename(Test::dataDirectory(), "mycustomappcache", nullptr));
@@ -258,8 +287,8 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_manager_get_disk_cache_directory(baseDataManager.get()), ==, diskCacheDirectory.get());
 
     ALLOW_DEPRECATED_DECLARATIONS_END
-}
 #endif
+}
 
 static void ephemeralViewloadChanged(WebKitWebView* webView, WebKitLoadEvent loadEvent, WebViewTest* test)
 {
@@ -271,8 +300,13 @@ static void ephemeralViewloadChanged(WebKitWebView* webView, WebKitLoadEvent loa
 
 static void testWebsiteDataEphemeral(WebViewTest* test, gconstpointer)
 {
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitNetworkSession> session = adoptGRef(webkit_network_session_new_ephemeral());
+    GRefPtr<WebKitWebsiteDataManager> manager = webkit_network_session_get_website_data_manager(session.get());
+#else
     GRefPtr<WebKitWebsiteDataManager> manager = adoptGRef(webkit_website_data_manager_new_ephemeral());
     g_assert_true(webkit_website_data_manager_is_ephemeral(manager.get()));
+#endif
     g_assert_null(webkit_website_data_manager_get_base_data_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_base_cache_directory(manager.get()));
 
@@ -286,22 +320,35 @@ static void testWebsiteDataEphemeral(WebViewTest* test, gconstpointer)
     g_assert_null(webkit_website_data_manager_get_itp_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_service_worker_registrations_directory(manager.get()));
     ALLOW_DEPRECATED_DECLARATIONS_END
-#endif
 
     // Configuration is ignored when is-ephemeral is used.
     manager = adoptGRef(WEBKIT_WEBSITE_DATA_MANAGER(g_object_new(WEBKIT_TYPE_WEBSITE_DATA_MANAGER, "base-data-directory", Test::dataDirectory(), "is-ephemeral", TRUE, nullptr)));
     g_assert_true(webkit_website_data_manager_is_ephemeral(manager.get()));
     g_assert_null(webkit_website_data_manager_get_base_data_directory(manager.get()));
+#endif
 
+#if ENABLE(2022_GLIB_API)
+    webkit_network_session_set_itp_enabled(session.get(), TRUE);
+    g_assert_true(webkit_network_session_get_itp_enabled(session.get()));
+#else
     webkit_website_data_manager_set_itp_enabled(manager.get(), TRUE);
-    g_assert(webkit_website_data_manager_get_itp_enabled(manager.get()));
+    g_assert_true(webkit_website_data_manager_get_itp_enabled(manager.get()));
+#endif
 
     // Non persistent data can be queried in an ephemeral manager.
+#if ENABLE(2022_GLIB_API)
+    auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+        "web-context", webkit_web_view_get_context(test->m_webView),
+        "network-session", session.get(),
+        nullptr));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == session.get());
+#else
     GRefPtr<WebKitWebContext> webContext = adoptGRef(webkit_web_context_new_with_website_data_manager(manager.get()));
     g_assert_true(webkit_web_context_is_ephemeral(webContext.get()));
     auto webView = Test::adoptView(Test::createWebView(webContext.get()));
     g_assert_true(webkit_web_view_is_ephemeral(webView.get()));
     g_assert_true(webkit_web_view_get_website_data_manager(webView.get()) == manager.get());
+#endif
 
     g_signal_connect(webView.get(), "load-changed", G_CALLBACK(ephemeralViewloadChanged), test);
     webkit_web_view_load_uri(webView.get(), kServer->getURIForPath("/empty").data());
@@ -325,7 +372,11 @@ static void testWebsiteDataEphemeral(WebViewTest* test, gconstpointer)
     }, test);
     g_main_loop_run(test->m_mainLoop);
 
+#if ENABLE(2022_GLIB_API)
+    webkit_network_session_set_itp_enabled(session.get(), FALSE);
+#else
     webkit_website_data_manager_set_itp_enabled(manager.get(), FALSE);
+#endif
 }
 
 static void testWebsiteDataCache(WebsiteDataTest* test, gconstpointer)
@@ -682,31 +733,37 @@ static void testWebsiteDataDeviceIdHashSalt(WebsiteDataTest* test, gconstpointer
     webkit_settings_set_enable_mock_capture_devices(settings, enabled);
 }
 
-#if !ENABLE(2022_GLIB_API)
 static void testWebsiteDataITP(WebsiteDataTest* test, gconstpointer)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    const char* itpDirectory = webkit_website_data_manager_get_itp_directory(test->m_manager);
-    ALLOW_DEPRECATED_DECLARATIONS_END
-    GUniquePtr<char> itpDatabaseFile(g_build_filename(itpDirectory, "observations.db", nullptr));
+    GUniquePtr<char> itpDirectory(g_build_filename(Test::dataDirectory(), "itp", nullptr));
+    GUniquePtr<char> itpDatabaseFile(g_build_filename(itpDirectory.get(), "observations.db", nullptr));
 
     // Delete any previous data.
     g_unlink(itpDatabaseFile.get());
-    g_rmdir(itpDirectory);
+    g_rmdir(itpDirectory.get());
 
+#if ENABLE(2022_GLIB_API)
+    g_assert_false(webkit_network_session_get_itp_enabled(test->m_networkSession.get()));
+#else
     g_assert_false(webkit_website_data_manager_get_itp_enabled(test->m_manager));
+#endif
     test->loadURI(kServer->getURIForPath("/empty").data());
     test->waitUntilLoadFinished();
 
+#if ENABLE(2022_GLIB_API)
+    webkit_network_session_set_itp_enabled(test->m_networkSession.get(), TRUE);
+    g_assert_true(webkit_network_session_get_itp_enabled(test->m_networkSession.get()));
+#else
     webkit_website_data_manager_set_itp_enabled(test->m_manager, TRUE);
     g_assert_true(webkit_website_data_manager_get_itp_enabled(test->m_manager));
-    g_assert_false(g_file_test(itpDirectory, G_FILE_TEST_IS_DIR));
+#endif
+    g_assert_false(g_file_test(itpDirectory.get(), G_FILE_TEST_IS_DIR));
     g_assert_false(g_file_test(itpDatabaseFile.get(), G_FILE_TEST_IS_REGULAR));
 
     test->loadURI(kServer->getURIForPath("/empty").data());
     test->waitUntilLoadFinished();
     test->assertFileIsCreated(itpDatabaseFile.get());
-    g_assert_true(g_file_test(itpDirectory, G_FILE_TEST_IS_DIR));
+    g_assert_true(g_file_test(itpDirectory.get(), G_FILE_TEST_IS_DIR));
     g_assert_true(g_file_test(itpDatabaseFile.get(), G_FILE_TEST_IS_REGULAR));
 
     // Give some time for the database to be updated.
@@ -731,12 +788,16 @@ static void testWebsiteDataITP(WebsiteDataTest* test, gconstpointer)
     static const WebKitWebsiteDataTypes cacheAndITP = static_cast<WebKitWebsiteDataTypes>(WEBKIT_WEBSITE_DATA_ITP | WEBKIT_WEBSITE_DATA_MEMORY_CACHE | WEBKIT_WEBSITE_DATA_DISK_CACHE);
     test->clear(cacheAndITP, 0);
 
+#if ENABLE(2022_GLIB_API)
+    webkit_network_session_set_itp_enabled(test->m_networkSession.get(), FALSE);
+    g_assert_false(webkit_network_session_get_itp_enabled(test->m_networkSession.get()));
+#else
     webkit_website_data_manager_set_itp_enabled(test->m_manager, FALSE);
     g_assert_false(webkit_website_data_manager_get_itp_enabled(test->m_manager));
-
-    g_rmdir(itpDirectory);
-}
 #endif
+
+    g_rmdir(itpDirectory.get());
+}
 
 static void testWebsiteDataServiceWorkerRegistrations(WebsiteDataTest* test, gconstpointer)
 {
@@ -814,13 +875,21 @@ public:
         webkit_memory_pressure_settings_set_kill_threshold(settings, 1);
         webkit_memory_pressure_settings_set_strict_threshold(settings, 0.75);
         webkit_memory_pressure_settings_set_conservative_threshold(settings, 0.5);
+#if ENABLE(2022_GLIB_API)
+        webkit_network_session_set_memory_pressure_settings(settings);
+#else
         webkit_website_data_manager_set_memory_pressure_settings(settings);
+#endif
         webkit_memory_pressure_settings_free(settings);
     }
 
     static void teardown()
     {
+#if ENABLE(2022_GLIB_API)
+        webkit_network_session_set_memory_pressure_settings(nullptr);
+#else
         webkit_website_data_manager_set_memory_pressure_settings(nullptr);
+#endif
     }
 
     static gboolean loadFailedCallback(WebKitWebView* webView, WebKitLoadEvent loadEvent, const char* failingURI, GError* error, MemoryPressureTest* test)
@@ -859,9 +928,7 @@ void beforeAll()
     prepopulateHstsData();
 #endif
 
-#if !ENABLE(2022_GLIB_API)
     WebsiteDataTest::add("WebKitWebsiteData", "configuration", testWebsiteDataConfiguration);
-#endif
     WebViewTest::add("WebKitWebsiteData", "ephemeral", testWebsiteDataEphemeral);
     WebsiteDataTest::add("WebKitWebsiteData", "cache", testWebsiteDataCache);
     WebsiteDataTest::add("WebKitWebsiteData", "storage", testWebsiteDataStorage);
@@ -872,10 +939,7 @@ void beforeAll()
     WebsiteDataTest::add("WebKitWebsiteData", "hsts", testWebsiteDataHsts);
 #endif
     WebsiteDataTest::add("WebKitWebsiteData", "deviceidhashsalt", testWebsiteDataDeviceIdHashSalt);
-#if !ENABLE(2022_GLIB_API)
-    // FIXME: find a way to test this without deprecated API.
     WebsiteDataTest::add("WebKitWebsiteData", "itp", testWebsiteDataITP);
-#endif
     WebsiteDataTest::add("WebKitWebsiteData", "service-worker-registrations", testWebsiteDataServiceWorkerRegistrations);
     WebsiteDataTest::add("WebKitWebsiteData", "dom-cache", testWebsiteDataDOMCache);
     MemoryPressureTest::add("WebKitWebsiteData", "memory-pressure", testMemoryPressureSettings);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestAutocleanups.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestAutocleanups.cpp
@@ -36,9 +36,15 @@ static void testUIProcessAutocleanups(WebViewTest* test, gconstpointer)
     g_assert_true(WEBKIT_IS_WEB_CONTEXT(context));
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context));
 
+#if ENABLE(2022_GLIB_API)
+    g_autoptr(WebKitNetworkSession) session = webkit_network_session_new(nullptr, nullptr);
+    g_assert_true(WEBKIT_IS_NETWORK_SESSION(session));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(session));
+#else
     g_autoptr(WebKitWebsiteDataManager) manager = webkit_website_data_manager_new(nullptr);
     g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(context));
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(manager));
+#endif
 
     g_autoptr(WebKitUserScript) userScript = webkit_user_script_new("",
         WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES, WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START,

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -144,6 +144,7 @@ ADD_WK2_TEST_WEB_EXTENSION(WebProcessTest ${WebKitGLibAPIWebProcessTests})
 ADD_WK2_TEST(TestAuthentication ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp)
 ADD_WK2_TEST(TestAutomationSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp)
 ADD_WK2_TEST(TestBackForwardList ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp)
+ADD_WK2_TEST(TestCookieManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp)
 ADD_WK2_TEST(TestDownloads ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp)
 ADD_WK2_TEST(TestWebKitFindController ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp)
 ADD_WK2_TEST(TestEditor ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestEditor.cpp)
@@ -168,9 +169,8 @@ ADD_WK2_TEST(TestDOMElement ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestDOME
 ADD_WK2_TEST(TestGeolocationManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp)
 ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp)
 
-# FIXME: Enable for WPE and GTK4
-if (PORT STREQUAL "GTK" AND NOT USE_GTK4)
-    ADD_WK2_TEST(TestCookieManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp)
+if (ENABLE_2022_GLIB_API)
+    ADD_WK2_TEST(TestWebKitNetworkSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp)
 endif ()
 
 macro(ADD_WPE_QT_TEST test_name)

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
@@ -127,6 +127,8 @@ int main(int argc, char** argv)
     g_set_prgname(FileSystem::currentExecutableName().data());
     g_setenv("WEBKIT_EXEC_PATH", WEBKIT_EXEC_PATH, FALSE);
     g_setenv("WEBKIT_INJECTED_BUNDLE_PATH", WEBKIT_INJECTED_BUNDLE_PATH, FALSE);
+    // Sandbox requires using GApplication.
+    g_setenv("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1", TRUE);
     g_setenv("LC_ALL", "C", TRUE);
     g_setenv("GIO_USE_VFS", "local", TRUE);
     g_setenv("GSETTINGS_BACKEND", "memory", TRUE);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
@@ -52,13 +52,21 @@ void WebViewTest::initializeWebView()
 {
     g_assert_null(m_webView);
 
+#if ENABLE(2022_GLIB_API)
+    GRefPtr<WebKitNetworkSession> networkSession = shouldCreateEphemeralWebView ? adoptGRef(webkit_network_session_new_ephemeral()) : m_networkSession;
+#endif
+
     m_webView = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
 #if PLATFORM(WPE)
         "backend", Test::createWebViewBackend(),
 #endif
         "web-context", m_webContext.get(),
         "user-content-manager", m_userContentManager.get(),
+#if ENABLE(2022_GLIB_API)
+        "network-session", networkSession.get(),
+#else
         "is-ephemeral", shouldCreateEphemeralWebView,
+#endif
         nullptr));
 
     platformInitializeWebView();


### PR DESCRIPTION
#### 2d1b53b211b43047b94b7d2ef8a3907f00e724fb
<pre>
[WPE][GTK] Move network session APIs to a new WebKitNetworkSession class
<a href="https://bugs.webkit.org/show_bug.cgi?id=222366">https://bugs.webkit.org/show_bug.cgi?id=222366</a>

Reviewed by Michael Catanzaro.

Add new WebKitNetworkSession class to expose all the networking APIs
that were part of WebKitWebContext and WebKitWebsiteDataManager. Also
switch to use a single global network process.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::IconDatabase):
* Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
(webkitAutomationSessionCreate):
* Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp: Added.
(_WebKitNetworkSessionPrivate::_WebKitNetworkSessionPrivate):
(webkitNetworkSessionGetProperty):
(webkitNetworkSessionSetProperty):
(webkitNetworkSessionConstructed):
(webkit_network_session_class_init):
(webkitNetworkSessionDownloadStarted):
(createDefaultNetworkSession):
(webkit_network_session_get_default):
(webkit_network_session_new):
(webkit_network_session_new_ephemeral):
(webkit_network_session_is_ephemeral):
(webkit_network_session_get_website_data_manager):
(webkit_network_session_get_cookie_manager):
(webkit_network_session_set_itp_enabled):
(webkit_network_session_get_itp_enabled):
(webkit_network_session_set_persistent_credential_storage_enabled):
(webkit_network_session_get_persistent_credential_storage_enabled):
(webkit_network_session_set_tls_errors_policy):
(webkit_network_session_get_tls_errors_policy):
(webkit_network_session_allow_tls_certificate_for_host):
(webkit_network_session_set_proxy_settings):
(webkit_network_session_set_memory_pressure_settings):
(webkit_network_session_get_itp_summary):
(webkit_network_session_get_itp_summary_finish):
(webkit_network_session_prefetch_dns):
(webkit_network_session_download_uri):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSessionPrivate.h: Copied from Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h.
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextGetNetworkSessionForAutomation):
(webkitWebContextGetProperty):
(webkitWebContextSetProperty):
(webkitWebContextConstructed):
(webkitWebContextDispose):
(webkit_web_context_class_init):
(webkit_web_context_set_network_proxy_settings):
(webkit_web_context_prefetch_dns):
(webkitWebContextCreatePageForWebView):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebContextPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewIsEphemeral):
(webkitWebViewGetFaviconDatabase):
(webkitWebViewRequestFavicon):
(webkitWebViewWatchForChangesInFavicon):
(webkitWebViewConstructed):
(webkitWebViewSetProperty):
(webkitWebViewGetProperty):
(webkitWebViewDispose):
(webkit_web_view_class_init):
(webkitWebViewLoadChanged):
(webkitWebViewLoadFailedWithTLSErrors):
(webkitWebViewGetLoadDecisionForIcon):
(webkitWebViewSetIcon):
(webkitWebViewHandleAuthenticationChallenge):
(webkitWebViewGetWebsiteDataManager):
(webkit_web_view_get_network_session):
(webkitWebViewDisconnectFaviconDatabaseSignalHandlers): Deleted.
(webkit_web_view_download_uri): Deleted.
(webkit_web_view_get_tls_info): Deleted.
(webkit_web_view_get_snapshot): Deleted.
(webkit_web_view_get_snapshot_finish): Deleted.
(webkitWebViewWebProcessTerminated): Deleted.
(webkit_web_view_is_editable): Deleted.
(webkit_web_view_set_editable): Deleted.
(webkit_web_view_get_editor_state): Deleted.
(webkit_web_view_get_session_state): Deleted.
(webkit_web_view_restore_session_state): Deleted.
(webkit_web_view_add_frame_displayed_callback): Deleted.
(webkit_web_view_remove_frame_displayed_callback): Deleted.
(webkit_web_view_send_message_to_page): Deleted.
(webkit_web_view_send_message_to_page_finish): Deleted.
(webkit_web_view_set_input_method_context): Deleted.
(webkit_web_view_get_input_method_context): Deleted.
(webkit_web_view_get_website_policies): Deleted.
(webkitWebViewSetIsWebProcessResponsive): Deleted.
(webkit_web_view_get_is_web_process_responsive): Deleted.
(webkit_web_view_terminate_web_process): Deleted.
(webkit_web_view_set_cors_allowlist): Deleted.
(webkitWebViewConfigureMediaCapture): Deleted.
(webkit_web_view_get_camera_capture_state): Deleted.
(webkit_web_view_set_camera_capture_state): Deleted.
(webkit_web_view_get_microphone_capture_state): Deleted.
(webkit_web_view_set_microphone_capture_state): Deleted.
(webkit_web_view_get_display_capture_state): Deleted.
(webkit_web_view_set_display_capture_state): Deleted.
(webkitWebViewForceRepaintForTesting): Deleted.
(webkitSetCachedProcessSuspensionDelayForTesting): Deleted.
(webkit_web_view_get_web_extension_mode): Deleted.
(webkit_web_view_get_default_content_security_policy): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkitWebsiteDataManagerConstructed):
(webkit_website_data_manager_class_init):
(webkitWebsiteDataManagerGetDataStore):
(webkitWebsiteDataManagerCreate):
(webkit_website_data_manager_get_dom_cache_directory):
(webkitWebsiteDataManagerGetFaviconDatabasePath):
(webkit_website_data_manager_set_favicons_enabled):
(webkit_website_data_manager_get_favicons_enabled):
(webkit_website_data_manager_get_favicon_database):
(webkitITPThirdPartyCreate):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp:
(webkit_web_view_new_with_context):
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
(webkit_web_view_new_with_context):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::networkProcessForSession):
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(tlsErrorsDialogResponse):
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(webViewTitleChanged):
(downloadStarted):
(webViewCreate):
(webViewDecidePolicy):
(newTabCallback):
(openPrivateWindow):
(browserWindowFinalize):
(browser_window_new):
(browser_window_get_network_session):
(browser_window_load_session):
(browser_window_get_or_create_web_view_for_automation):
* Tools/MiniBrowser/gtk/BrowserWindow.h:
* Tools/MiniBrowser/gtk/main.c:
(createBrowserTab):
(aboutDataScriptMessageReceivedCallback):
(aboutDataHandleRequest):
(aboutITPHandleRequest):
(aboutURISchemeRequestCallback):
(activate):
* Tools/MiniBrowser/wpe/main.cpp:
(activate):
(main):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp:
(testWebViewAuthenticationStorage):
(ProxyAuthenticationTest::ProxyAuthenticationTest):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp:
(testCookieManagerAcceptPolicy):
(testCookieManagerEphemeral):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp:
(testDownloadEphemeralContext):
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp:
(testSSL):
(testInsecureContent):
(testTLSErrorsPolicy):
(testTLSErrorsRedirect):
(testTLSErrorsHTTPAuth):
(testLoadFailedWithTLSErrors):
(testSubresourceLoadFailedWithTLSErrors):
(testWebSocketTLSErrors):
(testTLSErrorsEphemeral):
(testClientSideCertificate):
(testWebSocketClientSideCertificate):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseInitialization):
(testFaviconDatabaseGetFavicon):
(testFaviconDatabaseEphemeral):
(testFaviconDatabaseClear):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp: Added.
(testNetworkSessionDefault):
(testNetworkSessionEphemeral):
(serverCallback):
(ProxyTest::webSocketProxyServerCallback):
(ProxyTest::ProxyTest):
(ProxyTest::loadURIAndGetMainResourceData):
(ProxyTest::proxyServerPortAsString):
(ProxyTest::webSocketConnected):
(ProxyTest::createWebSocketAndWaitUntilConnected):
(webSocketServerCallback):
(ephemeralViewloadChanged):
(testNetworkSessionProxySettings):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewEphemeral):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(WebsiteDataTest::WebsiteDataTest):
(testWebsiteDataConfiguration):
(testWebsiteDataEphemeral):
(testWebsiteDataITP):
(MemoryPressureTest::setup):
(MemoryPressureTest::teardown):
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestAutocleanups.cpp:
(testUIProcessAutocleanups):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp:
(main):
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::Test):
(Test::~Test):
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp:
(WebViewTest::initializeWebView):

Canonical link: <a href="https://commits.webkit.org/259433@main">https://commits.webkit.org/259433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/649d4a75faede98ce0709319dcad0c8444997846

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104878 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114146 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174338 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4882 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113169 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39178 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7302 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7397 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47198 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9187 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3455 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->