### PR TITLE
[GTK][WPE] WebsiteDataManger created by persistent network session should never return NULL for base cache and data directories

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h
@@ -22,9 +22,10 @@
 #include "WebResourceLoadStatisticsStore.h"
 #include "WebsiteDataStore.h"
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/CString.h>
 
 #if ENABLE(2022_GLIB_API)
-WebKitWebsiteDataManager* webkitWebsiteDataManagerCreate(GUniquePtr<char>&&, GUniquePtr<char>&&);
+WebKitWebsiteDataManager* webkitWebsiteDataManagerCreate(CString&&, CString&&);
 #endif
 WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteDataManager*);
 WebKitITPThirdParty* webkitITPThirdPartyCreate(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&&);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -380,6 +380,11 @@ public:
     static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
     static UnifiedOriginStorageLevel defaultUnifiedOriginStorageLevel();
 
+#if USE(GLIB)
+    static const String& defaultBaseCacheDirectory();
+    static const String& defaultBaseDataDirectory();
+#endif
+
     void resetQuota(CompletionHandler<void()>&&);
     void resetStoragePersistedState(CompletionHandler<void()>&&);
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -256,7 +256,12 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     g_assert_true(test->m_manager != defaultManager);
     g_assert_cmpstr(webkit_website_data_manager_get_base_data_directory(test->m_manager), !=, webkit_website_data_manager_get_base_data_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_base_cache_directory(test->m_manager), !=, webkit_website_data_manager_get_base_cache_directory(defaultManager));
-#if !ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
+    g_assert_nonnull(webkit_website_data_manager_get_base_data_directory(defaultManager));
+    g_assert_nonnull(webkit_website_data_manager_get_base_cache_directory(defaultManager));
+#else
+    g_assert_null(webkit_website_data_manager_get_base_data_directory(defaultManager));
+    g_assert_null(webkit_website_data_manager_get_base_cache_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_local_storage_directory(test->m_manager), !=, webkit_website_data_manager_get_local_storage_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_indexeddb_directory(test->m_manager), !=, webkit_website_data_manager_get_indexeddb_directory(defaultManager));
     g_assert_cmpstr(webkit_website_data_manager_get_disk_cache_directory(test->m_manager), !=, webkit_website_data_manager_get_disk_cache_directory(defaultManager));


### PR DESCRIPTION
#### 86dd3d71686a925f890f8fbadbf818be7f05dedf
<pre>
[GTK][WPE] WebsiteDataManger created by persistent network session should never return NULL for base cache and data directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=251255">https://bugs.webkit.org/show_bug.cgi?id=251255</a>

Reviewed by Adrian Perez de Castro.

When NULL is passed to network session constructor the default directory
is provided to website data manager to ensure the getters don&apos;t return
NULL.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkitNetworkSessionSetProperty):
(webkitNetworkSessionConstructed):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkitWebsiteDataManagerSetProperty):
(webkitWebsiteDataManagerConstructed):
(webkitWebsiteDataManagerGetDataStore):
(webkitWebsiteDataManagerCreate):
(webkit_website_data_manager_get_base_data_directory):
(webkit_website_data_manager_get_base_cache_directory):
(webkitWebsiteDataManagerGetFaviconDatabasePath):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp:
(WebKit::WebsiteDataStore::defaultBaseCacheDirectory):
(WebKit::WebsiteDataStore::defaultBaseDataDirectory):
(WebKit::WebsiteDataStore::cacheDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(testWebsiteDataConfiguration):

Canonical link: <a href="https://commits.webkit.org/259480@main">https://commits.webkit.org/259480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23edb3b7a3201854fe83971bd2ee5cb1d0c79a6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174448 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5003 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97320 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113278 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11759 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39269 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26387 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4329 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47298 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9301 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3481 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->