### PR TITLE
[WGSL] Keep source alive for as long as AST is alive

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTShaderModule.h
+++ b/Source/WebGPU/WGSL/AST/ASTShaderModule.h
@@ -40,8 +40,9 @@ class ShaderModule final : Node {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    ShaderModule(SourceSpan span, GlobalDirective::List&& directives, Decl::List&& decls)
+    ShaderModule(SourceSpan span, const String& source, GlobalDirective::List&& directives, Decl::List&& decls)
         : Node(span)
+        , m_source(source)
         , m_directives(WTFMove(directives))
     {
         for (size_t i = decls.size(); i > 0; --i) {
@@ -66,12 +67,14 @@ public:
 
     Kind kind() const override;
 
+    const String& source() { return m_source; }
     GlobalDirective::List& directives() { return m_directives; }
     StructDecl::List& structs() { return m_structs; }
     VariableDecl::List& globalVars() { return m_globalVars; }
     FunctionDecl::List& functions() { return m_functions; }
 
 private:
+    String m_source;
     GlobalDirective::List m_directives;
 
     StructDecl::List m_structs;

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -107,7 +107,7 @@ Expected<AST::ShaderModule, Error> parse(const String& wgsl)
     Lexer lexer(wgsl);
     Parser parser(lexer);
 
-    return parser.parseShader();
+    return parser.parseShader(wgsl);
 }
 
 Expected<AST::ShaderModule, Error> parseLChar(const String& wgsl)
@@ -138,7 +138,7 @@ void Parser<Lexer>::consume()
 }
 
 template<typename Lexer>
-Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader()
+Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader(const String& source)
 {
     START_PARSE();
 
@@ -151,7 +151,7 @@ Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader()
         decls.append(WTFMove(globalDecl));
     }
 
-    RETURN_NODE(ShaderModule, WTFMove(directives), WTFMove(decls));
+    RETURN_NODE(ShaderModule, source, WTFMove(directives), WTFMove(decls));
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/Parser.h
+++ b/Source/WebGPU/WGSL/Parser.h
@@ -32,9 +32,6 @@
 
 namespace WGSL {
 
-template<typename Lexer>
-Expected<AST::ShaderModule, Error> parse(const String& wgsl);
-
 Expected<AST::ShaderModule, Error> parseLChar(const String& wgsl);
 Expected<AST::ShaderModule, Error> parseUChar(const String& wgsl);
 

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -61,7 +61,7 @@ public:
     {
     }
 
-    Expected<AST::ShaderModule, Error> parseShader();
+    Expected<AST::ShaderModule, Error> parseShader(const String& source);
 
     // UniqueRef whenever it can return multiple types.
     Expected<UniqueRef<AST::Decl>, Error> parseGlobalDecl();


### PR DESCRIPTION
#### e9d5f63ecb2ca601e84b1f0cc2c23f63c43d21c2
<pre>
[WGSL] Keep source alive for as long as AST is alive
<a href="https://bugs.webkit.org/show_bug.cgi?id=251204">https://bugs.webkit.org/show_bug.cgi?id=251204</a>
&lt;rdar://problem/104691207&gt;

Reviewed by Myles C. Maxfield.

The `Identifier`s generated by the parser keep a reference and offset to the input source,
but no references are kept to make sure the source stays around, which resulted in it
being deallocated while the AST was still in use. I added a test that crashes if Guard Malloc
is enabled.

* Source/WebGPU/WGSL/AST/ASTShaderModule.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::parse):
(WGSL::Parser&lt;Lexer&gt;::parseShader):
* Source/WebGPU/WGSL/Parser.h:
* Source/WebGPU/WGSL/ParserPrivate.h:
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/259472@main">https://commits.webkit.org/259472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9096a2481ea13dc262e8a39510268b94820079e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114143 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174335 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4879 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113166 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39177 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7299 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27643 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4231 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6536 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9184 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->