### PR TITLE
Web Inspector: Backend fails to bind WebAnimation with custom properties in keyframes

### DIFF
--- a/LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt
+++ b/LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt
@@ -37,3 +37,32 @@ keyframes:
 ]
 
 
+-- Running test case: Animation.Lifecycle.WebAnimation.CustomProperty
+Adding named animation to body.
+PASS: Animation created 'customKeyframes'.
+FAIL: Animation type should be Web Animation.
+    Expected: "web-animation"
+    Actual: "css-animation"
+iterationCount: Infinity
+iterationDuration: 1000
+timingFunction: "linear"
+playbackDirection: "alternate"
+fillMode: "none"
+keyframes:
+[
+  {
+    "offset": 0,
+    "easing": "ease",
+    "style": "--customProperty: 0 0 -4;"
+  },
+  {
+    "offset": 1,
+    "easing": "ease",
+    "style": "--customProperty: 0 0 -4;"
+  }
+]
+
+Removing named animation from body.
+PASS: Animation destroyed.
+PASS: Removed animation has expected ID.
+

--- a/LayoutTests/inspector/animation/lifecycle-web-animation.html
+++ b/LayoutTests/inspector/animation/lifecycle-web-animation.html
@@ -4,6 +4,17 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script src="resources/lifecycle-utilities.js"></script>
 <script>
+
+function addNamedAnimationToBody()
+{
+    document.getElementsByTagName("body")[0].classList.add("customAnimation");
+}
+
+function removeNamedAnimationFromBody()
+{
+    document.getElementsByTagName("body")[0].classList.remove("customAnimation");
+}
+
 function test()
 {
     let suite = InspectorTest.createAsyncSuite("Animation.Lifecycle");
@@ -45,9 +56,53 @@ function test()
         },
     });
 
+    suite.addTestCase({
+        name: "Animation.Lifecycle.WebAnimation.CustomProperty",
+        description: "Check that Web Inspector is notified whenever web animations with custom properties are created/destroyed.",
+        async test() {
+            InspectorTest.log("Adding named animation to body.");
+            let creationResults = await Promise.all([
+                InspectorTest.AnimationLifecycleUtilities.awaitAnimationCreated(WI.Animation.Type.WebAnimation),
+                InspectorTest.evaluateInPage(`addNamedAnimationToBody()`),
+            ]);
+
+            let animationId = creationResults[0].animationId;
+
+            InspectorTest.log("Removing named animation from body.");
+            await Promise.all([
+                InspectorTest.AnimationLifecycleUtilities.awaitAnimationDestroyed(animationId),
+                InspectorTest.evaluateInPage(`removeNamedAnimationFromBody()`),
+            ]);
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>
+<style>
+@property --customProperty {
+    syntax: "<number>+|none";
+    inherits: false;
+    initial-value: none;
+}
+
+@keyframes customKeyframes {
+    from {
+        --customProperty: 0 0 -4;
+    }
+
+    to {
+        --customProperty: 0 1 -4;
+    }
+}
+
+.customAnimation {
+    animation-name: customKeyframes;
+    animation-iteration-count: infinite;
+    animation-duration: 1s;
+    animation-direction: alternate;
+}
+</style>
 </head>
 <body onload="runTest()">
     <p>Tests for the Animation.animationCreated and Animation.animationDestroyed events.</p>

--- a/LayoutTests/inspector/animation/resources/lifecycle-utilities.js
+++ b/LayoutTests/inspector/animation/resources/lifecycle-utilities.js
@@ -50,15 +50,8 @@ TestPage.registerInitializer(() => {
     InspectorTest.AnimationLifecycleUtilities = {};
 
     InspectorTest.AnimationLifecycleUtilities.awaitAnimationCreated = async function(animationType) {
-        let nameChangedPromise = null;
-        if (animationType === WI.Animation.Type.WebAnimation)
-            nameChangedPromise = WI.Animation.awaitEvent(WI.Animation.Event.NameChanged);
-
         let animationCollectionItemAddedEvent = await WI.animationManager.animationCollection.awaitEvent(WI.Collection.Event.ItemAdded);
-
         let animation = animationCollectionItemAddedEvent.data.item;
-
-        await nameChangedPromise;
 
         InspectorTest.pass(`Animation created '${animation.displayName}'.`);
 

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/Forward.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -44,6 +45,7 @@ class Frame;
 class KeyframeEffect;
 class Page;
 class WebAnimation;
+class WeakPtrImplWithEventTargetData;
 
 struct Styleable;
 
@@ -79,7 +81,8 @@ public:
 private:
     String findAnimationId(WebAnimation&);
     WebAnimation* assertAnimation(Inspector::Protocol::ErrorString&, const String& animationId);
-    void bindAnimation(WebAnimation&, bool captureBacktrace);
+    void bindAnimation(WebAnimation&, RefPtr<Inspector::Protocol::Console::StackTrace> backtrace);
+    void animationBindingTimerFired();
     void unbindAnimation(const String& animationId);
     void animationDestroyedTimerFired();
     void reset();
@@ -93,6 +96,10 @@ private:
     Page& m_inspectedPage;
 
     MemoryCompactRobinHoodHashMap<String, WebAnimation*> m_animationIdMap;
+
+    WeakHashMap<WebAnimation, Ref<Inspector::Protocol::Console::StackTrace>, WeakPtrImplWithEventTargetData> m_animationsPendingBinding;
+    Timer m_animationBindingTimer;
+
     Vector<String> m_removedAnimationIds;
     Timer m_animationDestroyedTimer;
 


### PR DESCRIPTION
#### 8a7cdf98234b35d9d4e5a1b2eb6daf449bef8258
<pre>
Web Inspector: Backend fails to bind WebAnimation with custom properties in keyframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=251173">https://bugs.webkit.org/show_bug.cgi?id=251173</a>
rdar://104555265

Reviewed by Antti Koivisto.

InspectorAnimationAgent::didCreateAnimation is called during WebCore::Document::updateStyleIfNeeded, but in order to
resolve custom properties of animations, we may have to again enter WebCore::Document::updateStyleIfNeeded via
WebCore::ComputedStyleExtractor::updateStyleIfNeededForProperty. Instead, we should wait until after styles have been
updated which will prevent us from reentering WebCore::Document::updateStyleIfNeeded in order to resolve custom
properties.

This also has the benefit that the frontend will no longer receive a WebAnimation immediately followed by an update to
its name, since the name is set later. This allows us to capture the animation after it has been fully set up via the
updating of styles.

* LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt:
* LayoutTests/inspector/animation/lifecycle-web-animation.html:
- Add test case to exercise the creation/deletion of animations with custom properties.

* LayoutTests/inspector/animation/resources/lifecycle-utilities.js:
- As a result of defering animation binding until later, the name no longer changes immediately after binding.

* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::InspectorAnimationAgent):
(WebCore::InspectorAnimationAgent::enable):
(WebCore::InspectorAnimationAgent::didCreateWebAnimation):
(WebCore::InspectorAnimationAgent::animationBindingTimerFired):
(WebCore::InspectorAnimationAgent::bindAnimation):
(WebCore::InspectorAnimationAgent::reset):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.h:

Canonical link: <a href="https://commits.webkit.org/259446@main">https://commits.webkit.org/259446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85ee31f9f3a9bc1c02c49b1ee2ab0a011d96dc46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114089 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174288 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4824 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113045 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11614 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94618 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialRequestOptionsMaximum, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMaximum1, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMaximum2 (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39135 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80799 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7345 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4194 "Found 2 new test failures: fast/images/avif-as-image.html, fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47142 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6513 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9131 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->