### PR TITLE
Optimize CSS images by caching StyleImages when possible

### DIFF
--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -50,7 +50,11 @@ bool CSSCanvasValue::equals(const CSSCanvasValue& other) const
 
 RefPtr<StyleImage> CSSCanvasValue::createStyleImage(Style::BuilderState&) const
 {
-    return StyleCanvasImage::create(m_name);
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    m_cachedStyleImage = StyleCanvasImage::create(m_name);
+    return m_cachedStyleImage;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCanvasValue.h
+++ b/Source/WebCore/css/CSSCanvasValue.h
@@ -50,6 +50,7 @@ private:
     explicit CSSCanvasValue(String&&);
 
     String m_name;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -59,10 +59,7 @@ String CSSFilterImageValue::customCSSText() const
 
 RefPtr<StyleImage> CSSFilterImageValue::createStyleImage(Style::BuilderState& state) const
 {
-    auto styleImage = state.createStyleImage(m_imageValueOrNone);
-    auto filterOperations = state.createFilterOperations(m_filterValue);
-
-    return StyleFilterImage::create(WTFMove(styleImage), filterOperations.value_or(FilterOperations { }));
+    return StyleFilterImage::create(state.createStyleImage(m_imageValueOrNone), state.createFilterOperations(m_filterValue).value_or(FilterOperations { }));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -36,6 +36,15 @@
 
 namespace WebCore {
 
+static bool styleImageIsCacheable(const CSSGradientColorStopList& stops)
+{
+    for (auto& stop : stops) {
+        if (stop.color && Style::BuilderState::isColorFromPrimitiveValueDerivedFromElement(*stop.color))
+            return false;
+    }
+    return true;
+}
+
 static inline std::optional<StyleColor> computeStyleColor(const RefPtr<CSSPrimitiveValue>& color, Style::BuilderState& state)
 {
     if (!color)
@@ -56,72 +65,121 @@ static decltype(auto) computeStops(const CSSGradientColorStopList& stops, Style:
 
 RefPtr<StyleImage> CSSLinearGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to LinearData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::LinearData { m_data, m_repeating },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 RefPtr<StyleImage> CSSPrefixedLinearGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to LinearData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::PrefixedLinearData { m_data, m_repeating },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 RefPtr<StyleImage> CSSDeprecatedLinearGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to LinearData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::DeprecatedLinearData { m_data },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 RefPtr<StyleImage> CSSRadialGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to RadialData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::RadialData { m_data, m_repeating },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 RefPtr<StyleImage> CSSPrefixedRadialGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to RadialData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::PrefixedRadialData { m_data, m_repeating },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 RefPtr<StyleImage> CSSDeprecatedRadialGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to RadialData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::DeprecatedRadialData { m_data },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 RefPtr<StyleImage> CSSConicGradientValue::createStyleImage(Style::BuilderState& state) const
 {
-    return StyleGradientImage::create(
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    auto styleImage = StyleGradientImage::create(
         // FIXME: The parameters to ConicData should convert down to a non-CSS specific type here (e.g. Length, double, etc.).
         StyleGradientImage::ConicData { m_data, m_repeating },
         m_colorInterpolationMethod,
         computeStops(m_stops, state)
     );
+    if (styleImageIsCacheable(m_stops))
+        m_cachedStyleImage = styleImage.ptr();
+
+    return styleImage;
 }
 
 static void appendHueInterpolationMethod(StringBuilder& builder, HueInterpolationMethod hueInterpolationMethod)

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -117,6 +117,7 @@ private:
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
@@ -124,6 +125,7 @@ private:
     CSSGradientColorStopList m_stops;
     CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSLinearGradientValue::Data&, const CSSLinearGradientValue::Data&);
@@ -164,6 +166,7 @@ private:
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
@@ -171,6 +174,7 @@ private:
     CSSGradientColorStopList m_stops;
     CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSPrefixedLinearGradientValue::Data&, const CSSPrefixedLinearGradientValue::Data&);
@@ -207,12 +211,14 @@ private:
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
     Data m_data;
     CSSGradientColorStopList m_stops;
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSDeprecatedLinearGradientValue::Data&, const CSSDeprecatedLinearGradientValue::Data&);
@@ -285,6 +291,7 @@ private:
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
@@ -292,6 +299,7 @@ private:
     CSSGradientColorStopList m_stops;
     CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSRadialGradientValue::Data&, const CSSRadialGradientValue::Data&);
@@ -340,6 +348,7 @@ private:
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
@@ -347,6 +356,7 @@ private:
     CSSGradientColorStopList m_stops;
     CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSPrefixedRadialGradientValue::Data&, const CSSPrefixedRadialGradientValue::Data&);
@@ -385,12 +395,14 @@ private:
         , m_data(other.m_data)
         , m_stops(other.m_stops)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
     Data m_data;
     CSSGradientColorStopList m_stops;
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSDeprecatedRadialGradientValue::Data&, const CSSDeprecatedRadialGradientValue::Data&);
@@ -431,6 +443,7 @@ private:
         , m_stops(other.m_stops)
         , m_repeating(other.m_repeating)
         , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+        , m_cachedStyleImage(other.m_cachedStyleImage)
     {
     }
 
@@ -438,6 +451,7 @@ private:
     CSSGradientColorStopList m_stops;
     CSSGradientRepeat m_repeating { CSSGradientRepeat::NonRepeating };
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 bool operator==(const CSSConicGradientValue::Data&, const CSSConicGradientValue::Data&);

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -50,7 +50,11 @@ bool CSSNamedImageValue::equals(const CSSNamedImageValue& other) const
 
 RefPtr<StyleImage> CSSNamedImageValue::createStyleImage(Style::BuilderState&) const
 {
-    return StyleNamedImage::create(m_name);
+    if (m_cachedStyleImage)
+        return m_cachedStyleImage;
+
+    m_cachedStyleImage = StyleNamedImage::create(m_name);
+    return m_cachedStyleImage;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSNamedImageValue.h
+++ b/Source/WebCore/css/CSSNamedImageValue.h
@@ -53,6 +53,7 @@ private:
     explicit CSSNamedImageValue(String&&);
 
     String m_name;
+    mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 766d0eca343b7fd0ca5f29ab89e12bdd4c531244
<pre>
Optimize CSS images by caching StyleImages when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=251162">https://bugs.webkit.org/show_bug.cgi?id=251162</a>
rdar://104654181

Reviewed by Antti Koivisto.

Add caching of StyleImages in CSSValue classes to avoid
duplicate processing and allocation where possible. This
is a pretty conservative pass of caching opertunities,
further opertunities may be available.

The largest optimization here is for CSS gradients, where
by caching the StyleGradientImage, we can avoid recomputing
color stops in many cases.

* Source/WebCore/css/CSSCanvasValue.cpp:
(WebCore::CSSCanvasValue::createStyleImage const):
* Source/WebCore/css/CSSCanvasValue.h:
* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::CSSLinearGradientValue::createStyleImage const):
(WebCore::CSSPrefixedLinearGradientValue::createStyleImage const):
(WebCore::CSSDeprecatedLinearGradientValue::createStyleImage const):
(WebCore::CSSRadialGradientValue::createStyleImage const):
(WebCore::CSSPrefixedRadialGradientValue::createStyleImage const):
(WebCore::CSSDeprecatedRadialGradientValue::createStyleImage const):
(WebCore::CSSConicGradientValue::createStyleImage const):
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSNamedImageValue.cpp:
* Source/WebCore/css/CSSNamedImageValue.h:

Canonical link: <a href="https://commits.webkit.org/259538@main">https://commits.webkit.org/259538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b795b1b1c71e5d758846656b2801419e55033bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114449 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174628 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5190 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97504 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39415 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81081 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7604 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4475 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6565 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9487 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->