### PR TITLE
Implement WEBGL_clip_cull_distance

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3935,6 +3935,7 @@ webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/oes-draw-buffers-indexed.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/promoted-extensions-in-shaders.html [ Pass ]
 webgl/2.0.y/conformance2/rendering/rasterizer-discard-and-implicit-clear.html [ Pass ]
+webgl/2.0.y/conformance2/extensions/webgl-clip-cull-distance.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html [ Pass ]
 webgl/2.0.y/conformance/reading/read-pixels-test.html [ Pass ]
 

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,9 +2,11 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 5 PASS, 0 FAIL
+TEST COMPLETE: 7 PASS, 0 FAIL
 
 
+PASS webgl2:WEBGL_clip_cull_distance: Supported
+PASS webgl2:WEBGL_clip_cull_distance: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_provoking_vertex: Supported

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -2,9 +2,10 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 4 PASS, 0 FAIL
+TEST COMPLETE: 5 PASS, 0 FAIL
 
 
+PASS webgl2:WEBGL_clip_cull_distance: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_provoking_vertex: Not supported

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,9 +2,11 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 5 PASS, 0 FAIL
+TEST COMPLETE: 7 PASS, 0 FAIL
 
 
+PASS webgl2:WEBGL_clip_cull_distance: Supported
+PASS webgl2:WEBGL_clip_cull_distance: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_provoking_vertex: Supported

--- a/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
+++ b/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
@@ -6,6 +6,7 @@ let currentDraftExtensions = {
     "webgl": [
     ],
     "webgl2" : [
+        "WEBGL_clip_cull_distance",
         "WEBGL_draw_instanced_base_vertex_base_instance",
         "WEBGL_multi_draw_instanced_base_vertex_base_instance",
         "WEBGL_provoking_vertex",

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,9 +2,11 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 7 PASS, 0 FAIL
+TEST COMPLETE: 9 PASS, 0 FAIL
 
 
+PASS webgl2:WEBGL_clip_cull_distance: Supported
+PASS webgl2:WEBGL_clip_cull_distance: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -2,9 +2,10 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 4 PASS, 0 FAIL
+TEST COMPLETE: 5 PASS, 0 FAIL
 
 
+PASS webgl2:WEBGL_clip_cull_distance: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_provoking_vertex: Not supported

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,9 +2,11 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 7 PASS, 0 FAIL
+TEST COMPLETE: 9 PASS, 0 FAIL
 
 
+PASS webgl2:WEBGL_clip_cull_distance: Supported
+PASS webgl2:WEBGL_clip_cull_distance: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1891,6 +1891,7 @@ if (ENABLE_WEBGL)
         html/canvas/OESVertexArrayObject.cpp
         html/canvas/WebGL2RenderingContext.cpp
         html/canvas/WebGLBuffer.cpp
+        html/canvas/WebGLClipCullDistance.cpp
         html/canvas/WebGLColorBufferFloat.cpp
         html/canvas/WebGLCompressedTextureASTC.cpp
         html/canvas/WebGLCompressedTextureETC.cpp
@@ -1959,6 +1960,7 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/WebGL2RenderingContext.idl
     html/canvas/WebGLActiveInfo.idl
     html/canvas/WebGLBuffer.idl
+    html/canvas/WebGLClipCullDistance.idl
     html/canvas/WebGLColorBufferFloat.idl
     html/canvas/WebGLCompressedTextureASTC.idl
     html/canvas/WebGLCompressedTextureETC.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1385,6 +1385,7 @@ $(PROJECT_DIR)/html/canvas/PredefinedColorSpace.idl
 $(PROJECT_DIR)/html/canvas/WebGL2RenderingContext.idl
 $(PROJECT_DIR)/html/canvas/WebGLActiveInfo.idl
 $(PROJECT_DIR)/html/canvas/WebGLBuffer.idl
+$(PROJECT_DIR)/html/canvas/WebGLClipCullDistance.idl
 $(PROJECT_DIR)/html/canvas/WebGLColorBufferFloat.idl
 $(PROJECT_DIR)/html/canvas/WebGLCompressedTextureASTC.idl
 $(PROJECT_DIR)/html/canvas/WebGLCompressedTextureETC.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2835,6 +2835,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLActiveInfo.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLActiveInfo.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLBuffer.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLBuffer.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLClipCullDistance.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLClipCullDistance.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLColorBufferFloat.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLColorBufferFloat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLCompressedTextureASTC.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1226,6 +1226,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/WebGL2RenderingContext.idl \
     $(WebCore)/html/canvas/WebGLActiveInfo.idl \
     $(WebCore)/html/canvas/WebGLBuffer.idl \
+    $(WebCore)/html/canvas/WebGLClipCullDistance.idl \
     $(WebCore)/html/canvas/WebGLColorBufferFloat.idl \
     $(WebCore)/html/canvas/WebGLCompressedTextureASTC.idl \
     $(WebCore)/html/canvas/WebGLCompressedTextureETC.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1442,6 +1442,7 @@ html/canvas/PlaceholderRenderingContext.cpp
 html/canvas/PredefinedColorSpace.cpp
 html/canvas/WebGL2RenderingContext.cpp
 html/canvas/WebGLBuffer.cpp
+html/canvas/WebGLClipCullDistance.cpp
 html/canvas/WebGLColorBufferFloat.cpp
 html/canvas/WebGLCompressedTextureASTC.cpp
 html/canvas/WebGLCompressedTextureETC.cpp
@@ -4199,6 +4200,7 @@ JSWebCodecsVideoFrame.cpp
 JSWebGL2RenderingContext.cpp
 JSWebGLActiveInfo.cpp
 JSWebGLBuffer.cpp
+JSWebGLClipCullDistance.cpp
 JSWebGLColorBufferFloat.cpp
 JSWebGLCompressedTextureASTC.cpp
 JSWebGLCompressedTextureETC.cpp

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -52,6 +52,7 @@
 #include "JSOESTextureHalfFloatLinear.h"
 #include "JSOESVertexArrayObject.h"
 #include "JSWebGLBuffer.h"
+#include "JSWebGLClipCullDistance.h"
 #include "JSWebGLColorBufferFloat.h"
 #include "JSWebGLCompressedTextureASTC.h"
 #include "JSWebGLCompressedTextureETC.h"
@@ -191,6 +192,7 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         TO_JS(OESTextureHalfFloat)
         TO_JS(OESTextureHalfFloatLinear)
         TO_JS(OESVertexArrayObject)
+        TO_JS(WebGLClipCullDistance)
         TO_JS(WebGLColorBufferFloat)
         TO_JS(WebGLCompressedTextureASTC)
         TO_JS(WebGLCompressedTextureETC)

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -51,6 +51,7 @@
 #include "WebCoreOpaqueRoot.h"
 #include "WebGLActiveInfo.h"
 #include "WebGLBuffer.h"
+#include "WebGLClipCullDistance.h"
 #include "WebGLCompressedTextureASTC.h"
 #include "WebGLCompressedTextureETC.h"
 #include "WebGLCompressedTextureETC1.h"
@@ -2613,6 +2614,7 @@ WebGLExtension* WebGL2RenderingContext::getExtension(const String& name)
     ENABLE_IF_REQUESTED(KHRParallelShaderCompile, m_khrParallelShaderCompile, "KHR_parallel_shader_compile"_s, KHRParallelShaderCompile::supported(*m_context));
     ENABLE_IF_REQUESTED(OESDrawBuffersIndexed, m_oesDrawBuffersIndexed, "OES_draw_buffers_indexed"_s, OESDrawBuffersIndexed::supported(*m_context));
     ENABLE_IF_REQUESTED(OESTextureFloatLinear, m_oesTextureFloatLinear, "OES_texture_float_linear"_s, OESTextureFloatLinear::supported(*m_context));
+    ENABLE_IF_REQUESTED(WebGLClipCullDistance, m_webglClipCullDistance, "WEBGL_clip_cull_distance"_s, WebGLClipCullDistance::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(WebGLCompressedTextureASTC, m_webglCompressedTextureASTC, "WEBGL_compressed_texture_astc"_s, WebGLCompressedTextureASTC::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLCompressedTextureETC, m_webglCompressedTextureETC, "WEBGL_compressed_texture_etc"_s, WebGLCompressedTextureETC::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLCompressedTextureETC1, m_webglCompressedTextureETC1, "WEBGL_compressed_texture_etc1"_s, WebGLCompressedTextureETC1::supported(*m_context));
@@ -2653,6 +2655,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("KHR_parallel_shader_compile", KHRParallelShaderCompile::supported(*m_context))
     APPEND_IF_SUPPORTED("OES_draw_buffers_indexed", OESDrawBuffersIndexed::supported(*m_context))
     APPEND_IF_SUPPORTED("OES_texture_float_linear", OESTextureFloatLinear::supported(*m_context))
+    APPEND_IF_SUPPORTED("WEBGL_clip_cull_distance", WebGLClipCullDistance::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("WEBGL_compressed_texture_astc", WebGLCompressedTextureASTC::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_compressed_texture_etc", WebGLCompressedTextureETC::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_compressed_texture_etc1", WebGLCompressedTextureETC1::supported(*m_context))
@@ -3181,6 +3184,24 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
         if (m_boundVertexArrayObject->isDefaultObject())
             return nullptr;
         return static_pointer_cast<WebGLVertexArrayObject>(m_boundVertexArrayObject);
+    case GraphicsContextGL::MAX_CLIP_DISTANCES_ANGLE:
+    case GraphicsContextGL::MAX_CULL_DISTANCES_ANGLE:
+    case GraphicsContextGL::MAX_COMBINED_CLIP_AND_CULL_DISTANCES_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE0_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE1_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE2_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE3_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE4_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE5_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE6_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE7_ANGLE:
+        if (m_webglClipCullDistance) {
+            if (pname >= GraphicsContextGL::CLIP_DISTANCE0_ANGLE && pname <= GraphicsContextGL::CLIP_DISTANCE7_ANGLE)
+                return getBooleanParameter(pname);
+            return getUnsignedIntParameter(pname);
+        }
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, WEBGL_clip_cull_distance not enabled");
+        return nullptr;
     case GraphicsContextGL::PROVOKING_VERTEX_ANGLE:
         if (m_webglProvokingVertex)
             return getUnsignedIntParameter(GraphicsContextGL::PROVOKING_VERTEX_ANGLE);
@@ -3209,6 +3230,18 @@ bool WebGL2RenderingContext::validateBlendEquation(const char* functionName, GCG
 bool WebGL2RenderingContext::validateCapability(const char* functionName, GCGLenum cap)
 {
     switch (cap) {
+    case GraphicsContextGL::CLIP_DISTANCE0_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE1_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE2_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE3_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE4_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE5_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE6_ANGLE:
+    case GraphicsContextGL::CLIP_DISTANCE7_ANGLE:
+        if (m_webglClipCullDistance)
+            return true;
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid capability, WEBGL_clip_cull_distance not enabled");
+        return false;
     case GraphicsContextGL::RASTERIZER_DISCARD:
         return true;
     default:

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBGL)
+#include "WebGLClipCullDistance.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLClipCullDistance);
+
+WebGLClipCullDistance::WebGLClipCullDistance(WebGLRenderingContextBase& context)
+    : WebGLExtension(context)
+{
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_clip_cull_distance"_s);
+}
+
+WebGLClipCullDistance::~WebGLClipCullDistance() = default;
+
+WebGLExtension::ExtensionName WebGLClipCullDistance::getName() const
+{
+    return WebGLClipCullDistanceName;
+}
+
+bool WebGLClipCullDistance::supported(GraphicsContextGL& context)
+{
+    return context.supportsExtension("GL_ANGLE_clip_cull_distance"_s);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.h
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebGLExtension.h"
+
+namespace WebCore {
+
+class WebGLClipCullDistance final : public WebGLExtension {
+    WTF_MAKE_ISO_ALLOCATED(WebGLClipCullDistance);
+public:
+    explicit WebGLClipCullDistance(WebGLRenderingContextBase&);
+    virtual ~WebGLClipCullDistance();
+
+    ExtensionName getName() const override;
+
+    static bool supported(GraphicsContextGL&);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.idl
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.idl
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    LegacyNoInterfaceObject,
+    Conditional=WEBGL,
+    GenerateIsReachable=ImplWebGLRenderingContext,
+] interface WebGLClipCullDistance {
+    const unsigned long MAX_CLIP_DISTANCES_WEBGL = 0x0D32;
+    const unsigned long MAX_CULL_DISTANCES_WEBGL = 0x82F9;
+    const unsigned long MAX_COMBINED_CLIP_AND_CULL_DISTANCES_WEBGL = 0x82FA;
+    const unsigned long CLIP_DISTANCE0_WEBGL = 0x3000;
+    const unsigned long CLIP_DISTANCE1_WEBGL = 0x3001;
+    const unsigned long CLIP_DISTANCE2_WEBGL = 0x3002;
+    const unsigned long CLIP_DISTANCE3_WEBGL = 0x3003;
+    const unsigned long CLIP_DISTANCE4_WEBGL = 0x3004;
+    const unsigned long CLIP_DISTANCE5_WEBGL = 0x3005;
+    const unsigned long CLIP_DISTANCE6_WEBGL = 0x3006;
+    const unsigned long CLIP_DISTANCE7_WEBGL = 0x3007;
+};

--- a/Source/WebCore/html/canvas/WebGLExtension.h
+++ b/Source/WebCore/html/canvas/WebGLExtension.h
@@ -79,6 +79,7 @@ public:
         OESTextureHalfFloatName,
         OESTextureHalfFloatLinearName,
         OESVertexArrayObjectName,
+        WebGLClipCullDistanceName,
         WebGLColorBufferFloatName,
         WebGLCompressedTextureASTCName,
         WebGLCompressedTextureETCName,

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -85,6 +85,7 @@
 #include "WebGL2RenderingContext.h"
 #include "WebGLActiveInfo.h"
 #include "WebGLBuffer.h"
+#include "WebGLClipCullDistance.h"
 #include "WebGLColorBufferFloat.h"
 #include "WebGLCompressedTextureASTC.h"
 #include "WebGLCompressedTextureETC.h"
@@ -3001,6 +3002,7 @@ bool WebGLRenderingContextBase::extensionIsEnabled(const String& name)
     CHECK_EXTENSION(m_oesTextureHalfFloat, "OES_texture_half_float");
     CHECK_EXTENSION(m_oesTextureHalfFloatLinear, "OES_texture_half_float_linear");
     CHECK_EXTENSION(m_oesVertexArrayObject, "OES_vertex_array_object");
+    CHECK_EXTENSION(m_webglClipCullDistance, "WEBGL_clip_cull_distance");
     CHECK_EXTENSION(m_webglColorBufferFloat, "WEBGL_color_buffer_float");
     CHECK_EXTENSION(m_webglCompressedTextureASTC, "WEBGL_compressed_texture_astc");
     CHECK_EXTENSION(m_webglCompressedTextureETC, "WEBGL_compressed_texture_etc");
@@ -5811,6 +5813,7 @@ void WebGLRenderingContextBase::loseExtensions(LostContextMode mode)
     LOSE_EXTENSION(m_oesTextureHalfFloat);
     LOSE_EXTENSION(m_oesTextureHalfFloatLinear);
     LOSE_EXTENSION(m_oesVertexArrayObject);
+    LOSE_EXTENSION(m_webglClipCullDistance);
     LOSE_EXTENSION(m_webglColorBufferFloat);
     LOSE_EXTENSION(m_webglCompressedTextureASTC);
     LOSE_EXTENSION(m_webglCompressedTextureETC);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -108,6 +108,7 @@ class OffscreenCanvas;
 #endif
 class WebCoreOpaqueRoot;
 class WebGLActiveInfo;
+class WebGLClipCullDistance;
 class WebGLColorBufferFloat;
 class WebGLCompressedTextureASTC;
 class WebGLCompressedTextureETC;
@@ -752,6 +753,7 @@ protected:
     RefPtr<OESTextureHalfFloat> m_oesTextureHalfFloat;
     RefPtr<OESTextureHalfFloatLinear> m_oesTextureHalfFloatLinear;
     RefPtr<OESVertexArrayObject> m_oesVertexArrayObject;
+    RefPtr<WebGLClipCullDistance> m_webglClipCullDistance;
     RefPtr<WebGLColorBufferFloat> m_webglColorBufferFloat;
     RefPtr<WebGLCompressedTextureASTC> m_webglCompressedTextureASTC;
     RefPtr<WebGLCompressedTextureETC> m_webglCompressedTextureETC;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -827,6 +827,19 @@ public:
     static constexpr GCGLenum RGB16_SNORM_EXT = 0x8F9A;
     static constexpr GCGLenum RGBA16_SNORM_EXT = 0x8F9B;
 
+    // GL_ANGLE_clip_cull_distance
+    static constexpr GCGLenum MAX_CLIP_DISTANCES_ANGLE = 0x0D32;
+    static constexpr GCGLenum MAX_CULL_DISTANCES_ANGLE = 0x82F9;
+    static constexpr GCGLenum MAX_COMBINED_CLIP_AND_CULL_DISTANCES_ANGLE = 0x82FA;
+    static constexpr GCGLenum CLIP_DISTANCE0_ANGLE = 0x3000;
+    static constexpr GCGLenum CLIP_DISTANCE1_ANGLE = 0x3001;
+    static constexpr GCGLenum CLIP_DISTANCE2_ANGLE = 0x3002;
+    static constexpr GCGLenum CLIP_DISTANCE3_ANGLE = 0x3003;
+    static constexpr GCGLenum CLIP_DISTANCE4_ANGLE = 0x3004;
+    static constexpr GCGLenum CLIP_DISTANCE5_ANGLE = 0x3005;
+    static constexpr GCGLenum CLIP_DISTANCE6_ANGLE = 0x3006;
+    static constexpr GCGLenum CLIP_DISTANCE7_ANGLE = 0x3007;
+
     // GL_ANGLE_provoking_vertex
     static constexpr GCGLenum FIRST_VERTEX_CONVENTION_ANGLE = 0x8E4D;
     static constexpr GCGLenum LAST_VERTEX_CONVENTION_ANGLE = 0x8E4E;


### PR DESCRIPTION
#### c2b37c11144baf6c3c17e6dd4fd333c24da226f0
<pre>
Implement WEBGL_clip_cull_distance
<a href="https://bugs.webkit.org/show_bug.cgi?id=251153">https://bugs.webkit.org/show_bug.cgi?id=251153</a>

Reviewed by Kimmo Kinnunen.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt:
* LayoutTests/webgl/resources/webgl-draft-extensions-flag.js:
* LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
(WebCore::convertToJSValue):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getExtension):
(WebCore::WebGL2RenderingContext::getSupportedExtensions):
(WebCore::WebGL2RenderingContext::getParameter):
(WebCore::WebGL2RenderingContext::validateCapability):
* Source/WebCore/html/canvas/WebGLClipCullDistance.cpp: Added.
(WebCore::WebGLClipCullDistance::WebGLClipCullDistance):
(WebCore::WebGLClipCullDistance::getName const):
(WebCore::WebGLClipCullDistance::supported):
* Source/WebCore/html/canvas/WebGLClipCullDistance.h: Added.
* Source/WebCore/html/canvas/WebGLClipCullDistance.idl: Added.
* Source/WebCore/html/canvas/WebGLExtension.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::extensionIsEnabled):
(WebCore::WebGLRenderingContextBase::loseExtensions):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/259435@main">https://commits.webkit.org/259435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab1ffa1f5411c0fe8ae539badf93b948929aa765

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114117 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174314 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4852 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113150 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39158 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26256 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80822 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27617 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7372 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4214 "Found 1 new test failure: fast/forms/fieldset/fieldset-multicolumn.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47167 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6510 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9158 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->