### PR TITLE
Port remaining WebCore/Modules types to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Modules/geolocation/GeolocationPositionData.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationPositionData.h
@@ -46,6 +46,19 @@ public:
         , accuracy(accuracy)
     {
     }
+    
+    GeolocationPositionData(double timestamp, double latitude, double longitude, double accuracy, std::optional<double> altitude, std::optional<double> altitudeAccuracy, std::optional<double> heading, std::optional<double> speed, std::optional<double> floorLevel)
+        : timestamp(timestamp)
+        , latitude(latitude)
+        , longitude(longitude)
+        , accuracy(accuracy)
+        , altitude(altitude)
+        , altitudeAccuracy(altitudeAccuracy)
+        , heading(heading)
+        , speed(speed)
+        , floorLevel(floorLevel)
+    {
+    }
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT explicit GeolocationPositionData(CLLocation*);
@@ -64,49 +77,7 @@ public:
     std::optional<double> floorLevel;
 
     bool isValid() const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, GeolocationPositionData&);
 };
-
-template<class Encoder>
-void GeolocationPositionData::encode(Encoder& encoder) const
-{
-    encoder << timestamp;
-    encoder << latitude;
-    encoder << longitude;
-    encoder << accuracy;
-    encoder << altitude;
-    encoder << altitudeAccuracy;
-    encoder << heading;
-    encoder << speed;
-    encoder << floorLevel;
-}
-
-template<class Decoder>
-bool GeolocationPositionData::decode(Decoder& decoder, GeolocationPositionData& position)
-{
-    if (!decoder.decode(position.timestamp))
-        return false;
-    if (!decoder.decode(position.latitude))
-        return false;
-    if (!decoder.decode(position.longitude))
-        return false;
-    if (!decoder.decode(position.accuracy))
-        return false;
-    if (!decoder.decode(position.altitude))
-        return false;
-    if (!decoder.decode(position.altitudeAccuracy))
-        return false;
-    if (!decoder.decode(position.heading))
-        return false;
-    if (!decoder.decode(position.speed))
-        return false;
-    if (!decoder.decode(position.floorLevel))
-        return false;
-
-    return true;
-}
 
 inline bool GeolocationPositionData::isValid() const
 {

--- a/Source/WebCore/Modules/highlight/AppHighlight.h
+++ b/Source/WebCore/Modules/highlight/AppHighlight.h
@@ -42,44 +42,7 @@ struct AppHighlight {
     std::optional<String> text;
     CreateNewGroupForHighlight isNewGroup;
     HighlightRequestOriginatedInApp requestOriginatedInApp;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<AppHighlight> decode(Decoder&);
 };
-
-
-template<class Encoder>
-void AppHighlight::encode(Encoder& encoder) const
-{
-    encoder << highlight;
-    encoder << text;
-    encoder << isNewGroup;
-    encoder << requestOriginatedInApp;
-}
-
-template<class Decoder>
-std::optional<AppHighlight> AppHighlight::decode(Decoder& decoder)
-{
-    std::optional<Ref<WebCore::FragmentedSharedBuffer>> highlight;
-    decoder >> highlight;
-    if (!highlight)
-        return std::nullopt;
-
-    std::optional<std::optional<String>> text;
-    decoder >> text;
-    if (!text)
-        return std::nullopt;
-
-    CreateNewGroupForHighlight isNewGroup;
-    if (!decoder.decode(isNewGroup))
-        return std::nullopt;
-
-    HighlightRequestOriginatedInApp requestOriginatedInApp;
-    if (!decoder.decode(requestOriginatedInApp))
-        return std::nullopt;
-
-    return { { WTFMove(*highlight), WTFMove(*text), isNewGroup, requestOriginatedInApp } };
-}
 
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaDeviceHashSalts.h
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceHashSalts.h
@@ -33,24 +33,7 @@ namespace WebCore {
 struct MediaDeviceHashSalts {
     String persistentDeviceSalt;
     String ephemeralDeviceSalt;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, MediaDeviceHashSalts&);
 };
-
-template<class Encoder>
-void MediaDeviceHashSalts::encode(Encoder& encoder) const
-{
-    encoder << persistentDeviceSalt
-    << ephemeralDeviceSalt;
-}
-
-template<class Decoder>
-bool MediaDeviceHashSalts::decode(Decoder& decoder, MediaDeviceHashSalts& settings)
-{
-    return decoder.decode(settings.persistentDeviceSalt)
-    && decoder.decode(settings.ephemeralDeviceSalt);
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -44,7 +44,7 @@ namespace WebCore {
 class AudioStreamDescription;
 class PlatformAudioData;
 class SpeechRecognitionUpdate;
-enum class SpeechRecognitionUpdateType;
+enum class SpeechRecognitionUpdateType : uint8_t;
 
 class SpeechRecognitionCaptureSourceImpl
     : public RealtimeMediaSource::Observer

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -30,6 +30,7 @@
 #include "NativeImage.h"
 #include "SystemImage.h"
 #include <optional>
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
@@ -57,12 +58,10 @@ public:
     Image* image() const { return m_image.get(); }
     void setImage(Image& image) { m_image = &image; }
 
-    RenderingResourceIdentifier imageIdentifier() const { return m_renderingResourceIdentifier; }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<Ref<ARKitBadgeSystemImage>> decode(Decoder&);
+    RenderingResourceIdentifier imageIdentifier() const;
 
 private:
+    friend struct IPC::ArgumentCoder<ARKitBadgeSystemImage, void>;
     ARKitBadgeSystemImage(Image& image)
         : SystemImage(SystemImageType::ARKitBadge)
         , m_image(&image)
@@ -81,31 +80,6 @@ private:
     RenderingResourceIdentifier m_renderingResourceIdentifier;
     FloatSize m_imageSize;
 };
-
-template<class Encoder>
-void ARKitBadgeSystemImage::encode(Encoder& encoder) const
-{
-    ASSERT(m_image);
-    ASSERT(m_image->nativeImage());
-    encoder << m_image->nativeImage()->renderingResourceIdentifier();
-    encoder << m_imageSize;
-}
-
-template<class Decoder>
-std::optional<Ref<ARKitBadgeSystemImage>> ARKitBadgeSystemImage::decode(Decoder& decoder)
-{
-    std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
-    decoder >> renderingResourceIdentifier;
-    if (!renderingResourceIdentifier)
-        return std::nullopt;
-
-    std::optional<FloatSize> imageSize;
-    decoder >> imageSize;
-    if (!imageSize)
-        return std::nullopt;
-
-    return ARKitBadgeSystemImage::create(WTFMove(*renderingResourceIdentifier), WTFMove(*imageSize));
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -80,6 +80,11 @@ static RetainPtr<CGPDFPageRef> systemPreviewLogo()
     return logoPage;
 }
 
+RenderingResourceIdentifier ARKitBadgeSystemImage::imageIdentifier() const
+{
+    return m_image ? m_image->nativeImage()->renderingResourceIdentifier() : m_renderingResourceIdentifier;
+}
+
 void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRect& rect) const
 {
     auto page = systemPreviewLogo();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1370,7 +1370,7 @@ void ArgumentCoder<SystemImage>::encode(Encoder& encoder, const SystemImage& sys
 #endif
 #if USE(SYSTEM_PREVIEW)
     case SystemImageType::ARKitBadge:
-        downcast<ARKitBadgeSystemImage>(systemImage).encode(encoder);
+        encoder << downcast<ARKitBadgeSystemImage>(systemImage);
         return;
 #endif
 #if USE(APPKIT)
@@ -1414,8 +1414,13 @@ std::optional<Ref<SystemImage>> ArgumentCoder<SystemImage>::decode(Decoder& deco
     }
 #endif
 #if USE(SYSTEM_PREVIEW)
-    case SystemImageType::ARKitBadge:
-        return ARKitBadgeSystemImage::decode(decoder);
+    case SystemImageType::ARKitBadge: {
+        std::optional<Ref<ARKitBadgeSystemImage>> image;
+        decoder >> image;
+        if (!image)
+            return std::nullopt;
+        return WTFMove(*image);
+    }
 #endif
 #if USE(APPKIT)
     case SystemImageType::AppKitControl: {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3032,3 +3032,60 @@ enum class WebCore::MediaPlayerPitchCorrectionAlgorithm : uint8_t {
     BestForMusic,
     BestForSpeech,
 };
+
+class WebCore::GeolocationPositionData {
+    double timestamp;
+    double latitude;
+    double longitude;
+    double accuracy;
+    std::optional<double> altitude;
+    std::optional<double> altitudeAccuracy;
+    std::optional<double> heading;
+    std::optional<double> speed;
+    std::optional<double> floorLevel;
+};
+
+#if ENABLE(APP_HIGHLIGHTS)
+enum class WebCore::CreateNewGroupForHighlight : bool
+
+enum class WebCore::HighlightRequestOriginatedInApp : bool
+
+struct WebCore::AppHighlight {
+    Ref<WebCore::FragmentedSharedBuffer> highlight;
+    std::optional<String> text;
+    WebCore::CreateNewGroupForHighlight isNewGroup;
+    WebCore::HighlightRequestOriginatedInApp requestOriginatedInApp;
+};
+#endif // ENABLE(APP_HIGHLIGHTS)
+
+struct WebCore::MediaDeviceHashSalts {
+    String persistentDeviceSalt;
+    String ephemeralDeviceSalt;
+};
+
+enum class WebCore::SpeechRecognitionUpdateType : uint8_t {
+    Start,
+    AudioStart,
+    SoundStart,
+    SpeechStart,
+    SpeechEnd,
+    SoundEnd,
+    AudioEnd,
+    Result,
+    NoMatch,
+    Error,
+    End
+};
+
+class WebCore::SpeechRecognitionUpdate {
+    WebCore::SpeechRecognitionConnectionClientIdentifier m_clientIdentifier;
+    WebCore::SpeechRecognitionUpdateType m_type;
+    std::variant<std::monostate, WebCore::SpeechRecognitionError, Vector<WebCore::SpeechRecognitionResultData>> m_content;
+};
+
+#if USE(SYSTEM_PREVIEW)
+[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ARKitBadgeSystemImage {
+    WebCore::RenderingResourceIdentifier imageIdentifier();
+    WebCore::FloatSize m_imageSize;
+};
+#endif

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -36,7 +36,7 @@
 #include <wtf/Deque.h>
 
 namespace WebCore {
-enum class SpeechRecognitionUpdateType;
+enum class SpeechRecognitionUpdateType : uint8_t;
 struct CaptureSourceOrError;
 struct ClientOrigin;
 }


### PR DESCRIPTION
#### f0db163d53959b80ccccc54a81188bac205c86a3
<pre>
Port remaining WebCore/Modules types to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251208">https://bugs.webkit.org/show_bug.cgi?id=251208</a>
rdar://104694336

Reviewed by Alex Christensen.

This change ports over the remaining WebCore/Modules types to the new
serialization format. This includes:
    - GeolocationPositionData
    - CreateNewGroupForHighlight
    - HighlightRequestOriginatedInApp
    - AppHighlight
    - MediaDeviceHashSalts
    - SpeechRecognitionUpdateType
    - SpeechRecognitionUpdate
    - ARKitBadgeSystemImage

* Source/WebCore/Modules/geolocation/GeolocationPositionData.h:
(WebCore::GeolocationPositionData::GeolocationPositionData):
(WebCore::GeolocationPositionData::encode const): Deleted.
(WebCore::GeolocationPositionData::decode): Deleted.
* Source/WebCore/Modules/highlight/AppHighlight.h:
(WebCore::AppHighlight::encode const): Deleted.
(WebCore::AppHighlight::decode): Deleted.
* Source/WebCore/Modules/mediastream/MediaDeviceHashSalts.h:
(WebCore::MediaDeviceHashSalts::encode const): Deleted.
(WebCore::MediaDeviceHashSalts::decode): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h:
* Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h:
(WebCore::SpeechRecognitionUpdate::encode const): Deleted.
(WebCore::SpeechRecognitionUpdate::decode): Deleted.
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h:
(WebCore::ARKitBadgeSystemImage::encode const): Deleted.
(WebCore::ARKitBadgeSystemImage::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:

Canonical link: <a href="https://commits.webkit.org/259587@main">https://commits.webkit.org/259587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5556370b7bf80a6ae2a9be86514aba96186d16f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114500 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174688 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5241 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114436 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39464 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7655 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27955 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4526 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47510 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6609 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9538 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->