### PR TITLE
[ResizeObserver] The initial last reported size of ResizeObservation should be -1x-1 which always notify observed elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-expected.txt
@@ -19,7 +19,7 @@ PASS test12: no observation is fired after the change of writing mode when box's
 PASS test13: an observation is fired after the change of writing mode when box's specified size comes from physical size properties.
 PASS test14: observe the same target but using a different box should override the previous one
 PASS test15: an observation is fired with box dimensions 0 when element's display property is set to inline
-FAIL test16: observations fire once with 0x0 size for non-replaced inline elements assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test16: observations fire once with 0x0 size for non-replaced inline elements
 PASS test17: Box sizing snd Resize Observer notifications
 FAIL test18: an observation is fired when device-pixel-content-box is being observed assert_unreached: Caught a throw, possible syntax error Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
@@ -19,5 +19,10 @@ PASS test7: observe svg:polyline
 PASS test8: observe svg:rect
 PASS test9: observe svg:text
 PASS test10: observe svg:svg, top/left is 0 even with padding
-FAIL test11: observe svg non-displayable element assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test11: observe svg non-displayable element
+PASS test12: observe svg:rect content box
+PASS test13: observe svg:rect border box
+PASS test14: observe g:rect content and border box
+PASS test15: observe svg:text content and border box
+FAIL test16: observe g:rect content, border and device-pixel-content boxes assert_unreached: Caught a throw, possible syntax error Reached unreachable code
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt
@@ -13,7 +13,7 @@ PASS test2: remove/appendChild trigger notification
 PASS test3: dimensions match
 PASS test4: transform do not cause notifications
 PASS test5: moving an element does not trigger notifications
-PASS test6: inline element notifies once with 0x0.
+FAIL test6: inline element notifies once with 0x0. assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
 PASS test7: unobserve inside notify callback
 PASS test8: observe inside notify callback
 PASS test9: disconnect inside notify callback

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt
@@ -19,5 +19,10 @@ PASS test7: observe svg:polyline
 PASS test8: observe svg:rect
 PASS test9: observe svg:text
 PASS test10: observe svg:svg, top/left is 0 even with padding
-FAIL test11: observe svg non-displayable element assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test11: observe svg non-displayable element
+PASS test12: observe svg:rect content box
+PASS test13: observe svg:rect border box
+PASS test14: observe g:rect content and border box
+FAIL test15: observe svg:text content and border box assert_equals: expected 30 but got 30.015625
+FAIL test16: observe g:rect content, border and device-pixel-content boxes assert_unreached: Caught a throw, possible syntax error Reached unreachable code
 

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -41,6 +41,7 @@ Ref<ResizeObservation> ResizeObservation::create(Element& target, ResizeObserver
 
 ResizeObservation::ResizeObservation(Element& element, ResizeObserverBoxOptions observedBox)
     : m_target { element }
+    , m_lastObservationSizes { LayoutSize(-1, -1), LayoutSize(-1, -1), LayoutSize(-1, -1) }
     , m_observedBox { observedBox }
 {
 }

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -84,6 +84,8 @@ private:
 
     Vector<Ref<ResizeObservation>> m_activeObservations;
     Vector<GCReachableRef<Element>> m_activeObservationTargets;
+    Vector<GCReachableRef<Element>> m_targetsWaitingForFirstObservation;
+
     bool m_hasSkippedObservations { false };
 };
 


### PR DESCRIPTION
#### 2861d8c4e29ca8c3384e47f260a0d0e1823c29ae
<pre>
[ResizeObserver] The initial last reported size of ResizeObservation should be -1x-1 which always notify observed elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=251015">https://bugs.webkit.org/show_bug.cgi?id=251015</a>

Reviewed by Oriol Brufau and Ryosuke Niwa.

This patch initializes the lastReportedSize of ResizeObservation to -1 x -1, which is the conclusion of [1],
it indicates that -1 x -1 is the initial size when first observing an element with ResizeObserver.

The previous change makes every ResizeObservation be delivered at least once, even if the target is a disconnected element.
When GC happens between observe and gather ResizeObservations, JSC::Weak&lt;JSC::JSObject&gt; m_callback inside JSCallbackDataWeak
could be released, and the element and JSResizeObserver might not be released, for they are not strong connected, this scenario
would trigger the ASSERT in ResizeObserver::deliverObservations. To fix it, this patch adds m_targetsWaitingForFirstObservation
to extend the life cycle of ResizeObserver to the first time of deliverObservations. The fix is similar to
what IntersectionObserver does in bug 231235.

The test6 of resize-observer/notify.html still fails in mac-wk1, because updaterendering is not triggered properly.
Filed [2] to track it.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/3664">https://github.com/w3c/csswg-drafts/issues/3664</a>
[2] <a href="https://bugs.webkit.org/show_bug.cgi?id=250900">https://bugs.webkit.org/show_bug.cgi?id=250900</a>

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/observe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/resize-observer/notify-expected.txt.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/resize-observer/svg-expected.txt:
* Source/WebCore/page/ResizeObservation.cpp:
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::observe):
(WebCore::ResizeObserver::deliverObservations):
(WebCore::ResizeObserver::isReachableFromOpaqueRoots const):
(WebCore::ResizeObserver::removeAllTargets):
(WebCore::ResizeObserver::removeObservation):
* Source/WebCore/page/ResizeObserver.h:

Canonical link: <a href="https://commits.webkit.org/259673@main">https://commits.webkit.org/259673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1408ba697584028bc6a0c5f438e923f2ecd2fe5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105519 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114776 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174924 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5843 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97821 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39684 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81379 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28173 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4761 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6683 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9923 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->