### PR TITLE
Ensure FixedBitVector's WordType matches the type of BitVector::m_bitsOrPointer.

### DIFF
--- a/Source/WTF/wtf/FixedBitVector.h
+++ b/Source/WTF/wtf/FixedBitVector.h
@@ -37,7 +37,7 @@ namespace WTF {
 
 class FixedBitVector final {
     WTF_MAKE_FAST_ALLOCATED;
-    using WordType = uintptr_t;
+    using WordType = decltype(BitVector::m_bitsOrPointer);
 
 public:
     FixedBitVector() = default;

--- a/Tools/TestWebKitAPI/Tests/WTF/Bitmap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Bitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -250,13 +250,13 @@ void testBitmapConcurrentTestAndSet()
     for (size_t i = 0; i < size; ++i)
         ASSERT_EQ(bitmap1.get(i), expectedBits1[i]);
     for (size_t i = 0; i < size; ++i)
-        ASSERT_EQ(bitmap1.testAndSet(i), expectedBits1[i]);
+        ASSERT_EQ(bitmap1.concurrentTestAndSet(i), expectedBits1[i]);
     ASSERT_TRUE(bitmap1.isFull());
 
     ASSERT_FALSE(smallBitmapZeroes.isFull());
     ASSERT_TRUE(smallBitmapZeroes.isEmpty());
     for (size_t i = 0; i < smallSize; ++i)
-        ASSERT_FALSE(smallBitmapZeroes.testAndSet(i));
+        ASSERT_FALSE(smallBitmapZeroes.concurrentTestAndSet(i));
     ASSERT_TRUE(smallBitmapZeroes.isFull());
 }
 
@@ -271,13 +271,13 @@ void testBitmapConcurrentTestAndClear()
     for (size_t i = 0; i < size; ++i)
         ASSERT_EQ(bitmap1.get(i), expectedBits1[i]);
     for (size_t i = 0; i < size; ++i)
-        ASSERT_EQ(bitmap1.testAndClear(i), expectedBits1[i]);
+        ASSERT_EQ(bitmap1.concurrentTestAndClear(i), expectedBits1[i]);
     ASSERT_TRUE(bitmap1.isEmpty());
 
     ASSERT_FALSE(smallBitmapOnes.isEmpty());
     ASSERT_TRUE(smallBitmapOnes.isFull());
     for (size_t i = 0; i < smallSize; ++i)
-        ASSERT_TRUE(smallBitmapOnes.testAndClear(i));
+        ASSERT_TRUE(smallBitmapOnes.concurrentTestAndClear(i));
     ASSERT_TRUE(smallBitmapOnes.isEmpty());
 }
 


### PR DESCRIPTION
#### c2393f9a46afe8d6e655c81ebf9f7f6ad37026ce
<pre>
Ensure FixedBitVector&apos;s WordType matches the type of BitVector::m_bitsOrPointer.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251251">https://bugs.webkit.org/show_bug.cgi?id=251251</a>
&lt;rdar://problem/104731974&gt;

Reviewed by Yusuke Suzuki.

The rest of FixedBitVector&apos;s code relies on this relationship.  So, let&apos;s make it explicit.

Also, fixed a bug in BitMap&apos;s API tests: testBitmapConcurrentTestAndSet() and
testBitmapConcurrentTestAndClear() were exercising testAndSet() and testAndClear()
respectively instead of their concurrent versions.  This is now fixed.  This issue was
originally found by Yijia Huang in <a href="https://bugs.webkit.org/show_bug.cgi?id=250847.">https://bugs.webkit.org/show_bug.cgi?id=250847.</a>

* Source/WTF/wtf/FixedBitVector.h:
* Tools/TestWebKitAPI/Tests/WTF/Bitmap.cpp:
(TestWebKitAPI::testBitmapConcurrentTestAndSet):
(TestWebKitAPI::testBitmapConcurrentTestAndClear):

Canonical link: <a href="https://commits.webkit.org/259490@main">https://commits.webkit.org/259490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5405097b0c021569e66e0cdc35bf679203405cde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114252 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174438 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4992 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113268 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39266 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26376 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94836 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27735 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92875 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5138 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7501 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4320 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30271 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47287 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101570 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9289 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25345 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3488 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->