### PR TITLE
Detect complex custom property cycles involving multiple loops

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cycles-expected.txt
@@ -6,8 +6,8 @@ PASS Cycle that starts in the middle of a chain
 PASS Cycle with extra edge
 PASS Cycle with extra edge (2)
 PASS Cycle with extra edge (3)
-FAIL Cycle with secondary cycle assert_equals: --a expected "" but got "cycle"
-FAIL Cycle with overlapping secondary cycle assert_equals: --a expected "" but got "cycle"
-FAIL Cycle with deeper secondary cycle assert_equals: --c expected "" but got "cycle"
+PASS Cycle with secondary cycle
+PASS Cycle with overlapping secondary cycle
+PASS Cycle with deeper secondary cycle
 PASS Cycle via fallback
 

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -134,6 +134,7 @@ private:
 
     HashSet<String> m_appliedCustomProperties;
     HashSet<String> m_inProgressCustomProperties;
+    HashSet<String> m_inCycleCustomProperties;
     Bitmap<numCSSProperties> m_inProgressProperties;
     Bitmap<numCSSProperties> m_inUnitCycleProperties;
 


### PR DESCRIPTION
#### fc0d8fbdae064b740a609102f1c75f9ffee73887
<pre>
Detect complex custom property cycles involving multiple loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=251269">https://bugs.webkit.org/show_bug.cgi?id=251269</a>
&lt;rdar://problem/104744972&gt;

Reviewed by Simon Fraser.

We fail in some complex cycle cases.

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cycles-expected.txt:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomProperty):

Track property cycles with a separate m_inCycleCustomProperties map instead of eagerly computing them to
an invalid value on first detection. This allows the detection of multiple cycles passing through
the same property. It also simplifies the code.

* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/259506@main">https://commits.webkit.org/259506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/211c2e521301a1cc9f0b34b0520fe1033b5ada27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114296 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174479 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5034 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113309 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11786 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39298 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26415 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27774 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7544 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6551 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9333 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->