### PR TITLE
Do some cleanup around screenPropertiesStateChanged() and displayReconfigurationCallBack()

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4176,8 +4176,10 @@ void WebPageProxy::accessibilitySettingsDidChange()
     if (!hasRunningProcess())
         return;
 
+#if PLATFORM(COCOA)
     // Also update screen properties which encodes invert colors.
-    process().processPool().screenPropertiesStateChanged();
+    process().processPool().screenPropertiesChanged();
+#endif
     send(Messages::WebPage::AccessibilitySettingsDidChange());
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -402,19 +402,6 @@ void WebProcessPool::setApplicationIsActive(bool isActive)
     m_webProcessCache->setApplicationIsActive(isActive);
 }
 
-void WebProcessPool::screenPropertiesStateChanged()
-{
-#if PLATFORM(COCOA)
-    auto screenProperties = WebCore::collectScreenProperties();
-    sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
-
-#if PLATFORM(MAC)
-    if (auto process = gpuProcess())
-        process->setScreenProperties(screenProperties);
-#endif
-#endif
-}
-
 static bool shouldReportAuxiliaryProcessCrash(ProcessTerminationReason reason)
 {
     switch (reason) {

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -244,6 +244,14 @@ public:
 
     void handleMemoryPressureWarning(Critical);
 
+#if PLATFORM(COCOA)
+    void screenPropertiesChanged();
+#endif
+
+#if PLATFORM(MAC)
+    void displayPropertiesChanged(const WebCore::ScreenProperties&, WebCore::PlatformDisplayID, CGDisplayChangeSummaryFlags);
+#endif
+
 #if HAVE(CVDISPLAYLINK)
     DisplayLinkCollection& displayLinks() { return m_displayLinks; }
 
@@ -467,8 +475,6 @@ public:
     void didReachGoodTimeToPrewarm();
 
     void didCollectPrewarmInformation(const WebCore::RegistrableDomain&, const WebCore::PrewarmInformation&);
-
-    void screenPropertiesStateChanged();
 
     void addMockMediaDevice(const WebCore::MockMediaDevice&);
     void clearMockMediaDevices();

--- a/Source/WebKit/UIProcess/mac/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.cpp
@@ -185,6 +185,11 @@ void DisplayLink::decrementFullSpeedRequestClientCount(Client& client)
     removeInfoForClientIfUnused(client);
 }
 
+void DisplayLink::displayPropertiesChanged()
+{
+    // FIXME: Detect whether the refresh frequency changed.
+}
+
 void DisplayLink::setObserverPreferredFramesPerSecond(Client& client, DisplayLinkObserverID observerID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] DisplayLink " << this << " setPreferredFramesPerSecond - display " << m_displayID << " observer " << observerID << " fps " << preferredFramesPerSecond);

--- a/Source/WebKit/UIProcess/mac/DisplayLink.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.h
@@ -55,6 +55,8 @@ public:
 
     WebCore::PlatformDisplayID displayID() const { return m_displayID; }
     WebCore::FramesPerSecond nominalFramesPerSecond() const { return m_displayNominalFramesPerSecond; }
+    
+    void displayPropertiesChanged();
 
     void addObserver(Client&, DisplayLinkObserverID, WebCore::FramesPerSecond);
     void removeObserver(Client&, DisplayLinkObserverID);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2042,7 +2042,7 @@ void WebViewImpl::windowDidChangeOcclusionState()
 
 void WebViewImpl::screenDidChangeColorSpace()
 {
-    m_page->process().processPool().screenPropertiesStateChanged();
+    m_page->process().processPool().screenPropertiesChanged();
 }
 
 bool WebViewImpl::mightBeginDragWhileInactive()


### PR DESCRIPTION
#### 51bff517ffd151c5658c279a5ca289ff2b785f95
<pre>
Do some cleanup around screenPropertiesStateChanged() and displayReconfigurationCallBack()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251233">https://bugs.webkit.org/show_bug.cgi?id=251233</a>
rdar://104719183

Reviewed by Tim Horton.

WebProcessPool had both screenPropertiesStateChanged() and code in displayReconfigurationCallBack()
that did similar things, sending new screen properties to the WebProcess and, on macOS, the GPU process,
but the code was scattered around.

Clean it up by moving the code in displayReconfigurationCallBack() into a WebProcessPool member function;
this callback tells you about a specific display and what changed, but in it we gather properties for
all displays, but keep that behavior for now.

screenPropertiesStateChanged() is called via accessibility callbacks that indicate that screen-related
settings like &quot;invert colors&quot; changed. To show its relationship to WebProcessPool::displayPropertiesChanged()
put the two functions next to each other, but it was tricky to share code because this callback doesn&apos;t
get a displayID.

Add a DisplayLink::displayPropertiesChanged() stub that will be implemented in a future patch.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::screenPropertiesChanged):
(WebKit::WebProcessPool::displayPropertiesChanged):
(WebKit::displayReconfigurationCallBack):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::accessibilitySettingsDidChange):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::screenPropertiesStateChanged): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/DisplayLink.cpp:
(WebKit::DisplayLink::displayPropertiesChanged):
* Source/WebKit/UIProcess/mac/DisplayLink.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::screenDidChangeColorSpace):

Canonical link: <a href="https://commits.webkit.org/259495@main">https://commits.webkit.org/259495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24a1699bc4ad45cefb3475c0219c94924a9dccb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114210 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4949 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113237 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39234 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7368 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27703 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4290 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47255 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6547 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9252 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->