### PR TITLE
Change disconnectOwnerElement call to RELEASE_ASSERT in HTMLFrameOwnerElement destructor

### DIFF
--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -84,8 +84,7 @@ void HTMLFrameOwnerElement::disconnectContentFrame()
 
 HTMLFrameOwnerElement::~HTMLFrameOwnerElement()
 {
-    if (m_contentFrame)
-        m_contentFrame->disconnectOwnerElement();
+    RELEASE_ASSERT_WITH_MESSAGE(!m_contentFrame, "clearContentFrame needs to be called before destroying this HTMLFrameOwnerElement");
 }
 
 Document* HTMLFrameOwnerElement::contentDocument() const


### PR DESCRIPTION
#### e906962817be3c692da415fd75181e45a4ef647c
<pre>
Change disconnectOwnerElement call to RELEASE_ASSERT in HTMLFrameOwnerElement destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=251170">https://bugs.webkit.org/show_bug.cgi?id=251170</a>
rdar://104660865

Reviewed by NOBODY (OOPS!).

Calling disconnectOwnerElement calls clearContentFrame which creates a RefPtr to this.
If that happens during the destructor call, then in debug builds we get an assertion
that m_deletionHasBegun is true when ref is called.  I hit this in a bunch of experimental
work, and I feel like any bugs in this area need to be well avoided.

* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::~HTMLFrameOwnerElement):
</pre>