### PR TITLE
Cherry-pick 252432.942@safari-7614-branch (d7af255eed5c). rdar://104649116

### DIFF
--- a/LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload-expected.txt
+++ b/LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload-expected.txt
@@ -1,0 +1,10 @@
+This tests that cross-origin-initiated navigations always fire the load event at their embedding iframe element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS onload fired 2 times.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload.html
+++ b/LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("This tests that cross-origin-initiated navigations always fire the load event at their embedding iframe element.");
+jsTestIsAsync = true;
+
+window.onload = function() {
+    window.postMessage("postmessage", "*");
+    document.querySelector('iframe').src = "http://localhost:8000/navigation/resources/postmessage-on-hashchange.html#anchor1";
+}
+
+let onloadCount = 0;
+
+window.addEventListener('message', function (e) {
+    if (onloadCount == 2)
+        testPassed("onload fired 2 times.");
+    else
+        testFailed("onload fired " + onloadCount + " time(s).");
+    
+    finishJSTest();
+});
+
+function onloadFired() {
+    onloadCount++;
+}       
+</script>
+<iframe src="http://localhost:8000/navigation/resources/postmessage-on-hashchange.html" onload="onloadFired()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/postmessage-on-hashchange.html
+++ b/LayoutTests/http/tests/navigation/resources/postmessage-on-hashchange.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        window.addEventListener('hashchange', function () {
+            window.parent.postMessage('hashchange', '*');
+        });
+    </script>
+</head>
+<body>
+    This page posts a message to its parent on hashchange.
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1209,6 +1209,11 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
         m_frame.document()->enqueueHashchangeEvent(oldURL.string(), url.string());
         m_client->dispatchDidChangeLocationWithinPage();
     }
+
+    if (auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent()); parentFrame
+        && (m_frame.document()->processingLoadEvent() || m_frame.document()->loadEventFinished())
+        && !m_frame.document()->securityOrigin().isSameOriginAs(parentFrame->document()->securityOrigin()))
+        m_frame.document()->dispatchWindowLoadEvent();
     
     // FrameLoaderClient::didFinishLoad() tells the internal load delegate the load finished with no error
     m_client->didFinishLoad();


### PR DESCRIPTION
#### 13819101c22430f8c2705f29c3aa1de4330bb25b
<pre>
Cherry-pick 252432.942@safari-7614-branch (d7af255eed5c). rdar://104649116

    cross origin iframe load event can be used for a malicious way
    <a href="https://bugs.webkit.org/show_bug.cgi?id=241753">https://bugs.webkit.org/show_bug.cgi?id=241753</a>
    rdar://95467115

    Reviewed by Chris Dumez and Ryan Haddad.

    This bug describes an issue where it is possible to guess a URL that is
    redirected to by a cross-origin iframe. To fix this, WebKit should fire a
    load event when the direct parent frame is cross-origin.

    This fix is very similar to what is described in <a href="https://crbug.com/1248444.">https://crbug.com/1248444.</a>

    * Source/WebCore/loader/FrameLoader.cpp:
    (WebCore::FrameLoader::loadInSameDocument):
    * LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload-expected.txt: Added.
    * LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload.html: Added.
    * LayoutTests/http/tests/navigation/resources/postmessage-on-hashchange.html: Added.

    Canonical link: <a href="https://commits.webkit.org/252432.942@safari-7614-branch">https://commits.webkit.org/252432.942@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259384@main">https://commits.webkit.org/259384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/095f65bdd84a29884ab0c75b7bd98ade90357776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114016 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4749 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112938 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110500 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94566 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108207 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26180 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7173 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27536 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92631 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7276 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30189 "Passed tests") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/103557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47096 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101319 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6471 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9063 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | | | 
<!--EWS-Status-Bubble-End-->