### PR TITLE
Implement margin-trim for floats in block containers that contain only block boxes.

### DIFF
--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-end-inline-layout.html
@@ -1,0 +1,39 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    display: flow-root;
+    width: max-content;
+    background-color: green;
+    margin-trim: block;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-end: 50px;
+}
+span {
+    display: inline-block;
+    width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-block-start-inline-layout.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block with inline content present">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: block-start;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-start: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-end-inline-layout.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-inline-layout.html
@@ -1,0 +1,43 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline should trim inline-start edge for floats that touch the inline-start edge of container and inline-end edge for floats that touch inline-end edge of container">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating-left {
+    display: block;
+    width: 25px;
+    float: left;
+    margin-inline-start: 20px;
+}
+.floating-right {
+    display: block;
+    width: 25px;
+    float: right;
+    margin-inline-end: 20px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating-left"></item>
+    <item></item>
+    <item class="floating-right"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-inline-start-inline-layout.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-min-content-inline-layout.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-size: 0px;
+    margin-trim: inline;
+    background-color: green;
+}
+item {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-inline: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    margin-trim: block;
+    display: flow-root;
+    width: max-content;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    margin-block-end: 50px;
+    float: left;
+}
+span {
+    display: inline-block;
+    width: 25px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container style="background-color: green;">
+<item style="width: 50px;"></item>
+<container>
+    <span></span>
+    <item></item>
+</container>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
@@ -1,0 +1,41 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="When a float is not able to fit on the current line, it should have its margins trimmed when placed under other floats">
+<style>
+container {
+    display: block;
+    width: 110px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 25px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+    height: 50px;
+}
+.float-left {
+    float: left;
+}
+.overflowing {
+    margin-inline-start: 55px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="inline-block"></item>
+    <item class="float-left"></item>
+    <item class="float-left overflowing"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
+++ b/LayoutTests/fast/inline/legacy-margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="float that overflows into another item stays on the same line due to trimmed margin">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block-content {
+    display: inline-block;
+    width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item style="float: left"></item>
+    <item class="inline-block-content"></item>
+    <item style="float: right; margin-inline-end: 150px;"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    display: flow-root;
+    width: max-content;
+    background-color: green;
+    margin-trim: block;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-end: 50px;
+}
+span {
+    display: inline-block;
+    width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers-vert-lr.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end of a float should have its margin trimmed up to the content in its BFC">
+<style>
+container {
+    display: flow-root;
+    inline-size: 100px;
+    background-color: green;
+    writing-mode: vertical-lr;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 40px;
+}
+.float {
+    float: right;
+    block-size: 30px;
+    background-color: green;
+    margin-block-end: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item></item>
+<div style="border: 10px solid green; margin-trim: block;">
+<item class="float"></item>
+</div>
+<item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-different-containers.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end of a float should have its margin trimmed up to the content in its BFC">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    background-color: green;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 40px;
+}
+.float {
+    float: right;
+    height: 30px;
+    background-color: green;
+    margin-block-end: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item></item>
+<div style="border: 10px solid green; margin-trim: block;">
+<item class="float"></item>
+</div>
+<item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-up-to-content-block-layout-same-container.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end of a float should have its margin trimmed up to the content in its BFC">
+<style>
+container {
+    display: flow-root;
+    width: 100px;
+    margin-trim: block-end;
+    background-color: green;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-block-start: 50px;
+}
+.float {
+    float: right;
+    height: 30px;
+    margin-block-end: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+<item class="float"></item>
+<item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    border: 1px solid black;
+}
+item {
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-block-layout.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    border: 1px solid black;
+    margin-trim: block-start;
+}
+item {
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    margin-block-start: 10px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<container>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-start should be trimmed for float that touches the top of the containing block with inline content present">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: block-start;
+    font-size: 0px;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-block-start: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+.float {
+    float: right;
+    margin-inline-end: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="float"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-end should be trimmed for float in block container that touches container inline-end edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-end;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-end: 30px;
+    float: right;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline should trim inline-start edge for floats that touch the inline-start edge of container and inline-end edge for floats that touch inline-end edge of container">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating-left {
+    display: block;
+    width: 25px;
+    float: left;
+    margin-inline-start: 20px;
+}
+.floating-right {
+    display: block;
+    width: 25px;
+    float: right;
+    margin-inline-end: 20px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating-left"></item>
+    <item></item>
+    <item class="floating-right"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge">
+<style>
+container {
+    display: block;
+    width: min-content;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 100px;
+    background-color: red;
+}
+.float {
+    float: left;
+    margin-inline-start: 50px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="float"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="inline-start should be trimmed for float in block container that touches container inline-start edge with inline content present">
+<style>
+container {
+    display: block;
+    width: 100px;
+    font-size: 0px;
+    margin-trim: inline-start;
+}
+item {
+    display: inline-block;
+    width: 50px;
+    height: 100px;
+    background-color: green;
+}
+.floating {
+    margin-inline-start: 30px;
+    float: left;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="floating"></item>
+    <item></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout-vert-lr</title>
+<meta name="assert" content="trimmed inline margins for first float should allow second float to sit at same top offset">
+<style>
+container {
+    display: block;
+    inline-size: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    inline-size: 100px;
+    block-size: 50px;
+    background-color: green;
+}
+.floating-item {
+  float: left;
+  inline-size: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container style="writing-mode: vertical-lr;">
+  <item></item>
+  <item class="floating-item" style="margin-inline: 50px;"></item>
+  <item class="floating-item"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout</title>
+<meta name="assert" content="trimmed inline margins for first float should allow second float to sit at same top offset">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.floating-item {
+  float: left;
+  width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+  <item></item>
+  <item class="floating-item" style="margin-inline: 50px;"></item>
+  <item class="floating-item"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+<style>
+container {
+    display: block;
+    width: min-content;
+    font-size: 0px;
+    margin-trim: inline;
+    background-color: green;
+}
+item {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+}
+.floating {
+    display: block;
+    float: left;
+    margin-inline: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="floating"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-with-block-content-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="floats should not contribute trimmed margins for container intrinsic sizing">
+<style>
+container {
+    display: block;
+    width: min-content;
+    height: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.float {
+    float: left;
+    margin-inline: 100px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item></item>
+    <item class="float"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<style>
+container {
+    margin-trim: block;
+    display: flow-root;
+    width: max-content;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    margin-block-end: 50px;
+    float: left;
+}
+span {
+    display: inline-block;
+    width: 25px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container style="background-color: green;">
+<item style="width: 50px;"></item>
+<container>
+    <span></span>
+    <item></item>
+</container>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html
@@ -1,0 +1,41 @@
+<!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="When a float is not able to fit on the current line, it should have its margins trimmed when placed under other floats">
+<style>
+container {
+    display: block;
+    width: 110px;
+    margin-trim: inline;
+    font-size: 0px;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 25px;
+    background-color: green;
+}
+.inline-block {
+    display: inline-block;
+    height: 50px;
+}
+.float-left {
+    float: left;
+}
+.overflowing {
+    margin-inline-start: 55px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item class="inline-block"></item>
+    <item class="float-left"></item>
+    <item class="float-left overflowing"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-right-trimmed-margin-allows-float-to-fit-block-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-float-left-trimmed-margin-allows-float-to-fit-block-layout</title>
+<meta name="assert" content="trimmed inline margins for first float should allow second float to sit at same top offset">
+<style>
+container {
+    display: block;
+    width: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.floating-item {
+  float: right;
+  width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+  <item></item>
+  <item class="floating-item" style="margin-inline: 50px;"></item>
+  <item class="floating-item"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="float that overflows into another item stays on the same line due to trimmed margin">
+<style>
+container {
+    display: block;
+    width: 100px;
+    height: 100px;
+    margin-trim: inline;
+}
+item {
+    display: block;
+    width: 25px;
+    height: 100px;
+    background-color: green;
+}
+.inline-block-content {
+    display: inline-block;
+    width: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<container>
+    <item style="float: left"></item>
+    <item class="inline-block-content"></item>
+    <item style="float: right; margin-inline-end: 150px;"></item>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-overflowing-float-margins-trimmed-at-final-position-block-layout</title>
+<meta name="assert" content="the third float should be able to sit right under the first float with its margins trimmed">
+<style>
+.container {
+    width: 100px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<div class="container">
+  <div style="width: 100px; height: 50px; background-color: green"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: blue;"></div>
+  <div style="width: 25px; height: 50px; float: right; height: 80px; background-color: red;"></div>
+  <div style="width: 100px; height: 50px;"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: purple;"></div>
+</container>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-overflowing-float-margins-tirmmed-at-final-position-block-layout.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<title>margin-trim: block-container-overflowing-float-margins-trimmed-at-final-position-block-layout</title>
+<meta name="assert" content="the third float should be able to sit right under the first float with its margins trimmed">
+<style>
+.container {
+    width: 100px;
+    margin-trim: inline;
+}
+</style>
+</head>
+<body>
+<div class="container">
+  <div style="width: 100px; height: 50px; background-color: green"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: blue; margin-inline-start: 20px;"></div>
+  <div style="width: 25px; height: 50px; float: right; height: 80px; background-color: red; margin-inline-end: 20px;"></div>
+  <div style="width: 25px; height: 50px; float: left; background-color: purple; margin-inline-start: 80px;"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -49,6 +49,7 @@ public:
     const FloatingState& floatingState() const { return m_floatingState; }
 
     LayoutPoint positionForFloat(const Box&, const HorizontalConstraints&) const;
+    bool isFloaingCandidateLogicallyLeftPositioned(const Box&) const;
     LayoutPoint positionForNonFloatingFloatAvoider(const Box&) const;
 
     struct PositionWithClearance {
@@ -76,7 +77,6 @@ public:
 private:
     std::optional<LayoutUnit> bottom(Clear) const;
 
-    bool isFloaingCandidateLogicallyLeftPositioned(const Box&) const;
     Clear logicalClear(const Box&) const;
 
     const LayoutState& layoutState() const { return m_floatingState.layoutState(); }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
@@ -144,6 +144,9 @@ private:
     LayoutUnit adjustGeometryForInitialLetterIfNeeded(const Box& floatBox);
     enum LineBoxConstraintApplies : uint8_t { Yes, No };
     bool tryPlacingFloatBox(const InlineItem&, LineBoxConstraintApplies);
+    bool placedFloatsContainsLeftPositionedFloat() const;
+    bool placedFloatsContainsRightPositionedFloat() const;
+    void trimMarginFromFloatGeometry(BoxGeometry&, MarginTrimType);
     Result handleInlineContent(InlineContentBreaker&, const InlineItemRange& needsLayoutRange, const LineCandidate&);
     std::tuple<InlineRect, bool> lineBoxForCandidateInlineContent(const LineCandidate&) const;
     size_t rebuildLineWithInlineContent(const InlineItemRange& needsLayoutRange, const InlineItem& lastInlineItemToAdd);

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -366,8 +366,8 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
             if (renderer.isFloating() && !renderer.parent()->style().isHorizontalWritingMode())
                 return false;
 #endif
-            if (renderer.isFloating() && (flow.fragmentedFlowState() != RenderObject::NotInsideFragmentedFlow || !flow.style().marginTrim().isEmpty())) {
-                // Floats inside fragmentation and ones under margin-trim need integration support.
+            if (renderer.isFloating() && flow.fragmentedFlowState() != RenderObject::NotInsideFragmentedFlow) {
+                // Floats inside fragmentation need integration support.
                 return false;
             }
             if (renderer.isOutOfFlowPositioned()) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -366,8 +366,8 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
             if (renderer.isFloating() && !renderer.parent()->style().isHorizontalWritingMode())
                 return false;
 #endif
-            if (renderer.isFloating() && flow.fragmentedFlowState() != RenderObject::NotInsideFragmentedFlow) {
-                // Floats inside fragmentation need integration support.
+            if (renderer.isFloating() && (flow.fragmentedFlowState() != RenderObject::NotInsideFragmentedFlow || !flow.style().marginTrim().isEmpty())) {
+                // Floats inside fragmentation and ones under margin-trim need integration support.
                 return false;
             }
             if (renderer.isOutOfFlowPositioned()) {

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -112,6 +112,13 @@ LayoutSize FloatingObject::translationOffsetToAncestor() const
     return locationOffsetOfBorderBox() - renderer().locationOffset();
 }
 
+bool FloatingObject::containingBlockHasBlockEndMarginTrim() const
+{
+    if (auto containingBlock = m_renderer->containingBlock())
+        return containingBlock->style().marginTrim().contains(MarginTrimType::BlockEnd);
+    return false;
+}
+
 #if ENABLE(TREE_DEBUGGING)
 
 TextStream& operator<<(TextStream& stream, const FloatingObject& object)

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -64,7 +64,7 @@ public:
     void setX(LayoutUnit x) { ASSERT(!isInPlacedTree()); m_frameRect.setX(x); }
     void setY(LayoutUnit y) { ASSERT(!isInPlacedTree()); m_frameRect.setY(y); }
     void setWidth(LayoutUnit width) { ASSERT(!isInPlacedTree()); m_frameRect.setWidth(width); }
-    void setHeight(LayoutUnit height) { ASSERT(!isInPlacedTree()); m_frameRect.setHeight(height); }
+    void setHeight(LayoutUnit height) { ASSERT(!isInPlacedTree() || containingBlockHasBlockEndMarginTrim()); m_frameRect.setHeight(height); }
 
     void setMarginOffset(LayoutSize offset) { ASSERT(!isInPlacedTree()); m_marginOffset = offset; }
 
@@ -92,6 +92,10 @@ public:
     void clearOriginatingLine() { m_originatingLine = nullptr; }
     void setOriginatingLine(LegacyRootInlineBox& line) { m_originatingLine = line; }
 
+    bool containingBlockHasBlockEndMarginTrim() const;
+    void setHasTrimmedMargins(bool hasTrimmedMargins) { m_hasTrimmedMargins = hasTrimmedMargins; }
+    bool hasTrimmedMargins() const { return m_hasTrimmedMargins; }
+
     LayoutSize locationOffsetOfBorderBox() const
     {
         ASSERT(isPlaced());
@@ -110,6 +114,7 @@ private:
     unsigned m_paintsFloat : 1;
     unsigned m_isDescendant : 1;
     unsigned m_isPlaced : 1;
+    unsigned m_hasTrimmedMargins : 1;
 #if ASSERT_ENABLED
     unsigned m_isInPlacedTree : 1;
 #endif

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -2352,5 +2352,15 @@ const FrameViewLayoutContext& LegacyLineLayout::layoutContext() const
     return m_flow.view().frameView().layoutContext();
 }
 
+LayoutUnit LegacyLineLayout::contentBoxLogicalHeight() const
+{
+    auto firstLine = m_lineBoxes.firstLineBox();
+    auto lastLine = m_lineBoxes.lastLineBox();
+    if (firstLine && lastLine)
+        return LayoutUnit { lastLine->logicalFrameRect().maxY() - firstLine->logicalFrameRect().y() };
+    if (firstLine)
+        return LayoutUnit { firstLine->logicalFrameRect().maxY() };
+    return 0_lu;
+}
 
 }

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -72,6 +72,7 @@ public:
 
     size_t lineCount() const;
     size_t lineCountUntil(const LegacyRootInlineBox*) const;
+    LayoutUnit contentBoxLogicalHeight() const;
 
     static void appendRunsForObject(BidiRunList<BidiRun>*, int start, int end, RenderObject&, InlineBidiResolver&);
     static void updateLogicalWidthForAlignment(RenderBlockFlow&, const TextAlignMode&, const LegacyRootInlineBox*, BidiRun* trailingSpaceRun, float& logicalLeft, float& totalLogicalWidth, float& availableLogicalWidth, int expansionOpportunityCount);

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -235,9 +235,11 @@ public:
     enum ApplyLayoutDeltaMode { ApplyLayoutDelta, DoNotApplyLayoutDelta };
     LayoutUnit logicalWidthForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.width() : child.height(); }
     LayoutUnit logicalHeightForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.height() : child.width(); }
+    LayoutUnit logicalMarginBoxHeightForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.marginBoxRect().height() : child.marginBoxRect().width(); }
     LayoutSize logicalSizeForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.size() : child.size().transposedSize(); }
     LayoutUnit logicalTopForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.y() : child.x(); }
     LayoutUnit logicalLeftForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.x() : child.y(); }
+    LayoutUnit logicalMarginBoxTopForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.marginBoxRect().y() : child.marginBoxRect().x(); }
     void setLogicalLeftForChild(RenderBox& child, LayoutUnit logicalLeft, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
     void setLogicalTopForChild(RenderBox& child, LayoutUnit logicalTop, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
     LayoutUnit marginBeforeForChild(const RenderBoxModelObject& child) const { return child.marginBefore(&style()); }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4809,6 +4809,7 @@ LayoutUnit RenderBlockFlow::blockFormattingContextInFlowContentHeight() const
         ASSERT(legacyLineLayout());
         return legacyLineLayout()->contentBoxLogicalHeight();
     }
+
     // For block layout we should just be able to check the height of the last in flow box
     auto lastChild = lastInFlowChildBox();
     if (!lastChild)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -559,7 +559,7 @@ void RenderBlockFlow::layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalH
         // so we need to go through the floats that this BFC is aware of and check if any of
         // the float's need their block-end margin trimmed
         if (m_floatingObjects && createsBlockFormattingContext())
-            trimFloatBlockEndMargins(blockFormattingContextInFlowBlockLevelContentHeight());
+            trimFloatBlockEndMargins(blockFormattingContextInFlowContentHeight());
 
         // Expand our intrinsic height to encompass floats.
         LayoutUnit toAdd = borderAndPaddingAfter() + scrollbarLogicalHeight();
@@ -4797,9 +4797,18 @@ bool RenderBlockFlow::tryComputePreferredWidthsUsingModernPath(LayoutUnit& minLo
     return true;
 }
 
-LayoutUnit RenderBlockFlow::blockFormattingContextInFlowBlockLevelContentHeight() const
+LayoutUnit RenderBlockFlow::blockFormattingContextInFlowContentHeight() const
 {
     ASSERT(createsBlockFormattingContext());
+
+    if (childrenInline()) {
+        if (lineLayoutPath() == ModernPath) {
+            ASSERT(modernLineLayout());
+            return modernLineLayout()->contentBoxLogicalHeight();
+        }
+        ASSERT(legacyLineLayout());
+        return legacyLineLayout()->contentBoxLogicalHeight();
+    }
     // For block layout we should just be able to check the height of the last in flow box
     auto lastChild = lastInFlowChildBox();
     if (!lastChild)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -192,10 +192,30 @@ RenderBlockFlow* RenderBlockFlow::previousSiblingWithOverhangingFloats(bool& par
     return nullptr;
 }
 
+void RenderBlockFlow::markLayoutNeededOnFloatsWithTrimmedMargins()
+{
+    if (!m_floatingObjects)
+        return;
+    // If this is not done then we may run into incorrect reults when going
+    // through multiple iterations of layout. Since the floating object's width
+    // includes m_marginBox inline sizes, we can run into issues because:
+    // 1.) The first iteration of layout will create the float with the correct witdth and magins
+    // 2.) Those margins will get trimmed at some point during layout (which gets reflected by seting the m_marginBox values to 0)
+    // 3.) A second iteration of layout will occur and RenderBlockFlow will clear its FloatingObjects
+    // 4.) The floating objects will be created with the wrong width since they grab the trimmed margins from the m_marginBox
+    auto& floatingObjectSet = m_floatingObjects->set();
+    for (auto itr = floatingObjectSet.begin(); itr != floatingObjectSet.end(); ++itr) {
+        auto floatingObject = itr->get();
+        if (floatingObject->isDescendant() && floatingObject->hasTrimmedMargins())
+            floatingObject->renderer().setNeedsLayout();
+    }
+}
+
 void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
 {
     if (m_floatingObjects)
         m_floatingObjects->setHorizontalWritingMode(isHorizontalWritingMode());
+    markLayoutNeededOnFloatsWithTrimmedMargins();
 
     HashSet<RenderBox*> oldIntrudingFloatSet;
     if (!childrenInline() && m_floatingObjects) {
@@ -534,6 +554,13 @@ void RenderBlockFlow::layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalH
             setChildrenInline(true);
         dirtyForLayoutFromPercentageHeightDescendants();
         layoutInFlowChildren(relayoutChildren, repaintLogicalTop, repaintLogicalBottom, maxFloatLogicalBottom);
+
+        // The containing block's of the floats within this BFC may specify margin-trim: block-end
+        // so we need to go through the floats that this BFC is aware of and check if any of
+        // the float's need their block-end margin trimmed
+        if (m_floatingObjects && createsBlockFormattingContext())
+            trimFloatBlockEndMargins(blockFormattingContextInFlowBlockLevelContentHeight());
+
         // Expand our intrinsic height to encompass floats.
         LayoutUnit toAdd = borderAndPaddingAfter() + scrollbarLogicalHeight();
         if (lowestFloatLogicalBottom() > (logicalHeight() - toAdd) && createsNewFormattingContext())
@@ -1365,6 +1392,51 @@ bool RenderBlockFlow::shouldTrimChildMargin(MarginTrimType marginTrimType, const
     if (marginTrimType == MarginTrimType::BlockStart)
         return firstInFlowChildBox() == &child;
     return lastInFlowChildBox() == &child;
+}
+
+void RenderBlockFlow::trimFloatBlockEndMargins(LayoutUnit blockFormattingContextInFlowContentHeight)
+{
+    ASSERT(m_floatingObjects && createsBlockFormattingContext());
+    auto computeFloatMarginAfterStartLocationInBlockFormattingContext = [&](const RenderBox& floatBox) {
+        // Start with the location of the float within its containing block. If this containing
+        // block is the BFC in which we are trimming, then we can use this as the starting location
+        // since this is the float's positin within the BFC. If not, add the containing block's location
+        // to the float's location. This new value should be the location of the float relative to this
+        // new containing block. Keep doing this until we find the containing block that establishes
+        // a BFC
+        auto startLocation = logicalTopForChild(floatBox);
+        auto containingBlock = floatBox.containingBlock();
+        ASSERT(containingBlock);
+        while (!containingBlock->createsBlockFormattingContext()) {
+            startLocation += logicalTopForChild(*containingBlock);
+            containingBlock = containingBlock->containingBlock();
+        }
+        return startLocation + logicalHeightForChild(floatBox);
+    };
+    for (auto& floatingObject : m_floatingObjects->set()) {
+        auto& floatBox = floatingObject->renderer();
+        if (!floatBox.parentStyle()->marginTrim().contains(MarginTrimType::BlockEnd) || !floatBox.marginAfter())
+            continue;
+
+        // There are 3 different cases that need to be taken into consideration when trimming the
+        // block-end margin of a float:
+        // 1.) The float margin box extends past the deepest past of content (margin should be trimmed all the way)
+        // 2.) The end of the deepest piece of is in between the float's border box and marign box (marign should be trimmed up to the content)
+        // 3.) The deepest piece of content is below the float's margin box (no trimming occurs)
+        auto floatMarginAfterStartLocation = computeFloatMarginAfterStartLocationInBlockFormattingContext(floatBox);
+        if (floatMarginAfterStartLocation >= blockFormattingContextInFlowContentHeight)
+            trimMarginForFloat(*floatingObject, MarginTrimType::BlockEnd, floatBox.marginAfter(&style()));
+        else if (blockFormattingContextInFlowContentHeight > floatMarginAfterStartLocation && (blockFormattingContextInFlowContentHeight < floatMarginAfterStartLocation + floatBox.marginAfter()))
+            trimMarginForFloat(*floatingObject, MarginTrimType::BlockEnd, floatMarginAfterStartLocation + floatBox.marginAfter(&style()) - blockFormattingContextInFlowContentHeight);
+    }
+}
+
+bool RenderBlockFlow::shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType marginSide, const RenderElement& child) const
+{
+    // For the purposes of computing a block container's intrinsic size, a float should not
+    // include its trimmed margins in its intrinsic size contributions
+    ASSERT(marginSide == MarginTrimType::InlineStart || marginSide == MarginTrimType::InlineEnd);
+    return !child.isFloating() || !style().marginTrim().contains(marginSide);
 }
 
 LayoutUnit RenderBlockFlow::clearFloatsIfNeeded(RenderBox& child, MarginInfo& marginInfo, LayoutUnit oldTopPosMargin, LayoutUnit oldTopNegMargin, LayoutUnit yPos)
@@ -2414,7 +2486,7 @@ FloatingObject* RenderBlockFlow::insertFloatingObject(RenderBox& floatBox)
     // Create the special floatingObject entry & append it to the list
 
     std::unique_ptr<FloatingObject> floatingObject = FloatingObject::create(floatBox);
-    
+
     // Our location is irrelevant if we're unsplittable or no pagination is in effect. Just lay out the float.
     bool isChildRenderBlock = floatBox.isRenderBlock();
     if (isChildRenderBlock && !floatBox.needsLayout() && view().frameView().layoutContext().layoutState()->pageLogicalHeightChanged())
@@ -2517,6 +2589,32 @@ LayoutUnit RenderBlockFlow::logicalRightOffsetForPositioningFloat(LayoutUnit log
     return adjustLogicalRightOffsetForLine(offset, applyTextIndent);
 }
 
+void RenderBlockFlow::trimMarginForFloat(FloatingObject& floatingObject, MarginTrimType marginTrimType, LayoutUnit trimAmount)
+{
+    switch (marginTrimType) {
+    case MarginTrimType::InlineStart: {
+        setLogicalWidthForFloat(floatingObject, logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginStart(&style()));
+        floatingObject.renderer().setMarginStart(0_lu, &style());
+        break; 
+    }
+    case MarginTrimType::InlineEnd: {
+        setLogicalWidthForFloat(floatingObject, logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginEnd(&style()));
+        floatingObject.renderer().setMarginEnd(0_lu, &style());
+        break;
+    }
+    case MarginTrimType::BlockStart:
+        setLogicalHeightForFloat(floatingObject, logicalHeightForFloat(floatingObject) - floatingObject.renderer().marginBefore(&style()));
+        floatingObject.renderer().setMarginBefore(0_lu, &style());
+        break;
+    case MarginTrimType::BlockEnd: {
+        ASSERT(trimAmount <= floatingObject.renderer().marginAfter(&style()) && trimAmount);
+        setLogicalHeightForFloat(floatingObject, logicalHeightForFloat(floatingObject) - trimAmount);
+        break;
+    }
+    }
+    floatingObject.setHasTrimmedMargins(true);
+}
+
 void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObject, LayoutUnit& logicalTopOffset)
 {
     auto& childBox = floatingObject.renderer();
@@ -2527,6 +2625,20 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
 
     LayoutUnit floatLogicalLeft;
 
+    auto containingBlockMarginTrim = style().marginTrim();
+    auto floatWidthWithoutMargin = [&](FloatingObject& floatingObject, MarginTrimType marginSide) {
+        auto& containingBlockStyle = style();
+        switch (marginSide) {
+        case MarginTrimType::InlineStart:
+            return logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginStart(&containingBlockStyle);
+        case MarginTrimType::InlineEnd:
+            return logicalWidthForFloat(floatingObject) - floatingObject.renderer().marginEnd(&containingBlockStyle);
+        default: {
+            ASSERT_NOT_REACHED();
+            return logicalWidthForFloat(floatingObject);
+        }
+        }
+    };
     bool insideFragmentedFlow = enclosingFragmentedFlow();
     bool isInitialLetter = childBox.style().styleType() == PseudoId::FirstLetter && childBox.style().initialLetterDrop() > 0;
     
@@ -2544,7 +2656,10 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
         LayoutUnit heightRemainingLeft = 1_lu;
         LayoutUnit heightRemainingRight = 1_lu;
         floatLogicalLeft = logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
-        while (logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight) - floatLogicalLeft < floatLogicalWidth) {
+        auto availableSpace = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight) - floatLogicalLeft;
+        while (availableSpace < floatLogicalWidth) {
+            if (containingBlockMarginTrim.contains(MarginTrimType::InlineStart) && floatLogicalLeft == logicalLeftOffset && availableSpace >= floatWidthWithoutMargin(floatingObject, MarginTrimType::InlineStart))
+                break;
             logicalTopOffset += std::min(heightRemainingLeft, heightRemainingRight);
             floatLogicalLeft = logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
             if (insideFragmentedFlow) {
@@ -2553,13 +2668,22 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
                 logicalLeftOffset = logicalLeftOffsetForContent(logicalTopOffset); // Constant part of left offset.
                 floatLogicalWidth = std::min(logicalWidthForFloat(floatingObject), logicalRightOffset - logicalLeftOffset);
             }
+            availableSpace = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight) - floatLogicalLeft;
         }
         floatLogicalLeft = std::max(logicalLeftOffset - borderAndPaddingLogicalLeft(), floatLogicalLeft);
+        
+        if (containingBlockMarginTrim.contains(MarginTrimType::InlineStart) && logicalLeftOffset == floatLogicalLeft)
+            trimMarginForFloat(floatingObject, MarginTrimType::InlineStart);
+        if (containingBlockMarginTrim.contains(MarginTrimType::InlineEnd) && floatLogicalLeft + logicalWidthForFloat(floatingObject) == logicalRightOffset)
+            trimMarginForFloat(floatingObject, MarginTrimType::InlineEnd);
     } else {
         LayoutUnit heightRemainingLeft = 1_lu;
         LayoutUnit heightRemainingRight = 1_lu;
         floatLogicalLeft = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight);
-        while (floatLogicalLeft - logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft) < floatLogicalWidth) {
+        auto availableSpace = floatLogicalLeft - logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
+        while (availableSpace < floatLogicalWidth) {
+            if (containingBlockMarginTrim.contains(MarginTrimType::InlineEnd) && (availableSpace >= floatWidthWithoutMargin(floatingObject, MarginTrimType::InlineEnd)))
+                break;
             logicalTopOffset += std::min(heightRemainingLeft, heightRemainingRight);
             floatLogicalLeft = logicalRightOffsetForPositioningFloat(logicalTopOffset, logicalRightOffset, false, &heightRemainingRight);
             if (insideFragmentedFlow) {
@@ -2568,12 +2692,22 @@ void RenderBlockFlow::computeLogicalLocationForFloat(FloatingObject& floatingObj
                 logicalLeftOffset = logicalLeftOffsetForContent(logicalTopOffset); // Constant part of left offset.
                 floatLogicalWidth = std::min(logicalWidthForFloat(floatingObject), logicalRightOffset - logicalLeftOffset);
             }
+            availableSpace = floatLogicalLeft - logicalLeftOffsetForPositioningFloat(logicalTopOffset, logicalLeftOffset, false, &heightRemainingLeft);
         }
+        // We trim before we update floatLogicalLeft becaue it currently represents the logical
+        // right for the float. We would have to otherwise update floatLogicalLeft each time we
+        // trim a margin by adding the trimmed margin to its value
+        if (containingBlockMarginTrim.contains(MarginTrimType::InlineEnd) && logicalRightOffset == floatLogicalLeft)
+            trimMarginForFloat(floatingObject, MarginTrimType::InlineEnd);    
+        if (containingBlockMarginTrim.contains(MarginTrimType::InlineStart) && floatLogicalLeft - logicalWidthForFloat(floatingObject) == logicalLeftOffset)
+            trimMarginForFloat(floatingObject, MarginTrimType::InlineStart);
         // Use the original width of the float here, since the local variable
         // |floatLogicalWidth| was capped to the available line width. See
         // fast/block/float/clamped-right-float.html.
         floatLogicalLeft -= logicalWidthForFloat(floatingObject);
     }
+    if (style().marginTrim().contains(MarginTrimType::BlockStart) && logicalTopOffset == borderAndPaddingBefore())
+        trimMarginForFloat(floatingObject, MarginTrimType::BlockStart);
 
     LayoutUnit childLogicalLeftMargin = style().isLeftToRightDirection() ? marginStartForChild(childBox) : marginEndForChild(childBox);
     LayoutUnit childBeforeMargin = marginBeforeForChild(childBox);
@@ -4387,8 +4521,8 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                     if (!child->isFloating())
                         lastText = nullptr;
                     LayoutUnit margins;
-                    Length startMargin = childStyle.marginStartUsing(&style());
-                    Length endMargin = childStyle.marginEndUsing(&style());
+                    Length startMargin = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineStart, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginStartUsing(&style()) : Length(0, LengthType::Fixed); 
+                    Length endMargin = shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType::InlineEnd, *dynamicDowncast<RenderElement>(child)) ? childStyle.marginEndUsing(&style()) : Length(0, LengthType::Fixed);
                     if (startMargin.isFixed())
                         margins += LayoutUnit::fromFloatCeil(startMargin.value());
                     if (endMargin.isFixed())
@@ -4661,6 +4795,17 @@ bool RenderBlockFlow::tryComputePreferredWidthsUsingModernPath(LayoutUnit& minLo
     for (auto walker = InlineWalker(*this); !walker.atEnd(); walker.advance())
         walker.current()->setPreferredLogicalWidthsDirty(false);
     return true;
+}
+
+LayoutUnit RenderBlockFlow::blockFormattingContextInFlowBlockLevelContentHeight() const
+{
+    ASSERT(createsBlockFormattingContext());
+    // For block layout we should just be able to check the height of the last in flow box
+    auto lastChild = lastInFlowChildBox();
+    if (!lastChild)
+        return 0_lu;
+    // Child's margin box starting location + border box height + margin after size
+    return logicalMarginBoxTopForChild(*lastChild) + logicalMarginBoxHeightForChild(*lastChild);
 }
 
 }

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -226,6 +226,8 @@ public:
     LayoutUnit marginOffsetForSelfCollapsingBlock();
 
     bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const final;
+    void trimFloatBlockEndMargins(LayoutUnit blockFormattingContextInFlowContentHeight);
+    bool shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType, const RenderElement&) const;
 
     void layoutBlockChild(RenderBox& child, MarginInfo&, LayoutUnit& previousFloatLogicalBottom, LayoutUnit& maxFloatLogicalBottom);
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);
@@ -284,6 +286,7 @@ public:
     void removeFloatingObjects();
     void markAllDescendantsWithFloatsForLayout(RenderBox* floatToRemove = nullptr, bool inLayout = true);
     void markSiblingsWithFloatsForLayout(RenderBox* floatToRemove = nullptr);
+    void markLayoutNeededOnFloatsWithTrimmedMargins();
 
     const FloatingObjectSet* floatingObjectSet() const { return m_floatingObjects ? &m_floatingObjects->set() : nullptr; }
 
@@ -331,6 +334,7 @@ public:
         else
             floatingObject.setMarginOffset(LayoutSize(logicalBeforeMargin, logicalLeftMargin));
     }
+    void trimMarginForFloat(FloatingObject&, MarginTrimType, LayoutUnit trimAmount = 0);
 
     LayoutPoint flipFloatForWritingModeForChild(const FloatingObject&, const LayoutPoint&) const;
 
@@ -400,6 +404,7 @@ public:
 
     std::optional<LayoutUnit> lowestInitialLetterLogicalBottom() const;
 
+    LayoutUnit blockFormattingContextInFlowBlockLevelContentHeight() const;
 protected:
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -404,7 +404,7 @@ public:
 
     std::optional<LayoutUnit> lowestInitialLetterLogicalBottom() const;
 
-    LayoutUnit blockFormattingContextInFlowBlockLevelContentHeight() const;
+    LayoutUnit blockFormattingContextInFlowContentHeight() const;
 protected:
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4970,6 +4970,24 @@ bool RenderBox::establishesIndependentFormattingContext() const
     return isGridItem() || RenderElement::establishesIndependentFormattingContext();
 }
 
+bool RenderBox::createsBlockFormattingContext() const
+{
+    const auto& boxStyle = style();
+    if (!boxStyle.isDisplayBlockLevel())
+        return false;
+    auto isBlockWithOverFlowOtherThanVisibleAndClip = [&]() {
+        auto boxOverflowX = effectiveOverflowX();
+        auto boxOverflowY = effectiveOverflowY();
+        return boxOverflowX != Overflow::Visible && boxOverflowX != Overflow::Clip
+            && boxOverflowY != Overflow::Visible && boxOverflowY != Overflow::Clip;
+    };
+    return dynamicDowncast<HTMLHtmlElement>(element()) || isFloatingOrOutOfFlowPositioned() 
+    || isInlineBlockOrInlineTable() || isTableCell() || isTableCaption() || isBlockWithOverFlowOtherThanVisibleAndClip()
+    || boxStyle.display() == DisplayType::FlowRoot || boxStyle.containsLayoutOrPaint()
+    || isFlexItemIncludingDeprecated() || isGridItem() || boxStyle.specifiesColumns()
+    || boxStyle.columnSpan() == ColumnSpan::All;
+}
+
 bool RenderBox::avoidsFloats() const
 {
     return isReplacedOrInlineBlock() || isLegend() || isFieldset() || createsNewFormattingContext();
@@ -5628,6 +5646,16 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
     auto height = style().containIntrinsicHeight();
     ASSERT(height.has_value());
     return std::optional<LayoutUnit> { height->value() };
+}
+
+RenderBlockFlow* RenderBox::blockFormattingContextRoot() const
+{
+    // This method should probably not be called on the initial containing block
+    ASSERT(!is<HTMLHtmlElement>(element()));
+    auto cb = containingBlock();
+    while (cb && !cb->createsBlockFormattingContext())
+        cb = cb->containingBlock();
+    return dynamicDowncast<RenderBlockFlow>(cb);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -196,6 +196,7 @@ public:
     RenderBox* nextSiblingBox() const;
     RenderBox* nextInFlowSiblingBox() const;
 
+    RenderBlockFlow* blockFormattingContextRoot() const;
     // Visual and layout overflow are in the coordinate space of the box.  This means that they aren't purely physical directions.
     // For horizontal-tb and vertical-lr they will match physical directions, but for horizontal-bt and vertical-rl, the top/bottom and left/right
     // respectively are flipped when compared to their physical counterparts.  For example minX is on the left in vertical-lr,
@@ -705,6 +706,7 @@ public:
     }
 
     bool establishesIndependentFormattingContext() const override;
+    bool createsBlockFormattingContext() const;
 
 protected:
     RenderBox(Element&, RenderStyle&&, BaseTypeFlags);

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -364,7 +364,14 @@ inline void BreakingContext::handleOutOfFlowPositioned(Vector<RenderBox*>& posit
 inline void BreakingContext::handleFloat()
 {
     auto& floatBox = downcast<RenderBox>(*m_current.renderer());
-    const auto& floatingObject = *m_lineBreaker.insertFloatingObject(floatBox);
+    auto& floatingObject = *m_lineBreaker.insertFloatingObject(floatBox);
+    
+    // Check to see if there is anything on the left/right (depending on the position of the float) that this float
+    // would get pushed against. If there is nothing then we can trim the margins for this float
+    if (m_blockStyle.marginTrim().contains(MarginTrimType::InlineStart) && RenderStyle::usedFloat(floatBox) == UsedFloat::Left && m_block.logicalLeftOffsetForLine(m_block.logicalHeight(), DoNotIndentText)  == m_block.logicalLeftOffsetForContent(m_block.logicalHeight()))
+        m_block.trimMarginForFloat(floatingObject, MarginTrimType::InlineStart);
+    else if (m_blockStyle.marginTrim().contains(MarginTrimType::InlineEnd) && RenderStyle::usedFloat(floatBox) == UsedFloat::Right && m_block.logicalRightOffsetForLine(m_block.logicalHeight(), DoNotIndentText) == m_block.logicalRightOffsetForContent(m_block.logicalHeight()))
+        m_block.trimMarginForFloat(floatingObject, MarginTrimType::InlineEnd);
     // check if it fits in the current line.
     // If it does, position it now, otherwise, position
     // it after moving to next line (in clearFloats() func)


### PR DESCRIPTION
Implement margin-trim for inline layout in IFC.
https://bugs.webkit.org/show_bug.cgi?id=251154
rdar://104650698

Reviewed by NOBODY (OOPS!).

Adds the equivalent logic from the legacy inline patch into IFC. The
premise is:
- As we position the floats, check to see if there is anything on the
left/right (depending on the position of the float) of the containing
block
- If there is nothing on that side we can trim the respective margin
- Otherwise the float may need to get placed under some other floats
  so we wait to trim once we determine its position

For each float we can determine that there is nothing on its respective
side. We check to see if there are any floats on that side that we
have previously positioned on this line (placedFloatsContainsLeft/RightPositionedFloat)
as well as to see if there are any intruding floats from the previous
lines (floatConstraints()). This logic is done in the scenario where
we are placing an overflowing float and when the line is not considered
empty. If the line is considered empty we can just wait to trim the
margin after it gets its final position from
floatingContext.positionForFloat since there is no risk of the float
not fitting on the line.

The examples are the same as from the legacy inline layout patch.

```
<div style="margin-trim: inline;">
  <div style="float: left; width: 50px; height: 50px; background-color: green; margin-inline-start: 30px;"></div>
  <div style="float: right; width: 50px; height: 50px; background-color: red; margin-inline-end: 30px;"></div>
</div>
```

1.) For the first float we see that the line is empty so we trim its
    margins after it gets its final position.
2.) For the second float since the line is no longer empty we try to
    see if we can can trim its margin based off of previously positioned
    floats and any intruding ones. This is because we might be able to
    fit it on the line with a trimmed margin. In this case we see that
    we have nothing on the right side of the box so we can trim its
    inline-end margin.

```
<style>
container {
    display: block;
    width: 110px;
    margin-trim: inline;
    font-size: 0px;
}
item {
    display: block;
    width: 100px;
    height: 25px;
    background-color: green;
}
.inline-block {
    display: inline-block;
    height: 50px;
}
.float-left {
    float: left;
}
.overflowing {
    margin-inline-start: 55px;
}
</style>
<container>
    <item class="inline-block"></item>
    <item class="float-left"></item>
    <item class="float-left overflowing"></item>
</container>
```
In this particular example for the final float we see that we have other
items on the left side when we try to find its position so we cannot
trim that margin early. Instead we have to wait until it gets its final
position under the other float to trim the margin.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-end-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-block-start-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-end-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-inline-start-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-min-content-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-multiple-formatting-contexts-inline-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-overflowing-margin-has-margin-trimmed-at-final-position.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-float-trimmed-margin-allows-float-to-fit-inline-layout.html: Added.
* Source/WebCore/layout/floats/FloatingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::placedFloatsContainsLeftPositionedFloat const):
(WebCore::Layout::LineBuilder::placedFloatsContainsRightPositionedFloat const):
(WebCore::Layout::LineBuilder::trimMarginFromFloatGeometry):
(WebCore::Layout::LineBuilder::tryPlacingFloatBox):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h:
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForChild):