### PR TITLE
WebGPU: Compute passes

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -70,6 +70,10 @@ public:
 
     bool bindingContainsStage(uint32_t bindingIndex, ShaderStage renderStage) const;
 
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    static WGPUBindGroupLayoutEntry createEntryFromStructMember(MTLStructMember *, uint32_t&, WGPUShaderStage);
+#endif
+
 private:
     BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&&, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>);
     BindGroupLayout();

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -218,6 +218,32 @@ bool BindGroupLayout::bindingContainsStage(uint32_t bindingIndex, ShaderStage sh
     return containsStage(m_shaderStageForBinding.find(bindingIndex + 1)->value, shaderStage);
 }
 
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+WGPUBindGroupLayoutEntry BindGroupLayout::createEntryFromStructMember(MTLStructMember *structMember, uint32_t& currentBindingIndex, WGPUShaderStage shaderStage)
+{
+    WGPUBindGroupLayoutEntry entry = { };
+    entry.binding = currentBindingIndex++;
+    entry.visibility = shaderStage;
+    switch (structMember.dataType) {
+    case MTLDataTypeTexture:
+        entry.texture.sampleType = WGPUTextureSampleType_Float;
+        entry.texture.viewDimension = WGPUTextureViewDimension_2D;
+        break;
+    case MTLDataTypeSampler:
+        entry.sampler.type = WGPUSamplerBindingType_Filtering;
+        break;
+    case MTLDataTypePointer:
+        entry.buffer.type = WGPUBufferBindingType_Uniform;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    return entry;
+}
+#endif // HAVE(METAL_BUFFER_BINDING_REFLECTION)
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -118,8 +118,16 @@ void CommandEncoder::finalizeBlitCommandEncoder()
 
 Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDescriptor& descriptor)
 {
-    UNUSED_PARAM(descriptor);
-    return ComputePassEncoder::createInvalid(m_device);
+    if (descriptor.nextInChain)
+        return ComputePassEncoder::createInvalid(m_device);
+
+    MTLComputePassDescriptor* computePassDescriptor = [MTLComputePassDescriptor computePassDescriptor];
+    computePassDescriptor.dispatchType = MTLDispatchTypeSerial;
+
+    id<MTLComputeCommandEncoder> computeCommandEncoder = [m_commandBuffer computeCommandEncoderWithDescriptor:computePassDescriptor];
+    computeCommandEncoder.label = fromAPI(descriptor.label);
+
+    return ComputePassEncoder::create(computeCommandEncoder, m_device);
 }
 
 bool CommandEncoder::validateRenderPassDescriptor(const WGPURenderPassDescriptor& descriptor) const
@@ -133,7 +141,6 @@ bool CommandEncoder::validateRenderPassDescriptor(const WGPURenderPassDescriptor
 
 Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescriptor& descriptor)
 {
-    UNUSED_PARAM(descriptor);
     if (descriptor.nextInChain)
         return RenderPassEncoder::createInvalid(m_device);
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -85,6 +85,7 @@ private:
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;
+    MTLSize m_threadsPerThreadgroup;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -55,19 +55,18 @@ void ComputePassEncoder::beginPipelineStatisticsQuery(const QuerySet& querySet, 
 
 void ComputePassEncoder::dispatch(uint32_t x, uint32_t y, uint32_t z)
 {
-    UNUSED_PARAM(x);
-    UNUSED_PARAM(y);
-    UNUSED_PARAM(z);
+    [m_computeCommandEncoder dispatchThreadgroups:MTLSizeMake(x, y, z) threadsPerThreadgroup:m_threadsPerThreadgroup];
 }
 
 void ComputePassEncoder::dispatchIndirect(const Buffer& indirectBuffer, uint64_t indirectOffset)
 {
-    UNUSED_PARAM(indirectBuffer);
-    UNUSED_PARAM(indirectOffset);
+    // FIXME: ensure higher levels perform validation on indirectOffset before reaching this callsite
+    [m_computeCommandEncoder dispatchThreadgroupsWithIndirectBuffer:indirectBuffer.buffer() indirectBufferOffset:indirectOffset threadsPerThreadgroup:m_threadsPerThreadgroup];
 }
 
 void ComputePassEncoder::endPass()
 {
+    [m_computeCommandEncoder endEncoding];
 }
 
 void ComputePassEncoder::endPipelineStatisticsQuery()
@@ -121,15 +120,16 @@ void ComputePassEncoder::pushDebugGroup(String&& groupLabel)
 
 void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group, uint32_t dynamicOffsetCount, const uint32_t* dynamicOffsets)
 {
-    UNUSED_PARAM(groupIndex);
-    UNUSED_PARAM(group);
     UNUSED_PARAM(dynamicOffsetCount);
     UNUSED_PARAM(dynamicOffsets);
+    [m_computeCommandEncoder setBuffer:group.computeArgumentBuffer() offset:0 atIndex:groupIndex];
 }
 
 void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
 {
-    UNUSED_PARAM(pipeline);
+    ASSERT(pipeline.computePipelineState());
+    [m_computeCommandEncoder setComputePipelineState:pipeline.computePipelineState()];
+    m_threadsPerThreadgroup = pipeline.threadsPerThreadgroup();
 }
 
 void ComputePassEncoder::setLabel(String&& label)

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import "BindGroupLayout.h"
+
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
@@ -36,14 +38,19 @@ namespace WebGPU {
 
 class BindGroupLayout;
 class Device;
+class PipelineLayout;
 
 // https://gpuweb.github.io/gpuweb/#gpucomputepipeline
 class ComputePipeline : public WGPUComputePipelineImpl, public RefCounted<ComputePipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, Device& device)
+    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, const PipelineLayout& pipelineLayout, MTLSize threadsPerThreadgroup, Device& device)
     {
-        return adoptRef(*new ComputePipeline(computePipelineState, device));
+        return adoptRef(*new ComputePipeline(computePipelineState, pipelineLayout, threadsPerThreadgroup, device));
+    }
+    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, MTLComputePipelineReflection* reflection, MTLSize threadsPerThreadgroup, Device& device)
+    {
+        return adoptRef(*new ComputePipeline(computePipelineState, reflection, threadsPerThreadgroup, device));
     }
     static Ref<ComputePipeline> createInvalid(Device& device)
     {
@@ -60,14 +67,22 @@ public:
     id<MTLComputePipelineState> computePipelineState() const { return m_computePipelineState; }
 
     Device& device() const { return m_device; }
+    MTLSize threadsPerThreadgroup() const { return m_threadsPerThreadgroup; }
 
 private:
-    ComputePipeline(id<MTLComputePipelineState>, Device&);
+    ComputePipeline(id<MTLComputePipelineState>, const PipelineLayout&, MTLSize, Device&);
+    ComputePipeline(id<MTLComputePipelineState>, MTLComputePipelineReflection*, MTLSize, Device&);
     ComputePipeline(Device&);
 
     const id<MTLComputePipelineState> m_computePipelineState { nil };
 
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    MTLComputePipelineReflection *m_reflection { nil };
+#endif
+    const PipelineLayout *m_pipelineLayout { nullptr };
     const Ref<Device> m_device;
+    HashMap<uint32_t, Ref<BindGroupLayout>> m_cachedBindGroupLayouts;
+    const MTLSize m_threadsPerThreadgroup;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -123,7 +123,7 @@ static id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflec
     return function;
 }
 
-static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> device, id<MTLFunction> function, const PipelineLayout& pipelineLayout, const WGSL::Reflection::Compute& computeInformation, NSString *label)
+static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> device, id<MTLFunction> function, const PipelineLayout& pipelineLayout, const WGSL::Reflection::Compute& computeInformation, NSString *label, MTLComputePipelineReflection **reflection, MTLPipelineOption pipelineOptions)
 {
     auto computePipelineDescriptor = [MTLComputePipelineDescriptor new];
     computePipelineDescriptor.computeFunction = function;
@@ -136,10 +136,16 @@ static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> devi
     computePipelineDescriptor.label = label;
     NSError *error = nil;
     // FIXME: Run the asynchronous version of this
-    id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithDescriptor:computePipelineDescriptor options:MTLPipelineOptionNone reflection:nil error:&error];
+    id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithDescriptor:computePipelineDescriptor options:pipelineOptions reflection:reflection error:&error];
+
     if (error)
         WTFLogAlways("Pipeline state creation error: %@", error);
     return computePipelineState;
+}
+
+static MTLSize metalSize(auto workgroupSize)
+{
+    return MTLSizeMake(workgroupSize.width, workgroupSize.height, workgroupSize.depth);
 }
 
 Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDescriptor& descriptor)
@@ -151,22 +157,33 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
     const PipelineLayout& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
     auto label = fromAPI(descriptor.label);
 
-    auto libraryCreationResult = createLibrary(m_device, shaderModule, pipelineLayout, fromAPI(descriptor.compute.entryPoint), label);
-    if (!libraryCreationResult)
-        return ComputePipeline::createInvalid(*this);
+    const auto& computeFunctionName = String::fromLatin1(descriptor.compute.entryPoint);
+    id<MTLFunction> function = shaderModule.getNamedFunction(computeFunctionName, buildKeyValueReplacements(descriptor.compute));
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=251171 - this should come from the WGSL compiler
+    WGSL::Reflection::Compute computeInformation { .workgroupSize = { .width = 1, .height = 1, .depth = 1 } };
+    if (!function) {
+        auto libraryCreationResult = createLibrary(m_device, shaderModule, pipelineLayout, fromAPI(descriptor.compute.entryPoint), label);
+        if (!libraryCreationResult)
+            return ComputePipeline::createInvalid(*this);
 
-    auto library = libraryCreationResult->library;
-    const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
+        auto library = libraryCreationResult->library;
+        const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
 
-    if (!std::holds_alternative<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint))
-        return ComputePipeline::createInvalid(*this);
-    const auto& computeInformation = std::get<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint);
+        if (!std::holds_alternative<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint))
+            return ComputePipeline::createInvalid(*this);
+        computeInformation = std::get<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint);
 
-    auto function = createFunction(library, entryPointInformation, descriptor.compute, label);
+        function = createFunction(library, entryPointInformation, descriptor.compute, label);
+    }
 
-    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, computeInformation, label);
+    MTLComputePipelineReflection *reflection;
+    bool hasBindGroups = pipelineLayout.numberOfBindGroupLayouts() > 0;
+    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, computeInformation, label, &reflection, hasBindGroups ? MTLPipelineOptionNone : MTLPipelineOptionArgumentInfo);
 
-    return ComputePipeline::create(computePipelineState, *this);
+    if (hasBindGroups)
+        return ComputePipeline::create(computePipelineState, pipelineLayout, metalSize(computeInformation.workgroupSize), *this);
+
+    return ComputePipeline::create(computePipelineState, reflection, metalSize(computeInformation.workgroupSize), *this);
 }
 
 void Device::createComputePipelineAsync(const WGPUComputePipelineDescriptor& descriptor, CompletionHandler<void(WGPUCreatePipelineAsyncStatus, Ref<ComputePipeline>&&, String&& message)>&& callback)
@@ -178,14 +195,30 @@ void Device::createComputePipelineAsync(const WGPUComputePipelineDescriptor& des
     });
 }
 
-ComputePipeline::ComputePipeline(id<MTLComputePipelineState> computePipelineState, Device& device)
+ComputePipeline::ComputePipeline(id<MTLComputePipelineState> computePipelineState, const PipelineLayout& pipelineLayout, MTLSize threadsPerThreadgroup, Device& device)
     : m_computePipelineState(computePipelineState)
+    , m_pipelineLayout(&pipelineLayout)
     , m_device(device)
+    , m_threadsPerThreadgroup(threadsPerThreadgroup)
 {
+}
+
+ComputePipeline::ComputePipeline(id<MTLComputePipelineState> computePipelineState, MTLComputePipelineReflection *reflection, MTLSize threadsPerThreadgroup, Device& device)
+    : m_computePipelineState(computePipelineState)
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    , m_reflection(reflection)
+#endif
+    , m_device(device)
+    , m_threadsPerThreadgroup(threadsPerThreadgroup)
+{
+#if !HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    UNUSED_PARAM(reflection);
+#endif
 }
 
 ComputePipeline::ComputePipeline(Device& device)
     : m_device(device)
+    , m_threadsPerThreadgroup(MTLSizeMake(0, 0, 0))
 {
 }
 
@@ -193,8 +226,37 @@ ComputePipeline::~ComputePipeline() = default;
 
 BindGroupLayout* ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
 {
+    if (m_pipelineLayout)
+        return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
+
+    auto it = m_cachedBindGroupLayouts.find(groupIndex + 1);
+    if (it != m_cachedBindGroupLayouts.end())
+        return it->value.ptr();
+
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    uint32_t bindingIndex = 0;
+    Vector<WGPUBindGroupLayoutEntry> entries;
+    for (id<MTLBufferBinding> binding in m_reflection.bindings) {
+        if (binding.index != groupIndex)
+            continue;
+
+        ASSERT(binding.type == MTLBindingTypeBuffer);
+        for (MTLStructMember *structMember in binding.bufferStructType.members)
+            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Compute));
+    }
+
+    WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };
+    bindGroupLayoutDescriptor.label = "getBindGroup() generated layout";
+    bindGroupLayoutDescriptor.entryCount = entries.size();
+    bindGroupLayoutDescriptor.entries = entries.size() ? &entries[0] : nullptr;
+    auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
+    m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
+
+    return bindGroupLayout.ptr();
+#else
     UNUSED_PARAM(groupIndex);
     return nullptr;
+#endif
 }
 
 void ComputePipeline::setLabel(String&&)

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -129,6 +129,14 @@ private:
 
     void loseTheDevice(WGPUDeviceLostReason);
     void captureFrameIfNeeded() const;
+    auto buildKeyValueReplacements(const auto& stage) const
+    {
+        HashMap<String, decltype(WGPUConstantEntry::value)> keyValueReplacements;
+        for (auto* kvp = stage.constants, *endKvp = kvp + stage.constantCount; kvp != endKvp; ++kvp)
+            keyValueReplacements.set(String::fromUTF8(kvp->key), kvp->value);
+
+        return keyValueReplacements;
+    }
 
     struct Error {
         WGPUErrorType type;

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -346,17 +346,6 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState)
     return vertexDescriptor;
 }
 
-static auto buildKeyValueReplacements(const auto& stage)
-{
-    HashMap<String, decltype(WGPUConstantEntry::value)> keyValueReplacements;
-    for (size_t i = 0; i < stage.constantCount; ++i) {
-        auto& kvp = stage.constants[i];
-        keyValueReplacements.set(String::fromUTF8(kvp.key), kvp.value);
-    }
-
-    return keyValueReplacements;
-}
-
 static void populateStencilOperation(MTLStencilDescriptor *mtlStencil, const WGPUStencilFaceState& stencil, uint32_t stencilReadMask, uint32_t stencilWriteMask)
 {
     mtlStencil.stencilCompareFunction =  convertToMTLCompare(stencil.compare);
@@ -464,12 +453,13 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
     // FIXME: GPUPrimitiveState.unclippedDepth
 
     MTLRenderPipelineReflection *reflection;
-    id<MTLRenderPipelineState> renderPipelineState = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor options:MTLPipelineOptionArgumentInfo reflection:&reflection error:nil];
+    const auto& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
+    bool hasBindGroups = pipelineLayout.numberOfBindGroupLayouts() > 0;
+    id<MTLRenderPipelineState> renderPipelineState = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor options: hasBindGroups ? MTLPipelineOptionNone : MTLPipelineOptionArgumentInfo reflection:&reflection error:nil];
     if (!renderPipelineState)
         return RenderPipeline::createInvalid(*this);
 
-    const auto& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
-    if (pipelineLayout.numberOfBindGroupLayouts())
+    if (hasBindGroups)
         return RenderPipeline::create(renderPipelineState, mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, depthStencilDescriptor, pipelineLayout, *this);
 
     return RenderPipeline::create(renderPipelineState, mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, depthStencilDescriptor, reflection, *this);
@@ -522,32 +512,6 @@ RenderPipeline::RenderPipeline(Device& device)
 
 RenderPipeline::~RenderPipeline() = default;
 
-#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
-static WGPUBindGroupLayoutEntry createEntryFromStructMember(MTLStructMember *structMember, uint32_t& currentBindingIndex, WGPUShaderStage shaderStage)
-{
-    WGPUBindGroupLayoutEntry entry = { };
-    entry.binding = currentBindingIndex++;
-    entry.visibility = shaderStage;
-    switch (structMember.dataType) {
-    case MTLDataTypeTexture:
-        entry.texture.sampleType = WGPUTextureSampleType_Float;
-        entry.texture.viewDimension = WGPUTextureViewDimension_2D;
-        break;
-    case MTLDataTypeSampler:
-        entry.sampler.type = WGPUSamplerBindingType_Filtering;
-        break;
-    case MTLDataTypePointer:
-        entry.buffer.type = WGPUBufferBindingType_Uniform;
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-
-    return entry;
-}
-#endif // HAVE(METAL_BUFFER_BINDING_REFLECTION)
-
 BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 {
     if (m_pipelineLayout)
@@ -567,7 +531,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
         for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Vertex));
+            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Vertex));
     }
 
     for (id<MTLBufferBinding> binding in m_reflection.fragmentBindings) {
@@ -576,7 +540,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
         for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Fragment));
+            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Fragment));
     }
 
     WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };


### PR DESCRIPTION
#### af82bfdea3946b9862c5291ac5ef1c301c31e5e4
<pre>
WebGPU: Compute passes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250863">https://bugs.webkit.org/show_bug.cgi?id=250863</a>
&lt;radar://83213548&gt;

Reviewed by Myles C. Maxfield.

Implement compute passes which are needed to start
passing a lot of the CTS tests which create a simple
compute shader and read back the result, to ensure
the adapter was created.

<a href="https://bugs.webkit.org/show_bug.cgi?id=251171">https://bugs.webkit.org/show_bug.cgi?id=251171</a> has
been filed for tracking getting the threads per thread
group size from the shader compiler.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):

* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::dispatch):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::ComputePassEncoder::setBindGroup):
(WebGPU::ComputePassEncoder::setPipeline):
(WebGPU::ComputePassEncoder::endPass):

* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::BindGroupLayout::createEntryFromStructMember):
Moved so both compute and render pipeline can access.

* Source/WebGPU/WebGPU/ComputePipeline.h:
(WebGPU::ComputePipeline::create):
(WebGPU::ComputePipeline::threadsPerThreadgroup const):

* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::buildKeyValueReplacements const):
Moved to common path.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::getBindGroupLayout):
(WebGPU::buildKeyValueReplacements): Deleted.
(WebGPU::createEntryFromStructMember): Deleted.
Moved to common path.

Canonical link: <a href="https://commits.webkit.org/259634@main">https://commits.webkit.org/259634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/838a0cc0dd4d61ad158eeacb194ecc706ce1e93a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114735 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15871 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97781 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12161 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94026 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7864 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13991 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6648 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->