### PR TITLE
[WGSL] Add a pass to rewrite globals

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTFunctionDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunctionDecl.h
@@ -38,7 +38,7 @@ namespace WGSL::AST {
 enum class ParameterRole {
     UserDefined,
     StageIn,
-    GlobalVariable,
+    ArgumentBuffer,
 };
 
 class Parameter final : public Node {

--- a/Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTExpression.h"
+#include "ASTStructureAccess.h"
 
 #include <wtf/text/WTFString.h>
 
@@ -46,6 +47,12 @@ public:
 
 private:
     String m_identifier;
+
+protected:
+    // FIXME: This is necessary because we replace an IdentifierExpression with
+    // a StructureAccess for globals, so the sizes must be compatible. We need to
+    // introduce an IdentityExpression and remove this hack
+    uint8_t m_padding[sizeof(StructureAccess) - sizeof(Expression) - sizeof(String)];
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTStructureDecl.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureDecl.h
@@ -63,6 +63,7 @@ enum class StructRole : uint8_t {
     FragmentInput,
     ComputeInput,
     VertexOutput,
+    ArgumentBuffer,
 };
 
 class StructDecl final : public Decl {

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GlobalVariableRewriter.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+#include "CallGraph.h"
+#include "WGSL.h"
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+
+namespace WGSL {
+
+class RewriteGlobalVariables : public AST::Visitor {
+public:
+    RewriteGlobalVariables(CallGraph& callGraph, const HashMap<String, PipelineLayout>& pipelineLayouts)
+        : AST::Visitor()
+        , m_callGraph(callGraph)
+    {
+        UNUSED_PARAM(pipelineLayouts);
+    }
+
+    void run();
+
+    void visit(AST::FunctionDecl&) override;
+    void visit(AST::VariableDecl&) override;
+    void visit(AST::IdentifierExpression&) override;
+
+private:
+    template<typename Value>
+    using IndexMap = HashMap<unsigned, Value, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
+
+    using IndexSet = HashSet<unsigned, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
+
+    struct Global {
+        struct Resource {
+            unsigned m_group;
+            unsigned m_binding;
+        };
+
+        std::optional<Resource> m_resource;
+        AST::VariableDecl* m_declaration;
+    };
+
+    static String argumentBufferParameterName(unsigned group);
+    static String argumentBufferStructName(unsigned group);
+
+    void def(const String&);
+    Global* read(const String&);
+
+    void collectGlobals();
+    void insertStructs();
+    void visitEntryPoint(AST::FunctionDecl&);
+    IndexSet requiredGroups();
+    void insertParameters(AST::FunctionDecl&, const IndexSet& requiredGroups);
+
+    CallGraph& m_callGraph;
+    HashMap<String, Global> m_globals;
+    IndexMap<IndexMap<Global*>> m_groupBindingMap;
+    HashSet<String> m_defs;
+    HashSet<String> m_reads;
+};
+
+void RewriteGlobalVariables::run()
+{
+    collectGlobals();
+    insertStructs();
+    for (auto& entryPoint : m_callGraph.entrypoints())
+        visitEntryPoint(entryPoint.m_function);
+    m_callGraph.ast().globalVars().clear();
+}
+
+void RewriteGlobalVariables::visit(AST::FunctionDecl& function)
+{
+    // FIXME: visit callee once we have any
+
+    for (auto& parameter : function.parameters())
+        def(parameter.name());
+
+    // FIXME: detect when we shadow a global that a callee needs
+    AST::Visitor::visit(function.body());
+}
+
+void RewriteGlobalVariables::visit(AST::VariableDecl& variableDecl)
+{
+    def(variableDecl.name());
+}
+
+template <typename TargetType, typename CurrentType, typename... Arguments>
+void replace(CurrentType& dst, Arguments&&... arguments)
+{
+    static_assert(sizeof(TargetType) <= sizeof(CurrentType));
+    new (&dst) TargetType(dst.span(), std::forward<Arguments>(arguments)...);
+}
+
+void RewriteGlobalVariables::visit(AST::IdentifierExpression& identifier)
+{
+    auto name = identifier.identifier();
+    if (Global* global = read(name)) {
+        if (auto resource = global->m_resource) {
+            replace<AST::StructureAccess>(identifier,
+                makeUniqueRef<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->m_group)),
+                WTFMove(name));
+        }
+    }
+}
+
+void RewriteGlobalVariables::collectGlobals()
+{
+    auto& globalVars = m_callGraph.ast().globalVars();
+    for (auto& globalVar : globalVars) {
+        std::optional<unsigned> group;
+        std::optional<unsigned> binding;
+        for (auto& attribute : globalVar.attributes()) {
+            if (attribute->kind() == AST::Node::Kind::GroupAttribute) {
+                group = { downcast<AST::GroupAttribute>(attribute.get()).group() };
+                continue;
+            }
+            if (attribute->kind() == AST::Node::Kind::BindingAttribute) {
+                binding = { downcast<AST::BindingAttribute>(attribute.get()).binding() };
+                continue;
+            }
+        }
+        std::optional<Global::Resource> resource;
+        if (group.has_value()) {
+            RELEASE_ASSERT(binding.has_value());
+            resource = { *group, *binding };
+        }
+
+        auto result = m_globals.add(globalVar.name(), Global {
+            resource,
+            &globalVar
+        });
+        ASSERT(result, result.isNewEntry);
+
+        if (resource.has_value()) {
+            Global& global = result.iterator->value;
+            auto result = m_groupBindingMap.add(resource->m_group, IndexMap<Global*>());
+            result.iterator->value.add(resource->m_binding, &global);
+        }
+    }
+}
+
+void RewriteGlobalVariables::visitEntryPoint(AST::FunctionDecl& function)
+{
+    m_reads.clear();
+    m_defs.clear();
+
+    visit(function);
+    if (m_reads.isEmpty())
+        return;
+
+    auto groupsToGenerate = requiredGroups();
+    // FIXME: not all globals are parameters
+    insertParameters(function, groupsToGenerate);
+}
+
+
+auto RewriteGlobalVariables::requiredGroups() -> IndexSet
+{
+    IndexSet groups;
+    for (const auto& globalName : m_reads) {
+        auto it = m_globals.find(globalName);
+        RELEASE_ASSERT(it != m_globals.end());
+        auto& global = it->value;
+        if (!global.m_resource.has_value())
+            continue;
+        groups.add(global.m_resource->m_group);
+    }
+    return groups;
+}
+
+void RewriteGlobalVariables::insertStructs()
+{
+    for (auto& groupBinding : m_groupBindingMap) {
+        unsigned group = groupBinding.key;
+        const auto& bindingGlobalMap = groupBinding.value;
+
+        String structName = argumentBufferStructName(group);
+        AST::StructMember::List structMembers;
+
+        for (auto& bindingGlobal : bindingGlobalMap) {
+            unsigned binding = bindingGlobal.key;
+            auto& global = *bindingGlobal.value;
+
+            ASSERT(global.m_declaration->maybeTypeDecl());
+            auto span = global.m_declaration->span();
+            structMembers.append(makeUniqueRef<AST::StructMember>(
+                span,
+                global.m_declaration->name(),
+                adoptRef(*new AST::ReferenceType(span, *global.m_declaration->maybeTypeDecl())),
+                AST::Attribute::List {
+                    adoptRef(*new AST::BindingAttribute(span, binding))
+                }
+            ));
+        }
+
+        m_callGraph.ast().structs().append(makeUniqueRef<AST::StructDecl>(
+            SourceSpan(0, 0, 0, 0),
+            structName,
+            WTFMove(structMembers),
+            AST::Attribute::List { },
+            AST::StructRole::ArgumentBuffer
+        ));
+    }
+}
+
+void RewriteGlobalVariables::insertParameters(AST::FunctionDecl& function, const IndexSet& requiredGroups)
+{
+    auto span = function.span();
+    for (unsigned group : requiredGroups) {
+        function.parameters().append(makeUniqueRef<AST::Parameter>(
+            span,
+            argumentBufferParameterName(group),
+            adoptRef(* new AST::NamedType(span, argumentBufferStructName(group))),
+            AST::Attribute::List {
+                adoptRef(*new AST::GroupAttribute(span, group))
+            },
+            AST::ParameterRole::ArgumentBuffer
+        ));
+    }
+}
+
+void RewriteGlobalVariables::def(const String& name)
+{
+    m_defs.add(name);
+}
+
+auto RewriteGlobalVariables::read(const String& name) -> Global*
+{
+    if (m_defs.contains(name))
+        return nullptr;
+    auto it = m_globals.find(name);
+    if (it == m_globals.end())
+        return nullptr;
+    m_reads.add(name);
+    return &it->value;
+}
+
+String RewriteGlobalVariables::argumentBufferParameterName(unsigned group)
+{
+    return makeString("__ArgumentBufer_", String::number(group));
+}
+
+String RewriteGlobalVariables::argumentBufferStructName(unsigned group)
+{
+    return makeString("__ArgumentBuferT_", String::number(group));
+}
+
+void rewriteGlobalVariables(CallGraph& callGraph, const HashMap<String, PipelineLayout>& pipelineLayouts)
+{
+    RewriteGlobalVariables(callGraph, pipelineLayouts).run();
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.h
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WGSL {
+
+class CallGraph;
+struct PipelineLayout;
+
+void rewriteGlobalVariables(CallGraph&, const HashMap<String, PipelineLayout>&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -54,6 +54,8 @@ public:
     void visit(AST::BuiltinAttribute&) override;
     void visit(AST::LocationAttribute&) override;
     void visit(AST::StageAttribute&) override;
+    void visit(AST::GroupAttribute&) override;
+    void visit(AST::BindingAttribute&) override;
 
     void visit(AST::FunctionDecl&) override;
     void visit(AST::StructDecl&) override;
@@ -84,6 +86,7 @@ public:
     void visit(AST::ReferenceType&) override;
 
     void visit(AST::Parameter&) override;
+    void visitArgumentBufferParameter(AST::Parameter&);
 
 private:
     StringBuilder& m_stringBuilder;
@@ -118,8 +121,8 @@ void FunctionDefinitionWriter::visit(AST::FunctionDecl& functionDefinition)
             checkErrorAndVisit(parameter);
             m_stringBuilder.append(" [[stage_in]]");
             break;
-        case AST::ParameterRole::GlobalVariable:
-            // FIXME: add support for global variables
+        case AST::ParameterRole::ArgumentBuffer:
+            visitArgumentBufferParameter(parameter);
             break;
         }
         first = false;
@@ -140,6 +143,8 @@ void FunctionDefinitionWriter::visit(AST::StructDecl& structDecl)
         IndentationScope scope(m_indent);
         for (auto& member : structDecl.members()) {
             m_stringBuilder.append(m_indent);
+            if (m_structRole == AST::StructRole::ArgumentBuffer)
+                m_stringBuilder.append("const device ");
             visit(member.type());
             m_stringBuilder.append(" ", member.name());
             for (auto &attribute : member.attributes()) {
@@ -203,6 +208,18 @@ void FunctionDefinitionWriter::visit(AST::StageAttribute& stage)
     }
 }
 
+void FunctionDefinitionWriter::visit(AST::GroupAttribute& group)
+{
+    // FIXME: the correct function to compute the group number with the appropriate
+    // limits is implemented in Device::vertexBufferIndexForBindGroup.
+    m_stringBuilder.append("[[buffer(", 8 - group.group(), ")]]");
+}
+
+void FunctionDefinitionWriter::visit(AST::BindingAttribute& binding)
+{
+    m_stringBuilder.append("[[id(", binding.binding(), ")]]");
+}
+
 void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
 {
     if (m_structRole.has_value()) {
@@ -213,6 +230,8 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         case AST::StructRole::VertexOutput:
         case AST::StructRole::FragmentInput:
             m_stringBuilder.append("[[user(loc", location.location(), ")]]");
+            return;
+        case AST::StructRole::ArgumentBuffer:
             return;
         case AST::StructRole::VertexInput:
         case AST::StructRole::ComputeInput:
@@ -322,6 +341,17 @@ void FunctionDefinitionWriter::visit(AST::Parameter& parameter)
 {
     visit(parameter.type());
     m_stringBuilder.append(" ", parameter.name());
+    for (auto& attribute : parameter.attributes()) {
+        m_stringBuilder.append(" ");
+        checkErrorAndVisit(attribute);
+    }
+}
+
+void FunctionDefinitionWriter::visitArgumentBufferParameter(AST::Parameter& parameter)
+{
+    m_stringBuilder.append("const device ");
+    visit(parameter.type());
+    m_stringBuilder.append("& ", parameter.name());
     for (auto& attribute : parameter.attributes()) {
         m_stringBuilder.append(" ");
         checkErrorAndVisit(attribute);

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CallGraph.h"
 #include "EntryPointRewriter.h"
+#include "GlobalVariableRewriter.h"
 #include "Metal/MetalCodeGenerator.h"
 #include "Parser.h"
 #include "PhaseTimer.h"
@@ -88,7 +89,6 @@ SuccessfulCheck::~SuccessfulCheck() = default;
 
 PrepareResult prepare(AST::ShaderModule& ast, const HashMap<String, PipelineLayout>& pipelineLayouts)
 {
-    UNUSED_PARAM(pipelineLayouts);
     PhaseTimes phaseTimes;
     Metal::RenderMetalCode generatedCode;
 
@@ -98,6 +98,7 @@ PrepareResult prepare(AST::ShaderModule& ast, const HashMap<String, PipelineLayo
         RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast);
         RUN_PASS(resolveTypeReferences, ast);
         RUN_PASS(rewriteEntryPoints, callGraph);
+        RUN_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts);
 
         dumpASTAtEndIfNeeded(ast);
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		979240C5297558F10050EA2C /* ResolveTypeReferences.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C3297558F10050EA2C /* ResolveTypeReferences.h */; };
 		979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C629769AC00050EA2C /* EntryPointRewriter.h */; };
 		979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240C729769AC00050EA2C /* EntryPointRewriter.cpp */; };
+		97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */; };
+		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
 
@@ -350,6 +352,8 @@
 		979240C3297558F10050EA2C /* ResolveTypeReferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResolveTypeReferences.h; sourceTree = "<group>"; };
 		979240C629769AC00050EA2C /* EntryPointRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntryPointRewriter.h; sourceTree = "<group>"; };
 		979240C729769AC00050EA2C /* EntryPointRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntryPointRewriter.cpp; sourceTree = "<group>"; };
+		97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalVariableRewriter.cpp; sourceTree = "<group>"; };
+		97F547B7298055D90011D79A /* GlobalVariableRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalVariableRewriter.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -630,6 +634,8 @@
 				1CEBD8042716BFAB00A5254D /* config.h */,
 				979240C729769AC00050EA2C /* EntryPointRewriter.cpp */,
 				979240C629769AC00050EA2C /* EntryPointRewriter.h */,
+				97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */,
+				97F547B7298055D90011D79A /* GlobalVariableRewriter.h */,
 				338BB2D527B6B68700E066AB /* Lexer.cpp */,
 				338BB2D327B6B66C00E066AB /* Lexer.h */,
 				339B7B1A27D800090072BF9A /* Parser.cpp */,
@@ -778,6 +784,7 @@
 				9789C31B297EA105009E9006 /* CallGraph.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
+				97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
 				979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */,
 				979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */,
@@ -963,6 +970,7 @@
 				9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
+				97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
 				979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */,
 				979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */,


### PR DESCRIPTION
#### 5357882f7ca7dfe24290ebfd8611dca74bd46246
<pre>
[WGSL] Add a pass to rewrite globals
<a href="https://bugs.webkit.org/show_bug.cgi?id=251205">https://bugs.webkit.org/show_bug.cgi?id=251205</a>
&lt;rdar://problem/104691861&gt;

Reviewed by Myles C. Maxfield.

Add a new pass that removes global variables and creates structs compatible
with Metal argument buffers. For now, the pass only generates the structs based
on the globals available in the source program, but we should use the pipeline
layout in the future. Fow now what it does is:

1. Find all the globals in the source and remove them
2. Creates a struct per bind group to receive the globals
3. Traverse the call graph and identify which functions use which globals
4. Insert parameters in the functions that need to receive the globals
5. Rewrite the global accesses with struct accesses to load the globals from
   the structs received via the parameters.

In order for this patch to work correct, GlobalVariableRewriter needs to be updated
to use a ReferenceType, which is being introduce in PR #9174.

This PR also includes a fair amount of FIXMEs, but it was getting pretty large so I
paused here and will upload follow up patches shortly.

* Source/WebGPU/WGSL/AST/ASTFunctionDecl.h:
* Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h:
* Source/WebGPU/WGSL/AST/ASTStructureDecl.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp: Added.
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::visit):
(WGSL::replace):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::requiredGroups):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertParameters):
(WGSL::RewriteGlobalVariables::def):
(WGSL::RewriteGlobalVariables::read):
(WGSL::RewriteGlobalVariables::argumentBufferParameterName):
(WGSL::RewriteGlobalVariables::argumentBufferStructName):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h: Added.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::visitArgumentBufferParameter):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepare):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259477@main">https://commits.webkit.org/259477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c84c4a54fe63658947e4a820bf2026768068cf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114269 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5007 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113282 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7423 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7517 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13572 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6541 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9306 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->