### PR TITLE
[WGSL] Fix hardcoded buffer index calculation in MetalFunctionWriter

### DIFF
--- a/Source/WebGPU/WGSL/API.h
+++ b/Source/WebGPU/WGSL/API.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WGSL  {
+
+inline uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex, uint32_t maxIndex)
+{
+    ASSERT(groupIndex <= maxIndex);
+    return groupIndex > maxIndex ? 0 : (maxIndex - groupIndex);
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/AST/ASTShaderModule.h
+++ b/Source/WebGPU/WGSL/AST/ASTShaderModule.h
@@ -29,6 +29,7 @@
 #include "ASTGlobalDirective.h"
 #include "ASTStructureDecl.h"
 #include "ASTVariableDecl.h"
+#include "WGSL.h"
 
 #include <wtf/HashMap.h>
 #include <wtf/text/StringHash.h>
@@ -40,9 +41,10 @@ class ShaderModule final : Node {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    ShaderModule(SourceSpan span, const String& source, GlobalDirective::List&& directives, Decl::List&& decls)
+    ShaderModule(SourceSpan span, const String& source, const Configuration& configuration, GlobalDirective::List&& directives, Decl::List&& decls)
         : Node(span)
         , m_source(source)
+        , m_configuration(configuration)
         , m_directives(WTFMove(directives))
     {
         for (size_t i = decls.size(); i > 0; --i) {
@@ -67,7 +69,8 @@ public:
 
     Kind kind() const override;
 
-    const String& source() { return m_source; }
+    const String& source() const { return m_source; }
+    const Configuration& configuration() const { return m_configuration; }
     GlobalDirective::List& directives() { return m_directives; }
     StructDecl::List& structs() { return m_structs; }
     VariableDecl::List& globalVars() { return m_globalVars; }
@@ -75,6 +78,7 @@ public:
 
 private:
     String m_source;
+    Configuration m_configuration;
     GlobalDirective::List m_directives;
 
     StructDecl::List m_structs;

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -102,22 +102,24 @@ namespace WGSL {
     } while (false)
 
 template<typename Lexer>
-Expected<AST::ShaderModule, Error> parse(const String& wgsl)
+Expected<AST::ShaderModule, Error> parse(const String& wgsl, const Configuration& configuration)
 {
     Lexer lexer(wgsl);
     Parser parser(lexer);
 
-    return parser.parseShader(wgsl);
+    // FIXME: Add a top-level class so that we don't have to plumb all this
+    // information until we parse the root node
+    return parser.parseShader(wgsl, configuration);
 }
 
-Expected<AST::ShaderModule, Error> parseLChar(const String& wgsl)
+Expected<AST::ShaderModule, Error> parseLChar(const String& wgsl, const Configuration& configuration)
 {
-    return parse<Lexer<LChar>>(wgsl);
+    return parse<Lexer<LChar>>(wgsl, configuration);
 }
 
-Expected<AST::ShaderModule, Error> parseUChar(const String& wgsl)
+Expected<AST::ShaderModule, Error> parseUChar(const String& wgsl, const Configuration& configuration)
 {
-    return parse<Lexer<UChar>>(wgsl);
+    return parse<Lexer<UChar>>(wgsl, configuration);
 }
 
 template<typename Lexer>
@@ -138,7 +140,7 @@ void Parser<Lexer>::consume()
 }
 
 template<typename Lexer>
-Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader(const String& source)
+Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader(const String& source, const Configuration& configuration)
 {
     START_PARSE();
 
@@ -151,7 +153,7 @@ Expected<AST::ShaderModule, Error> Parser<Lexer>::parseShader(const String& sour
         decls.append(WTFMove(globalDecl));
     }
 
-    RETURN_NODE(ShaderModule, source, WTFMove(directives), WTFMove(decls));
+    RETURN_NODE(ShaderModule, source, configuration, WTFMove(directives), WTFMove(decls));
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/Parser.h
+++ b/Source/WebGPU/WGSL/Parser.h
@@ -27,12 +27,13 @@
 
 #include "ASTShaderModule.h"
 #include "CompilationMessage.h"
-#include "Lexer.h"
 #include <wtf/Expected.h>
 
 namespace WGSL {
 
-Expected<AST::ShaderModule, Error> parseLChar(const String& wgsl);
-Expected<AST::ShaderModule, Error> parseUChar(const String& wgsl);
+struct Configuration;
+
+Expected<AST::ShaderModule, Error> parseLChar(const String& wgsl, const Configuration&);
+Expected<AST::ShaderModule, Error> parseUChar(const String& wgsl, const Configuration&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -52,6 +52,8 @@ enum class AccessMode : uint8_t;
 enum class StorageClass : uint8_t;
 }
 
+struct Configuration;
+
 template<typename Lexer>
 class Parser {
 public:
@@ -61,7 +63,7 @@ public:
     {
     }
 
-    Expected<AST::ShaderModule, Error> parseShader(const String& source);
+    Expected<AST::ShaderModule, Error> parseShader(const String& source, const Configuration&);
 
     // UniqueRef whenever it can return multiple types.
     Expected<UniqueRef<AST::Decl>, Error> parseGlobalDecl();

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -63,9 +63,9 @@ namespace WGSL {
         return pass(__VA_ARGS__); \
     }();
 
-std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&)
+std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&, const Configuration& configuration)
 {
-    Expected<AST::ShaderModule, Error> parserResult = wgsl.is8Bit() ? parseLChar(wgsl) : parseUChar(wgsl);
+    Expected<AST::ShaderModule, Error> parserResult = wgsl.is8Bit() ? parseLChar(wgsl, configuration) : parseUChar(wgsl, configuration);
     if (!parserResult.has_value()) {
         // FIXME: Add support for returning multiple errors from the parser.
         return FailedCheck { { parserResult.error() }, { /* warnings */ } };

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -65,7 +65,11 @@ struct SourceMap {
     // https://sourcemaps.info/spec.html
 };
 
-std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&);
+struct Configuration {
+    uint32_t maxBuffersPlusVertexBuffersForVertexStage;
+};
+
+std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&, const Configuration&);
 
 //
 // Step 2

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		9789C31B297EA105009E9006 /* CallGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C319297EA105009E9006 /* CallGraph.h */; };
 		9789C32229802690009E9006 /* ASTBinaryExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C32029802690009E9006 /* ASTBinaryExpression.h */; };
 		9789C32329802690009E9006 /* ASTPointerDereference.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C32129802690009E9006 /* ASTPointerDereference.h */; };
+		978A911B2984076900B37E5E /* API.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A911A2984076900B37E5E /* API.h */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -343,6 +344,7 @@
 		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
 		9789C32029802690009E9006 /* ASTBinaryExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTBinaryExpression.h; sourceTree = "<group>"; };
 		9789C32129802690009E9006 /* ASTPointerDereference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTPointerDereference.h; sourceTree = "<group>"; };
+		978A911A2984076900B37E5E /* API.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = API.h; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 			children = (
 				33EA185C27BC193D00A1DD52 /* AST */,
 				979240B1297018290050EA2C /* Metal */,
+				978A911A2984076900B37E5E /* API.h */,
 				9789C318297EA105009E9006 /* CallGraph.cpp */,
 				9789C319297EA105009E9006 /* CallGraph.h */,
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
@@ -748,6 +751,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				978A911B2984076900B37E5E /* API.h in Headers */,
 				3ACCE80628FE1872004A0914 /* AST.h in Headers */,
 				3A7E164C28C57BB8003F49C9 /* ASTArrayAccess.h in Headers */,
 				33EA188027BC24E200A1DD52 /* ASTAssignmentStatement.h in Headers */,

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "Device.h"
 
+#import "API.h"
 #import "APIConversions.h"
 #import "BindGroup.h"
 #import "BindGroupLayout.h"
@@ -262,8 +263,7 @@ uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
 uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const
 {
     auto maxIndex = maxBuffersPlusVertexBuffersForVertexStage();
-    ASSERT(groupIndex <= maxIndex);
-    return groupIndex > maxIndex ? 0 : (maxIndex - groupIndex);
+    return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxIndex);
 }
 
 void Device::captureFrameIfNeeded() const

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -112,7 +112,7 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
     if (!shaderModuleParameters)
         return ShaderModule::createInvalid(*this);
 
-    auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgsl.code), std::nullopt);
+    auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgsl.code), std::nullopt, { maxBuffersPlusVertexBuffersForVertexStage() });
 
     if (std::holds_alternative<WGSL::SuccessfulCheck>(checkResult) && shaderModuleParameters->hints && shaderModuleParameters->hints->hintsCount) {
         if (auto result = earlyCompileShaderModule(*this, WTFMove(checkResult), *shaderModuleParameters->hints, fromAPI(descriptor.label)))

--- a/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
@@ -42,6 +42,8 @@ static String toString(WGSL::AST::ShaderModule& shaderModule)
 
 TEST(WGSLASTDumperTests, dumpTriangleVert)
 {
+    WGSL::Configuration configuration;
+    configuration.maxBuffersPlusVertexBuffersForVertexStage = 8;
     auto shader = WGSL::parseLChar(
         "@vertex\n"
         "fn main(\n"
@@ -53,7 +55,7 @@ TEST(WGSLASTDumperTests, dumpTriangleVert)
         "        vec2<f32>(0.5, -0.5)\n"
         "    );\n\n"
         "    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);\n"
-        "}\n"_s);
+        "}\n"_s, configuration);
 
     EXPECT_SHADER(shader);
     EXPECT_EQ(

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -67,11 +67,18 @@ static void checkVec4F32Type(WGSL::AST::TypeDecl& type)
 
 namespace TestWGSLAPI {
 
+inline Expected<WGSL::AST::ShaderModule, WGSL::Error> parse(const String& wgsl)
+{
+    WGSL::Configuration configuration;
+    configuration.maxBuffersPlusVertexBuffersForVertexStage = 8;
+    return WGSL::parseLChar(wgsl, configuration);
+}
+
 static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, const Vector<String>& typeNames)
 {
     ASSERT(fieldNames.size() == typeNames.size());
 
-    auto shader = WGSL::parseLChar(program);
+    auto shader = parse(program);
 
     EXPECT_SHADER(shader);
     EXPECT_TRUE(shader.has_value());
@@ -104,7 +111,7 @@ TEST(WGSLParserTests, SourceLifecycle)
             " "_s,
             "x: B;"_s
         );
-        return WGSL::parseLChar(source);
+        return parse(source);
     })();
 
     EXPECT_SHADER(shader);
@@ -161,7 +168,7 @@ TEST(WGSLParserTests, Struct)
 
 TEST(WGSLParserTests, GlobalVariable)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "@group(0) @binding(0)\n"
         "var<storage, read_write> x: B;\n"_s);
 
@@ -190,7 +197,7 @@ TEST(WGSLParserTests, GlobalVariable)
 
 TEST(WGSLParserTests, FunctionDecl)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "@compute\n"
         "fn main() {\n"
         "    x.a = 42i;\n"
@@ -227,7 +234,7 @@ TEST(WGSLParserTests, FunctionDecl)
 
 TEST(WGSLParserTests, TrivialGraphicsShader)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "@vertex\n"
         "fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {\n"
         "    return x;\n"
@@ -303,7 +310,7 @@ TEST(WGSLParserTests, TrivialGraphicsShader)
 
 TEST(WGSLParserTests, LocalVariable)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "@vertex\n"
         "fn main() -> vec4<f32> {\n"
         "    var x = vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
@@ -364,7 +371,7 @@ TEST(WGSLParserTests, LocalVariable)
 
 TEST(WGSLParserTests, ArrayAccess)
 {
-    auto shader = WGSL::parseLChar("fn test() { return x[42i]; }"_s);
+    auto shader = parse("fn test() { return x[42i]; }"_s);
 
     EXPECT_SHADER(shader);
     EXPECT_TRUE(shader.has_value());
@@ -399,7 +406,7 @@ TEST(WGSLParserTests, ArrayAccess)
 
 TEST(WGSLParserTests, UnaryExpression)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "fn negate(x: f32) -> f32 {\n"
         "    return -x;\n"
         "}"_s);
@@ -439,7 +446,7 @@ TEST(WGSLParserTests, UnaryExpression)
 
 TEST(WGSLParserTests, BinaryExpression)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "fn add(x: f32, y: f32) -> f32 {\n"
         "    return x + y;\n"
         "}"_s);
@@ -486,7 +493,7 @@ TEST(WGSLParserTests, BinaryExpression)
 
 TEST(WGSLParserTests, TriangleVert)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "@vertex\n"
         "fn main(\n"
         "    @builtin(vertex_index) VertexIndex : u32\n"
@@ -561,7 +568,7 @@ TEST(WGSLParserTests, TriangleVert)
 
 TEST(WGSLParserTests, RedFrag)
 {
-    auto shader = WGSL::parseLChar(
+    auto shader = parse(
         "@fragment\n"
         "fn main() -> @location(0) vec4<f32> {\n"
         "    return vec4<f32>(1.0, 0.0, 0.0, 1.0);\n"


### PR DESCRIPTION
#### 536fc726cd22a49ccfdab8468c47e70e16aed264
<pre>
[WGSL] Fix hardcoded buffer index calculation in MetalFunctionWriter
<a href="https://bugs.webkit.org/show_bug.cgi?id=251264">https://bugs.webkit.org/show_bug.cgi?id=251264</a>
&lt;rdar://problem/104742151&gt;

Reviewed by Myles C. Maxfield.

Add a configuration object to be passed into the WGSL compiler, which for now
only contains the limit for `maxBuffersPlusVertexBuffersForVertexStage`. Also
moved the implementation of the function that calculates the buffer index for
a bind group using the limit into WGSL so it can be shared between the compiler
and the API. The plumbing to get it into the `AST::ShaderModule` is a bit
unfortunate for now, but will be addressed in a subsequent patch.

* Source/WebGPU/WGSL/API.h: Added.
(WGSL::vertexBufferIndexForBindGroup):
* Source/WebGPU/WGSL/AST/ASTShaderModule.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::FunctionDefinitionWriter):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitMetalFunctions):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::parse):
(WGSL::parseLChar):
(WGSL::parseUChar):
(WGSL::Parser&lt;Lexer&gt;::parseShader):
* Source/WebGPU/WGSL/Parser.h:
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::vertexBufferIndexForBindGroup const):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):

Canonical link: <a href="https://commits.webkit.org/259547@main">https://commits.webkit.org/259547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2465e7470c4947f6c28b13304501c0fec396f41e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114287 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174470 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5025 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113300 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94779 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26406 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27765 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4346 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47317 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6570 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9324 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->