### PR TITLE
[WGSL] Add reference types

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -68,7 +68,7 @@ class ArrayType;
 class NamedType;
 class ParameterizedType;
 class StructType;
-class TypeReference;
+class ReferenceType;
 
 class Parameter;
 class StructMember;

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -79,7 +79,7 @@ public:
         NamedType,
         ParameterizedType,
         StructType,
-        TypeReference,
+        ReferenceType,
 
         Parameter,
         StructMember,

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -371,9 +371,10 @@ void StringDumper::visit(StructType& type)
     m_out.print(type.structDecl().name());
 }
 
-void StringDumper::visit(TypeReference& type)
+void StringDumper::visit(ReferenceType& type)
 {
     visit(type.type());
+    m_out.print("&");
 }
 
 void StringDumper::visit(Parameter& parameter)

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -81,7 +81,7 @@ public:
     void visit(NamedType&) override;
     void visit(ParameterizedType&) override;
     void visit(StructType&) override;
-    void visit(TypeReference&) override;
+    void visit(ReferenceType&) override;
 
     void visit(Parameter&) override;
     void visit(StructMember&) override;

--- a/Source/WebGPU/WGSL/AST/ASTTypeDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeDecl.h
@@ -174,11 +174,11 @@ private:
     StructDecl& m_structDecl;
 };
 
-class TypeReference final : public TypeDecl {
+class ReferenceType final : public TypeDecl {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    TypeReference(SourceSpan span, Ref<TypeDecl>&& type)
+    ReferenceType(SourceSpan span, Ref<TypeDecl>&& type)
         : TypeDecl(span)
         , m_type(WTFMove(type))
     {
@@ -207,7 +207,7 @@ static bool isType(const WGSL::AST::Node& node)
     case WGSL::AST::Node::Kind::NamedType:
     case WGSL::AST::Node::Kind::ParameterizedType:
     case WGSL::AST::Node::Kind::StructType:
-    case WGSL::AST::Node::Kind::TypeReference:
+    case WGSL::AST::Node::Kind::ReferenceType:
         return true;
     default:
         return false;
@@ -219,4 +219,4 @@ SPECIALIZE_TYPE_TRAITS_WGSL_AST(ArrayType)
 SPECIALIZE_TYPE_TRAITS_WGSL_AST(NamedType)
 SPECIALIZE_TYPE_TRAITS_WGSL_AST(ParameterizedType)
 SPECIALIZE_TYPE_TRAITS_WGSL_AST(StructType)
-SPECIALIZE_TYPE_TRAITS_WGSL_AST(TypeReference)
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(ReferenceType)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -323,8 +323,8 @@ void Visitor::visit(TypeDecl& typeDecl)
     case Node::Kind::StructType:
         checkErrorAndVisit(downcast<StructType>(typeDecl));
         break;
-    case Node::Kind::TypeReference:
-        checkErrorAndVisit(downcast<TypeReference>(typeDecl));
+    case Node::Kind::ReferenceType:
+        checkErrorAndVisit(downcast<ReferenceType>(typeDecl));
         break;
     default:
         ASSERT_NOT_REACHED("Unhandled type declaration kind");
@@ -350,8 +350,9 @@ void Visitor::visit(StructType&)
 {
 }
 
-void Visitor::visit(TypeReference&)
+void Visitor::visit(ReferenceType& referenceType)
 {
+    checkErrorAndVisit(referenceType.type());
 }
 
 //

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -83,7 +83,7 @@ public:
     virtual void visit(NamedType&);
     virtual void visit(ParameterizedType&);
     virtual void visit(StructType&);
-    virtual void visit(TypeReference&);
+    virtual void visit(ReferenceType&);
 
     virtual void visit(Parameter&);
     virtual void visit(StructMember&);

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -78,9 +78,6 @@ private:
 
 AST::TypeDecl& EntryPointRewriter::getResolvedType(AST::TypeDecl& type)
 {
-    if (type.kind() == AST::Node::Kind::TypeReference)
-        return getResolvedType(downcast<AST::TypeReference>(type).type());
-
     if (type.kind() == AST::Node::Kind::NamedType) {
         if (auto* resolvedType = downcast<AST::NamedType>(type).maybeResolvedReference())
             return getResolvedType(*resolvedType);
@@ -141,12 +138,10 @@ void EntryPointRewriter::constructInputStruct()
     // insert `var ${parameter.name()} = ${structName}.${parameter.name()}`
     AST::StructMember::List structMembers;
     for (auto& parameter : m_parameters) {
-        auto parameterType = adoptRef(*new AST::TypeReference(m_emptySourceSpan, parameter.m_type.copyRef()));
-
         structMembers.append(makeUniqueRef<AST::StructMember>(
             m_emptySourceSpan,
-            parameter.m_name,
-            parameterType.copyRef(),
+            WTFMove(parameter.m_name),
+            WTFMove(parameter.m_type),
             WTFMove(parameter.m_attributes)
         ));
     }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -81,7 +81,7 @@ public:
     void visit(AST::NamedType&) override;
     void visit(AST::ParameterizedType&) override;
     void visit(AST::StructType&) override;
-    void visit(AST::TypeReference&) override;
+    void visit(AST::ReferenceType&) override;
 
     void visit(AST::Parameter&) override;
 
@@ -312,9 +312,10 @@ void FunctionDefinitionWriter::visit(AST::StructType& structType)
     m_stringBuilder.append(structType.structDecl().name());
 }
 
-void FunctionDefinitionWriter::visit(AST::TypeReference& type)
+void FunctionDefinitionWriter::visit(AST::ReferenceType& type)
 {
     visit(type.type());
+    m_stringBuilder.append("&");
 }
 
 void FunctionDefinitionWriter::visit(AST::Parameter& parameter)


### PR DESCRIPTION
#### 343b74e1ec191107d59e432dff63836078880f9c
<pre>
[WGSL] Add reference types
<a href="https://bugs.webkit.org/show_bug.cgi?id=251202">https://bugs.webkit.org/show_bug.cgi?id=251202</a>
&lt;rdar://problem/104689979&gt;

Reviewed by Myles C. Maxfield.

Remove the existing `TypeReference` node, which was a workaround to have a node
that points to another type node, but it&apos;s now no longer necessary.

Replace it with a `ReferenceType` node. The similar name is a bit confusing,
but this actually refers to a reference to type, i.e. `T&amp;` in source.

The node still isn&apos;t used in this patch, but another patch will follow this one.

* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTTypeDecl.h:
(isType):
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::getResolvedType):
(WGSL::EntryPointRewriter::constructInputStruct):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/259474@main">https://commits.webkit.org/259474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c193b4957d5ba4c83f2c91a9f6da9861421898

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114136 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4871 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97195 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113160 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80833 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7291 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27636 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4225 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6535 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9176 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->