### PR TITLE
Restrict the set of defaults-overridable flags to better match shipping Safari

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -81,6 +81,7 @@ class Preference
   attr_accessor :type
   attr_accessor :refinedType
   attr_accessor :status
+  attr_accessor :defaultsOverridable
   attr_accessor :humanReadableName
   attr_accessor :humanReadableDescription
   attr_accessor :webcoreBinding
@@ -95,6 +96,7 @@ class Preference
     @type = opts["type"]
     @refinedType = opts["refinedType"]
     @status = opts["status"]
+    @defaultsOverridable = opts["defaultsOverridable"] || false
     @humanReadableName = (opts["humanReadableName"] || "")
     if not humanReadableName.start_with? "WebKitAdditions"
         @humanReadableName = '"' + humanReadableName + '"'
@@ -191,8 +193,8 @@ class Preference
     %w{ unstable internal testable }.include? @status
   end
 
-  def defaultOverridable?
-    %w{ internal }.include? @status
+  def defaultsOverridable?
+    @defaultsOverridable
   end
 
   # FIXME: These names correspond to the "experimental features" and "internal

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -60,6 +60,11 @@
 #   web platform feature or a "shipping" feature intended to be always-on.
 #   ANY default value.
 #
+# == Defaults Overridable ==
+#  When features are declared with "defaultsOverridable: true", platform user
+#  defaults may override a default value at runtime, using the preference
+#  name prefixed with "WebKitDebug".
+#
 # FIXME: Currently, default values are unchecked. We should audit and refactor
 # features so that their defaults agree with their status's definition, and use
 # the generator to enforce this in the future.
@@ -107,6 +112,7 @@ AcceleratedCompositingForFixedPositionEnabled:
 AcceleratedDrawingEnabled:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "GraphicsLayerCA accelerated drawing"
   humanReadableDescription: "Enable GraphicsLayerCA accelerated drawing"
   defaultValue:
@@ -1339,6 +1345,7 @@ ColorFilterEnabled:
 CompositingBordersVisible:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Compositing borders visible"
   webKitLegacyPreferenceKey: WebKitShowDebugBorders
   webcoreName: showDebugBorders
@@ -1356,6 +1363,7 @@ CompositingBordersVisible:
 CompositingRepaintCountersVisible:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Compositing repaint counters visible"
   webKitLegacyPreferenceKey: WebKitShowRepaintCounter
   webcoreName: showRepaintCounter
@@ -1814,6 +1822,7 @@ DeprecationReportingEnabled:
 DeveloperExtrasEnabled:
   type: bool
   status: embedder
+  defaultsOverridable: true
   webKitLegacyPreferenceKey: WebKitDeveloperExtrasEnabledPreferenceKey
   webKitLegacyBinding: custom
   defaultValue:
@@ -1926,6 +1935,7 @@ DirectoryUploadEnabled:
 DisableScreenSizeOverride:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Disable screen size override"
   webcoreBinding: DeprecatedGlobalSettings
   condition: PLATFORM(IOS_FAMILY)
@@ -1966,6 +1976,7 @@ DisallowSyncXHRDuringPageDismissalEnabled:
 DisplayListDrawingEnabled:
   type: bool
   status: unstable
+  defaultsOverridable: true
   humanReadableName: "DisplayList Drawing"
   humanReadableDescription: "Enable display-list drawing"
   defaultValue:
@@ -2289,6 +2300,7 @@ FocusVisibleEnabled:
 ForceAlwaysUserScalable:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Force always user-scalable"
   webcoreBinding: none
   condition: PLATFORM(IOS_FAMILY)
@@ -3314,6 +3326,7 @@ LegacyEncryptedMediaAPIEnabled:
 LegacyLineLayoutVisualCoverageEnabled:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Legacy line layout visual coverage"
   humanReadableDescription: "Enable legacy line layout visual coverage"
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
@@ -3503,6 +3516,7 @@ LocalStorageEnabled:
 LogsPageMessagesToSystemConsoleEnabled:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Log page messages to system console"
   humanReadableDescription: "Enable logging page messages to system console"
   defaultValue:
@@ -4108,7 +4122,8 @@ NeedsFrameNameFallbackToIdQuirk:
 
 NeedsInAppBrowserPrivacyQuirks:
   type: bool
-  status: embedder
+  status: internal
+  defaultsOverridable: true
   humanReadableName: "Needs In-App Browser Privacy Quirks"
   humanReadableDescription: "Enable quirks needed to support In-App Browser privacy"
   webcoreBinding: none
@@ -4884,6 +4899,7 @@ ResourceLoadSchedulingEnabled:
 ResourceUsageOverlayVisible:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Resource usage overlay"
   humanReadableDescription: "Make resource usage overlay visible"
   condition: ENABLE(RESOURCE_USAGE)
@@ -5907,6 +5923,7 @@ ThreadedScrollingEnabled:
 TiledScrollingIndicatorVisible:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "Tiled scrolling indicator"
   humanReadableDescription: "Make tiled scrolling indicator visible"
   webcoreName: showTiledScrollingIndicator
@@ -6343,6 +6360,7 @@ ViewGestureDebuggingEnabled:
 VisibleDebugOverlayRegions:
   type: uint32_t
   status: embedder
+  defaultsOverridable: true
   webcoreType: DebugOverlayRegions
   defaultValue:
     WebKitLegacy:
@@ -6702,6 +6720,7 @@ WebGPU:
 WebInspectorEngineeringSettingsAllowed:
   type: bool
   status: internal
+  defaultsOverridable: true
   humanReadableName: "WebInspector engineering settings allowed"
   defaultValue:
     WebKitLegacy:

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
@@ -70,7 +70,7 @@
 
 
 #define FOR_EACH_DEFAULT_OVERRIDABLE_WEBKIT_PREFERENCE(macro) \
-<%- for @pref in @exposedPreferences.select(&:defaultOverridable?) do -%>
+<%- for @pref in @exposedPreferences.select(&:defaultsOverridable?) do -%>
     macro(<%= @pref.name %>, <%= @pref.nameLower %>, <%= @pref.typeUpper %>, <%= @pref.type %>, DEFAULT_VALUE_FOR_<%= @pref.name %>, <%= @pref.humanReadableName %>, <%= @pref.humanReadableDescription %>) \
 <%- end -%>
     \

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -130,6 +130,17 @@ static void setDebugBoolValueIfInUserDefaults(const String& identifier, const St
     store.setBoolValueForKey(key, [object boolValue]);
 }
 
+static void setDebugUInt32ValueIfInUserDefaults(const String& identifier, const String& keyPrefix, const String& globalDebugKeyPrefix, const String& key, WebPreferencesStore& store)
+{
+    id object = debugUserDefaultsValue(identifier, keyPrefix, globalDebugKeyPrefix, key);
+    if (!object)
+        return;
+    if (![object respondsToSelector:@selector(unsignedIntegerValue)])
+        return;
+
+    store.setUInt32ValueForKey(key, [object unsignedIntegerValue]);
+}
+
 void WebPreferences::platformInitializeStore()
 {
     @autoreleasepool {


### PR DESCRIPTION
#### 0f58ae8a9cfeded106727881a403f817a692d8f4
<pre>
Restrict the set of defaults-overridable flags to better match shipping Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=251183">https://bugs.webkit.org/show_bug.cgi?id=251183</a>
&lt;rdar://104657361&gt;

Reviewed by Elliott Williams.

The new feature generator logic attempts to persist all `internal` feature flags such
that a developer can use a &apos;WebKitDebug&apos;-prefix for a setting to override it. This is
only desired for a small set of feature flags (those that lived in the
Source/WTF/Scripts/Preferences/WebPreferencesDebug.yaml file previously).

This patch does the following:

1. Corrects a handful of feature flags that were moved from `internal` to `embedder`, improperly.
2. Adds a new key, `defaultsOverridable`, to UnifiedWebPreferences.yaml. Flags that
have this key with a `true` value will get additional logic to support
&apos;WebKitDebug&apos;-prefix overrides.
3. Changes the predicate from &apos;defaultOverridable?&apos; to `defaultsOverridable?&apos; for consistency.
4. Partial revert of 258448@main to restore the ability to honor debug overrides for UInt32 types.

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb:
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::setDebugUInt32ValueIfInUserDefaults): Partial revert of 258448@main. We actually
do need this method.

Canonical link: <a href="https://commits.webkit.org/259458@main">https://commits.webkit.org/259458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ce2257391425e5dd61b8438f718e83b552931af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114196 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4935 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113217 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110690 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108391 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26329 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94787 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27688 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92818 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5085 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7447 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30247 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47240 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101512 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6526 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9238 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25321 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->