### PR TITLE
ASSERTION FAILED: m_element in WebFullScreenManager::setAnimatingFullScreen

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -365,8 +365,8 @@ static const float minVideoWidth = 468; // Keep in sync with `--controls-bar-wid
         _page->scalePage(_savedScale, WebCore::IntPoint());
         [self _manager]->restoreScrollPosition();
         _page->setTopContentInset(_savedTopContentInset);
-        [self _manager]->didExitFullScreen();
         [self _manager]->setAnimatingFullScreen(false);
+        [self _manager]->didExitFullScreen();
 
         // FIXME(53342): remove once pointer events fire when elements move out from under the pointer.
         NSEvent *fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
@@ -532,8 +532,8 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     makeResponderFirstResponderIfDescendantOfView(_webView.window, firstResponder, _webView);
 
     // These messages must be sent after the swap or flashing will occur during forceRepaint:
-    [self _manager]->didExitFullScreen();
     [self _manager]->setAnimatingFullScreen(false);
+    [self _manager]->didExitFullScreen();
     _page->scalePage(_savedScale, WebCore::IntPoint());
     [self _manager]->restoreScrollPosition();
     _page->setTopContentInset(_savedTopContentInset);


### PR DESCRIPTION
#### 4bbaaeffdd01c947764f4645eb48b7a55db6ae89
<pre>
ASSERTION FAILED: m_element in WebFullScreenManager::setAnimatingFullScreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=251247">https://bugs.webkit.org/show_bug.cgi?id=251247</a>
rdar://104728830

Reviewed by Youenn Fablet.

Calling
    [self _manager]-&gt;didExitFullScreen();
will prevent:
    [self _manager]-&gt;setAnimatingFullScreen(false);

From doing anything as a pointer gets cleared. Considering that outside of this code the pattern
to exit full screen is:
        [self _manager]-&gt;setAnimatingFullScreen(false);
        [self _manager]-&gt;didExitFullScreen();

We make the code pattern to exit fullscreen consistent.

No test was included because TestWebKitAPI is not allowed to enter fullscreen or PiP as its not
a &quot;real&quot; application.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):

Canonical link: <a href="https://commits.webkit.org/259513@main">https://commits.webkit.org/259513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f310f9e0d2087ad1bd3be71c68a4bc040fd29d15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114249 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4989 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113265 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39260 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4317 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47286 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6556 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9286 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->