### PR TITLE
[JSC] Enable more V8 wasm tests

### DIFF
--- a/JSTests/wasm/v8/anyfunc.js
+++ b/JSTests/wasm/v8/anyfunc.js
@@ -1,15 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Object <Error(RuntimeError: Funcref must be an exported wasm function (evaluating 'instance.exports.main({'hello': 'world'})'))> is not an instance of <TypeError> but of <RuntimeError>
-// MjsUnitAssertionError@mjsunit.js:36:27
-// failWithMessage@mjsunit.js:323:36
-// assertInstanceof@mjsunit.js:563:22
-// checkException@mjsunit.js:498:23
-// assertThrows@mjsunit.js:518:21
-// testAnyFuncIdentityFunction@anyfunc.js:30:15
-// global code@anyfunc.js:34:3
-
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -27,7 +16,7 @@ load("wasm-module-builder.js");
 
   const instance = builder.instantiate();
 
-//  assertThrows(() => instance.exports.main(print), TypeError);
+  assertThrows(() => instance.exports.main(print), TypeError);
   assertThrows(() => instance.exports.main({'hello': 'world'}), TypeError);
   assertSame(
       instance.exports.main, instance.exports.main(instance.exports.main));

--- a/JSTests/wasm/v8/bigint-rematerialize.js
+++ b/JSTests/wasm/v8/bigint-rematerialize.js
@@ -1,10 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Skipping this test due to the following issues:
-// call to %Is64Bit()
-// call to %OptimizeFunctionOnNextCall()
-// call to %PrepareFunctionForOptimization()
-
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -35,16 +29,14 @@ function f(x) {
   }
 }
 
-%PrepareFunctionForOptimization(f);
 assertEquals(0n, f(1n));
 assertEquals(1n, f(2n));
-%OptimizeFunctionOnNextCall(f);
+for (var i = 0; i < 10000; ++i) {
+    f(1n);
+    f(2n);
+}
 assertEquals(0n, f(1n));
-assertOptimized(f);
 // After optimization, the result of the js wasm call is stored in word64 and
 // passed to StateValues without conversion. Rematerialization will happen
 // in deoptimizer.
 assertEquals(-1n, f(0));
-if (%Is64Bit()) {
-  assertUnoptimized(f);
-}

--- a/JSTests/wasm/v8/bigint.js
+++ b/JSTests/wasm/v8/bigint.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure:
-//  expected:
-//  contains ''value' must be a WebAssembly type'
-//  found:
-//  "WebAssembly.Global expects its 'value' field to be the string 'i32', 'i64', 'f32', 'f64', 'anyfunc', 'funcref', or 'externref'"
-// Looks like we need to change the expected exception.
-
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -172,7 +163,7 @@ load("wasm-module-builder.js");
   try {
     new WebAssembly.Global(argument);
   } catch (e) {
-    assertContains("'value' must be a WebAssembly type", e.message);
+    assertContains("expects its 'value' field to be the string", e.message);
   }
 })();
 

--- a/JSTests/wasm/v8/bit-shift-right.js
+++ b/JSTests/wasm/v8/bit-shift-right.js
@@ -1,8 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Skipping this test due to the following issues:
-// call to %WasmTierUpFunction()
-
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bulk-memory.js
+++ b/JSTests/wasm/v8/bulk-memory.js
@@ -1,16 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Object <Error(LinkError: Invalid data segment initialization: segment of 2 bytes memory of 65536 bytes, at offset 65535, segment writes outside of memory (evaluating 'new WebAssembly.Instance(module, ffi)'))> is not an instance of <RuntimeError> but of <LinkError>
-//
-//  Stack: MjsUnitAssertionError@mjsunit.js:36:27
-//  failWithMessage@mjsunit.js:323:36
-//  assertInstanceof@mjsunit.js:563:22
-//  checkException@mjsunit.js:498:23
-//  assertThrows@mjsunit.js:518:21
-//  TestLazyDataSegmentBoundsCheck@bulk-memory.js:208:15
-//  global code@bulk-memory.js:214:3
-
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -267,5 +255,5 @@ function getMemoryFill(mem) {
   assertEquals(false, WebAssembly.validate(builder.toBuffer()));
   assertThrows(
       () => builder.toModule(), WebAssembly.CompileError,
-      /invalid numeric opcode: 0xfc790/);
+      /invalid 0xfc extended op 1936/);
 })();

--- a/JSTests/wasm/v8/code-space-overflow.js
+++ b/JSTests/wasm/v8/code-space-overflow.js
@@ -1,9 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: ReferenceError: Can't find variable: performance
-//  global code@code-space-overflow.js:23:26
-
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -20,9 +15,9 @@
 
 load("wasm-module-builder.js");
 
-const start = performance.now();
+const start = Date.now();
 function time(name) {
-  const ms_since_start = (performance.now() - start).toFixed(1).padStart(7);
+  const ms_since_start = (Date.now() - start).toFixed(1).padStart(7);
   // print(`[${ms_since_start}] ${name}`);
 }
 

--- a/JSTests/wasm/v8/instantiate-module-basic.js
+++ b/JSTests/wasm/v8/instantiate-module-basic.js
@@ -1,13 +1,4 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
-// Failure:
-// Exception: Failure:
-//  expected:
-//  contains 'Argument 0'
-//  found:
-//  "TypeError: first argument to WebAssembly.Instance must be a WebAssembly.Module (evaluating 'new WebAssembly.Instance(invalid_cases[i])')"
-// Looks like we need to update the exception strings.
-
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -96,7 +87,7 @@ assertFalse(WebAssembly.validate(bytes(88, 88, 88, 88, 88, 88, 88, 88)));
       let instance = new WebAssembly.Instance(invalid_cases[i]);
       assertUnreachable('should not be able to instantiate invalid modules.');
     } catch (e) {
-      assertContains('Argument 0', e.toString());
+      assertContains('first argument to WebAssembly.Instance must', e.toString());
     }
   }
 })();


### PR DESCRIPTION
#### 9838d6852bfd9b263b0a73a87cb9fc4b4d9581f9
<pre>
[JSC] Enable more V8 wasm tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=251165">https://bugs.webkit.org/show_bug.cgi?id=251165</a>
rdar://104657752

Reviewed by Saam Barati and Justin Michaud.

Enable more V8 wasm tests to expand coverage.

* JSTests/wasm/v8/anyfunc.js:
(testAnyFuncIdentityFunction):
* JSTests/wasm/v8/bit-shift-right.js:
* JSTests/wasm/v8/bulk-memory.js:
(TestIllegalNumericOpcode):

Canonical link: <a href="https://commits.webkit.org/259405@main">https://commits.webkit.org/259405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f1b08b1693f0a8152fc323a97fdf593e4db6e58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114068 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4802 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97125 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110553 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94609 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93461 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27583 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92684 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4959 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7323 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30223 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47133 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101374 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9110 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3443 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->