### PR TITLE
Make it possible to get the scrolling tree with UI-side compositing on macOS

### DIFF
--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe-expected.txt
@@ -25,7 +25,7 @@
           (vertical scroll elasticity 0)
           (horizontal scrollbar mode 0)
           (vertical scrollbar mode 0))
-        (synchronous scrolling reasons Has slow repaint objects, Has slow repaint descendant scrollers)
+        (synchronous scrolling reasons Has slow repaint objects)
         (layout viewport (0,0) width=500 height=400)
         (min layoutViewport origin (0,0))
         (max layoutViewport origin (0,0))

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1559,9 +1559,12 @@ window.UIHelper = class UIHelper {
 
     static getScrollingTree()
     {
-        if (!this.isWebKit2() || !this.isIOSFamily())
-            return Promise.resolve();
+        if (!this.isWebKit2())
+            return Promise.resolve('');
 
+        if (window.internals.haveScrollingTree())
+            return Promise.resolve(window.internals.scrollingTreeAsText());
+            
         return new Promise(resolve => {
             testRunner.runUIScript(`(() => {
                 return uiController.scrollingTreeAsText;

--- a/LayoutTests/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe.html
+++ b/LayoutTests/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe.html
@@ -12,13 +12,20 @@
             border: 1px solid black;
         }
     </style>
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
-        if (window.testRunner)
+        if (window.testRunner) {
             testRunner.dumpAsText();
+            testRunner.waitUntilDone();            
+        }
 
-        window.addEventListener('load', () => {
-            if (window.internals)
-                document.getElementById('scrollingTree').innerText = window.internals.scrollingTreeAsText() + "\n";
+        window.addEventListener('load', async () => {
+            if (!window.internals)
+                return
+
+            document.getElementById('scrollingTree').innerText = await UIHelper.getScrollingTree();
+            if (window.testRunner)
+                testRunner.notifyDone();
         }, false);
     </script>
 </head>

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -1074,6 +1074,11 @@ String AsyncScrollingCoordinator::scrollingTreeAsText(OptionSet<ScrollingStateTr
     return m_scrollingTree->scrollingTreeAsText(behavior);
 }
 
+bool AsyncScrollingCoordinator::haveScrollingTree() const
+{
+    return !!m_scrollingTree;
+}
+
 void AsyncScrollingCoordinator::setActiveScrollSnapIndices(ScrollingNodeID scrollingNodeID, std::optional<unsigned> horizontalIndex, std::optional<unsigned> verticalIndex)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -84,6 +84,8 @@ protected:
 
     WEBCORE_EXPORT String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const override;
     WEBCORE_EXPORT String scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const override;
+    WEBCORE_EXPORT bool haveScrollingTree() const override;
+
     WEBCORE_EXPORT void willCommitTree() override;
     void synchronizeStateFromScrollingTree();
     void scheduleRenderingUpdate();

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -173,6 +173,7 @@ public:
     virtual void reconcileViewportConstrainedLayerPositions(ScrollingNodeID, const LayoutRect&, ScrollingLayerPositionAction) { }
     virtual String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const;
     virtual String scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const;
+    virtual bool haveScrollingTree() const { return false; }
     virtual bool isRubberBandInProgress(ScrollingNodeID) const { return false; }
     virtual bool isUserScrollInProgress(ScrollingNodeID) const { return false; }
     virtual bool isScrollSnapInProgress(ScrollingNodeID) const { return false; }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3206,6 +3206,25 @@ ExceptionOr<String> Internals::scrollingTreeAsText() const
     return scrollingCoordinator->scrollingTreeAsText();
 }
 
+ExceptionOr<bool> Internals::haveScrollingTree() const
+{
+    auto* document = contextDocument();
+    if (!document || !document->frame())
+        return Exception { InvalidAccessError };
+
+    document->updateLayoutIgnorePendingStylesheets();
+
+    auto page = document->page();
+    if (!page)
+        return false;
+
+    auto scrollingCoordinator = page->scrollingCoordinator();
+    if (!scrollingCoordinator)
+        return false;
+
+    return scrollingCoordinator->haveScrollingTree();
+}
+
 ExceptionOr<String> Internals::synchronousScrollingReasons() const
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -485,6 +485,7 @@ public:
 
     ExceptionOr<String> scrollingStateTreeAsText() const;
     ExceptionOr<String> scrollingTreeAsText() const;
+    ExceptionOr<bool> haveScrollingTree() const;
     ExceptionOr<String> synchronousScrollingReasons() const;
     ExceptionOr<Ref<DOMRectList>> nonFastScrollableRects() const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -613,6 +613,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     DOMString scrollingStateTreeAsText();
     DOMString scrollingTreeAsText();
+    boolean haveScrollingTree();
     DOMString synchronousScrollingReasons();
     DOMRectList nonFastScrollableRects();
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -82,6 +82,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_dismissContactPickerWithContacts:(NSArray *)contacts;
 
 @property (nonatomic, setter=_setScrollingUpdatesDisabledForTesting:) BOOL _scrollingUpdatesDisabledForTesting;
+@property (nonatomic, readonly) NSString *_scrollingTreeAsText;
 
 - (void)_processWillSuspendForTesting:(void (^)(void))completionHandler;
 - (void)_processWillSuspendImminentlyForTesting;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -31,6 +31,7 @@
 #import "MediaSessionCoordinatorProxyPrivate.h"
 #import "PlaybackSessionManagerProxy.h"
 #import "PrintInfo.h"
+#import "RemoteScrollingCoordinatorProxy.h"
 #import "UserMediaProcessManager.h"
 #import "ViewGestureController.h"
 #import "WebPageProxy.h"
@@ -138,6 +139,15 @@
 {
     // For subclasses to override;
     return NO;
+}
+
+- (NSString *)_scrollingTreeAsText
+{
+    WebKit::RemoteScrollingCoordinatorProxy* coordinator = _page->scrollingCoordinatorProxy();
+    if (!coordinator)
+        return @"";
+
+    return coordinator->scrollingTreeAsText();
 }
 
 - (void)_setScrollingUpdatesDisabledForTesting:(BOOL)disabled

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -43,7 +43,6 @@
 @property (nonatomic, readonly) NSString *formInputLabel;
 @property (nonatomic, readonly) NSArray<NSValue *> *_uiTextSelectionRects;
 @property (nonatomic, readonly) CGRect _inputViewBoundsInWindow;
-@property (nonatomic, readonly) NSString *_scrollingTreeAsText;
 @property (nonatomic, readonly) NSString *_uiViewTreeAsText;
 @property (nonatomic, readonly) NSNumber *_stableStateOverride;
 @property (nonatomic, readonly) CGRect _dragCaretRect;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -30,7 +30,6 @@
 
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeViews.h"
-#import "RemoteScrollingCoordinatorProxy.h"
 #import "UIKitSPI.h"
 #import "WKContentViewInteraction.h"
 #import "WKFullScreenWindowController.h"
@@ -221,15 +220,6 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
     [_contentView _updateChangedSelection];
 
     return [_contentView _uiTextSelectionRects];
-}
-
-- (NSString *)_scrollingTreeAsText
-{
-    WebKit::RemoteScrollingCoordinatorProxy* coordinator = _page->scrollingCoordinatorProxy();
-    if (!coordinator)
-        return @"";
-
-    return coordinator->scrollingTreeAsText();
 }
 
 static String allowListedClassToString(UIView *view)

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -54,6 +54,8 @@ private:
     JSRetainPtr<JSStringRef> firstRedoLabel() const override;
     NSUndoManager *platformUndoManager() const override;
 
+    JSRetainPtr<JSStringRef> scrollingTreeAsText() const override;
+
     void setDidShowContextMenuCallback(JSValueRef) override;
     void setDidDismissContextMenuCallback(JSValueRef) override;
     bool isShowingContextMenu() const override;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -104,6 +104,11 @@ void UIScriptControllerCocoa::completeTaskAsynchronouslyAfterActivityStateUpdate
     });
 }
 
+JSRetainPtr<JSStringRef> UIScriptControllerCocoa::scrollingTreeAsText() const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef)[webView() _scrollingTreeAsText]));
+}
+
 void UIScriptControllerCocoa::removeViewFromWindow(JSValueRef callback)
 {
     // FIXME: On iOS, we never invoke the completion callback that's passed in. Fixing this causes the layout

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
@@ -65,7 +65,7 @@ private:
     void chooseMenuAction(JSStringRef, JSValueRef) override;
 
     void activateAtPoint(long x, long y, JSValueRef callback) override;
-    
+
     void sendEventStream(JSStringRef, JSValueRef) override;
 
     NSTableView *dataListSuggestionsTableView() const;


### PR DESCRIPTION
#### e4fa5c5f61bb9b6d345275cf05d8246fb5ac9952
<pre>
Make it possible to get the scrolling tree with UI-side compositing on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=251193">https://bugs.webkit.org/show_bug.cgi?id=251193</a>
rdar://104681297

Reviewed by Tim Horton.

`window.internals.scrollingTreeAsText()` only works when we have a scrolling tree in the web process,
i.e. only with non-UI-side compositing. In order to make tests work with both UI-side and non-UI-side
compositing, add `internals.haveScrollingTree()` and use it in `UIHelper.getScrollingTree()` to know
when we should use UIScriptController to fetch the scrolling tree from the UI process.

Make the existing WKWebView testing code for getting the scrolling tree work on both
macOS and iOS.

Fix up one test (fixed-background-in-overflow-in-iframe.html) to use the new thing; other
tests will be fixed soon.

* LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe-expected.txt: Copied from LayoutTests/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe-expected.txt.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.getScrollingTree):
* LayoutTests/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe-expected.txt:
* LayoutTests/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-overflow-in-iframe.html:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::haveScrollingTree const):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::haveScrollingTree const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::haveScrollingTree const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _scrollingTreeAsText]):
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _scrollingTreeAsText]): Deleted.
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::scrollingTreeAsText const):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.h:

Canonical link: <a href="https://commits.webkit.org/259457@main">https://commits.webkit.org/259457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca5b9a5a75f01b4c1980b17f9c8dd9a0252e87b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114170 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174360 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4907 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113192 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39198 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80860 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7327 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27666 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4254 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6527 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9212 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->