### PR TITLE
Fix Ed25519 public key generation from private key material

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
@@ -3,7 +3,7 @@ PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
-FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_true: Round trip works expected true got false
+PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, [])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
@@ -3,7 +3,7 @@ PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, true, [])
 PASS Good parameters: Ed25519 bits (pkcs8, buffer(48), {name: Ed25519}, true, [sign])
-FAIL Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign]) assert_true: Round trip works expected true got false
+PASS Good parameters: Ed25519 bits (jwk, object(crv, d, x, kty), {name: Ed25519}, true, [sign])
 PASS Good parameters: Ed25519 bits (spki, buffer(44), {name: Ed25519}, false, [])
 PASS Good parameters: Ed25519 bits (jwk, object(kty, crv, x), {name: Ed25519}, false, [])
 PASS Good parameters: Ed25519 bits (raw, buffer(32), {name: Ed25519}, false, [])

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any-expected.txt
@@ -15,6 +15,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and AES-CTR
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and AES-CTR
 PASS Can unwrap ECDH private key non-extractable keys using jwk and AES-CTR
+PASS Can wrap and unwrap Ed25519 public key keys using spki and AES-CTR
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and AES-CTR
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CTR
@@ -75,6 +82,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and AES-CBC
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and AES-CBC
 PASS Can unwrap ECDH private key non-extractable keys using jwk and AES-CBC
+PASS Can wrap and unwrap Ed25519 public key keys using spki and AES-CBC
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and AES-CBC
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CBC
@@ -135,6 +149,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and AES-GCM
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and AES-GCM
 PASS Can unwrap ECDH private key non-extractable keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 public key keys using spki and AES-GCM
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and AES-GCM
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-GCM
@@ -181,6 +202,8 @@ PASS Can wrap and unwrap RSASSA-PKCS1-v1_5 private key keys as non-extractable u
 PASS Can wrap and unwrap RSASSA-PKCS1-v1_5 private key keys using jwk and AES-GCM
 PASS Can wrap and unwrap RSASSA-PKCS1-v1_5 private key keys as non-extractable using jwk and AES-GCM
 PASS Can unwrap RSASSA-PKCS1-v1_5 private key non-extractable keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-KW
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-KW
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-KW
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-KW
 PASS Can wrap and unwrap AES-CBC keys using raw and AES-KW
@@ -208,6 +231,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and RSA-OAEP
 PASS Can unwrap ECDH private key non-extractable keys using jwk and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 public key keys using spki and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and RSA-OAEP
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using jwk and RSA-OAEP

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker-expected.txt
@@ -14,6 +14,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and AES-CTR
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and AES-CTR
 PASS Can unwrap ECDH private key non-extractable keys using jwk and AES-CTR
+PASS Can wrap and unwrap Ed25519 public key keys using spki and AES-CTR
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and AES-CTR
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and AES-CTR
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CTR
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CTR
@@ -74,6 +81,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and AES-CBC
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and AES-CBC
 PASS Can unwrap ECDH private key non-extractable keys using jwk and AES-CBC
+PASS Can wrap and unwrap Ed25519 public key keys using spki and AES-CBC
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and AES-CBC
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and AES-CBC
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-CBC
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-CBC
@@ -134,6 +148,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and AES-GCM
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and AES-GCM
 PASS Can unwrap ECDH private key non-extractable keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 public key keys using spki and AES-GCM
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and AES-GCM
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-GCM
 PASS Can wrap and unwrap AES-CTR keys using jwk and AES-GCM
@@ -180,6 +201,8 @@ PASS Can wrap and unwrap RSASSA-PKCS1-v1_5 private key keys as non-extractable u
 PASS Can wrap and unwrap RSASSA-PKCS1-v1_5 private key keys using jwk and AES-GCM
 PASS Can wrap and unwrap RSASSA-PKCS1-v1_5 private key keys as non-extractable using jwk and AES-GCM
 PASS Can unwrap RSASSA-PKCS1-v1_5 private key non-extractable keys using jwk and AES-GCM
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and AES-KW
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and AES-KW
 PASS Can wrap and unwrap AES-CTR keys using raw and AES-KW
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and AES-KW
 PASS Can wrap and unwrap AES-CBC keys using raw and AES-KW
@@ -207,6 +230,13 @@ PASS Can wrap and unwrap ECDH private key keys as non-extractable using pkcs8 an
 PASS Can wrap and unwrap ECDH private key keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap ECDH private key keys as non-extractable using jwk and RSA-OAEP
 PASS Can unwrap ECDH private key non-extractable keys using jwk and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 public key keys using spki and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 public key keys using jwk and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys using pkcs8 and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using pkcs8 and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys using jwk and RSA-OAEP
+PASS Can wrap and unwrap Ed25519 private key keys as non-extractable using jwk and RSA-OAEP
+PASS Can unwrap Ed25519 private key non-extractable keys using jwk and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys as non-extractable using raw and RSA-OAEP
 PASS Can wrap and unwrap AES-CTR keys using jwk and RSA-OAEP

--- a/Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp
@@ -314,8 +314,11 @@ String CryptoKeyOKP::generateJwkX() const
         return base64URLEncodeToString(m_data);
 
     ASSERT(type() == CryptoKeyType::Private);
+
+    auto* di = ccsha512_di();
     ccec25519pubkey publicKey;
-    cccurve25519_make_pub(publicKey, m_data.data());
+    cced25519_make_pub(di, publicKey, m_data.data());
+
     return base64URLEncodeToString(Span<const uint8_t> { publicKey, sizeof(publicKey) });
 }
 


### PR DESCRIPTION
#### 9634103dadcb850770c77b497803c468f9b81518
<pre>
Fix Ed25519 public key generation from private key material
<a href="https://bugs.webkit.org/show_bug.cgi?id=251252">https://bugs.webkit.org/show_bug.cgi?id=251252</a>
rdar://problem/104733721

Reviewed by Chris Dumez.

Use cced25519_make_pub to generate the public key.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker-expected.txt:
* Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::generateJwkX const):

Canonical link: <a href="https://commits.webkit.org/259489@main">https://commits.webkit.org/259489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/238b2de267658261ec9a55fa996ba991f36935fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114255 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174441 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4995 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113271 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11752 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39265 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26381 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27740 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7504 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4323 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6545 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9292 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->