### PR TITLE
Cherry-pick 252432.947@safari-7614-branch (2d531cf29dfa). rdar://104657691

### DIFF
--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-crash.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-crash.html
@@ -1,0 +1,17 @@
+
+<marquee id="m"></marquee>
+<html>
+<head>
+  <script>
+    onload = () => {
+      m.scrollTo({behavior: 'smooth'});
+      m.remove();
+    };
+    if (window.testRunner)
+          testRunner.dumpAsText();
+  </script>
+</head>
+<body>
+<p>This test passes if it does not crash.</p>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -86,6 +86,11 @@ void RenderLayerScrollableArea::clear()
     auto& renderer = m_layer.renderer();
     if (m_registeredScrollableArea)
         renderer.view().frameView().removeScrollableArea(this);
+    
+    if (m_isRegisteredForAnimatedScroll) {
+        renderer.view().frameView().removeScrollableAreaForAnimatedScroll(this);
+        m_isRegisteredForAnimatedScroll = false;
+    }
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     unregisterAsTouchEventListenerForScrolling();


### PR DESCRIPTION
#### b5fe944862632c834056aba49b3cccc5ca10509a
<pre>
Cherry-pick 252432.947@safari-7614-branch (2d531cf29dfa). rdar://104657691

    jsc_fuz/wktr: heap-use-after-free in WebCore::ScrollableArea::existingScrollAnimator() const ScrollableArea.h:188
    <a href="https://bugs.webkit.org/show_bug.cgi?id=249242">https://bugs.webkit.org/show_bug.cgi?id=249242</a>
    &lt;rdar://103294792&gt;

    Reviewed by Simon Fraser and Ryan Haddad.

    Remove scrollable area from m_scrollableAreasForAnimatedScroll
    if scrollable area will be destroyed.

    * LayoutTests/fast/scrolling/mac/smooth-scroll-crash-expected.txt: Added.
    * LayoutTests/fast/scrolling/mac/smooth-scroll-crash.html: Added.
    * Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
    (WebCore::RenderLayerScrollableArea::clear):

    Canonical link: <a href="https://commits.webkit.org/252432.947@safari-7614-branch">https://commits.webkit.org/252432.947@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/259448@main">https://commits.webkit.org/259448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cb4d2dbe728e8fcf2ab0f49414628d69ce4ef78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37664 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114038 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated wpe dependencies; Compiled WebKit") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174247 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4770 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112961 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39113 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108226 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80777 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94677 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27577 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92653 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4938 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7296 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4153 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30210 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103576 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47110 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101342 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6519 "Build was cancelled. Recent messages:Validated committer, reviewer not found; Cleaned up git repository; Checked out pull request; Verified commit is squashed; Validated commit message; Compiled WebKit (warnings); layout-tests (exception)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9082 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25281 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3466 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->