### PR TITLE
[GLIB] always update the active uri of the frame

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -27,6 +27,7 @@
 #include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <JavaScriptCore/JSLock.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameLoader.h>
 #include <WebCore/JSNode.h>
 #include <WebCore/ScriptController.h>
 #include <jsc/JSCContextPrivate.h>
@@ -63,10 +64,27 @@ static void webkit_frame_class_init(WebKitFrameClass*)
 {
 }
 
+static CString getURL(WebFrame* webFrame)
+{
+    auto* documentLoader = webFrame->coreFrame()->loader().provisionalDocumentLoader();
+    if (!documentLoader)
+        documentLoader = webFrame->coreFrame()->loader().documentLoader();
+
+    ASSERT(documentLoader);
+
+    if (!documentLoader->unreachableURL().isEmpty())
+        return documentLoader->unreachableURL().string().utf8();
+
+    return documentLoader->url().string().utf8();
+}
+
 WebKitFrame* webkitFrameCreate(WebFrame* webFrame)
 {
     WebKitFrame* frame = WEBKIT_FRAME(g_object_new(WEBKIT_TYPE_FRAME, NULL));
     frame->priv->webFrame = webFrame;
+
+    frame->priv->uri = getURL(webFrame);
+
     return frame;
 }
 
@@ -95,6 +113,14 @@ Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*
         }
         return jsValue ? jscContextGetOrCreateValue(jsContext.get(), jsValue) : nullptr;
     });
+}
+
+void webkitFrameSetURI(WebKitFrame* frame, const CString& uri)
+{
+    if (frame->priv->uri == uri)
+        return;
+
+    frame->priv->uri = uri;
 }
 
 /**

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFramePrivate.h
@@ -31,3 +31,4 @@ WebKitFrame* webkitFrameCreate(WebKit::WebFrame*);
 WebKit::WebFrame* webkitFrameGetWebFrame(WebKitFrame*);
 GRefPtr<JSCValue> webkitFrameGetJSCValueForElementInWorld(WebKitFrame*, WebCore::Element&, WebKitScriptWorld*);
 Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*, const Vector<RefPtr<WebCore::Element>>&, WebKitScriptWorld*);
+void webkitFrameSetURI(WebKitFrame*, const CString&);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -134,15 +134,24 @@ static WebFrameMap& webFrameMap()
     return map;
 }
 
-static WebKitFrame* webkitFrameGetOrCreate(WebFrame* webFrame)
+static WebKitFrame* webkitFrameGet(WebFrame* webFrame)
 {
     auto wrapperPtr = webFrameMap().get(webFrame);
     if (wrapperPtr)
         return wrapperPtr->webkitFrame();
 
+    return nullptr;
+}
+
+static WebKitFrame* webkitFrameGetOrCreate(WebFrame* webFrame)
+{
+    if (auto* webKitFrame = webkitFrameGet(webFrame))
+        return webKitFrame;
+
     std::unique_ptr<WebKitFrameWrapper> wrapper = makeUnique<WebKitFrameWrapper>(*webFrame);
-    wrapperPtr = wrapper.get();
+    auto wrapperPtr = wrapper.get();
     webFrameMap().set(webFrame, WTFMove(wrapper));
+
     return wrapperPtr->webkitFrame();
 }
 
@@ -179,30 +188,62 @@ private:
 
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame& frame, RefPtr<API::Object>&) override
     {
-        if (!frame.isMainFrame())
+        auto* webKitFrame = webkitFrameGet(&frame);
+        if (!webKitFrame && !frame.isMainFrame())
             return;
-        webkitWebPageSetURI(m_webPage, getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader()));
+
+        const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader());
+
+        if (webKitFrame)
+            webkitFrameSetURI(webKitFrame, uri);
+
+        if (frame.isMainFrame())
+            webkitWebPageSetURI(m_webPage, uri);
     }
 
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebPage&, WebFrame& frame, RefPtr<API::Object>&) override
     {
-        if (!frame.isMainFrame())
+        auto* webKitFrame = webkitFrameGet(&frame);
+        if (!webKitFrame && !frame.isMainFrame())
             return;
-        webkitWebPageSetURI(m_webPage, getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader()));
+
+        const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader());
+
+        if (webKitFrame)
+            webkitFrameSetURI(webKitFrame, uri);
+
+        if (frame.isMainFrame())
+            webkitWebPageSetURI(m_webPage, uri);
     }
 
     void didSameDocumentNavigationForFrame(WebPage&, WebFrame& frame, SameDocumentNavigationType, RefPtr<API::Object>&) override
     {
-        if (!frame.isMainFrame())
+        auto* webKitFrame = webkitFrameGet(&frame);
+        if (!webKitFrame && !frame.isMainFrame())
             return;
-        webkitWebPageSetURI(m_webPage, frame.coreFrame()->document()->url().string().utf8());
+
+        const auto uri = frame.coreFrame()->document()->url().string().utf8();
+
+        if (webKitFrame)
+            webkitFrameSetURI(webKitFrame, uri);
+
+        if (frame.isMainFrame())
+            webkitWebPageSetURI(m_webPage, uri);
     }
 
     void didCommitLoadForFrame(WebPage&, WebFrame& frame, RefPtr<API::Object>&) override
     {
-        if (!frame.isMainFrame())
+        auto* webKitFrame = webkitFrameGet(&frame);
+        if (!webKitFrame && !frame.isMainFrame())
             return;
-        webkitWebPageSetURI(m_webPage, getDocumentLoaderURL(frame.coreFrame()->loader().documentLoader()));
+
+        const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().documentLoader());
+
+        if (webKitFrame)
+            webkitFrameSetURI(webKitFrame, uri);
+
+        if (frame.isMainFrame())
+            webkitWebPageSetURI(m_webPage, uri);
     }
 
     void didFinishDocumentLoadForFrame(WebPage&, WebFrame& frame, RefPtr<API::Object>&) override

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
@@ -189,6 +189,11 @@ static void emitURIChanged(GDBusConnection* connection, const char* uri)
 
 static void uriChangedCallback(WebKitWebPage* webPage, GParamSpec* pspec, WebKitWebExtension* extension)
 {
+    WebKitFrame* frame = webkit_web_page_get_main_frame(webPage);
+    g_assert_true(WEBKIT_IS_FRAME(frame));
+    g_assert_true(webkit_frame_is_main_frame(frame));
+    g_assert_cmpstr(webkit_web_page_get_uri(webPage), ==, webkit_frame_get_uri(frame));
+
     gpointer data = g_object_get_data(G_OBJECT(extension), "dbus-connection");
     if (data)
         emitURIChanged(G_DBUS_CONNECTION(data), webkit_web_page_get_uri(webPage));


### PR DESCRIPTION
#### 4a9e02aa3418af0c2117db77f0e7edd70955fa23
<pre>
[GLIB] always update the active uri of the frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=251256">https://bugs.webkit.org/show_bug.cgi?id=251256</a>

Reviewed by Carlos Garcia Campos.

It fixes the case when the uri has changed after first call of
webkit_frame_get_uri and then webkit_frame_get_uri is called again.
Without this fix the returned uri is the initial one not the actual one.

Test: I modified existing caillback for uri change and add there additional
asserts to test added functionality.

* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
(webkitFrameSetUri):
(webkit_frame_get_uri):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFramePrivate.h:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp:
(uriChangedCallback):

Canonical link: <a href="https://commits.webkit.org/259999@main">https://commits.webkit.org/259999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/773027b921625da20884eee60d5e5268d1091317

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115211 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6262 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98238 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40108 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81784 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5090 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48079 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10373 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3719 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->