### PR TITLE
[WPE][GTK] Add more padding to WebKitWebView vtable

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -378,13 +378,48 @@ struct _WebKitWebViewClass {
     gboolean   (* query_permission_state)      (WebKitWebView               *web_view,
                                                 WebKitPermissionStateQuery  *query);
 
-#if PLATFORM(WPE)
+#if PLATFORM(WPE) && !ENABLE(2022_GLIB_API)
     /*< private >*/
     void (*_webkit_reserved0) (void);
     void (*_webkit_reserved1) (void);
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
     void (*_webkit_reserved4) (void);
+#endif
+
+#if ENABLE(2022_GLIB_API)
+    /*< private >*/
+    void (*_webkit_reserved0)  (void);
+    void (*_webkit_reserved1)  (void);
+    void (*_webkit_reserved2)  (void);
+    void (*_webkit_reserved3)  (void);
+    void (*_webkit_reserved4)  (void);
+    void (*_webkit_reserved5)  (void);
+    void (*_webkit_reserved6)  (void);
+    void (*_webkit_reserved7)  (void);
+    void (*_webkit_reserved8)  (void);
+    void (*_webkit_reserved9)  (void);
+    void (*_webkit_reserved10) (void);
+    void (*_webkit_reserved11) (void);
+    void (*_webkit_reserved12) (void);
+    void (*_webkit_reserved13) (void);
+    void (*_webkit_reserved14) (void);
+    void (*_webkit_reserved15) (void);
+    void (*_webkit_reserved16) (void);
+    void (*_webkit_reserved17) (void);
+    void (*_webkit_reserved18) (void);
+    void (*_webkit_reserved19) (void);
+    void (*_webkit_reserved20) (void);
+    void (*_webkit_reserved21) (void);
+    void (*_webkit_reserved22) (void);
+    void (*_webkit_reserved23) (void);
+    void (*_webkit_reserved24) (void);
+    void (*_webkit_reserved25) (void);
+    void (*_webkit_reserved26) (void);
+    void (*_webkit_reserved27) (void);
+    void (*_webkit_reserved28) (void);
+    void (*_webkit_reserved29) (void);
+    void (*_webkit_reserved30) (void);
 #endif
 };
 


### PR DESCRIPTION
#### 5737721c0eb39a3de42346e17d086abadf43e448
<pre>
[WPE][GTK] Add more padding to WebKitWebView vtable
<a href="https://bugs.webkit.org/show_bug.cgi?id=240472">https://bugs.webkit.org/show_bug.cgi?id=240472</a>

Reviewed by Adrian Perez de Castro.

Let&apos;s add more padding here than we anticipate needing during the next
10-15 years.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:

Canonical link: <a href="https://commits.webkit.org/259425@main">https://commits.webkit.org/259425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a0f3dd6732c080a970c5e989cae84627139f816

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114154 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4891 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113176 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110647 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94671 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26292 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7311 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27651 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7404 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47202 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6504 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9196 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->