### PR TITLE
[JSC] Reload baseMemory and boundsCheckingSize in the same way to instance

### DIFF
--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -261,8 +261,8 @@ BufferMemoryHandle::~BufferMemoryHandle()
         void* memory = this->memory();
         BufferMemoryManager::singleton().freePhysicalBytes(m_size);
         switch (m_mode) {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         case MemoryMode::Signaling: {
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
             // nullBasePointer's zero-sized memory is not used for MemoryMode::Signaling.
             constexpr bool readable = true;
             constexpr bool writable = true;
@@ -275,9 +275,9 @@ BufferMemoryHandle::~BufferMemoryHandle()
                 RELEASE_ASSERT_NOT_REACHED();
             }
             BufferMemoryManager::singleton().freeFastMemory(memory);
+#endif
             break;
         }
-#endif
         case MemoryMode::BoundsChecking: {
             switch (m_sharingMode) {
             case MemorySharingMode::Default: {

--- a/Source/JavaScriptCore/runtime/MemoryMode.cpp
+++ b/Source/JavaScriptCore/runtime/MemoryMode.cpp
@@ -38,11 +38,9 @@ void printInternal(PrintStream& out, JSC::MemoryMode mode)
     case JSC::MemoryMode::BoundsChecking:
         out.print("BoundsChecking");
         return;
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     case JSC::MemoryMode::Signaling:
         out.print("Signaling");
         return;
-#endif
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/JavaScriptCore/runtime/MemoryMode.h
+++ b/Source/JavaScriptCore/runtime/MemoryMode.h
@@ -30,9 +30,7 @@ namespace JSC {
 // FIXME: We should support other modes. see: https://bugs.webkit.org/show_bug.cgi?id=162693
 enum class MemoryMode : uint8_t {
     BoundsChecking,
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-    Signaling
-#endif
+    Signaling,
 };
 
 static constexpr size_t numberOfMemoryModes = 2;

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp
@@ -564,6 +564,9 @@ auto AirIRGenerator32::emitCheckAndPreparePointer(ExpressionType pointer, uint32
         });
         break;
     }
+    case MemoryMode::Signaling: {
+        break;
+    }
     }
 
     append(AddPtr, memoryBase, result);

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -715,11 +715,7 @@ private:
 
     bool useSignalingMemory() const
     {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         return m_mode == MemoryMode::Signaling;
-#else
-        return false;
-#endif
     }
 
 };
@@ -984,8 +980,8 @@ inline AirIRGenerator64::ExpressionType AirIRGenerator64::emitCheckAndPreparePoi
         break;
     }
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     case MemoryMode::Signaling: {
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
         // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
         // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -1015,9 +1011,9 @@ inline AirIRGenerator64::ExpressionType AirIRGenerator64::emitCheckAndPreparePoi
                 this->emitThrowException(jit, ExceptionType::OutOfBoundsMemoryAccess);
             });
         }
+#endif
         break;
     }
-#endif
     }
 
     if constexpr (isARM64())

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -688,8 +688,9 @@ private:
     int32_t WARN_UNUSED_RETURN fixupPointerPlusOffset(Value*&, uint32_t);
     Value* WARN_UNUSED_RETURN fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
 
-    void restoreWasmContextInstance(Procedure&, BasicBlock*, Value*);
-    void restoreWebAssemblyGlobalState(const MemoryInformation&, Value* instance, Procedure&, BasicBlock*, bool restoreInstance = true);
+    void restoreWasmContextInstance(BasicBlock*, Value*);
+    void restoreWebAssemblyGlobalState(const MemoryInformation&, Value* instance, BasicBlock*);
+    void reloadMemoryRegistersFromInstance(const MemoryInformation&, Value* instance, BasicBlock*);
 
     Value* loadFromScratchBuffer(unsigned& indexInBuffer, Value* pointer, B3::Type);
     void connectControlAtEntrypoint(unsigned& indexInBuffer, Value* pointer, ControlData&, Stack& expressionStack, ControlData& currentData, bool fillLoopPhis = false);
@@ -763,11 +764,7 @@ private:
 
     bool useSignalingMemory() const
     {
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         return m_mode == MemoryMode::Signaling;
-#else
-        return false;
-#endif
     }
 
     FunctionParser<B3IRGenerator>* m_parser { nullptr };
@@ -800,12 +797,23 @@ private:
 
     std::optional<bool> m_hasExceptionHandlers;
 
-    Value* m_instanceValue { nullptr }; // Always use the accessor below to ensure the instance value is materialized when used.
-    bool m_usesInstanceValue { false };
+    Value* m_instanceValue { nullptr };
+    Value* m_baseMemoryValue { nullptr };
+    Value* m_boundsCheckingSizeValue { nullptr };
+
     Value* instanceValue()
     {
-        m_usesInstanceValue = true;
         return m_instanceValue;
+    }
+
+    Value* baseMemoryValue()
+    {
+        return m_baseMemoryValue;
+    }
+
+    Value* boundsCheckingSizeValue()
+    {
+        return m_boundsCheckingSizeValue;
     }
 
     uint32_t m_maxNumJSCallArguments { 0 };
@@ -831,11 +839,11 @@ int32_t B3IRGenerator::fixupPointerPlusOffset(Value*& ptr, uint32_t offset)
     return offset;
 }
 
-void B3IRGenerator::restoreWasmContextInstance(Procedure& proc, BasicBlock* block, Value* arg)
+void B3IRGenerator::restoreWasmContextInstance(BasicBlock* block, Value* arg)
 {
     // FIXME: Because WasmToWasm call clobbers wasmContextInstance register and does not restore it, we need to restore it in the caller side.
     // This prevents us from using ArgumentReg to this (logically) immutable pinned register.
-    PatchpointValue* patchpoint = block->appendNew<PatchpointValue>(proc, B3::Void, Origin());
+    PatchpointValue* patchpoint = block->appendNew<PatchpointValue>(m_proc, B3::Void, Origin());
     Effects effects = Effects::none();
     effects.writesPinned = true;
     effects.reads = B3::HeapRange::top();
@@ -880,25 +888,44 @@ B3IRGenerator::B3IRGenerator(const ModuleInformation& info, Callee& callee, Proc
             case MemoryMode::BoundsChecking:
                 ASSERT_UNUSED(pinnedGPR, GPRInfo::wasmBoundsCheckingSizeRegister == pinnedGPR);
                 break;
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
             case MemoryMode::Signaling:
                 ASSERT_UNUSED(pinnedGPR, InvalidGPRReg == pinnedGPR);
                 break;
-#endif
             }
             this->emitExceptionCheck(jit, ExceptionType::OutOfBoundsMemoryAccess);
         });
     }
 
     {
-        B3::PatchpointValue* getInstance = m_topLevelBlock->appendNew<B3::PatchpointValue>(m_proc, pointerType(), Origin());
         // FIXME: Because WasmToWasm call clobbers wasmContextInstance register and does not restore it, we need to restore it in the caller side.
         // This prevents us from using ArgumentReg to this (logically) immutable pinned register.
+
+        B3::PatchpointValue* getInstance = m_topLevelBlock->appendNew<B3::PatchpointValue>(m_proc, pointerType(), Origin());
         getInstance->effects.writesPinned = false;
         getInstance->effects.readsPinned = true;
         getInstance->resultConstraints = { ValueRep::reg(GPRInfo::wasmContextInstancePointer) };
         getInstance->setGenerator([=] (CCallHelpers&, const B3::StackmapGenerationParams&) { });
         m_instanceValue = getInstance;
+
+        if (!!m_info.memory) {
+            if (useSignalingMemory() || m_info.memory.isShared()) {
+                // Capacity and basePointer will not be changed in this case.
+                if (m_mode == MemoryMode::BoundsChecking) {
+                    B3::PatchpointValue* getBoundsCheckingSize = m_topLevelBlock->appendNew<B3::PatchpointValue>(m_proc, pointerType(), Origin());
+                    getBoundsCheckingSize->effects.writesPinned = false;
+                    getBoundsCheckingSize->effects.readsPinned = true;
+                    getBoundsCheckingSize->resultConstraints = { ValueRep::reg(GPRInfo::wasmBoundsCheckingSizeRegister) };
+                    getBoundsCheckingSize->setGenerator([=] (CCallHelpers&, const B3::StackmapGenerationParams&) { });
+                    m_boundsCheckingSizeValue = getBoundsCheckingSize;
+                }
+                B3::PatchpointValue* getBaseMemory = m_topLevelBlock->appendNew<B3::PatchpointValue>(m_proc, pointerType(), Origin());
+                getBaseMemory->effects.writesPinned = false;
+                getBaseMemory->effects.readsPinned = true;
+                getBaseMemory->resultConstraints = { ValueRep::reg(GPRInfo::wasmBaseMemoryPointer) };
+                getBaseMemory->setGenerator([=] (CCallHelpers&, const B3::StackmapGenerationParams&) { });
+                m_baseMemoryValue = getBaseMemory;
+            }
+        }
     }
 
     m_prologueGenerator = createSharedTask<B3::Air::PrologueGeneratorFunction>([=, this] (CCallHelpers& jit, B3::Air::Code& code) {
@@ -978,18 +1005,48 @@ B3IRGenerator::B3IRGenerator(const ModuleInformation& info, Callee& callee, Proc
         m_currentBlock = m_proc.addBlock();
 }
 
-void B3IRGenerator::restoreWebAssemblyGlobalState(const MemoryInformation& memory, Value* instance, Procedure& proc, BasicBlock* block, bool restoreInstance)
+void B3IRGenerator::restoreWebAssemblyGlobalState(const MemoryInformation& memory, Value* instance, BasicBlock* block)
 {
-    if (restoreInstance)
-        restoreWasmContextInstance(proc, block, instance);
+    restoreWasmContextInstance(block, instance);
 
+    if (!!memory) {
+        if (useSignalingMemory() || memory.isShared()) {
+            RegisterSet clobbers;
+            clobbers.add(GPRInfo::wasmBaseMemoryPointer, IgnoreVectors);
+            if (m_mode == MemoryMode::BoundsChecking)
+                clobbers.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
+
+            B3::PatchpointValue* patchpoint = block->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
+            Effects effects = Effects::none();
+            effects.writesPinned = true;
+            effects.reads = B3::HeapRange::top();
+            patchpoint->effects = effects;
+            patchpoint->clobber(clobbers);
+
+            patchpoint->append(baseMemoryValue(), ValueRep::SomeRegister);
+            if (m_mode == MemoryMode::BoundsChecking)
+                patchpoint->append(boundsCheckingSizeValue(), ValueRep::SomeRegister);
+            patchpoint->setGenerator([](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+                jit.move(params[0].gpr(), GPRInfo::wasmBaseMemoryPointer);
+                if (params.size() == 2)
+                    jit.move(params[1].gpr(), GPRInfo::wasmBoundsCheckingSizeRegister);
+            });
+            return;
+        }
+
+        reloadMemoryRegistersFromInstance(memory, instance, block);
+    }
+}
+
+void B3IRGenerator::reloadMemoryRegistersFromInstance(const MemoryInformation& memory, Value* instance, BasicBlock* block)
+{
     if (!!memory) {
         RegisterSet clobbers;
         clobbers.add(GPRInfo::wasmBaseMemoryPointer, IgnoreVectors);
         clobbers.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
         clobbers.merge(RegisterSetBuilder::macroClobberedRegisters());
 
-        B3::PatchpointValue* patchpoint = block->appendNew<B3::PatchpointValue>(proc, B3::Void, origin());
+        B3::PatchpointValue* patchpoint = block->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
         Effects effects = Effects::none();
         effects.writesPinned = true;
         effects.reads = B3::HeapRange::top();
@@ -1442,7 +1499,7 @@ auto B3IRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, V
     }
 
     // The call could have been to another WebAssembly instance, and / or could have modified our Memory.
-    restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_proc, m_currentBlock);
+    restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_currentBlock);
 
     return { };
 }
@@ -1452,7 +1509,7 @@ auto B3IRGenerator::addGrowMemory(ExpressionType delta, ExpressionType& result) 
     result = push(callWasmOperation(m_currentBlock, Int32, operationGrowMemory,
         instanceValue(), get(delta)));
 
-    restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_proc, m_currentBlock);
+    restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_currentBlock);
 
     return { };
 }
@@ -1696,8 +1753,8 @@ inline Value* B3IRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_t
         break;
     }
 
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     case MemoryMode::Signaling: {
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
         // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
         // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -1712,9 +1769,9 @@ inline Value* B3IRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_t
             size_t maximum = m_info.memory.maximum() ? m_info.memory.maximum().bytes() : std::numeric_limits<uint32_t>::max();
             m_currentBlock->appendNew<WasmBoundsCheckValue>(m_proc, origin(), pointer, sizeOfOperation + offset - 1, maximum);
         }
+#endif
         break;
     }
-#endif
     }
 
     pointer = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), pointer);
@@ -3474,7 +3531,7 @@ Value* B3IRGenerator::emitCatchImpl(CatchKind kind, ControlType& data, unsigned 
     HandlerType handlerType = kind == CatchKind::Catch ? HandlerType::Catch : HandlerType::CatchAll;
     m_exceptionHandlers.append({ handlerType, data.tryStart(), data.tryEnd(), 0, m_tryCatchDepth, exceptionIndex });
 
-    restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_proc, m_currentBlock, false);
+    reloadMemoryRegistersFromInstance(m_info.memory, instanceValue(), m_currentBlock);
 
     Value* pointer = m_currentBlock->appendNew<ArgumentRegValue>(m_proc, Origin(), GPRInfo::argumentGPR0);
 
@@ -3919,7 +3976,7 @@ auto B3IRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signat
             fillResults(result);
 
         // The call could have been to another WebAssembly instance, and / or could have modified our Memory.
-        restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_proc, m_currentBlock);
+        restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_currentBlock);
 
         return { };
 
@@ -3967,7 +4024,7 @@ auto B3IRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signat
     fillResults(callResult);
 
     if (m_info.callCanClobberInstance(functionIndex))
-        restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_proc, m_currentBlock);
+        restoreWebAssemblyGlobalState(m_info.memory, instanceValue(), m_currentBlock);
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -168,13 +168,11 @@ bool CalleeGroup::isSafeToRun(MemoryMode memoryMode)
     switch (m_mode) {
     case MemoryMode::BoundsChecking:
         return true;
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     case MemoryMode::Signaling:
         // Code being in Signaling mode means that it performs no bounds checks.
         // Its memory, even if empty, absolutely must also be in Signaling mode
         // because the page protection detects out-of-bounds accesses.
         return memoryMode == MemoryMode::Signaling;
-#endif
     }
     RELEASE_ASSERT_NOT_REACHED();
     return false;

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -371,8 +371,8 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
         ASSERT(basePointer() == newMemory);
         return success();
     }
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     case MemoryMode::Signaling: {
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
         size_t extraBytes = desiredSize - size();
         RELEASE_ASSERT(extraBytes);
         bool allocationSuccess = tryAllocate(vm,
@@ -402,8 +402,10 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
 
         m_handle->updateSize(desiredSize);
         return success();
-    }
+#else
+        return oldPageCount;
 #endif
+    }
     }
 
     RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 9e128ee528b7525975e9328b95718f29167fc4ff
<pre>
[JSC] Reload baseMemory and boundsCheckingSize in the same way to instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=251161">https://bugs.webkit.org/show_bug.cgi?id=251161</a>
rdar://104653875

Reviewed by Justin Michaud.

If wasm memory mode is Signaling or memory is Shared one,

    1. baseMemory pointer never changes.
    2. boundsCheckingSize never changes.

So, this is effectively the same to instance pointer which also never changes.
We should do the same thing to instance&apos;s reloading scheme.
This improves wasm CallIndirect significantly: JetStream2/richards-wasm Runtime gets improved by 15% (16.129 -&gt; 18.587).

* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryHandle::~BufferMemoryHandle):
* Source/JavaScriptCore/runtime/MemoryMode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/MemoryMode.h:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::useSignalingMemory const):
(JSC::Wasm::AirIRGenerator64::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::useSignalingMemory const):
(JSC::Wasm::B3IRGenerator::instanceValue):
(JSC::Wasm::B3IRGenerator::baseMemoryValue):
(JSC::Wasm::B3IRGenerator::boundsCheckingSizeValue):
(JSC::Wasm::B3IRGenerator::B3IRGenerator):
(JSC::Wasm::B3IRGenerator::restoreWebAssemblyGlobalState):
(JSC::Wasm::B3IRGenerator::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::isSafeToRun):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::grow):

Canonical link: <a href="https://commits.webkit.org/259387@main">https://commits.webkit.org/259387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d83d4aa4eeba6e490310a2dfa75bec48d67f5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13865 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/14998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4794 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110545 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/14998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/14998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92675 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101365 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3434 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->