### PR TITLE
CacheStorageCache should only read record information instead of full record when possible

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -40,7 +40,7 @@ private:
     CacheStorageDiskStore(const String& cacheName, const String& path, Ref<WorkQueue>&&);
 
     // CacheStorageStore
-    void readAllRecords(ReadAllRecordsCallback&&) final;
+    void readAllRecordInfos(ReadAllRecordInfosCallback&&) final;
     void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) final;
     void deleteRecords(const Vector<CacheStorageRecordInformation>&, WriteRecordsCallback&&) final;
     void writeRecords(Vector<CacheStorageRecord>&&, WriteRecordsCallback&&) final;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
@@ -40,11 +40,11 @@ static CacheStorageRecord copyCacheStorageRecord(const CacheStorageRecord& recor
     return { record.info, record.requestHeadersGuard, record.request, record.options, record.referrer, record.responseHeadersGuard, record.responseData.isolatedCopy(), record.responseBodySize, WebCore::DOMCacheEngine::copyResponseBody(record.responseBody) };
 }
 
-void CacheStorageMemoryStore::readAllRecords(ReadAllRecordsCallback&& callback)
+void CacheStorageMemoryStore::readAllRecordInfos(ReadAllRecordInfosCallback&& callback)
 {
     callback(WTF::map(m_records.values(), [](const auto& record) {
         RELEASE_ASSERT(record);
-        return copyCacheStorageRecord(*record);
+        return record->info;
     }));
 }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h
@@ -39,7 +39,7 @@ public:
 private:
     CacheStorageMemoryStore() = default;
     // CacheStorageStore
-    void readAllRecords(ReadAllRecordsCallback&&) final;
+    void readAllRecordInfos(ReadAllRecordInfosCallback&&) final;
     void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) final;
     void deleteRecords(const Vector<CacheStorageRecordInformation>&, WriteRecordsCallback&&) final;
     void writeRecords(Vector<CacheStorageRecord>&&, WriteRecordsCallback&&) final;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
@@ -36,10 +36,10 @@ struct CacheStorageRecordInformation;
 class CacheStorageStore : public RefCounted<CacheStorageStore> {
 public:
     virtual ~CacheStorageStore() = default;
-    using ReadAllRecordsCallback = CompletionHandler<void(Vector<CacheStorageRecord>&&)>;
+    using ReadAllRecordInfosCallback = CompletionHandler<void(Vector<CacheStorageRecordInformation>&&)>;
     using ReadRecordsCallback = CompletionHandler<void(Vector<std::optional<CacheStorageRecord>>&&)>;
     using WriteRecordsCallback = CompletionHandler<void(bool)>;
-    virtual void readAllRecords(ReadAllRecordsCallback&&) = 0;
+    virtual void readAllRecordInfos(ReadAllRecordInfosCallback&&) = 0;
     virtual void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) = 0;
     virtual void deleteRecords(const Vector<CacheStorageRecordInformation>&, WriteRecordsCallback&&) = 0;
     virtual void writeRecords(Vector<CacheStorageRecord>&&, WriteRecordsCallback&&) = 0;


### PR DESCRIPTION
#### e336cd312522197d529e20885f684c35c09d62f9
<pre>
CacheStorageCache should only read record information instead of full record when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=251213">https://bugs.webkit.org/show_bug.cgi?id=251213</a>
rdar://104696982

Reviewed by Youenn Fablet.

Reading a full record, which might include reading record body from disk, decoding record body and computing body hash,
can be more expensive than reading just record information, so we should avoid it if not necessary.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::getSize):
(WebKit::CacheStorageCache::open):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::readRecordInfoFromFileData):
(WebKit::CacheStorageDiskStore::readRecordFromFileData):
(WebKit::CacheStorageDiskStore::readAllRecordInfos):
(WebKit::CacheStorageDiskStore::readAllRecords): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp:
(WebKit::CacheStorageMemoryStore::readAllRecordInfos):
(WebKit::CacheStorageMemoryStore::readAllRecords): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageStore.h:

Canonical link: <a href="https://commits.webkit.org/259463@main">https://commits.webkit.org/259463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/893903146bb13ab888b4e8c18213651a2171fdf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114190 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4929 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113222 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39212 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26325 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7347 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27684 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4272 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47236 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9232 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->