### PR TITLE
[WebAuthn] Create new session for each CCID message and seize FIDO hid devices during authentication session

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
+++ b/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
@@ -222,7 +222,8 @@ enum IOHIDReportType {
 };
 
 enum {
-    kIOHIDOptionsTypeNone     = 0x00,
+    kIOHIDOptionsTypeNone        = 0x00,
+    kIOHIDOptionsTypeSeizeDevice = 0x01,
 };
 typedef uint32_t IOHIDOptionsType;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -66,7 +66,7 @@ HidConnection::~HidConnection()
 
 void HidConnection::initialize()
 {
-    IOHIDDeviceOpen(m_device.get(), kIOHIDOptionsTypeNone);
+    IOHIDDeviceOpen(m_device.get(), kIOHIDOptionsTypeSeizeDevice);
     IOHIDDeviceScheduleWithRunLoop(m_device.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
     m_inputBuffer.resize(kHidMaxPacketSize);
     IOHIDDeviceRegisterInputReportCallback(m_device.get(), m_inputBuffer.data(), m_inputBuffer.size(), &reportReceived, this);

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -54,6 +54,10 @@
     reply(TRUE, nil);
 }
 
+- (void)endSession
+{
+}
+
 - (void)transmitRequest:(NSData *)request reply:(void(^)(NSData * response, NSError * error))reply
 {
     reply(m_service->nextReply().get(), nil);


### PR DESCRIPTION
#### cef8b0cbe1016c382a7c1e2aa52f5d2c2b1d4aa8
<pre>
[WebAuthn] Create new session for each CCID message and seize FIDO hid devices during authentication session
<a href="https://bugs.webkit.org/show_bug.cgi?id=251155">https://bugs.webkit.org/show_bug.cgi?id=251155</a>
rdar://104386820

Reviewed by Brent Fulgham.

* Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(WebKit::CcidConnection::detectContactless):
(WebKit::CcidConnection::trySelectFidoApplet):
(WebKit::CcidConnection::transact const):
(WebKit::CcidConnection::startPolling):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::HidConnection::initialize):
It&apos;s not required nor recommended to keep a smart card session open over the entirity of the
CCIDConnection, so instead we create one for each message. This prevents issues when presenting
a contactless key, taking it away when you enter a pin, and then presenting it again.

This change also prevents the smart card library from seizing a device that can also be used over
the FIDO hid driver, in other words, a security key that exposes FIDO+CCID. This allows the HID
connection to be able to seize the device for FIDO HID communication in the event both are presented.

Canonical link: <a href="https://commits.webkit.org/259426@main">https://commits.webkit.org/259426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/605635cd40c8c0d20fc4fd3d772c4376930521c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114059 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174261 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4791 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112973 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27578 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7314 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4163 "Found 1 new test failure: fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6506 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9101 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->