### PR TITLE
Match SVGFEDropShadowElement and SVGFEGaussianBlurElement.setStdDeviation() with the specs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
@@ -320,7 +320,7 @@ PASS SVGFEDropShadowElement interface: attribute dx
 PASS SVGFEDropShadowElement interface: attribute dy
 PASS SVGFEDropShadowElement interface: attribute stdDeviationX
 PASS SVGFEDropShadowElement interface: attribute stdDeviationY
-FAIL SVGFEDropShadowElement interface: operation setStdDeviation(float, float) assert_equals: property has wrong .length expected 2 but got 0
+PASS SVGFEDropShadowElement interface: operation setStdDeviation(float, float)
 PASS SVGFEDropShadowElement interface: attribute x
 PASS SVGFEDropShadowElement interface: attribute y
 PASS SVGFEDropShadowElement interface: attribute width
@@ -355,7 +355,7 @@ PASS SVGFEGaussianBlurElement interface: attribute in1
 PASS SVGFEGaussianBlurElement interface: attribute stdDeviationX
 PASS SVGFEGaussianBlurElement interface: attribute stdDeviationY
 PASS SVGFEGaussianBlurElement interface: attribute edgeMode
-FAIL SVGFEGaussianBlurElement interface: operation setStdDeviation(float, float) assert_equals: property has wrong .length expected 2 but got 0
+PASS SVGFEGaussianBlurElement interface: operation setStdDeviation(float, float)
 PASS SVGFEGaussianBlurElement interface: attribute x
 PASS SVGFEGaussianBlurElement interface: attribute y
 PASS SVGFEGaussianBlurElement interface: attribute width

--- a/LayoutTests/svg/dynamic-updates/SVGFEDropShadowElement-svgdom-stdDeviation-prop-expected.txt
+++ b/LayoutTests/svg/dynamic-updates/SVGFEDropShadowElement-svgdom-stdDeviation-prop-expected.txt
@@ -7,6 +7,11 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS dropShadowElement.stdDeviationX.baseVal is 0
 PASS dropShadowElement.stdDeviationY.baseVal is 0
+PASS dropShadowElement.setStdDeviation(10, 10) did not throw exception.
+PASS dropShadowElement.setStdDeviation(NaN, NaN) threw exception TypeError: The provided value is non-finite.
+PASS dropShadowElement.setStdDeviation(Infinity, Infinity) threw exception TypeError: The provided value is non-finite.
+PASS dropShadowElement.setStdDeviation() threw exception TypeError: Not enough arguments.
+PASS dropShadowElement.setStdDeviation(0) threw exception TypeError: Not enough arguments.
 PASS dropShadowElement.stdDeviationX.baseVal is 10
 PASS dropShadowElement.stdDeviationY.baseVal is 10
 PASS successfullyParsed is true

--- a/LayoutTests/svg/dynamic-updates/SVGFEDropShadowElement-svgdom-stdDeviation-prop.html
+++ b/LayoutTests/svg/dynamic-updates/SVGFEDropShadowElement-svgdom-stdDeviation-prop.html
@@ -47,7 +47,13 @@ shouldBe("dropShadowElement.stdDeviationX.baseVal", "0");
 shouldBe("dropShadowElement.stdDeviationY.baseVal", "0");
 
 function repaintTest() {
-    dropShadowElement.setStdDeviation(10, 10);
+    shouldNotThrow('dropShadowElement.setStdDeviation(10, 10)');
+
+    shouldThrow('dropShadowElement.setStdDeviation(NaN, NaN)');
+    shouldThrow('dropShadowElement.setStdDeviation(Infinity, Infinity)');
+    shouldThrow('dropShadowElement.setStdDeviation()');
+    shouldThrow('dropShadowElement.setStdDeviation(0)');
+
     shouldBe("dropShadowElement.stdDeviationX.baseVal", "10");
     shouldBe("dropShadowElement.stdDeviationY.baseVal", "10");
 

--- a/LayoutTests/svg/dynamic-updates/SVGFEGaussianBlurElement-dom-stdDeviation-call-expected.txt
+++ b/LayoutTests/svg/dynamic-updates/SVGFEGaussianBlurElement-dom-stdDeviation-call-expected.txt
@@ -7,6 +7,11 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS blurElement.stdDeviationX.baseVal is 5
 PASS blurElement.stdDeviationY.baseVal is 5
+PASS blurElement.setStdDeviation(10, 10) did not throw exception.
+PASS dropShadowElement.setStdDeviation(NaN, NaN) threw exception ReferenceError: Can't find variable: dropShadowElement.
+PASS dropShadowElement.setStdDeviation(Infinity, Infinity) threw exception ReferenceError: Can't find variable: dropShadowElement.
+PASS dropShadowElement.setStdDeviation() threw exception ReferenceError: Can't find variable: dropShadowElement.
+PASS dropShadowElement.setStdDeviation(0) threw exception ReferenceError: Can't find variable: dropShadowElement.
 PASS blurElement.stdDeviationX.baseVal is 10
 PASS blurElement.stdDeviationY.baseVal is 10
 PASS successfullyParsed is true

--- a/LayoutTests/svg/dynamic-updates/SVGFEGaussianBlurElement-dom-stdDeviation-call.html
+++ b/LayoutTests/svg/dynamic-updates/SVGFEGaussianBlurElement-dom-stdDeviation-call.html
@@ -48,7 +48,13 @@ shouldBe("blurElement.stdDeviationX.baseVal", "5");
 shouldBe("blurElement.stdDeviationY.baseVal", "5");
 
 function repaintTest() {
-    blurElement.setStdDeviation(10, 10);
+    shouldNotThrow('blurElement.setStdDeviation(10, 10)');
+
+    shouldThrow('dropShadowElement.setStdDeviation(NaN, NaN)');
+    shouldThrow('dropShadowElement.setStdDeviation(Infinity, Infinity)');
+    shouldThrow('dropShadowElement.setStdDeviation()');
+    shouldThrow('dropShadowElement.setStdDeviation(0)');
+
     shouldBe("blurElement.stdDeviationX.baseVal", "10");
     shouldBe("blurElement.stdDeviationY.baseVal", "10");
 

--- a/Source/WebCore/svg/SVGFEDropShadowElement.idl
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.idl
@@ -26,8 +26,7 @@
     readonly attribute SVGAnimatedNumber stdDeviationX;
     readonly attribute SVGAnimatedNumber stdDeviationY;
 
-    undefined setStdDeviation(optional unrestricted float stdDeviationX = NaN,
-                         optional unrestricted float stdDeviationY = NaN);
+    undefined setStdDeviation(float stdDeviationX, float stdDeviationY);
 };
 
 SVGFEDropShadowElement includes SVGFilterPrimitiveStandardAttributes;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.idl
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.idl
@@ -38,8 +38,7 @@
     readonly attribute SVGAnimatedNumber stdDeviationY;
     readonly attribute SVGAnimatedEnumeration edgeMode;
 
-    undefined setStdDeviation(optional unrestricted float stdDeviationX = NaN,
-                         optional unrestricted float stdDeviationY = NaN);
+    undefined setStdDeviation(float stdDeviationX, float stdDeviationY);
 };
 
 SVGFEGaussianBlurElement includes SVGFilterPrimitiveStandardAttributes;


### PR DESCRIPTION
#### 8ded595d93ee13a06fba590b472274d547483c56
<pre>
Match SVGFEDropShadowElement and SVGFEGaussianBlurElement.setStdDeviation() with the specs
<a href="https://bugs.webkit.org/show_bug.cgi?id=251182">https://bugs.webkit.org/show_bug.cgi?id=251182</a>
rdar://104671451

Reviewed by Ryosuke Niwa.

The specs state that the inputs of this method are two non optional finite float
arguments.

<a href="https://drafts.fxtf.org/filter-effects/#InterfaceSVGFEGaussianBlurElement">https://drafts.fxtf.org/filter-effects/#InterfaceSVGFEGaussianBlurElement</a>
<a href="https://drafts.fxtf.org/filter-effects/#InterfaceSVGFEDropShadowElement">https://drafts.fxtf.org/filter-effects/#InterfaceSVGFEDropShadowElement</a>

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt:
* LayoutTests/svg/dynamic-updates/SVGFEDropShadowElement-svgdom-stdDeviation-prop-expected.txt:
* LayoutTests/svg/dynamic-updates/SVGFEDropShadowElement-svgdom-stdDeviation-prop.html:
* LayoutTests/svg/dynamic-updates/SVGFEGaussianBlurElement-dom-stdDeviation-call-expected.txt:
* LayoutTests/svg/dynamic-updates/SVGFEGaussianBlurElement-dom-stdDeviation-call.html:
* Source/WebCore/svg/SVGFEDropShadowElement.idl:
* Source/WebCore/svg/SVGFEGaussianBlurElement.idl:

Canonical link: <a href="https://commits.webkit.org/259666@main">https://commits.webkit.org/259666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f96e522a2e77efba835f3fb4d9f7f11ef0b69d5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114174 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174364 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4911 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113196 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39202 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26310 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80864 "Found 4 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/audio-usermedia-permission-request, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-permission-requests, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7331 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7424 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4258 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47221 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6679 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9216 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->