### PR TITLE
[WGSL] Always visit vertex entry point output

### DIFF
--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
@@ -27,9 +27,7 @@ async function helloTriangle() {
     const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {}}] });
     const pipelineLayoutDesc = { bindGroupLayouts: [uniformBindGroupLayout] };
     const layout = device.createPipelineLayout(pipelineLayoutDesc);
-/*
-    FIXME: Add support for binary expressions to match the metal code
-*/
+
     const wgslSource = `
                      struct Vertex {
                          @builtin(position) Position: vec4<f32>,
@@ -45,7 +43,7 @@ async function helloTriangle() {
                          );
                          var vertex_out : Vertex;
                          vertex_out.Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-                         vertex_out.color = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                         vertex_out.color = vec4<f32>(pos[VertexIndex] + vec2<f32>(0.5, 0.5), 0.0, 1.0);
                          return vertex_out;
                      }
 


### PR DESCRIPTION
#### 8298a862fed61d92b48e246066f4968c43fe8bcb
<pre>
[WGSL] Always visit vertex entry point output
<a href="https://bugs.webkit.org/show_bug.cgi?id=251268">https://bugs.webkit.org/show_bug.cgi?id=251268</a>
&lt;rdar://problem/104744731&gt;

Reviewed by Myles C. Maxfield.

Right now, in order to translate the struct member attributes correctly to metal,
we check whether a struct is being used as an output of the vertex entry point
(in order to use the `[[user()]]` attributes to connect it with the fragment entry
point. This is a bit hacky, but works for now. However, the bug was that we didn&apos;t
perform this check if we didn&apos;t need to rewrite the entry point&apos;s input arguments,
but the two things are unrelated. This had broken the hello-triangle demo.

Also fixed the FIXME in the example since we now support binary add.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::checkReturnType):
* Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js:
(async helloTriangle):

Canonical link: <a href="https://commits.webkit.org/259546@main">https://commits.webkit.org/259546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95d46606bedb7f193e8bef6086028eef83b8cdf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114294 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5032 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113307 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39296 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80960 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7448 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27771 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4353 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47323 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6573 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9331 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->