### PR TITLE
Improve VectorShuffle on arm

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -5511,13 +5511,6 @@ public:
         RELEASE_ASSERT(b == a + 1);
         m_assembler.tbl2(dest, a, b, control);
     }
-    void vectorShuffle(TrustedImm64, TrustedImm64, FPRegisterID, FPRegisterID, FPRegisterID) 
-    {
-        // This macro should have been lowered by now.
-        bool hideNoReturn = true;
-        if (hideNoReturn)
-            RELEASE_ASSERT_NOT_REACHED();
-    }
 
     // Misc helper functions.
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -1833,7 +1833,6 @@ public:
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorMulSat);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorDotProduct);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSwizzle);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorShuffle);
 
     template<PtrTag resultTag, PtrTag locationTag>
     static CodePtr<resultTag> readCallTarget(CodeLocationCall<locationTag> call)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -3960,15 +3960,13 @@ public:
         m_assembler.vpmaddwd_rrr(b, a, dest);
     }
 
-    void vectorShuffle(TrustedImm64 immLow, TrustedImm64 immHigh, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { (void) immLow; (void) immHigh; (void) a; (void) b; (void) dest; }
-
     // Misc helper functions.
 
     static bool supportsFloatingPoint() { return true; }
     static bool supportsFloatingPointTruncate() { return true; }
     static bool supportsFloatingPointSqrt() { return true; }
     static bool supportsFloatingPointAbs() { return true; }
-    
+
     template<PtrTag resultTag, PtrTag locationTag>
     static CodePtr<resultTag> readCallTarget(CodeLocationCall<locationTag> call)
     {

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -522,9 +522,6 @@ void printInternal(PrintStream& out, Opcode opcode)
     case VectorSwizzle:
         out.print("VectorSwizzle");
         return;
-    case VectorShuffle:
-        out.print("VectorShuffle");
-        return;
     case Upsilon:
         out.print("Upsilon");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -410,7 +410,6 @@ enum Opcode : uint8_t {
     VectorExtaddPairwise,
     VectorMulSat,
     VectorSwizzle,
-    VectorShuffle,
 
     // SSA support, in the style of DFG SSA.
     Upsilon, // This uses the UpsilonValue class.
@@ -418,14 +417,14 @@ enum Opcode : uint8_t {
 
     // Jump.
     Jump,
-    
+
     // Polymorphic branch, usable with any integer type. Branches if not equal to zero. The 0-index
     // successor is the true successor.
     Branch,
 
     // Switch. Switches over either Int32 or Int64. Uses the SwitchValue class.
     Switch,
-    
+
     // Multiple entrypoints are supported via the EntrySwitch operation. Place this in the root
     // block and list the entrypoints as the successors. All blocks backwards-reachable from
     // EntrySwitch are duplicated for each entrypoint.

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -91,7 +91,6 @@ public:
         case VectorExtaddPairwise:
         case VectorMulSat:
         case VectorSwizzle:
-        case VectorShuffle:
         case VectorDotProduct:
             return true;
         default:

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -494,13 +494,14 @@ public:
                 VALIDATE(value->child(1)->type() == V128, ("At ", *value));
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i16x8, ("At ", *value));
                 break;
-            
+
             case VectorSwizzle:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
-                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->numChildren() == 2 || value->numChildren() == 3, ("At ", *value));
                 VALIDATE(value->type() == V128, ("At ", *value));
                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
                 VALIDATE(value->child(1)->type() == V128, ("At ", *value));
+                VALIDATE(value->numChildren() == 2 || value->child(2)->type() == V128, ("At ", *value));
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i8x16, ("At ", *value));
                 break;
 
@@ -639,16 +640,6 @@ public:
                 VALIDATE(value->child(1)->type() == V128, ("At ", *value));
                 VALIDATE(value->child(2)->type() == V128, ("At ", *value));
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::v128, ("At ", *value));
-                VALIDATE(value->asSIMDValue()->signMode() == SIMDSignMode::None, ("At ", *value));
-                break;
-            case VectorShuffle:
-                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
-                VALIDATE(value->numChildren() == 2, ("At ", *value));
-                VALIDATE(value->type() == V128, ("At ", *value));
-                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
-                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
-                VALIDATE(value->isSIMDValue(), ("At ", *value));
-                VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i8x16, ("At ", *value));
                 VALIDATE(value->asSIMDValue()->signMode() == SIMDSignMode::None, ("At ", *value));
                 break;
             case CCall:

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -687,7 +687,6 @@ Effects Value::effects() const
     case VectorExtaddPairwise:
     case VectorMulSat:
     case VectorSwizzle:
-    case VectorShuffle:
         break;
     case Div:
     case UDiv:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -529,9 +529,7 @@ protected:
         case VectorShl:
         case VectorShr:
         case VectorMulSat:
-        case VectorSwizzle:
         case VectorAvgRound:
-        case VectorShuffle:
             return 2 * sizeof(Value*);
         case Select:
         case AtomicWeakCAS:
@@ -544,6 +542,7 @@ protected:
         case CheckSub:
         case CheckMul:
         case Patchpoint:
+        case VectorSwizzle:
             return sizeof(Vector<Value*, 3>);
 #ifdef NDEBUG
         default:
@@ -743,8 +742,6 @@ private:
         case VectorShl:
         case VectorShr:
         case VectorMulSat:
-        case VectorSwizzle:
-        case VectorShuffle:
         case VectorAvgRound:
             if (UNLIKELY(numArgs != 2))
                 badKind(kind, numArgs);

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -227,7 +227,6 @@ namespace JSC { namespace B3 {
     case VectorExtaddPairwise: \
     case VectorMulSat: \
     case VectorSwizzle: \
-    case VectorShuffle: \
         return MACRO(SIMDValue); \
     default: \
         RELEASE_ASSERT_NOT_REACHED(); \

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1989,9 +1989,6 @@ x86_64: VectorDotProduct U:F:128, U:F:128, D:F:128
 arm64: VectorSwizzle2 U:F:128, U:F:128, U:F:128, D:F:128
     Tmp, Tmp*, Tmp, Tmp
 
-64: VectorShuffle U:G:64, U:G:64, U:F:128, U:F:128, D:F:128
-    BigImm, BigImm, Tmp, Tmp, Tmp
-
 Oops /terminal
 
 # This is a terminal but we express it as a Custom because we don't want it to have a code

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -483,7 +483,7 @@ public:
         return { };
     }
 
-    auto addSIMDSwizzleHelperX86(ExpressionType& a, ExpressionType& b, ExpressionType& result) -> PartialResult
+    auto fixupOutOfBoundsIndicesForSwizzle(ExpressionType& a, ExpressionType& b, ExpressionType& result) -> PartialResult
     {
         ASSERT(isX86() && result.type() == Types::V128);
         // Let each byte mask be 112 (0x70) then after VectorAddSat
@@ -529,7 +529,7 @@ public:
         }
 
         if (isX86() && airOp == B3::Air::VectorSwizzle) {
-            addSIMDSwizzleHelperX86(a, b, result);
+            fixupOutOfBoundsIndicesForSwizzle(a, b, result);
             return { };
         }
 
@@ -1673,27 +1673,45 @@ auto AirIRGenerator64::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionTy
 {
     result = v128();
 
-    if (isX86()) {
+    if constexpr (isX86()) {
+        v128_t leftImm = imm;
+        v128_t rightImm = imm;
+        for (unsigned i = 0; i < 16; ++i) {
+            if (leftImm.u8x16[i] > 15)
+                leftImm.u8x16[i] = 0xFF; // Force OOB
+            if (rightImm.u8x16[i] < 16 || rightImm.u8x16[i] > 31)
+                rightImm.u8x16[i] = 0xFF; // Force OOB
+        }
         // Store each byte (w/ index < 16) of `a` to result
         // and zero clear each byte (w/ index > 15) in result.
-        auto indexes = addConstant(imm);
-        addSIMDSwizzleHelperX86(a, indexes, result);
+        auto left = v128();
+        auto leftImmConst = addConstant(leftImm);
+        append(B3::Air::VectorSwizzle, a, leftImmConst, left);
 
         // Store each byte (w/ index - 16 >= 0) of `b` to result2
         // and zero clear each byte (w/ index - 16 < 0) in result2.
-        auto result2 = v128();
-        v128_t mask;
-        mask.u64x2[0] = 0x1010101010101010;
-        mask.u64x2[1] = 0x1010101010101010;
-        append(VectorSub, Arg::simdInfo(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }), indexes, addConstant(mask), indexes);
-        append(B3::Air::VectorSwizzle, b, indexes, result2);
+        auto right = v128();
+        auto rightImmConst = addConstant(rightImm);
+        append(B3::Air::VectorSwizzle, b, rightImmConst, right);
 
-        // Since each index in [0, 31], we can return result2 VectorOr result.
-        append(VectorOr, Arg::simdInfo(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }), result, result2, result);
+        append(VectorOr, Arg::simdInfo(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }), left, right, result);
         return { };
     }
 
-    append(VectorShuffle, Arg::bigImm(imm.u64x2[0]), Arg::bigImm(imm.u64x2[1]), a, b, result);
+    if constexpr (!isARM64())
+        UNREACHABLE_FOR_PLATFORM();
+
+#if CPU(ARM64)
+    // The tbl instruction requires these values to be adjacent.
+    Tmp n(ARM64Registers::q30);
+    Tmp m(ARM64Registers::q31);
+#else
+    Tmp n;
+    Tmp m;
+#endif
+    append(MoveVector, a, n);
+    append(MoveVector, b, m);
+    append(VectorSwizzle2, n, m, addConstant(imm), result);
 
     return { };
 }


### PR DESCRIPTION
#### 34f0ba48fd68b5467f5b0d5c2f09a14f8d5834fa
<pre>
Improve VectorShuffle on arm
<a href="https://bugs.webkit.org/show_bug.cgi?id=251172">https://bugs.webkit.org/show_bug.cgi?id=251172</a>
rdar://104661654

Reviewed by Yusuke Suzuki.

VectorShuffle is very hot in tfjs, so let&apos;s make it lower directly to
tbl like other engines do.

Also fix up some intel redundancy.

This is a 2x speedup on tfjs on arm.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorSwizzle2):
(JSC::MacroAssemblerARM64::vectorShuffle): Deleted.
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorShuffle): Deleted.
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::fixupOutOfBoundsIndicesForSwizzle):
(JSC::Wasm::AirIRGenerator64::addSIMDV_VV):
(JSC::Wasm::AirIRGenerator64::addSIMDShuffle):
(JSC::Wasm::AirIRGenerator64::addSIMDSwizzleHelperX86): Deleted.
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::fixupOutOfBoundsIndicesForSwizzle):
(JSC::Wasm::B3IRGenerator::addSIMDV_VV):
(JSC::Wasm::B3IRGenerator::addSIMDShuffle):

Canonical link: <a href="https://commits.webkit.org/259388@main">https://commits.webkit.org/259388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a42b01eff004eb351f6229f24d5bcbec969ac11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13869 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/37693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/15002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4798 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/112979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110549 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/15002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/37693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/15002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/37693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/37693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92679 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/4956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/30222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/37693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101369 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/6479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3435 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->