### PR TITLE
[WebGPU] de-couple vertex buffer binding indices from bind group binding indices (251185)

### DIFF
--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -109,6 +109,9 @@ public:
     Instance& instance() const { return m_adapter->instance(); }
     bool hasUnifiedMemory() const { return m_device.hasUnifiedMemory; }
 
+    uint32_t maxBuffersPlusVertexBuffersForVertexStage() const;
+    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
+
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);
     Device(Adapter&);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -253,6 +253,19 @@ void Device::generateAValidationError(String&& message)
     }
 }
 
+uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
+{
+    // FIXME: use value in HardwareCapabilities from https://github.com/gpuweb/gpuweb/issues/2749
+    return 8;
+}
+
+uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const
+{
+    auto maxIndex = maxBuffersPlusVertexBuffersForVertexStage();
+    ASSERT(groupIndex <= maxIndex);
+    return groupIndex > maxIndex ? 0 : (maxIndex - groupIndex);
+}
+
 void Device::captureFrameIfNeeded() const
 {
     GPUFrameCapture::captureSingleFrameIfNeeded(m_device);

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -227,7 +227,7 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& gro
     for (const auto& resource : group.resources())
         m_resources.append(resource);
 
-    [icbCommand setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:groupIndex];
+    [icbCommand setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:m_device->vertexBufferIndexForBindGroup(groupIndex)];
     [icbCommand setFragmentBuffer:group.fragmentArgumentBuffer() offset:0 atIndex:groupIndex];
 }
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -102,7 +102,6 @@ private:
     id<MTLBuffer> m_indexBuffer { nil };
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
-    NSUInteger m_vertexShaderInputBufferCount { 0 };
     NSUInteger m_visibilityResultBufferOffset { 0 };
     NSUInteger m_visibilityResultBufferSize { 0 };
     bool m_depthReadOnly { false };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -177,7 +177,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
     for (const auto& resource : group.resources())
         [m_renderCommandEncoder useResource:resource.mtlResource usage:resource.usage stages:resource.renderStages];
 
-    [m_renderCommandEncoder setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:groupIndex + m_vertexShaderInputBufferCount];
+    [m_renderCommandEncoder setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:m_device->vertexBufferIndexForBindGroup(groupIndex)];
     [m_renderCommandEncoder setFragmentBuffer:group.fragmentArgumentBuffer() offset:0 atIndex:groupIndex];
 }
 
@@ -202,7 +202,6 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
         return;
 
     m_primitiveType = pipeline.primitiveType();
-    m_vertexShaderInputBufferCount = pipeline.vertexShaderInputBufferCount();
 
     if (pipeline.renderPipelineState())
         [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -43,14 +43,14 @@ class PipelineLayout;
 class RenderPipeline : public WGPURenderPipelineImpl, public RefCounted<RenderPipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthStencilDescriptor *depthStencilDescriptor, MTLRenderPipelineReflection *reflection, uint32_t vertexShaderInputBufferCount, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthStencilDescriptor *depthStencilDescriptor, MTLRenderPipelineReflection *reflection, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilDescriptor, reflection, vertexShaderInputBufferCount, device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilDescriptor, reflection, device));
     }
 
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthStencilDescriptor *depthStencilDescriptor, const PipelineLayout &pipelineLayout, uint32_t vertexShaderInputBufferCount, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, MTLDepthStencilDescriptor *depthStencilDescriptor, const PipelineLayout &pipelineLayout, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilDescriptor, pipelineLayout, vertexShaderInputBufferCount, device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilDescriptor, pipelineLayout, device));
     }
 
     static Ref<RenderPipeline> createInvalid(Device& device)
@@ -73,11 +73,10 @@ public:
     MTLCullMode cullMode() const { return m_cullMode; }
 
     Device& device() const { return m_device; }
-    uint32_t vertexShaderInputBufferCount() const { return m_vertexShaderInputBufferCount; }
 
 private:
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthStencilDescriptor *, MTLRenderPipelineReflection*, uint32_t, Device&);
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthStencilDescriptor *, const PipelineLayout&, uint32_t, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthStencilDescriptor *, MTLRenderPipelineReflection*, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthStencilDescriptor *, const PipelineLayout&, Device&);
     RenderPipeline(Device&);
 
     const id<MTLRenderPipelineState> m_renderPipelineState { nil };
@@ -94,7 +93,6 @@ private:
     MTLRenderPipelineReflection *m_reflection { nil };
 #endif
     const PipelineLayout *m_pipelineLayout { nullptr };
-    uint32_t m_vertexShaderInputBufferCount { 0 };
 };
 
 } // namespace WebGPU

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
@@ -107,7 +107,7 @@ async function helloCube() {
                     device float *time [[id(0)]];
                 };
     
-                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     Vertex vout;
                     float alpha = values.time[0];
@@ -158,7 +158,7 @@ async function helloCube() {
     const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
     
     const uniformBindGroup = device.createBindGroup({
-        layout: renderPipeline.getBindGroupLayout(1),
+        layout: renderPipeline.getBindGroupLayout(0),
         entries: [
           {
             binding: 0,
@@ -224,7 +224,7 @@ async function helloCube() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
         renderPassEncoder.end();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube-indirect.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube-indirect.js
@@ -135,7 +135,7 @@ async function helloCube() {
                     device float *time [[id(0)]];
                 };
     
-                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     Vertex vout;
                     float alpha = values.time[0];
@@ -239,7 +239,7 @@ async function helloCube() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.drawIndirect(indirectBuffer, 0);
         renderPassEncoder.end();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube.js
@@ -123,7 +123,7 @@ async function helloCube() {
                     device float *time [[id(0)]];
                 };
     
-                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     Vertex vout;
                     float alpha = values.time[0];
@@ -227,7 +227,7 @@ async function helloCube() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
         renderPassEncoder.end();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js
@@ -116,7 +116,7 @@ async function helloCube() {
                     device float *time [[id(0)]];
                 };
     
-                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     Vertex vout;
                     float alpha = values.time[0];
@@ -221,7 +221,7 @@ async function helloCube() {
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
         renderPassEncoder.setIndexBuffer(indexBuffer, "uint16", 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.drawIndexed(36, 1, 0, 0, 0); // 36 indices, 1 instance, 0th index, 0th vertex, 0th instance.
         renderPassEncoder.end();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js
@@ -171,7 +171,7 @@ async function helloCube() {
                     sampler textureSampler;
                 };
     
-                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     VertexOut vout;
                     float alpha = values.time[0];
@@ -196,7 +196,7 @@ async function helloCube() {
                     return vout;
                 }
 
-                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(1)]])
+                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(0)]])
                 {
                     return 0.5 * in.color + 0.5 * float4(values.colorTexture.sample(values.textureSampler, in.uv));
                 }
@@ -227,7 +227,7 @@ async function helloCube() {
     const renderBundleEncoder = device.createRenderBundleEncoder({ colorFormats: ["bgra8unorm"] });
     const vertexBufferSlot = 0;
     renderBundleEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-    renderBundleEncoder.setBindGroup(1, uniformBindGroup);
+    renderBundleEncoder.setBindGroup(0, uniformBindGroup);
     renderBundleEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
     
     renderBundle = renderBundleEncoder.finish();

--- a/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
@@ -154,7 +154,7 @@ async function helloCube() {
                     sampler textureSampler;
                 };
     
-                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]], unsigned InstanceIndex [[instance_id]])
+                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]], unsigned InstanceIndex [[instance_id]])
                 {
                     VertexOut vout;
                     unsigned offset = InstanceIndex * 3;
@@ -182,7 +182,7 @@ async function helloCube() {
                     return vout;
                 }
 
-                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(1)]])
+                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(0)]])
                 {
                     return 0.5 * in.color + 0.5 * float4(values.colorTexture.sample(values.textureSampler, in.uv));
                 }
@@ -234,7 +234,7 @@ async function helloCube() {
     const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
 
     const uniformBindGroup = device.createBindGroup({
-        layout: renderPipeline.getBindGroupLayout(1),
+        layout: renderPipeline.getBindGroupLayout(0),
         entries: [
           {
             binding: 0,
@@ -340,7 +340,7 @@ async function helloCube() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.draw(36, instanceCount, 0, 0); // 36 vertices, 10 instances, 0th vertex, 0th instance.
         renderPassEncoder.end();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
@@ -92,7 +92,7 @@ async function helloTriangle() {
                     device float *time [[id(0)]];
                 };
 
-                vertex Vertex vsmain(const device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex Vertex vsmain(const device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                    float2 pos[3] = {
                        float2( 0.0,  0.5 + .05 * values.time[0]),
@@ -190,7 +190,7 @@ async function helloTriangle() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.beginOcclusionQuery(0);
         renderPassEncoder.draw(3, 1, 0, 0); // 3 vertices, 1 instance, 0th vertex, 0th instance.
         renderPassEncoder.endOcclusionQuery();

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
@@ -178,7 +178,7 @@ async function helloCube() {
                     sampler textureSampler;
                 };
     
-                vertex VertexOut vsmain(VertexIn vin [[stage_in]], const device VertexShaderArguments &values [[buffer(1)]])
+                vertex VertexOut vsmain(VertexIn vin [[stage_in]], const device VertexShaderArguments &values [[buffer(8)]])
                 {
                     VertexOut vout;
                     float alpha = values.time[0] * alphaMultiplier;

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
@@ -171,7 +171,7 @@ async function helloCube() {
                     sampler textureSampler;
                 };
     
-                vertex VertexOut vsmain(VertexIn vin [[stage_in]], const device VertexShaderArguments &values [[buffer(1)]])
+                vertex VertexOut vsmain(VertexIn vin [[stage_in]], const device VertexShaderArguments &values [[buffer(8)]])
                 {
                     VertexOut vout;
                     float alpha = values.time[0];

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
@@ -172,7 +172,7 @@ async function helloCube() {
                     sampler textureSampler;
                 };
     
-                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     VertexOut vout;
                     float alpha = values.time[0];
@@ -197,7 +197,7 @@ async function helloCube() {
                     return vout;
                 }
 
-                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(1)]])
+                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(0)]])
                 {
                     return 0.5 * in.color + 0.5 * float4(values.colorTexture.sample(values.textureSampler, in.uv));
                 }
@@ -273,7 +273,7 @@ async function helloCube() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
         renderPassEncoder.draw(36); // 36 vertices
         renderPassEncoder.end();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
@@ -136,7 +136,7 @@ async function helloCube() {
                     device float *time [[id(0)]];
                 };
     
-                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     Vertex vout;
                     float alpha = values.time[0];
@@ -249,9 +249,9 @@ async function helloCube() {
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
         renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
-        renderPassEncoder.setBindGroup(1, uniformBindGroup1);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup1);
         renderPassEncoder.draw(36); // 36 vertices
-        renderPassEncoder.setBindGroup(1, uniformBindGroup2);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup2);
         renderPassEncoder.draw(36); // 36 vertices
         renderPassEncoder.end();
         


### PR DESCRIPTION
#### 1303b0d0d672202dce205e4d17996955ba96be3d
<pre>
[WebGPU] de-couple vertex buffer binding indices from bind group binding indices (251185)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251185">https://bugs.webkit.org/show_bug.cgi?id=251185</a>
&lt;radar://104673394&gt;

Reviewed by Myles C. Maxfield.

The shader compiler needs to know what offset to start generating
buffer indices from, so partition the available buffers into two ranges:
one for stage_in or calls to setVertexBuffer and the other for uniform bind groups.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setBindGroup):
(WebGPU::RenderPassEncoder::setPipeline):
* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::create):
(WebGPU::RenderPipeline::device const):
(WebGPU::RenderPipeline::vertexShaderInputBufferCount const): Deleted.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::RenderPipeline):
(WebGPU::RenderPipeline::getBindGroupLayout):
* Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js:
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/hello-cube-indirect.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/hello-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js:
* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js:
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/query-sets.js:
(async helloTriangle.async frameUpdate):
(async helloTriangle):
* Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js:
* Websites/webkit.org/demos/webgpu/scripts/two-cubes.js:
(async helloCube.frameUpdate):
(async helloCube):

Canonical link: <a href="https://commits.webkit.org/259414@main">https://commits.webkit.org/259414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb0baa2d06ead17327a7e582e86a33c8f720c9df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114122 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4857 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113151 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110613 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94645 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26261 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27622 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7374 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47172 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6493 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9163 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->