### PR TITLE
Cherry-pick 252432.945@safari-7614-branch (f8d24d4f0141). rdar://104657147

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -368,9 +368,10 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
         return Seconds::fromMilliseconds(250);
     }();
 
+    WeakPtr weakThis { *this };
     auto startTime = MonotonicTime::now();
     while (process.connection()->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives)) {
-        if (activityStateChangeID == ActivityStateChangeAsynchronous || activityStateChangeID <= m_activityStateChangeID)
+        if (!weakThis || activityStateChangeID == ActivityStateChangeAsynchronous || activityStateChangeID <= m_activityStateChangeID)
             return;
     }
 }


### PR DESCRIPTION
#### 2caba6db920732740468c72d2decc5c3e3adba7b
<pre>
Cherry-pick 252432.945@safari-7614-branch (f8d24d4f0141). rdar://104657147

    Protect against RemoteLayerTreeDrawingAreaProxy getting destroyed during waitForAndDispatchImmediately() call
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248660">https://bugs.webkit.org/show_bug.cgi?id=248660</a>
    rdar://101806758

    Reviewed by Wenson Hsieh and Ryan Haddad.

    In RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(), during the execution of
    IPC::Connection::waitForAndDispatchImmediately(), `this` might get destroyed as a result of
    processing an incoming IPC from the WebProcess. For this reason, we need to check that `this`
    is still alive after the call returns.

    Note that we cannot easily protect `this` since this is not a RefCounted object.

    * Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
    (WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):

    Canonical link: <a href="https://commits.webkit.org/252432.945@safari-7614-branch">https://commits.webkit.org/252432.945@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259445@main">https://commits.webkit.org/259445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e2adbd46fdd1b8859b555800aeb2fe20e432c6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114033 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174243 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4765 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112957 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39105 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108221 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80769 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94673 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27561 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92648 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4934 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7291 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4147 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30204 "Passed tests") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/103572 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 9133") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47113 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101337 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6518 "Build was cancelled. Recent messages:Validated committer, reviewer not found; Cleaned up git repository; Checked out pull request; Verified commit is squashed; Validated commit message; Compiled WebKit (warnings); layout-tests (exception)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9077 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25277 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3464 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->