### PR TITLE
Make DOMFormData a subclass of ContextDestructionObserver

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -193,7 +193,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         return std::nullopt;
     };
 
-    auto form = DOMFormData::create(PAL::UTF8Encoding());
+    auto form = DOMFormData::create(context, PAL::UTF8Encoding());
     auto mimeType = parseMIMEType(contentType);
     if (auto multipartBoundary = parseMultipartBoundary(mimeType)) {
         auto boundaryWithDashes = makeString("--", *multipartBoundary);

--- a/Source/WebCore/html/DOMFormData.cpp
+++ b/Source/WebCore/html/DOMFormData.cpp
@@ -37,14 +37,15 @@
 
 namespace WebCore {
 
-DOMFormData::DOMFormData(const PAL::TextEncoding& encoding)
-    : m_encoding(encoding)
+DOMFormData::DOMFormData(ScriptExecutionContext* context, const PAL::TextEncoding& encoding)
+    : ContextDestructionObserver(context)
+    , m_encoding(encoding)
 {
 }
 
-ExceptionOr<Ref<DOMFormData>> DOMFormData::create(HTMLFormElement* form)
+ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext& context, HTMLFormElement* form)
 {
-    auto formData = adoptRef(*new DOMFormData);
+    auto formData = adoptRef(*new DOMFormData(&context));
     if (!form)
         return formData;
     
@@ -56,14 +57,14 @@ ExceptionOr<Ref<DOMFormData>> DOMFormData::create(HTMLFormElement* form)
     return result.releaseNonNull();
 }
 
-Ref<DOMFormData> DOMFormData::create(const PAL::TextEncoding& encoding)
+Ref<DOMFormData> DOMFormData::create(ScriptExecutionContext* context, const PAL::TextEncoding& encoding)
 {
-    return adoptRef(*new DOMFormData(encoding));
+    return adoptRef(*new DOMFormData(context, encoding));
 }
 
 Ref<DOMFormData> DOMFormData::clone() const
 {
-    auto newFormData = adoptRef(*new DOMFormData(this->encoding()));
+    auto newFormData = adoptRef(*new DOMFormData(scriptExecutionContext(), this->encoding()));
     newFormData->m_items = m_items;
     
     return newFormData;

--- a/Source/WebCore/html/DOMFormData.h
+++ b/Source/WebCore/html/DOMFormData.h
@@ -41,7 +41,7 @@ namespace WebCore {
 template<typename> class ExceptionOr;
 class HTMLFormElement;
 
-class DOMFormData : public RefCounted<DOMFormData> {
+class DOMFormData : public RefCounted<DOMFormData>, public ContextDestructionObserver {
 public:
     using FormDataEntryValue = std::variant<RefPtr<File>, String>;
 
@@ -50,8 +50,8 @@ public:
         FormDataEntryValue data;
     };
 
-    static ExceptionOr<Ref<DOMFormData>> create(HTMLFormElement*);
-    static Ref<DOMFormData> create(const PAL::TextEncoding&);
+    static ExceptionOr<Ref<DOMFormData>> create(ScriptExecutionContext&, HTMLFormElement*);
+    static Ref<DOMFormData> create(ScriptExecutionContext*, const PAL::TextEncoding&);
 
     const Vector<Item>& items() const { return m_items; }
     const PAL::TextEncoding& encoding() const { return m_encoding; }
@@ -78,7 +78,7 @@ public:
     Iterator createIterator(ScriptExecutionContext*) { return Iterator { *this }; }
 
 private:
-    explicit DOMFormData(const PAL::TextEncoding& = PAL::UTF8Encoding());
+    explicit DOMFormData(ScriptExecutionContext*, const PAL::TextEncoding& = PAL::UTF8Encoding());
 
     void set(const String& name, Item&&);
 

--- a/Source/WebCore/html/DOMFormData.idl
+++ b/Source/WebCore/html/DOMFormData.idl
@@ -36,7 +36,7 @@ typedef (File or USVString) FormDataEntryValue;
     JSGenerateToJSObject,
     InterfaceName=FormData,
 ] interface DOMFormData {
-    constructor(optional HTMLFormElement form);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional HTMLFormElement form);
 
     undefined append(USVString name, USVString value);
     undefined append(USVString name, Blob blobValue, optional USVString filename);

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -273,7 +273,7 @@ void FormAssociatedCustomElement::restoreFormControlState(const FormControlState
     if (savedState.size() == 1)
         restoredState.emplace<String>(savedState[0]);
     else {
-        auto formData = DOMFormData::create(PAL::UTF8Encoding());
+        auto formData = DOMFormData::create(&asHTMLElement().document(), PAL::UTF8Encoding());
         for (size_t i = 0; i < savedState.size(); i += 2)
             formData->append(savedState[i], savedState[i + 1]);
         restoredState.emplace<RefPtr<DOMFormData>>(formData.ptr());

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -210,7 +210,7 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
     }
 
     auto dataEncoding = isMailtoForm ? PAL::UTF8Encoding() : encodingFromAcceptCharset(copiedAttributes.acceptCharset(), document);
-    auto domFormData = DOMFormData::create(dataEncoding.encodingForFormSubmissionOrURLParsing());
+    auto domFormData = DOMFormData::create(&document, dataEncoding.encodingForFormSubmissionOrURLParsing());
     StringPairVector formValues;
 
     auto result = form.constructEntryList(submitter.copyRef(), WTFMove(domFormData), &formValues);


### PR DESCRIPTION
#### 4e04f1a26a82b2864243e22e78cb142e38d0e1f2
<pre>
Make DOMFormData a subclass of ContextDestructionObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=251167">https://bugs.webkit.org/show_bug.cgi?id=251167</a>
rdar://104659126

Reviewed by Chris Dumez.

We make DOMFormData inherit from ContextDestructionObserver so we have easier
access to the context. We&apos;ll use this in later patches when we must obtain the
relevant top-level origin from the context.

* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/html/DOMFormData.cpp:
(WebCore::DOMFormData::DOMFormData):
(WebCore::DOMFormData::create):
(WebCore::DOMFormData::clone const):
* Source/WebCore/html/DOMFormData.h:
* Source/WebCore/html/DOMFormData.idl:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::restoreFormControlState):
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::create):

Canonical link: <a href="https://commits.webkit.org/259431@main">https://commits.webkit.org/259431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd07469aa5c7a85dfaceb3596f50b1e6f83107c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114090 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174289 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4825 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113087 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11630 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94619 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialRequestOptionsMaximum, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMaximum1, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMaximum2 (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39136 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80800 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27593 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4197 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47143 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9132 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3453 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->