### PR TITLE
Give URLKeepingBlobAlive a top-origin SecurityOriginData

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -88,7 +88,7 @@ public:
     void setNavigationPreloadIdentifier(FetchIdentifier identifier) { m_navigationPreloadIdentifier = identifier; }
 
 private:
-    FetchRequest(ScriptExecutionContext*, std::optional<FetchBody>&&, Ref<FetchHeaders>&&, ResourceRequest&&, FetchOptions&&, String&& referrer);
+    FetchRequest(ScriptExecutionContext&, std::optional<FetchBody>&&, Ref<FetchHeaders>&&, ResourceRequest&&, FetchOptions&&, String&& referrer);
 
     ExceptionOr<void> initializeOptions(const Init&);
     ExceptionOr<void> initializeWith(FetchRequest&, Init&&);
@@ -106,18 +106,6 @@ private:
     Ref<AbortSignal> m_signal;
     FetchIdentifier m_navigationPreloadIdentifier;
 };
-
-inline FetchRequest::FetchRequest(ScriptExecutionContext* context, std::optional<FetchBody>&& body, Ref<FetchHeaders>&& headers, ResourceRequest&& request, FetchOptions&& options, String&& referrer)
-    : FetchBodyOwner(context, WTFMove(body), WTFMove(headers))
-    , m_request(WTFMove(request))
-    , m_requestURL(m_request.url())
-    , m_options(WTFMove(options))
-    , m_referrer(WTFMove(referrer))
-    , m_signal(AbortSignal::create(context))
-{
-    m_request.setRequester(ResourceRequestRequester::Fetch);
-    updateContentType();
-}
 
 WebCoreOpaqueRoot root(FetchRequest*);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3546,7 +3546,9 @@ void Document::setURL(const URL& url)
 
     if (SecurityOrigin::shouldIgnoreHost(newURL))
         newURL.setHostAndPort({ });
-    m_url = WTFMove(newURL);
+    // SecurityContext::securityOrigin may not be initialized at this time if setURL() is called in the constructor, therefore calling topOrigin() is not always safe.
+    auto topOrigin = isTopDocument() && !SecurityContext::securityOrigin() ? SecurityOrigin::create(url)->data() : this->topOrigin().data();
+    m_url = { WTFMove(newURL), topOrigin };
 
     m_documentURI = m_url.url().string();
     m_adjustedURL = adjustedURL();

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -41,6 +41,7 @@
 #include "ReadableStream.h"
 #include "ReadableStreamSource.h"
 #include "ScriptExecutionContext.h"
+#include "SecurityOrigin.h"
 #include "SharedBuffer.h"
 #include "ThreadableBlobRegistry.h"
 #include "WebCoreOpaqueRoot.h"
@@ -118,6 +119,7 @@ Blob::Blob(UninitializedContructor, ScriptExecutionContext* context, URL&& url, 
     : ActiveDOMObject(context)
     , m_type(WTFMove(type))
     , m_internalURL(WTFMove(url))
+    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
 }
 
@@ -125,6 +127,7 @@ Blob::Blob(ScriptExecutionContext* context)
     : ActiveDOMObject(context)
     , m_size(0)
     , m_internalURL(BlobURL::createInternalURL())
+    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     ThreadableBlobRegistry::registerBlobURL(m_internalURL, { }, { });
 }
@@ -164,6 +167,7 @@ Blob::Blob(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVa
     , m_type(normalizedContentType(propertyBag.type))
     , m_memoryCost(computeMemoryCost(blobPartVariants))
     , m_internalURL(BlobURL::createInternalURL())
+    , m_topOrigin(context.topOrigin().data())
 {
     ThreadableBlobRegistry::registerBlobURL(m_internalURL, buildBlobData(WTFMove(blobPartVariants), propertyBag), m_type);
 }
@@ -174,6 +178,7 @@ Blob::Blob(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String
     , m_size(data.size())
     , m_memoryCost(data.size())
     , m_internalURL(BlobURL::createInternalURL())
+    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     ThreadableBlobRegistry::registerBlobURL(m_internalURL, { BlobPart(WTFMove(data)) }, contentType);
 }
@@ -184,6 +189,7 @@ Blob::Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext* context, 
     , m_size(blob.size())
     , m_memoryCost(blob.memoryCost())
     , m_internalURL(BlobURL::createInternalURL())
+    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     ThreadableBlobRegistry::registerBlobURL(m_internalURL, { BlobPart(blob.url()) } , m_type);
 }
@@ -194,6 +200,7 @@ Blob::Blob(DeserializationContructor, ScriptExecutionContext* context, const URL
     , m_size(size)
     , m_memoryCost(memoryCost)
     , m_internalURL(BlobURL::createInternalURL())
+    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     if (fileBackedPath.isEmpty())
         ThreadableBlobRegistry::registerBlobURL(nullptr, { }, m_internalURL, srcURL);
@@ -206,6 +213,7 @@ Blob::Blob(ScriptExecutionContext* context, const URL& srcURL, long long start, 
     , m_type(normalizedContentType(type))
     , m_memoryCost(memoryCost)
     , m_internalURL(BlobURL::createInternalURL())
+    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
     // m_size is not necessarily equal to end - start so we do not initialize it here.
 {
     ThreadableBlobRegistry::registerBlobURLForSlice(m_internalURL, srcURL, start, end, m_type);
@@ -405,7 +413,7 @@ const char* Blob::activeDOMObjectName() const
 
 URLKeepingBlobAlive Blob::handle() const
 {
-    return { m_internalURL };
+    return { m_internalURL, m_topOrigin };
 }
 
 WebCoreOpaqueRoot root(Blob* blob)

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -36,6 +36,7 @@
 #include "FileReaderLoader.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptWrappable.h"
+#include "SecurityOriginData.h"
 #include "URLKeepingBlobAlive.h"
 #include "URLRegistry.h"
 #include <variant>
@@ -155,6 +156,7 @@ private:
     // as an identifier for this blob. The internal URL is never used to source the blob's content
     // into an HTML or for FileRead'ing, public blob URLs must be used for those purposes.
     URL m_internalURL;
+    SecurityOriginData m_topOrigin;
 
     HashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
 };

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
@@ -30,14 +30,16 @@
 
 namespace WebCore {
 
-URLKeepingBlobAlive::URLKeepingBlobAlive(URL&& url)
-    : m_url(WTFMove(url))
+URLKeepingBlobAlive::URLKeepingBlobAlive(const URL& url, const SecurityOriginData& topOrigin)
+    : m_url(url)
+    , m_topOrigin(topOrigin)
 {
     registerBlobURLHandleIfNecessary();
 }
 
 URLKeepingBlobAlive::URLKeepingBlobAlive(const URLKeepingBlobAlive& other)
     : m_url(other.m_url)
+    , m_topOrigin(other.m_topOrigin)
 {
     registerBlobURLHandleIfNecessary();
 }
@@ -47,12 +49,11 @@ URLKeepingBlobAlive::~URLKeepingBlobAlive()
     unregisterBlobURLHandleIfNecessary();
 }
 
-URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URL&& url)
+void URLKeepingBlobAlive::clear()
 {
     unregisterBlobURLHandleIfNecessary();
-    m_url = WTFMove(url);
-    registerBlobURLHandleIfNecessary();
-    return *this;
+    m_url = { };
+    m_topOrigin = { };
 }
 
 URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(const URLKeepingBlobAlive& other)
@@ -62,6 +63,7 @@ URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(const URLKeepingBlobAlive& o
 
     unregisterBlobURLHandleIfNecessary();
     m_url = other.m_url;
+    m_topOrigin = other.m_topOrigin;
     registerBlobURLHandleIfNecessary();
     return *this;
 }
@@ -73,6 +75,7 @@ URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URLKeepingBlobAlive&& other)
 
     unregisterBlobURLHandleIfNecessary();
     m_url = std::exchange(other.m_url, URL { });
+    m_topOrigin = std::exchange(other.m_topOrigin, { });
     return *this;
 }
 
@@ -90,12 +93,11 @@ void URLKeepingBlobAlive::unregisterBlobURLHandleIfNecessary()
 
 URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() const &
 {
-    return { m_url.isolatedCopy() };
+    return { m_url.isolatedCopy(), m_topOrigin.isolatedCopy() };
 }
 
 URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() &&
 {
-    return { WTFMove(m_url).isolatedCopy() };
+    return { WTFMove(m_url).isolatedCopy(), WTFMove(m_topOrigin).isolatedCopy() };
 }
-
 } // namespace WebCore

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "SecurityOriginData.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -33,8 +34,7 @@ namespace WebCore {
 class URLKeepingBlobAlive {
 public:
     URLKeepingBlobAlive() = default;
-    URLKeepingBlobAlive(URL&&);
-    URLKeepingBlobAlive(const URL& url) : URLKeepingBlobAlive(URL { url }) { }
+    URLKeepingBlobAlive(const URL&, const SecurityOriginData&);
     ~URLKeepingBlobAlive();
 
     URLKeepingBlobAlive(URLKeepingBlobAlive&&) = default;
@@ -45,8 +45,7 @@ public:
     operator const URL&() const { return m_url; }
     const URL& url() const { return m_url; }
 
-    URLKeepingBlobAlive& operator=(URL&&);
-    URLKeepingBlobAlive& operator=(const URL& url) { return *this = URL { url }; }
+    void clear();
 
     URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() const &;
     URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() &&;
@@ -56,6 +55,7 @@ private:
     void unregisterBlobURLHandleIfNecessary();
 
     URL m_url;
+    SecurityOriginData m_topOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -125,7 +125,7 @@ protected:
         : ScheduledNavigation(delay, lockHistory, lockBackForwardList, duringLoad, isLocationChange, initiatingDocument.shouldOpenExternalURLsPolicyToPropagate())
         , m_initiatingDocument { initiatingDocument }
         , m_securityOrigin { securityOrigin }
-        , m_url { url }
+        , m_url { url, initiatingDocument.topOrigin().data() }
         , m_referrer { referrer }
     {
     }

--- a/Source/WebCore/loader/PolicyChecker.h
+++ b/Source/WebCore/loader/PolicyChecker.h
@@ -91,7 +91,7 @@ public:
 
 private:
     void handleUnimplementablePolicy(const ResourceError&);
-    URLKeepingBlobAlive extendBlobURLLifetimeIfNecessary(const ResourceRequest&, PolicyDecisionMode = PolicyDecisionMode::Asynchronous) const;
+    URLKeepingBlobAlive extendBlobURLLifetimeIfNecessary(const ResourceRequest&, const Document&, PolicyDecisionMode = PolicyDecisionMode::Asynchronous) const;
 
     Frame& m_frame;
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -376,7 +376,7 @@ ExceptionOr<void> WorkerGlobalScope::importScripts(const FixedVector<String>& ur
         URL url = completeURL(entry);
         if (!url.isValid())
             return Exception { SyntaxError };
-        completedURLs.uncheckedAppend(WTFMove(url));
+        completedURLs.uncheckedAppend({ WTFMove(url), m_topOrigin->data() });
     }
 
     FetchOptions::Cache cachePolicy = FetchOptions::Cache::Default;

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -113,7 +113,7 @@ SharedWorker::SharedWorker(Document& document, const SharedWorkerKey& key, Ref<M
     , m_identifier(SharedWorkerObjectIdentifier::generate())
     , m_port(WTFMove(port))
     , m_identifierForInspector("SharedWorker:" + Inspector::IdentifiersFactory::createIdentifier())
-    , m_blobURLExtension(m_key.url.protocolIsBlob() ? m_key.url : URL()) // Keep blob URL alive until the worker has finished loading.
+    , m_blobURLExtension({ m_key.url.protocolIsBlob() ? m_key.url : URL(), document.topOrigin().data() }) // Keep blob URL alive until the worker has finished loading.
 {
     SHARED_WORKER_RELEASE_LOG("SharedWorker:");
     allSharedWorkers().add(m_identifier, this);
@@ -149,7 +149,7 @@ void SharedWorker::didFinishLoading(const ResourceError& error)
         queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
         m_isActive = false;
     }
-    m_blobURLExtension = URL { };
+    m_blobURLExtension.clear();
 }
 
 bool SharedWorker::virtualHasPendingActivity() const

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -384,7 +384,7 @@ ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, boo
 
     auto newURL = url;
     context->contentSecurityPolicy()->upgradeInsecureRequestIfNeeded(newURL, ContentSecurityPolicy::InsecureRequestType::Load);
-    m_url = WTFMove(newURL);
+    m_url = { WTFMove(newURL), context->topOrigin().data() };
 
     m_async = async;
 
@@ -595,7 +595,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
 {
     // Only GET request is supported for blob URL.
     if (!m_async && m_url.url().protocolIsBlob() && m_method != "GET"_s) {
-        m_url = URL { };
+        m_url.clear();
         return Exception { NetworkError };
     }
 
@@ -748,7 +748,7 @@ void XMLHttpRequest::clearRequest()
 {
     m_requestHeaders.clear();
     m_requestEntityBody = nullptr;
-    m_url = URL { };
+    m_url.clear();
 }
 
 void XMLHttpRequest::genericError()
@@ -947,7 +947,7 @@ void XMLHttpRequest::didFinishLoading(ResourceLoaderIdentifier, const NetworkLoa
     m_responseBuilder.shrinkToFit();
 
     m_loadingActivity = std::nullopt;
-    m_url = URL { };
+    m_url.clear();
 
     m_sendFlag = false;
     changeState(DONE);


### PR DESCRIPTION
#### 6f0e501e8e36d638026626ed2051d73db57c8f88
<pre>
Give URLKeepingBlobAlive a top-origin SecurityOriginData
<a href="https://bugs.webkit.org/show_bug.cgi?id=251218">https://bugs.webkit.org/show_bug.cgi?id=251218</a>
rdar://104704879

Reviewed by Chris Dumez.

In this patch we construct the URLKeepingBlobAlive with its associated
top-level SecurityOrigin(Data). This will be helpful in a future patch where we
partition the Blob registry using that top-level origin. URLKeepingBlobAlive
needs this information, in particular, because it is responsible for
automatically registering and unregistering its Blob URL handle - thus keeping
the blob alive as long as it exists, as the class name implies.

* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::FetchRequest):
(WebCore::m_signal):
(WebCore::FetchRequest::initializeWith):
(WebCore::FetchRequest::create):
(WebCore::FetchRequest::clone):
(WebCore::FetchRequest::stop):
* Source/WebCore/Modules/fetch/FetchRequest.h:
(WebCore::FetchRequest::FetchRequest): Deleted.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setURL):
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::Blob):
(WebCore::Blob::handle const):
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/URLKeepingBlobAlive.cpp:
(WebCore::URLKeepingBlobAlive::URLKeepingBlobAlive):
(WebCore::URLKeepingBlobAlive::clear):
(WebCore::URLKeepingBlobAlive::operator=):
(WebCore::URLKeepingBlobAlive::isolatedCopy const):
(WebCore::URLKeepingBlobAlive::isolatedCopy):
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
(WebCore::URLKeepingBlobAlive::URLKeepingBlobAlive): Deleted.
(WebCore::URLKeepingBlobAlive::operator=): Deleted.
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::FrameLoader::PolicyChecker::extendBlobURLLifetimeIfNecessary const):
(WebCore::FrameLoader::PolicyChecker::checkNavigationPolicy):
(WebCore::FrameLoader::PolicyChecker::checkNewWindowPolicy):
* Source/WebCore/loader/PolicyChecker.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::importScripts):
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::SharedWorker):
(WebCore::SharedWorker::didFinishLoading):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::createRequest):
(WebCore::XMLHttpRequest::clearRequest):
(WebCore::XMLHttpRequest::didFinishLoading):

Canonical link: <a href="https://commits.webkit.org/260266@main">https://commits.webkit.org/260266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54ff2167c84946efd9a28455bccb3e691195ccd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7937 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99732 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41288 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83080 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9621 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29796 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6693 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49377 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11846 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3849 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->