### PR TITLE
Web Inspector: Add emulation toggles for forced-colors

### DIFF
--- a/LayoutTests/inspector/page/overrideUserPreference-expected.txt
+++ b/LayoutTests/inspector/page/overrideUserPreference-expected.txt
@@ -41,3 +41,16 @@ Removing PrefersColorScheme override
 PASS: (prefers-color-scheme: dark) media query does not match.
 PASS: --test-prefers-color-scheme: light
 
+-- Running test case: Page.overrideUserPreference.ForcedColors
+PASS: (forced-colors: active) media query does not match.
+PASS: --test-forced-colors: none
+Overriding ForcedColors value to Active
+PASS: (forced-colors: active) media query matches.
+PASS: --test-forced-colors: active
+Overriding ForcedColors value to None
+PASS: (forced-colors: active) media query does not match.
+PASS: --test-forced-colors: none
+Removing ForcedColors override
+PASS: (forced-colors: active) media query does not match.
+PASS: --test-forced-colors: none
+

--- a/LayoutTests/inspector/page/overrideUserPreference.html
+++ b/LayoutTests/inspector/page/overrideUserPreference.html
@@ -24,7 +24,6 @@ function test()
                 InspectorTest.expectTrue(matches, `${mediaQuery} media query matches.`);
             else
                 InspectorTest.expectFalse(matches, `${mediaQuery} media query does not match.`);
-
             InspectorTest.expectEqual(value, expectedValue, `${cssPropertyName}: ${expectedValue}`);
         }
     }
@@ -136,6 +135,41 @@ function test()
         },
     });
 
+    suite.addTestCase({
+        name: "Page.overrideUserPreference.ForcedColors",
+        description: "",
+        async test() {
+            let cssPropertyName = "--test-forced-colors";
+            let mediaQuery = "(forced-colors: active)";
+            let testCases = [
+                {
+                    expectedValue: "none",
+                    expectedMatchMedia: false,
+                },
+                {
+                    preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.ForcedColors,
+                    preferenceValue: InspectorBackend.Enum.Page.UserPreferenceValue.Active,
+                    expectedValue: "active",
+                    expectedMatchMedia: true,
+                },
+                {
+                    preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.ForcedColors,
+                    preferenceValue: InspectorBackend.Enum.Page.UserPreferenceValue.None,
+                    expectedValue: "none",
+                    expectedMatchMedia: false,
+                },
+                {
+                    preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.ForcedColors,
+                    preferenceValue: null,
+                    expectedValue: "none",
+                    expectedMatchMedia: false,
+                },
+            ];
+
+            await testOverridePreference({cssPropertyName, mediaQuery, testCases});
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 
@@ -149,6 +183,7 @@ function test()
         --test-prefers-reduced-motion: no-preference;
         --test-prefers-contrast: no-preference;
         --test-prefers-color-scheme: light;
+        --test-forced-colors: none;
     }
 
     @media (prefers-reduced-motion) {
@@ -166,6 +201,12 @@ function test()
     @media (prefers-color-scheme: dark) {
         body {
             --test-prefers-color-scheme: dark;
+        }
+    }
+
+    @media (forced-colors: active) {
+        body {
+            --test-forced-colors: active;
         }
     }
     </style>

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -36,13 +36,13 @@
         {
             "id": "UserPreferenceName",
             "type": "string",
-            "enum": ["PrefersReducedMotion", "PrefersContrast", "PrefersColorScheme"],
+            "enum": ["PrefersReducedMotion", "PrefersContrast", "PrefersColorScheme", "ForcedColors"],
             "description": "User preference name."
         },
         {
             "id": "UserPreferenceValue",
             "type": "string",
-            "enum": ["NoPreference", "Reduce", "More", "Light", "Dark"],
+            "enum": ["NoPreference", "Reduce", "More", "Light", "Dark", "Active", "None"],
             "description": "User preference value."
         },
         {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -160,6 +160,7 @@ private:
     void overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersColorScheme(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
+    void overrideForcedColors(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
 
     Ref<Inspector::Protocol::Page::Frame> buildObjectForFrame(Frame*);
     Ref<Inspector::Protocol::Page::FrameResourceTree> buildObjectForFrameTree(Frame*);

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -159,6 +159,13 @@ ForcedDisplayIsMonochromeAccessibilityValue:
     WebCore:
       default: ForcedAccessibilityValue::System
 
+ForcedForcedColorsAccessibilityValue:
+  type: uint32_t
+  refinedType: ForcedAccessibilityValue
+  defaultValue:
+    WebCore:
+      default: ForcedAccessibilityValue::System
+
 ForcedPrefersContrastAccessibilityValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -59,6 +59,7 @@ InternalSettings::Backup::Backup(Settings& settings)
     , m_forcedDisplayIsMonochromeAccessibilityValue(settings.forcedDisplayIsMonochromeAccessibilityValue())
     , m_forcedPrefersContrastAccessibilityValue(settings.forcedPrefersContrastAccessibilityValue())
     , m_forcedPrefersReducedMotionAccessibilityValue(settings.forcedPrefersReducedMotionAccessibilityValue())
+    , m_forcedForcedColorsAccessibilityValue(settings.forcedForcedColorsAccessibilityValue())
     , m_fontLoadTimingOverride(settings.fontLoadTimingOverride())
     , m_fetchAPIKeepAliveAPIEnabled(DeprecatedGlobalSettings::fetchAPIKeepAliveEnabled())
     , m_customPasteboardDataEnabled(DeprecatedGlobalSettings::customPasteboardDataEnabled())
@@ -113,6 +114,7 @@ void InternalSettings::Backup::restoreTo(Settings& settings)
     settings.setForcedDisplayIsMonochromeAccessibilityValue(m_forcedDisplayIsMonochromeAccessibilityValue);
     settings.setForcedPrefersContrastAccessibilityValue(m_forcedPrefersContrastAccessibilityValue);
     settings.setForcedPrefersReducedMotionAccessibilityValue(m_forcedPrefersReducedMotionAccessibilityValue);
+    settings.setForcedForcedColorsAccessibilityValue(m_forcedForcedColorsAccessibilityValue);
     settings.setFontLoadTimingOverride(m_fontLoadTimingOverride);
 
     DeprecatedGlobalSettings::setFetchAPIKeepAliveEnabled(m_fetchAPIKeepAliveAPIEnabled);
@@ -396,6 +398,16 @@ InternalSettings::ForcedAccessibilityValue InternalSettings::forcedPrefersReduce
 void InternalSettings::setForcedPrefersReducedMotionAccessibilityValue(InternalSettings::ForcedAccessibilityValue value)
 {
     settings().setForcedPrefersReducedMotionAccessibilityValue(value);
+}
+
+InternalSettings::ForcedAccessibilityValue InternalSettings::forcedForcedColorsAccessibilityValue() const
+{
+    return settings().forcedForcedColorsAccessibilityValue();
+}
+
+void InternalSettings::setForcedForcedColorsAccessibilityValue(InternalSettings::ForcedAccessibilityValue value)
+{
+    settings().setForcedForcedColorsAccessibilityValue(value);
 }
 
 InternalSettings::ForcedAccessibilityValue InternalSettings::forcedSupportsHighDynamicRangeValue() const

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -83,6 +83,8 @@ public:
     void setForcedPrefersContrastAccessibilityValue(ForcedAccessibilityValue);
     ForcedAccessibilityValue forcedPrefersReducedMotionAccessibilityValue() const;
     void setForcedPrefersReducedMotionAccessibilityValue(ForcedAccessibilityValue);
+    ForcedAccessibilityValue forcedForcedColorsAccessibilityValue() const;
+    void setForcedForcedColorsAccessibilityValue(ForcedAccessibilityValue);
     ForcedAccessibilityValue forcedSupportsHighDynamicRangeValue() const;
     void setForcedSupportsHighDynamicRangeValue(ForcedAccessibilityValue);
 
@@ -155,6 +157,7 @@ private:
         WebCore::ForcedAccessibilityValue m_forcedDisplayIsMonochromeAccessibilityValue;
         WebCore::ForcedAccessibilityValue m_forcedPrefersContrastAccessibilityValue;
         WebCore::ForcedAccessibilityValue m_forcedPrefersReducedMotionAccessibilityValue;
+        WebCore::ForcedAccessibilityValue m_forcedForcedColorsAccessibilityValue;
         WebCore::FontLoadTimingOverride m_fontLoadTimingOverride;
 
         // DeprecatedGlobalSettings

--- a/Source/WebCore/testing/InternalSettings.idl
+++ b/Source/WebCore/testing/InternalSettings.idl
@@ -60,6 +60,7 @@ enum UserInterfaceDirectionPolicy { "Content", "System" };
     attribute ForcedAccessibilityValue forcedDisplayIsMonochromeAccessibilityValue;
     attribute ForcedAccessibilityValue forcedPrefersContrastAccessibilityValue;
     attribute ForcedAccessibilityValue forcedPrefersReducedMotionAccessibilityValue;
+    attribute ForcedAccessibilityValue forcedForcedColorsAccessibilityValue;
     attribute ForcedAccessibilityValue forcedSupportsHighDynamicRangeValue;
 
     // DeprecatedGlobalSettings.

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -114,6 +114,8 @@ localizedStrings["Accessibility @ User Preferences Overrides"] = "Accessibility"
 localizedStrings["Action"] = "Action";
 /* Tooltip for a time range bar that represents when a CSS animation/transition is running */
 localizedStrings["Active"] = "Active";
+/* Label for a preference that is turned active. */
+localizedStrings["Active @ User Preferences Overrides"] = "Active";
 localizedStrings["Ad Click Attribution Debug Mode"] = "Ad Click Attribution Debug Mode";
 localizedStrings["Add"] = "Add";
 localizedStrings["Add %s Rule"] = "Add %s Rule";
@@ -737,6 +739,8 @@ localizedStrings["Font was synthesized to be bold because no bold font is availa
 localizedStrings["Font was synthesized to be oblique because no oblique font is available."] = "Font was synthesized to be oblique because no oblique font is available.";
 localizedStrings["Fonts"] = "Fonts";
 localizedStrings["Force print media styles"] = "Force print media styles";
+/* Label for input to override the preference for forced-colors. */
+localizedStrings["Forced colors @ User Preferences Overrides"] = "Forced colors";
 /* Layout phase records that were imperative (forced) */
 localizedStrings["Forced Layout"] = "Forced Layout";
 /* A context menu item to force (override) a DOM node's pseudo-classes */
@@ -1091,6 +1095,8 @@ localizedStrings["Node"] = "Node";
 localizedStrings["Node Removed @ DOM Breakpoint"] = "Node Removed";
 localizedStrings["Nodes"] = "Nodes";
 localizedStrings["None"] = "None";
+/* Label for a preference that is turned none. */
+localizedStrings["None @ User Preferences Overrides"] = "None";
 /* Property value for any `normal` CSS value. */
 localizedStrings["Normal @ Font Details Sidebar Property Value"] = "Normal";
 localizedStrings["Not found"] = "Not found";

--- a/Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js
@@ -168,6 +168,17 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
                 defaultValue: WI.CSSManager.UserPreferenceDefaultValue,
             });
 
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): `PrefersContrast` value for `Page.UserPreferenceName` did not exist yet.
+        if (InspectorBackend.Enum.Page?.UserPreferenceName?.ForcedColors)
+            this._createSelectElement({
+                contentElement,
+                id: "override-forced-colors",
+                label: WI.UIString("Forced Colors", "Forced colors @ User Preferences Overrides", "Label for input to override the preference for forced colors."),
+                preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.ForcedColors,
+                preferenceValues: [InspectorBackend.Enum.Page.UserPreferenceValue.Active, InspectorBackend.Enum.Page.UserPreferenceValue.None],
+                defaultValue: WI.CSSManager.UserPreferenceDefaultValue,
+            });
+
         return contentElement;
     }
 
@@ -181,6 +192,10 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
             return WI.UIString("On", "On @ User Preferences Overrides", "Label for a preference that is turned on.");
         case InspectorBackend.Enum.Page.UserPreferenceValue?.NoPreference:
             return WI.UIString("Off", "Off @ User Preferences Overrides", "Label for a preference that is turned off.");
+        case InspectorBackend.Enum.Page.UserPreferenceValue?.Active:
+            return WI.UIString("Active", "Active @ User Preferences Overrides", "Label for a preference that is active.");
+        case InspectorBackend.Enum.Page.UserPreferenceValue?.None:
+            return WI.UIString("None", "None @ User Preferences Overrides", "Label for a preference that is none.");
         case InspectorBackend.Enum.Page.UserPreferenceValue?.Light:
         case WI.CSSManager.Appearance.Light:
             return WI.UIString("Light", "Light @ User Preferences Overrides", "Label for the light color scheme preference.");


### PR DESCRIPTION
#### 8652bb7582ec7d2228836387dc181afe51416669
<pre>
Web Inspector: Add emulation toggles for forced-colors

<a href="https://bugs.webkit.org/show_bug.cgi?id=251082">https://bugs.webkit.org/show_bug.cgi?id=251082</a>

Reviewed by NOBODY (OOPS!).

This patch adds support for forced-colors emulation in
Page.overrideUserPreference and adds a toggle to the
WebInspector override UserPreferences popup.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b97125bdd73e8de62b0034b6361b9ee956134eca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114201 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174393 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4940 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113233 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39226 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80891 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27694 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92823 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5090 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4282 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30248 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47246 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101517 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9243 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25322 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->