### PR TITLE
[WGSL] Add IdentityExpression node

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -56,6 +56,7 @@ class Uint32Literal;
 class UnaryExpression;
 class BinaryExpression;
 class PointerDereference;
+class IdentityExpression;
 
 class Statement;
 class AssignmentStatement;

--- a/Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ASTExpression.h"
-#include "ASTStructureAccess.h"
 
 #include <wtf/text/WTFString.h>
 
@@ -47,12 +46,6 @@ public:
 
 private:
     String m_identifier;
-
-protected:
-    // FIXME: This is necessary because we replace an IdentifierExpression with
-    // a StructureAccess for globals, so the sizes must be compatible. We need to
-    // introduce an IdentityExpression and remove this hack
-    uint8_t m_padding[sizeof(StructureAccess) - sizeof(Expression) - sizeof(String)];
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,33 +25,31 @@
 
 #pragma once
 
-#include "ASTArrayAccess.h"
-#include "ASTAssignmentStatement.h"
-#include "ASTAttribute.h"
-#include "ASTBinaryExpression.h"
-#include "ASTBindingAttribute.h"
-#include "ASTBuiltinAttribute.h"
-#include "ASTCallableExpression.h"
-#include "ASTCompoundStatement.h"
-#include "ASTDecl.h"
 #include "ASTExpression.h"
-#include "ASTFunctionDecl.h"
-#include "ASTGlobalDirective.h"
-#include "ASTGroupAttribute.h"
-#include "ASTIdentifierExpression.h"
-#include "ASTIdentityExpression.h"
-#include "ASTLiteralExpressions.h"
-#include "ASTLocationAttribute.h"
-#include "ASTNode.h"
-#include "ASTPointerDereference.h"
-#include "ASTReturnStatement.h"
-#include "ASTShaderModule.h"
-#include "ASTStageAttribute.h"
-#include "ASTStatement.h"
-#include "ASTStructureAccess.h"
-#include "ASTStructureDecl.h"
-#include "ASTTypeDecl.h"
-#include "ASTUnaryExpression.h"
-#include "ASTVariableDecl.h"
-#include "ASTVariableQualifier.h"
-#include "ASTVariableStatement.h"
+
+namespace WGSL::AST {
+
+// This is a special node used when modifying the AST through compiler passes.
+// The passes can replace one node with another, but only if the size of the new
+// class fits in the existing space. This is a small node used when needing to insert a
+// larger node than the one current in the tree. E.g. replacing an identifier
+// with a structure access.
+class IdentityExpression final : public Expression {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    IdentityExpression(SourceSpan span, UniqueRef<Expression>&& expression)
+        : Expression(span)
+        , m_expression(WTFMove(expression))
+    {
+    }
+
+    Kind kind() const override;
+    Expression& expression() { return m_expression.get(); }
+
+private:
+    UniqueRef<Expression> m_expression;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(IdentityExpression)

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -65,6 +65,7 @@ public:
         UnaryExpression,
         BinaryExpression,
         PointerDereference,
+        IdentityExpression,
 
         ShaderModule,
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -195,6 +195,9 @@ void Visitor::visit(Expression& expression)
     case Expression::Kind::PointerDereference:
         checkErrorAndVisit(downcast<PointerDereference>(expression));
         break;
+    case Expression::Kind::IdentityExpression:
+        checkErrorAndVisit(downcast<IdentityExpression>(expression));
+        break;
     default:
         ASSERT_NOT_REACHED("Unhandled expression kind");
     }
@@ -260,6 +263,11 @@ void Visitor::visit(BinaryExpression& binaryExpression)
 void Visitor::visit(PointerDereference& pointerDereference)
 {
     checkErrorAndVisit(pointerDereference.target());
+}
+
+void Visitor::visit(IdentityExpression& identity)
+{
+    checkErrorAndVisit(identity.expression());
 }
 
 // Statement

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -69,6 +69,7 @@ public:
     virtual void visit(UnaryExpression&);
     virtual void visit(BinaryExpression&);
     virtual void visit(PointerDereference&);
+    virtual void visit(IdentityExpression&);
 
     // Statement
     virtual void visit(Statement&);

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -111,10 +111,12 @@ void RewriteGlobalVariables::visit(AST::VariableDecl& variableDecl)
 }
 
 template <typename TargetType, typename CurrentType, typename... Arguments>
-void replace(CurrentType& dst, Arguments&&... arguments)
+void replace(CurrentType&& dst, Arguments&&... arguments)
 {
     static_assert(sizeof(TargetType) <= sizeof(CurrentType));
-    new (&dst) TargetType(dst.span(), std::forward<Arguments>(arguments)...);
+    auto span = dst.span();
+    dst.~CurrentType();
+    new (&dst) TargetType(span, std::forward<Arguments>(arguments)...);
 }
 
 void RewriteGlobalVariables::visit(AST::IdentifierExpression& identifier)
@@ -122,9 +124,9 @@ void RewriteGlobalVariables::visit(AST::IdentifierExpression& identifier)
     auto name = identifier.identifier();
     if (Global* global = read(name)) {
         if (auto resource = global->m_resource) {
-            replace<AST::StructureAccess>(identifier,
-                makeUniqueRef<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->m_group)),
-                WTFMove(name));
+            auto base = makeUniqueRef<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->m_group));
+            auto structureAccess = makeUniqueRef<AST::StructureAccess>(identifier.span(), WTFMove(base), WTFMove(name));
+            replace<AST::IdentityExpression>(WTFMove(identifier), WTFMove(structureAccess));
         }
     }
 }

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		9789C32229802690009E9006 /* ASTBinaryExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C32029802690009E9006 /* ASTBinaryExpression.h */; };
 		9789C32329802690009E9006 /* ASTPointerDereference.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C32129802690009E9006 /* ASTPointerDereference.h */; };
 		978A911B2984076900B37E5E /* API.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A911A2984076900B37E5E /* API.h */; };
+		978A91192983FE3100B37E5E /* ASTIdentityExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A91182983FE3100B37E5E /* ASTIdentityExpression.h */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -345,6 +346,7 @@
 		9789C32029802690009E9006 /* ASTBinaryExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTBinaryExpression.h; sourceTree = "<group>"; };
 		9789C32129802690009E9006 /* ASTPointerDereference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTPointerDereference.h; sourceTree = "<group>"; };
 		978A911A2984076900B37E5E /* API.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = API.h; sourceTree = "<group>"; };
+		978A91182983FE3100B37E5E /* ASTIdentityExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTIdentityExpression.h; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -701,6 +703,7 @@
 				33EA185F27BC198100A1DD52 /* ASTGlobalDirective.h */,
 				3A2479D8290629CD0012B3E6 /* ASTGroupAttribute.h */,
 				33EA188127BC25D000A1DD52 /* ASTIdentifierExpression.h */,
+				978A91182983FE3100B37E5E /* ASTIdentityExpression.h */,
 				33EA188727BC361E00A1DD52 /* ASTLiteralExpressions.h */,
 				3A2479D9290629CE0012B3E6 /* ASTLocationAttribute.h */,
 				33EA185D27BC194F00A1DD52 /* ASTNode.h */,
@@ -768,6 +771,7 @@
 				33EA186027BC198100A1DD52 /* ASTGlobalDirective.h in Headers */,
 				3A2479DD290629CE0012B3E6 /* ASTGroupAttribute.h in Headers */,
 				33EA188227BC25D000A1DD52 /* ASTIdentifierExpression.h in Headers */,
+				978A91192983FE3100B37E5E /* ASTIdentityExpression.h in Headers */,
 				33EA188827BC361E00A1DD52 /* ASTLiteralExpressions.h in Headers */,
 				3A2479DE290629CE0012B3E6 /* ASTLocationAttribute.h in Headers */,
 				33EA185E27BC194F00A1DD52 /* ASTNode.h in Headers */,


### PR DESCRIPTION
#### 1e76207c4357149a69994b53bb756f31996c13df
<pre>
[WGSL] Add IdentityExpression node
<a href="https://bugs.webkit.org/show_bug.cgi?id=251262">https://bugs.webkit.org/show_bug.cgi?id=251262</a>
&lt;rdar://problem/104740808&gt;

Reviewed by Myles C. Maxfield.

Address the FIXME from IdentifierExpression by introducing an IdentityExpression node.
This new node is a special node that does nothing but point to another expression. It&apos;s
useful when replacing nodes, if the new node is larger than the existing node. In which
case, an identity node can be used to point to the larger node.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h:
* Source/WebGPU/WGSL/AST/ASTIdentityExpression.h: Copied from Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h.
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::replace):
(WGSL::RewriteGlobalVariables::visit):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259552@main">https://commits.webkit.org/259552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fda17215e2d8da15e5df53b04240d5712629d401

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114496 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5237 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97551 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110993 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93838 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81128 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7651 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13798 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6575 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9534 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->