### PR TITLE
[Style Guide] Only use the arrow for function return types if it allows you to omit redundant information

### DIFF
--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -969,6 +969,44 @@ for (Vector<RefPtr<FrameView> >::iterator it = frameViews.begin(); it != end; ++
 []() { return static_cast<unsigned>(-1); }
 ```
 
+[](#function-return-arrow) Only use the arrow for function return types if it allows you to omit redundant information.
+
+###### Right:
+
+```cpp
+int foo()
+{
+    ...
+}
+```
+
+###### Wrong:
+
+```cpp
+auto foo() -> int
+{
+    ...
+}
+```
+
+###### Right:
+
+```cpp
+auto Foo::bar() -> Baz
+{
+    ...
+}
+```
+
+###### Wrong:
+
+```cpp
+Foo::Baz Foo::bar()
+{
+    ...
+}
+```
+
 ### Pointers and References
 
 [](#pointers-non-cpp) **Pointer types in non-C++ code**


### PR DESCRIPTION
#### 0fa4caf58e80a19f7c8589e5019ff55d2889d6bc
<pre>
[Style Guide] Only use the arrow for function return types if it allows you to omit redundant information
<a href="https://bugs.webkit.org/show_bug.cgi?id=251239">https://bugs.webkit.org/show_bug.cgi?id=251239</a>
rdar://104722324

Reviewed by Ryosuke Niwa.

We probably don&apos;t want people using -&gt; in function signatures all over the place where it isn&apos;t necessary.

* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/259468@main">https://commits.webkit.org/259468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a44531258b9be035ab88c9dc4facdac1b75639d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114225 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4964 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113248 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11724 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26356 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27715 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7476 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6532 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9265 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->