### PR TITLE
Elide manual auth validation check when FPAC is supported.

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "CPU.h"
 
-#if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
+#if (CPU(X86) || CPU(X86_64) || CPU(ARM64E)) && OS(DARWIN)
 #include <mutex>
 #include <sys/sysctl.h>
 #endif
@@ -106,6 +106,24 @@ bool isARM64_LSE()
 #endif
 }
 #endif
+
+#if CPU(ARM64E)
+bool isARM64E_FPAC()
+{
+#if OS(DARWIN)
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        uint32_t val = 0;
+        size_t valSize = sizeof(val);
+        int rc = sysctlbyname("hw.optional.arm.FEAT_FPAC", &val, &valSize, nullptr, 0);
+        g_jscConfig.canUseFPAC = rc < 0 ? false : !!val;
+    });
+    return g_jscConfig.canUseFPAC;
+#else
+    return false;
+#endif
+}
+#endif // CPU(ARM64E)
 
 #if CPU(X86_64)
 bool isX86_64_AVX()

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,20 +70,22 @@ constexpr bool isARM64E()
 }
 
 #if CPU(ARM64)
+#if CPU(ARM64E)
+JS_EXPORT_PRIVATE bool isARM64E_FPAC();
+#else
+constexpr bool isARM64E_FPAC() { return false; }
+#endif
+
 #if CPU(ARM64E) || OS(MAC_OS_X)
 // ARM64E or all macOS ARM64 CPUs have LSE.
-constexpr bool isARM64_LSE()
-{
-    return true;
-}
+constexpr bool isARM64_LSE() { return true; }
 #else
 JS_EXPORT_PRIVATE bool isARM64_LSE();
 #endif
-#else
-constexpr bool isARM64_LSE()
-{
-    return false;
-}
+
+#else // not CPU(ARM64)
+constexpr bool isARM64_LSE() { return false; }
+constexpr bool isARM64E_FPAC() { return false; }
 #endif
 
 constexpr bool isX86()

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,6 +86,7 @@ void initialize()
             } else {
 #if CPU(ARM64E) && ENABLE(JIT)
                 g_jscConfig.arm64eHashPins.initializeAtStartup();
+                isARM64E_FPAC(); // Call this to initialize g_jscConfig.canUseFPAC.
 #endif
             }
             StructureAlignedMemoryAllocator::initializeStructureAddressSpace();

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,6 +76,10 @@ struct Config {
 #endif
         bool canUseJIT;
     } vm;
+
+#if CPU(ARM64E)
+    bool canUseFPAC;
+#endif
 
     ExecutableAllocator* executableAllocator;
     FixedVMPoolExecutableAllocator* fixedVMPoolExecutableAllocator;


### PR DESCRIPTION
#### 2bb6d041654cd8ae1999ca31b372dd9e1d5330f3
<pre>
Elide manual auth validation check when FPAC is supported.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251244">https://bugs.webkit.org/show_bug.cgi?id=251244</a>
&lt;rdar://problem/104725544&gt;

Reviewed by Yusuke Suzuki.

With FPAC, the aut instruction will validate its own result.  Hence, the
manual validation that we used to do after the aut is now redundant.

* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::isARM64E_FPAC):
* Source/JavaScriptCore/assembler/CPU.h:
(JSC::isARM64E_FPAC):
(JSC::isARM64_LSE):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h:
(JSC::MacroAssemblerARM64E::validateUntaggedPtr):
(JSC::MacroAssemblerARM64E::untagArrayPtr):
(JSC::MacroAssemblerARM64E::untagArrayPtrLength64):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCConfig.h:

Canonical link: <a href="https://commits.webkit.org/259491@main">https://commits.webkit.org/259491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32342d6f1daa618b5e15c30cc9397475591b787c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114246 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174431 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4986 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113262 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39259 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26372 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94830 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7400 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27731 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92869 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5132 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4315 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30268 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47283 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101564 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9283 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25339 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3487 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->