### PR TITLE
Add optional submitter parameter to FormData constructor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter-expected.txt
@@ -1,0 +1,12 @@
+
+
+
+
+PASS FormData construction should allow a null submitter
+PASS FormData construction should throw a TypeError if a non-null submitter is not a submit button
+PASS FormData construction should throw a 'NotFoundError' DOMException if a non-null submitter is not owned by the form
+PASS The constructed FormData object should contain an in-tree-order entry for a named submit button submitter
+PASS The constructed FormData object should not contain an entry for an unnamed submit button submitter
+PASS The constructed FormData object should contain in-tree-order entries for an activated Image Button submitter
+PASS The constructed FormData object should contain in-tree-order entries for an unactivated Image Button submitter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<meta charset='utf-8'>
+<link rel='help' href='https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set'>
+<link ref='help' href='https://xhr.spec.whatwg.org/#dom-formdata'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+
+<button name=outerNamed value=GO form='myform'></button>
+<form id='myform' onsubmit='return false'>
+  <input name=n1 value=v1>
+  <button name=named value=GO></button>
+  <button id=unnamed value=unnamed></button>
+  <button form="another" name=unassociated value=unassociated></button>
+  <input type=image name=namedImage src='/media/1x1-green.png'></button>
+  <input type=image id=unnamedImage src='/media/1x1-green.png'></button>
+  <input type=image name=unactivatedImage src='/media/1x1-green.png'></button>
+  <input name=n3 value=v3>
+</form>
+
+<form id='another'>
+  <button name=unassociated2 value=unassociated></button>
+</form>
+
+<script>
+function assertFormDataEntries(formData, expectedEntries) {
+  const expectedEntryNames = expectedEntries.map((entry) => entry[0]);
+  const actualEntries = [...formData.entries()];
+  const actualEntryNames = actualEntries.map((entry) => entry[0]);
+  assert_array_equals(actualEntryNames, expectedEntryNames);
+  for (let i = 0; i < actualEntries.length; i++) {
+    assert_array_equals(actualEntries[i], expectedEntries[i]);
+  }
+}
+
+const form = document.querySelector('#myform');
+
+test(() => {
+  assertFormDataEntries(
+    new FormData(form, null),
+    [['n1', 'v1'], ['n3', 'v3']]
+  );
+}, 'FormData construction should allow a null submitter'); // the use case here is so web developers can avoid null checks, e.g. `new FormData(e.target, e.submitter)`
+
+test(() => {
+  assert_throws_js(TypeError, () => new FormData(form, document.querySelector('[name=n1]')));
+}, 'FormData construction should throw a TypeError if a non-null submitter is not a submit button');
+
+test(() => {
+  assert_throws_dom('NotFoundError', () => new FormData(form, document.querySelector('[name=unassociated]')));
+  assert_throws_dom('NotFoundError', () => new FormData(form, document.querySelector('[name=unassociated2]')));
+}, "FormData construction should throw a 'NotFoundError' DOMException if a non-null submitter is not owned by the form");
+
+test(() => {
+  assertFormDataEntries(
+    new FormData(form, document.querySelector('[name=named]')),
+    [['n1', 'v1'], ['named', 'GO'], ['n3', 'v3']]
+  );
+  assertFormDataEntries(
+    new FormData(form, document.querySelector('[name=outerNamed]')),
+    [['outerNamed', 'GO'], ['n1', 'v1'], ['n3', 'v3']]
+  );
+}, 'The constructed FormData object should contain an in-tree-order entry for a named submit button submitter');
+
+test(() => {
+  assertFormDataEntries(
+    new FormData(form, document.querySelector('#unnamed')),
+    [['n1', 'v1'], ['n3', 'v3']]
+  );
+}, 'The constructed FormData object should not contain an entry for an unnamed submit button submitter');
+
+test(() => {
+  const submitter1 = document.querySelector('[name=namedImage]');
+  submitter1.click();
+  const submitter2 = document.querySelector('#unnamedImage');
+  submitter2.click();
+  assertFormDataEntries(
+    new FormData(form, submitter1),
+    [['n1', 'v1'], ['namedImage.x', '0'], ['namedImage.y', '0'], ['n3', 'v3']]
+  );
+  assertFormDataEntries(
+    new FormData(form, submitter2),
+    [['n1', 'v1'], ['x', '0'], ['y', '0'], ['n3', 'v3']]
+  );
+}, 'The constructed FormData object should contain in-tree-order entries for an activated Image Button submitter');
+
+test(() => {
+  assertFormDataEntries(
+    new FormData(form, document.querySelector('[name=unactivatedImage]')),
+    [['n1', 'v1'], ['unactivatedImage.x', '0'], ['unactivatedImage.y', '0'], ['n3', 'v3']]
+  );
+}, 'The constructed FormData object should contain in-tree-order entries for an unactivated Image Button submitter');
+</script>

--- a/Source/WebCore/html/DOMFormData.cpp
+++ b/Source/WebCore/html/DOMFormData.cpp
@@ -43,13 +43,22 @@ DOMFormData::DOMFormData(ScriptExecutionContext* context, const PAL::TextEncodin
 {
 }
 
-ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext& context, HTMLFormElement* form)
+ExceptionOr<Ref<DOMFormData>> DOMFormData::create(ScriptExecutionContext& context, HTMLFormElement* form, HTMLElement* submitter)
 {
+    // https://xhr.spec.whatwg.org/#dom-formdata
     auto formData = adoptRef(*new DOMFormData(&context));
     if (!form)
         return formData;
-    
-    auto result = form->constructEntryList(nullptr, WTFMove(formData), nullptr);
+
+    RefPtr<HTMLFormControlElement> control;
+    if (submitter) {
+        control = dynamicDowncast<HTMLFormControlElement>(*submitter);
+        if (!control || !control->isSubmitButton())
+            return Exception { TypeError, "The specified element is not a submit button."_s };
+        if (control->form() != form)
+            return Exception { NotFoundError, "The specified element is not owned by this form element."_s };
+    }
+    auto result = form->constructEntryList(control.get(), WTFMove(formData), nullptr);
     
     if (!result)
         return Exception { InvalidStateError, "Already constructing Form entry list."_s };

--- a/Source/WebCore/html/DOMFormData.h
+++ b/Source/WebCore/html/DOMFormData.h
@@ -39,6 +39,7 @@
 namespace WebCore {
 
 template<typename> class ExceptionOr;
+class HTMLElement;
 class HTMLFormElement;
 
 class DOMFormData : public RefCounted<DOMFormData>, public ContextDestructionObserver {
@@ -50,7 +51,7 @@ public:
         FormDataEntryValue data;
     };
 
-    static ExceptionOr<Ref<DOMFormData>> create(ScriptExecutionContext&, HTMLFormElement*);
+    static ExceptionOr<Ref<DOMFormData>> create(ScriptExecutionContext&, HTMLFormElement*, HTMLElement*);
     static Ref<DOMFormData> create(ScriptExecutionContext*, const PAL::TextEncoding&);
 
     const Vector<Item>& items() const { return m_items; }

--- a/Source/WebCore/html/DOMFormData.idl
+++ b/Source/WebCore/html/DOMFormData.idl
@@ -36,7 +36,7 @@ typedef (File or USVString) FormDataEntryValue;
     JSGenerateToJSObject,
     InterfaceName=FormData,
 ] interface DOMFormData {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional HTMLFormElement form);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional HTMLFormElement form, optional HTMLElement? submitter = null);
 
     undefined append(USVString name, USVString value);
     undefined append(USVString name, Blob blobValue, optional USVString filename);

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -354,13 +354,11 @@ ExceptionOr<void> HTMLFormElement::requestSubmit(HTMLElement* submitter)
     RefPtr<HTMLFormControlElement> control;
     if (submitter) {
         // https://html.spec.whatwg.org/multipage/forms.html#dom-form-requestsubmit
-        if (!is<HTMLFormControlElement>(submitter))
-            return Exception { TypeError };
-        control = downcast<HTMLFormControlElement>(submitter);
-        if (!control->isSubmitButton())
-            return Exception { TypeError };
+        control = dynamicDowncast<HTMLFormControlElement>(*submitter);
+        if (!control || !control->isSubmitButton())
+            return Exception { TypeError, "The specified element is not a submit button."_s };
         if (control->form() != this)
-            return Exception { NotFoundError };
+            return Exception { NotFoundError, "The specified element is not owned by this form element."_s };
     }
 
     submitIfPossible(nullptr, control.get(), SubmittedByJavaScript);


### PR DESCRIPTION
#### 136a23f12bae93a6dd2c9f93565aa6da6efdfef5
<pre>
Add optional submitter parameter to FormData constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=251220">https://bugs.webkit.org/show_bug.cgi?id=251220</a>

Reviewed by Chris Dumez

Implement the new submitter parameter to the FormData constructor
Spec PR: <a href="https://github.com/whatwg/xhr/pull/366">https://github.com/whatwg/xhr/pull/366</a>
WPT PR: <a href="https://github.com/web-platform-tests/wpt/pull/37895">https://github.com/web-platform-tests/wpt/pull/37895</a>

Test: imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter.html

* LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/formdata/constructor-submitter.html: Added.
* Source/WebCore/html/DOMFormData.cpp:
(WebCore::DOMFormData::create): add submitter support
* Source/WebCore/html/DOMFormData.h: update signature
* Source/WebCore/html/DOMFormData.idl: update interface
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::requestSubmit): improve error messages#

Canonical link: <a href="https://commits.webkit.org/259558@main">https://commits.webkit.org/259558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86174d63a2a68303d44e827354487f2fa10899ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114295 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174478 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5033 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113308 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94786 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39297 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80962 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7449 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27772 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7543 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4354 "Found 3 new test failures: fast/images/avif-as-image.html, fast/images/avif-heif-container-as-image.html, fast/images/background-image-relative-url-changes-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47324 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9332 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3520 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->