### PR TITLE
Revert [259432@main] Move Opaque Origin Identifier from SecurityOrigin to SecurityOriginData

### DIFF
--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -36,7 +36,6 @@
 
 #include <optional>
 #include <type_traits>
-#include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -154,11 +153,6 @@ public:
 private:
     T m_value;
 };
-
-template <typename T, typename Traits> inline void add(Hasher& hasher, const Markable<T, Traits>& value)
-{
-    add(hasher, value.asOptional());
-}
 
 template <typename T, typename Traits> constexpr bool operator==(const Markable<T, Traits>& x, const Markable<T, Traits>& y)
 {

--- a/Source/WebCore/page/SecurityOriginData.cpp
+++ b/Source/WebCore/page/SecurityOriginData.cpp
@@ -68,7 +68,7 @@ SecurityOriginData SecurityOriginData::fromFrame(Frame* frame)
 
 Ref<SecurityOrigin> SecurityOriginData::securityOrigin() const
 {
-    return SecurityOrigin::create(isolatedCopy());
+    return SecurityOrigin::create(protocol.isolatedCopy(), host.isolatedCopy(), port);
 }
 
 static const char separatorCharacter = '_';
@@ -127,7 +127,6 @@ SecurityOriginData SecurityOriginData::isolatedCopy() const &
     result.protocol = protocol.isolatedCopy();
     result.host = host.isolatedCopy();
     result.port = port;
-    result.opaqueOriginIdentifier = opaqueOriginIdentifier;
 
     return result;
 }
@@ -139,7 +138,6 @@ SecurityOriginData SecurityOriginData::isolatedCopy() &&
     result.protocol = WTFMove(protocol).isolatedCopy();
     result.host = WTFMove(host).isolatedCopy();
     result.port = port;
-    result.opaqueOriginIdentifier = opaqueOriginIdentifier;
 
     return result;
 }
@@ -151,7 +149,7 @@ bool operator==(const SecurityOriginData& a, const SecurityOriginData& b)
 
     return a.protocol == b.protocol
         && a.host == b.host
-        && a.port == b.port
-        && a.opaqueOriginIdentifier == b.opaqueOriginIdentifier;
+        && a.port == b.port;
 }
+
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1620,6 +1620,12 @@ struct WebCore::DataListSuggestionInformation {
 };
 #endif
 
+struct WebCore::SecurityOriginData {
+    [Validator='!protocol->isHashTableDeletedValue()'] String protocol;
+    String host;
+    std::optional<uint16_t> port;
+};
+
 struct WebCore::ClientOrigin {
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData topOrigin;
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData clientOrigin;
@@ -2704,6 +2710,7 @@ struct WebCore::SameSiteInfo {
     WebCore::SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
+    Markable<WebCore::OpaqueOriginIdentifier, WebCore::OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
     bool m_universalAccess;
     bool m_domainWasSetInDOM;
     bool m_canLoadLocalResources;


### PR DESCRIPTION
#### f325cba93a2768f07e00aef75d293292c2c24607
<pre>
Revert [259432@main] Move Opaque Origin Identifier from SecurityOrigin to SecurityOriginData
<a href="https://bugs.webkit.org/show_bug.cgi?id=251048">https://bugs.webkit.org/show_bug.cgi?id=251048</a>
rdar://104578586

Unreviewed, revert 259432@main as it regressed ProcessSwap.GetUserMediaCaptureState API test.

* Source/WTF/wtf/Markable.h:
(WTF::add): Deleted.
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::SecurityOrigin):
(WebCore::SecurityOrigin::isSameOriginDomain const):
(WebCore::SecurityOrigin::isSameOriginAs const):
(WebCore::SecurityOrigin::create):
(WebCore::SecurityOrigin::equal const):
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::SecurityOrigin::isOpaque const):
(WebCore::add):
* Source/WebCore/page/SecurityOriginData.cpp:
(WebCore::SecurityOriginData::securityOrigin const):
(WebCore::SecurityOriginData::isolatedCopy const):
(WebCore::SecurityOriginData::isolatedCopy):
(WebCore::operator==):
* Source/WebCore/page/SecurityOriginData.h:
(WebCore::SecurityOriginData::SecurityOriginData):
(WebCore::SecurityOriginData::isOpaque const):
(WebCore::add):
(): Deleted.
(WebCore::SecurityOriginData::createOpaque): Deleted.
(WebCore::SecurityOriginData::encode const): Deleted.
(WebCore::SecurityOriginData::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259496@main">https://commits.webkit.org/259496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f44a2c2fbe3e69eff1ad3bd0ac6220f9e9476e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114298 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5036 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/113311 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110791 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/94881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27775 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92920 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5182 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7546 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30279 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47327 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101616 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6546 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9335 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25352 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->