### PR TITLE
[iOS] fast/events/iOS/rotation are failing

### DIFF
--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -682,6 +682,7 @@ private:
     WKRetainPtr<WKArrayRef> m_openPanelFileURLs;
 #if PLATFORM(IOS_FAMILY)
     WKRetainPtr<WKDataRef> m_openPanelFileURLsMediaIcon;
+    bool m_didLockOrientation { false };
 #endif
 
     std::unique_ptr<EventSenderProxy> m_eventSenderProxy;


### PR DESCRIPTION
#### 30bf9df2e3d0b12f39ae0658cc9666e9cbfe6d0e
<pre>
[iOS] fast/events/iOS/rotation are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251227">https://bugs.webkit.org/show_bug.cgi?id=251227</a>
rdar://104203486

Reviewed by Wenson Hsieh.

This seems to have regressed with 255459@main, which updated the logic
to restore portrait orientation between tests when we added support
for the screen orientation API.

There are 2 ways to restore the orientation:
1. Call [UIScene requestGeometryUpdateWithPreferences:]
2. Lock the orientation to portrait then unlock

In 255459@main, I had replaced method 1 with method 2 because method 1
didn&apos;t work properly with the screen orientation lock tests. However,
it broke the tests in fast/events/iOS/rotation which rely on
`[UIScene requestGeometryUpdateWithPreferences:]` to simulate screen
rotation during the tests.

After several hours of trying to find a common mechanism to restore
orientation that would work for both screen rotation and orientation
lock tests, I still wasn&apos;t able to make it work.

For this reason, in my this, I am using method 2 only for tests that
lock the screen orientation and keep using the old method 1 for all
other tests. As a result, this restores pre-255459@main behavior and
fixes existing tests. It also doesn&apos;t regress the screen orientation
lock tests which were added in 255459@main.

* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(-[WindowDidRotateObserver initWithCallback:]):
(-[WindowDidRotateObserver dealloc]):
(-[WindowDidRotateObserver _windowDidRotate]):
(WTR::TestController::restorePortraitOrientationIfNeeded):
(WTR::TestController::lockScreenOrientation):

Canonical link: <a href="https://commits.webkit.org/259485@main">https://commits.webkit.org/259485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b51534651092e94448d706dc78291ad2d28de963

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114206 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174399 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4945 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113232 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39230 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26340 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80895 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27699 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7457 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4287 "Found 1 new test failure: fast/forms/fieldset/fieldset-overflow-auto.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47251 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9248 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3485 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->