### PR TITLE
[GTK] Use a weak reference of web view in webkitWebViewGetLoadDecisionForIcon

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -130,8 +130,10 @@ void webkitFaviconDatabaseGetLoadDecisionForIcon(WebKitFaviconDatabase* database
     database->priv->iconDatabase->checkIconURLAndSetPageURLIfNeeded(icon.url.string(), pageURL,
         isEphemeral ? IconDatabase::AllowDatabaseWrite::No : IconDatabase::AllowDatabaseWrite::Yes,
             [database = GRefPtr<WebKitFaviconDatabase>(database), url = icon.url.string().isolatedCopy(), pageURL = pageURL.isolatedCopy(), completionHandler = WTFMove(completionHandler)](bool found, bool changed) {
-            if (!webkitFaviconDatabaseIsOpen(database.get()))
+            if (!webkitFaviconDatabaseIsOpen(database.get())) {
+                completionHandler(false);
                 return;
+            }
 
             if (found && changed)
                 g_signal_emit(database.get(), signals[FAVICON_CHANGED], 0, pageURL.utf8().data(), url.utf8().data());

--- a/Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp
@@ -22,6 +22,7 @@
 
 #include "APIIconLoadingClient.h"
 #include "WebKitWebViewPrivate.h"
+#include <wtf/glib/GWeakPtr.h>
 
 using namespace WebKit;
 
@@ -43,16 +44,16 @@ private:
         }
 
         WebCore::LinkIcon copiedIcon = icon;
-        webkitWebViewGetLoadDecisionForIcon(m_webView, icon, [protectedWebView = GRefPtr<WebKitWebView>(m_webView), icon = WTFMove(copiedIcon), completionHandler = WTFMove(completionHandler)] (bool loadIcon) mutable {
-            if (!loadIcon) {
+        webkitWebViewGetLoadDecisionForIcon(m_webView, icon, [weakWebView = GWeakPtr<WebKitWebView>(m_webView), icon = WTFMove(copiedIcon), completionHandler = WTFMove(completionHandler)] (bool loadIcon) mutable {
+            if (!weakWebView || !loadIcon) {
                 completionHandler(nullptr);
                 return;
             }
 
-            completionHandler([protectedWebView = WTFMove(protectedWebView), icon = WTFMove(icon)] (API::Data* iconData) {
-                if (!iconData)
+            completionHandler([weakWebView = WTFMove(weakWebView), icon = WTFMove(icon)] (API::Data* iconData) {
+                if (!weakWebView || !iconData)
                     return;
-                webkitWebViewSetIcon(protectedWebView.get(), icon, *iconData);
+                webkitWebViewSetIcon(weakWebView.get(), icon, *iconData);
             });
         });
     }


### PR DESCRIPTION
#### 5757289eb640e50ec21bcbecb19aaaee0877ed43
<pre>
[GTK] Use a weak reference of web view in webkitWebViewGetLoadDecisionForIcon
<a href="https://bugs.webkit.org/show_bug.cgi?id=251266">https://bugs.webkit.org/show_bug.cgi?id=251266</a>

Reviewed by Michael Catanzaro.

We don&apos;t want to delay the dispose of a web view because an icon load
decision is still pending, so let&apos;s use a weak reference instead of a
strong one. This fixes memory leaks reported by unit tests with 2022 API
now that favicons are enabled by default.

* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseGetLoadDecisionForIcon):
* Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp:

Canonical link: <a href="https://commits.webkit.org/259524@main">https://commits.webkit.org/259524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aeacb8a51cc4a95175b03599540eadf3fa22615

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114291 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5029 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113304 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39292 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80961 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7445 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4350 "Found 1 new test failure: fast/forms/fieldset/fieldset-flexbox.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47321 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9328 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3507 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->