### PR TITLE
Cherry-pick 256843.2@webkit-2022.12-embargoed (155bed739000). rdar://104648588

### DIFF
--- a/LayoutTests/http/tests/security/embedded-self-reference-after-url-modified-expected.txt
+++ b/LayoutTests/http/tests/security/embedded-self-reference-after-url-modified-expected.txt
@@ -1,0 +1,8 @@
+This test passes if it doesn't crash or timeout.
+Additionally there should only be one child frame.
+
+--------
+Frame: '<!--frame1-->'
+--------
+This test passes if it doesn't crash or timeout.
+Additionally there should only be one child frame.

--- a/LayoutTests/http/tests/security/embedded-self-reference-after-url-modified.html
+++ b/LayoutTests/http/tests/security/embedded-self-reference-after-url-modified.html
@@ -1,0 +1,23 @@
+<style>
+embed { min-height: 1vmax; }
+.class4 { -webkit-margin-end: -1px; }
+html { column-count: 5; }
+</style>
+<script>
+
+if (window.testRunner) {
+    window.testRunner.dumpAsText();
+    window.testRunner.dumpChildFramesAsText();
+}
+
+function runTest() {
+  h = window.parent.history;
+  h.replaceState(null,"1","htmlvar00009");
+  dialog.setAttribute("class", "class4");
+}
+</script>
+<body onload=runTest()>
+<pre id="pre">This test passes if it doesn't crash or timeout.</pre>
+<dialog id="dialog" open="true"></dialog>
+<embed src="#" >Additionally there should only be one child frame.</embed>
+</body>

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -138,7 +138,8 @@ bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) co
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
-        if (equalIgnoringFragmentIdentifier(localFrame->document()->url(), completeURL)) {
+        // Use creationURL() because url() can be changed via History.replaceState() so it's not reliable.
+        if (equalIgnoringFragmentIdentifier(localFrame->document()->creationURL(), completeURL)) {
             if (foundOneSelfReference)
                 return true;
             foundOneSelfReference = true;


### PR DESCRIPTION
#### 562c83b8958666e8fb3d74344129490b96e3db9c
<pre>
Cherry-pick 256843.2@webkit-2022.12-embargoed (155bed739000). rdar://104648588

    HTMLFrameOwnerElement: use Document::creationURL() for self-reference check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248469">https://bugs.webkit.org/show_bug.cgi?id=248469</a>

    Reviewed by Darin Adler.

    Document::url() can be changed through the History API, therefore it&apos;s not
    a reliable source to verify whether a given URL is self-referencing. Use
    creationURL instead, which is immutable.

    * LayoutTests/http/tests/security/embedded-self-reference-after-url-modified-expected.txt: Added.
    * LayoutTests/http/tests/security/embedded-self-reference-after-url-modified.html: Added.
    * Source/WebCore/html/HTMLFrameOwnerElement.cpp:
    (WebCore::HTMLFrameOwnerElement::isProhibitedSelfReference const):

    Canonical link: <a href="https://commits.webkit.org/256843.2@webkit-2022.12-embargoed">https://commits.webkit.org/256843.2@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/259370@main">https://commits.webkit.org/259370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a752dc740650f4624de34d8a6013323f2edeee52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113996 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174198 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4729 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112922 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110481 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94550 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108190 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80738 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27520 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92613 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4901 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7257 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30172 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103542 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47079 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101300 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6460 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9045 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->