### PR TITLE
[GTK][WPE] Add GWeakPtr to WTF and use it instead of explicit g_object_add|remove_weak_pointer

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -7,6 +7,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/GSocketMonitor.h
     glib/GTypedefs.h
     glib/GUniquePtr.h
+    glib/GWeakPtr.h
     glib/RunLoopSourcePriority.h
     glib/Sandbox.h
     glib/SocketConnection.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -5,6 +5,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/GSocketMonitor.h
     glib/GTypedefs.h
     glib/GUniquePtr.h
+    glib/GWeakPtr.h
     glib/RunLoopSourcePriority.h
     glib/Sandbox.h
     glib/SocketConnection.h

--- a/Source/WTF/wtf/glib/GWeakPtr.h
+++ b/Source/WTF/wtf/glib/GWeakPtr.h
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2023 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#if USE(GLIB)
+
+#include <glib-object.h>
+#include <wtf/Noncopyable.h>
+
+namespace WTF {
+
+template <typename T> class GWeakPtr {
+    WTF_MAKE_NONCOPYABLE(GWeakPtr);
+public:
+    GWeakPtr() = default;
+
+    explicit GWeakPtr(T* ptr)
+        : m_ptr(ptr)
+    {
+        RELEASE_ASSERT(!ptr || G_IS_OBJECT(ptr));
+        addWeakPtr();
+    }
+
+    GWeakPtr(GWeakPtr&& other)
+    {
+        reset(other.get());
+        other.reset();
+    }
+
+    ~GWeakPtr()
+    {
+        removeWeakPtr();
+    }
+
+    T& operator*() const
+    {
+        ASSERT(m_ptr);
+        return *m_ptr;
+    }
+
+    T* operator->() const
+    {
+        ASSERT(m_ptr);
+        return m_ptr;
+    }
+
+    T* get() const
+    {
+        return m_ptr;
+    }
+
+    void reset(T* ptr = nullptr)
+    {
+        RELEASE_ASSERT(!ptr || G_IS_OBJECT(ptr));
+        removeWeakPtr();
+        m_ptr = ptr;
+        addWeakPtr();
+    }
+
+    GWeakPtr& operator=(nullptr_t)
+    {
+        reset();
+        return *this;
+    }
+
+    bool operator!() const { return !m_ptr; }
+
+    // This conversion operator allows implicit conversion to bool but not to other integer types.
+    typedef T* GWeakPtr::*UnspecifiedBoolType;
+    operator UnspecifiedBoolType() const { return m_ptr ? &GWeakPtr::m_ptr : 0; }
+
+private:
+    void addWeakPtr()
+    {
+        if (m_ptr)
+            g_object_add_weak_pointer(G_OBJECT(m_ptr), reinterpret_cast<void**>(&m_ptr));
+    }
+
+    void removeWeakPtr()
+    {
+        if (m_ptr)
+            g_object_remove_weak_pointer(G_OBJECT(m_ptr), reinterpret_cast<void**>(&m_ptr));
+    }
+
+    T* m_ptr { nullptr };
+};
+
+} // namespace WTF
+
+using WTF::GWeakPtr;
+
+#endif // USE(GLIB)

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -41,6 +41,8 @@ OBJC_CLASS NSWindow;
 OBJC_CLASS WKInspectorViewController;
 OBJC_CLASS WKRemoteWebInspectorUIProxyObjCAdapter;
 OBJC_CLASS WKWebView;
+#elif PLATFORM(GTK)
+#include <wtf/glib/GWeakPtr.h>
 #endif
 
 namespace WebCore {
@@ -180,8 +182,8 @@ private:
     WebCore::FloatRect m_sheetRect;
 #endif
 #if PLATFORM(GTK)
-    GtkWidget* m_webView { nullptr };
-    GtkWidget* m_window { nullptr };
+    GWeakPtr<GtkWidget> m_webView;
+    GWeakPtr<GtkWidget> m_window;
 #endif
 #if PLATFORM(WIN_CAIRO)
     HWND m_frontendHandle;

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -57,6 +57,8 @@ OBJC_CLASS WKWebInspectorUIProxyObjCAdapter;
 OBJC_CLASS WKInspectorViewController;
 #elif PLATFORM(WIN)
 #include "WebView.h"
+#elif PLATFORM(GTK)
+#include <wtf/glib/GWeakPtr.h>
 #endif
 
 namespace WebCore {
@@ -152,7 +154,7 @@ public:
 #endif
 
 #if PLATFORM(GTK)
-    GtkWidget* inspectorView() const { return m_inspectorView; };
+    GtkWidget* inspectorView() const { return m_inspectorView.get(); };
     void setClient(std::unique_ptr<WebInspectorUIProxyClient>&&);
 #endif
 
@@ -331,8 +333,8 @@ private:
     bool m_isObservingContentLayoutRect { false };
 #elif PLATFORM(GTK)
     std::unique_ptr<WebInspectorUIProxyClient> m_client;
-    GtkWidget* m_inspectorView { nullptr };
-    GtkWidget* m_inspectorWindow { nullptr };
+    GWeakPtr<GtkWidget> m_inspectorView;
+    GWeakPtr<GtkWidget> m_inspectorWindow;
     GtkWidget* m_headerBar { nullptr };
     String m_inspectedURLString;
 #elif PLATFORM(WIN)

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -44,7 +44,7 @@ void RemoteWebInspectorUIProxy::updateWindowTitle(const CString& targetName)
 {
     if (!m_window)
         return;
-    webkitInspectorWindowSetSubtitle(WEBKIT_INSPECTOR_WINDOW(m_window), !targetName.isNull() ? targetName.data() : nullptr);
+    webkitInspectorWindowSetSubtitle(WEBKIT_INSPECTOR_WINDOW(m_window.get()), !targetName.isNull() ? targetName.data() : nullptr);
 }
 
 static void remoteInspectorViewDestroyed(RemoteWebInspectorUIProxy* inspectorProxy)
@@ -68,32 +68,30 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
     pageConfiguration->setProcessPool(&WebKit::defaultInspectorProcessPool(inspectorLevelForPage(nullptr)));
     pageConfiguration->setPreferences(preferences.ptr());
     pageConfiguration->setPageGroup(pageGroup.ptr());
-    m_webView = GTK_WIDGET(webkitWebViewBaseCreate(*pageConfiguration.ptr()));
-    g_signal_connect_swapped(m_webView, "destroy", G_CALLBACK(remoteInspectorViewDestroyed), this);
-    g_object_add_weak_pointer(G_OBJECT(m_webView), reinterpret_cast<void**>(&m_webView));
+    m_webView.reset(GTK_WIDGET(webkitWebViewBaseCreate(*pageConfiguration.ptr())));
+    g_signal_connect_swapped(m_webView.get(), "destroy", G_CALLBACK(remoteInspectorViewDestroyed), this);
 
-    m_window = webkitInspectorWindowNew();
+    m_window.reset(webkitInspectorWindowNew());
 #if USE(GTK4)
-    gtk_window_set_child(GTK_WINDOW(m_window), m_webView);
+    gtk_window_set_child(GTK_WINDOW(m_window.get()), m_webView.get());
 #else
-    gtk_container_add(GTK_CONTAINER(m_window), m_webView);
-    gtk_widget_show(m_webView);
+    gtk_container_add(GTK_CONTAINER(m_window.get()), m_webView.get());
+    gtk_widget_show(m_webView.get());
 #endif
 
-    g_object_add_weak_pointer(G_OBJECT(m_window), reinterpret_cast<void**>(&m_window));
-    gtk_window_present(GTK_WINDOW(m_window));
+    gtk_window_present(GTK_WINDOW(m_window.get()));
 
-    return webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
+    return webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView.get()));
 }
 
 void RemoteWebInspectorUIProxy::platformCloseFrontendPageAndWindow()
 {
     if (m_webView) {
-        if (auto* webPage = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView)))
+        if (auto* webPage = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView.get())))
             webPage->close();
     }
     if (m_window)
-        gtk_widget_destroy(m_window);
+        gtk_widget_destroy(m_window.get());
 }
 
 void RemoteWebInspectorUIProxy::platformResetState()
@@ -103,7 +101,7 @@ void RemoteWebInspectorUIProxy::platformResetState()
 void RemoteWebInspectorUIProxy::platformBringToFront()
 {
     if (m_window)
-        gtk_window_present(GTK_WINDOW(m_window));
+        gtk_window_present(GTK_WINDOW(m_window.get()));
 }
 
 static void remoteFileReplaceContentsCallback(GObject* sourceObject, GAsyncResult* result, gpointer userData)
@@ -118,7 +116,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
     UNUSED_PARAM(forceSaveAs);
 
     GRefPtr<GtkFileChooserNative> dialog = adoptGRef(gtk_file_chooser_native_new("Save File",
-        GTK_WINDOW(m_window), GTK_FILE_CHOOSER_ACTION_SAVE, "Save", "Cancel"));
+        GTK_WINDOW(m_window.get()), GTK_FILE_CHOOSER_ACTION_SAVE, "Save", "Cancel"));
 
     GtkFileChooser* chooser = GTK_FILE_CHOOSER(dialog.get());
 #if !USE(GTK4)

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -16,6 +16,7 @@ list(APPEND TestWTF_SOURCES
 
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
+    Tests/WTF/glib/GWeakPtr.cpp
     Tests/WTF/glib/WorkQueueGLib.cpp
 )
 

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -16,6 +16,7 @@ list(APPEND TestWTF_SOURCES
 
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
+    Tests/WTF/glib/GWeakPtr.cpp
     Tests/WTF/glib/WorkQueueGLib.cpp
 )
 

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <wtf/glib/GWeakPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF_GWeakPtr, Basic)
+{
+    GWeakPtr<GObject> empty;
+    EXPECT_NULL(empty.get());
+    EXPECT_FALSE(empty);
+
+    GObject* obj = nullptr;
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        EXPECT_TRUE(weak);
+        EXPECT_EQ(weak->ref_count, 1);
+        g_clear_object(&obj);
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+    }
+    EXPECT_NULL(obj);
+
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        EXPECT_TRUE(weak);
+        g_object_ref(obj);
+        EXPECT_EQ(weak->ref_count, 2);
+        g_object_unref(obj);
+        EXPECT_EQ(obj, weak.get());
+        EXPECT_TRUE(weak);
+        EXPECT_EQ(weak->ref_count, 1);
+        g_clear_object(&obj);
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+    }
+    EXPECT_NULL(obj);
+}
+
+TEST(WTF_GWeakPtr, Reset)
+{
+    GObject* obj = nullptr;
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        weak.reset();
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+        EXPECT_EQ(obj->ref_count, 1);
+        g_clear_object(&obj);
+    }
+    EXPECT_NULL(obj);
+
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        weak = nullptr;
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+        EXPECT_EQ(obj->ref_count, 1);
+        g_clear_object(&obj);
+    }
+    EXPECT_NULL(obj);
+
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        GObject* obj2 = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        weak.reset(obj2);
+        EXPECT_EQ(obj2, weak.get());
+        EXPECT_TRUE(weak);
+        g_clear_object(&obj);
+        EXPECT_EQ(obj2, weak.get());
+        g_object_unref(obj2);
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+    }
+    EXPECT_NULL(obj);
+}
+
+TEST(WTF_GWeakPtr, Move)
+{
+    GObject* obj = nullptr;
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        EXPECT_TRUE(weak);
+        GWeakPtr<GObject> weak2 = WTFMove(weak);
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+        EXPECT_EQ(obj, weak2.get());
+        EXPECT_TRUE(weak2);
+        EXPECT_EQ(obj->ref_count, 1);
+        g_clear_object(&obj);
+        EXPECT_NULL(weak2.get());
+        EXPECT_FALSE(weak2);
+    }
+    EXPECT_NULL(obj);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### c995526f428610fc057ab7c141f31cbe99a1e2cb
<pre>
[GTK][WPE] Add GWeakPtr to WTF and use it instead of explicit g_object_add|remove_weak_pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251258">https://bugs.webkit.org/show_bug.cgi?id=251258</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

It&apos;s very common to forget to remove a weak references, GWeakPtr ensures
weak references are always removed and makes easier to create weak
GObjects.

* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/glib/GWeakPtr.h: Added.
(WTF::GWeakPtr::GWeakPtr):
(WTF::GWeakPtr::~GWeakPtr):
(WTF::GWeakPtr::get const):
(WTF::GWeakPtr::reset):
* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
(webkitDownloadCreate):
(webkit_download_get_web_view):
(_WebKitDownloadPrivate::~_WebKitDownloadPrivate): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseGetLoadDecisionForIcon):
* Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
(UIClient::~UIClient): Deleted.
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/259482@main">https://commits.webkit.org/259482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3d2ecf9281e939c960ea5eded8627c02a4d2a8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105025 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114288 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5026 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113301 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110781 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7442 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92910 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5172 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7536 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30276 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13591 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101606 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9325 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/25349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3483 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->