### PR TITLE
[GStreamer] Harness: Use GRefPtrs for sample/buffer/event push APIs

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -285,7 +285,7 @@ void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& shared
     }
 
     parserHarness->start(WTFMove(caps));
-    parserHarness->pushBuffer(buffer.leakRef());
+    parserHarness->pushBuffer(WTFMove(buffer));
 
     if (!m_decoderHarness) {
         GST_WARNING_OBJECT(parserHarness->element(), "Parsing failed");
@@ -294,7 +294,7 @@ void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& shared
 
     for (auto& stream : parserHarness->outputStreams()) {
         while (auto event = stream->pullEvent())
-            m_decoderHarness->pushEvent(event.leakRef());
+            m_decoderHarness->pushEvent(WTFMove(event));
     }
 
     m_decoderHarness->flush();

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -288,10 +288,10 @@ bool GStreamerInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bo
         GST_BUFFER_DTS(outputBuffer.get()) = GST_BUFFER_DTS(buffer);
         GST_BUFFER_DURATION(outputBuffer.get()) = GST_BUFFER_DURATION(buffer);
         auto convertedSample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
-        result = m_harness->pushSample(convertedSample.get());
+        result = m_harness->pushSample(WTFMove(convertedSample));
     } else
 #endif
-        result = m_harness->pushSample(sample);
+        result = m_harness->pushSample(GRefPtr<GstSample>(sample));
 
     return result;
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -84,9 +84,9 @@ public:
 
     void start(GRefPtr<GstCaps>&&);
 
-    bool pushSample(GstSample*);
-    bool pushBuffer(GstBuffer*);
-    bool pushEvent(GstEvent*);
+    bool pushSample(GRefPtr<GstSample>&&);
+    bool pushBuffer(GRefPtr<GstBuffer>&&);
+    bool pushEvent(GRefPtr<GstEvent>&&);
 
     GstPad* inputPad() const { return m_srcPad.get(); }
     const GRefPtr<GstCaps>& inputCaps() const { return m_inputCaps; }
@@ -100,7 +100,7 @@ public:
 private:
     GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessBufferCallback&&, std::optional<PadLinkCallback>&&);
 
-    GstFlowReturn pushBufferFull(GstBuffer*);
+    GstFlowReturn pushBufferFull(GRefPtr<GstBuffer>&&);
 
     bool srcQuery(GstPad*, GstObject*, GstQuery*);
     bool srcEvent(GstEvent*);


### PR DESCRIPTION
#### f5ad43b3b1b45827b8484fc9395e203e3d63a535
<pre>
[GStreamer] Harness: Use GRefPtrs for sample/buffer/event push APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=251257">https://bugs.webkit.org/show_bug.cgi?id=251257</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ImageDecoderGStreamer::pushEncodedData):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::decode):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::encode):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::start):
(WebCore::GStreamerElementHarness::pushStickyEvents):
(WebCore::GStreamerElementHarness::pushSample):
(WebCore::GStreamerElementHarness::pushBuffer):
(WebCore::GStreamerElementHarness::pushBufferFull):
(WebCore::GStreamerElementHarness::pushEvent):
(WebCore::GStreamerElementHarness::flush):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/259553@main">https://commits.webkit.org/259553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/746959f222e1c12d71f2268f9378b78a60b4b828

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114268 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174451 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5006 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113281 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39275 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7422 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27750 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4332 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6576 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9305 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->