### PR TITLE
Port ImageOrientation to the new serialization format

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3329,7 +3329,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return CSSPrimitiveValue::create(CSSValueNoLimit);
         return CSSPrimitiveValue::create(style.hyphenationLimitLines(), CSSUnitType::CSS_NUMBER);
     case CSSPropertyImageOrientation:
-        if (style.imageOrientation() == ImageOrientation::FromImage)
+        if (style.imageOrientation() == ImageOrientation::Orientation::FromImage)
             return CSSPrimitiveValue::create(CSSValueFromImage);
         return CSSPrimitiveValue::create(CSSValueNone);
     case CSSPropertyImageRendering:

--- a/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
+++ b/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
@@ -1242,7 +1242,7 @@ void BoxDecorationPainter::paintFillLayer(PaintingContext& paintingContext, cons
         op == CompositeOperator::SourceOver ? layer.composite() : op,
         layer.blendMode(),
         DecodingMode::Synchronous,
-        ImageOrientation::FromImage,
+        ImageOrientation::Orientation::FromImage,
         InterpolationQuality::Default
     };
 

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -578,7 +578,7 @@ DragImageRef DataTransfer::createDragImage(IntPoint& location) const
     location = m_dragLocation;
 
     if (m_dragImage)
-        return createDragImageFromImage(m_dragImage->image(), ImageOrientation::None);
+        return createDragImageFromImage(m_dragImage->image(), ImageOrientation::Orientation::None);
 
     if (m_dragImageElement) {
         if (Frame* frame = m_dragImageElement->document().frame())

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -383,8 +383,8 @@ void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, 
     }
 
     auto orientation = imageForRenderer->orientation();
-    if (orientation == ImageOrientation::FromImage)
-        orientation = ImageOrientation::None;
+    if (orientation == ImageOrientation::Orientation::FromImage)
+        orientation = ImageOrientation::Orientation::None;
 
     FloatRect destRect(FloatPoint(), outputSize);
     bitmapData->context().drawImage(*imageForRenderer, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(orientation) });
@@ -497,7 +497,7 @@ void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, 
     }
 
     FloatRect destRect(FloatPoint(), outputSize);
-    bitmapData->context().drawImage(*imageForRender, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::None) });
+    bitmapData->context().drawImage(*imageForRender, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });
 
     // 5. Set the origin-clean flag of the ImageBitmap object's bitmap to the same value as
     //    the origin-clean flag of the canvas element's bitmap.
@@ -632,7 +632,7 @@ void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, 
     auto imageForRender = existingImageBitmap->buffer()->copyImage();
 
     FloatRect destRect(FloatPoint(), outputSize);
-    bitmapData->context().drawImage(*imageForRender, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::None) });
+    bitmapData->context().drawImage(*imageForRender, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });
 
     // 5. Set the origin-clean flag of the ImageBitmap object's bitmap to the same
     //    value as the origin-clean flag of the bitmap of the image argument.
@@ -812,8 +812,8 @@ void ImageBitmap::createFromBuffer(ScriptExecutionContext& scriptExecutionContex
     }
 
     auto orientation = image->orientation();
-    if (orientation == ImageOrientation::FromImage)
-        orientation = ImageOrientation::None;
+    if (orientation == ImageOrientation::Orientation::FromImage)
+        orientation = ImageOrientation::Orientation::None;
 
     FloatRect destRect(FloatPoint(), outputSize);
     bitmapData->context().drawImage(image, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(orientation) });
@@ -881,7 +881,7 @@ void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, 
     }
     tempBitmapData->putPixelBuffer(imageData->pixelBuffer(), IntRect(0, 0, imageData->width(), imageData->height()), { }, alphaPremultiplication);
     FloatRect destRect(FloatPoint(), outputSize);
-    bitmapData->context().drawImageBuffer(*tempBitmapData, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::None) });
+    bitmapData->context().drawImageBuffer(*tempBitmapData, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });
 
     // 6.4.1. Resolve p with ImageBitmap.
     auto imageBitmap = create({ WTFMove(bitmapData) });

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1476,12 +1476,12 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLImageElement& imag
         return { };
     FloatRect imageRect = FloatRect(FloatPoint(), size(imageElement, ImageSizeType::BeforeDevicePixelRatio));
 
-    auto orientation = ImageOrientation::FromImage;
+    auto orientation = ImageOrientation::Orientation::FromImage;
     if (imageElement.allowsOrientationOverride()) {
         if (auto* renderer = imageElement.renderer())
-            orientation = renderer->style().imageOrientation();
+            orientation = renderer->style().imageOrientation().orientation();
         else if (auto* computedStyle = imageElement.computedStyle())
-            orientation = computedStyle->imageOrientation();
+            orientation = computedStyle->imageOrientation().orientation();
     }
 
     auto result = drawImage(imageElement.document(), imageElement.cachedImage(), imageElement.renderer(), imageRect, srcRect, dstRect, op, blendMode, orientation);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -364,7 +364,7 @@ private:
     ExceptionOr<void> drawImage(HTMLImageElement&, const FloatRect& srcRect, const FloatRect& dstRect);
     ExceptionOr<void> drawImage(HTMLImageElement&, const FloatRect& srcRect, const FloatRect& dstRect, const CompositeOperator&, const BlendMode&);
     ExceptionOr<void> drawImage(CanvasBase&, const FloatRect& srcRect, const FloatRect& dstRect);
-    ExceptionOr<void> drawImage(Document&, CachedImage*, const RenderObject*, const FloatRect& imageRect, const FloatRect& srcRect, const FloatRect& dstRect, const CompositeOperator&, const BlendMode&, ImageOrientation = ImageOrientation::FromImage);
+    ExceptionOr<void> drawImage(Document&, CachedImage*, const RenderObject*, const FloatRect& imageRect, const FloatRect& srcRect, const FloatRect& dstRect, const CompositeOperator&, const BlendMode&, ImageOrientation = ImageOrientation::Orientation::FromImage);
 #if ENABLE(VIDEO)
     ExceptionOr<void> drawImage(HTMLVideoElement&, const FloatRect& srcRect, const FloatRect& dstRect);
 #endif

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3642,7 +3642,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSourceHelper(TexImageFuncti
         if (!imageForRender)
             return { };
 
-        if (imageForRender->drawsSVGImage() || imageForRender->orientation() != ImageOrientation::None || imageForRender->hasDensityCorrectedSize())
+        if (imageForRender->drawsSVGImage() || imageForRender->orientation() != ImageOrientation::Orientation::None || imageForRender->hasDensityCorrectedSize())
             imageForRender = drawImageIntoBuffer(*imageForRender, image->width(), image->height(), 1, functionName);
 
         if (!imageForRender || !validateTexFunc(functionName, functionType, SourceHTMLImageElement, target, level, internalformat, imageForRender->width(), imageForRender->height(), depth, border, format, type, xoffset, yoffset, zoffset))

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -305,7 +305,7 @@ FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeT
     if (m_image->drawsSVGImage() && sizeType == UsedSize)
         return m_svgImageCache->imageSizeForRenderer(renderer);
 
-    return m_image->size(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::FromImage));
+    return m_image->size(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::Orientation::FromImage));
 }
 
 

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -97,10 +97,10 @@ RetainPtr<NSImage> createDragImageFromImage(Image* image, ImageOrientation orien
     if (is<BitmapImage>(*image)) {
         BitmapImage& bitmapImage = downcast<BitmapImage>(*image);
 
-        if (orientation == ImageOrientation::FromImage)
+        if (orientation == ImageOrientation::Orientation::FromImage)
             orientation = bitmapImage.orientationForCurrentFrame();
 
-        if (orientation != ImageOrientation::None) {
+        if (orientation != ImageOrientation::Orientation::None) {
             // Construct a correctly-rotated copy of the image to use as the drag image.
             FloatSize imageSize = image->size(orientation);
             RetainPtr<NSImage> rotatedDragImage = adoptNS([[NSImage alloc] initWithSize:(NSSize)(imageSize)]);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -101,7 +101,7 @@ public:
     bool needsCachedNativeImageInvalidationWorkaround(RenderingMode) final;
     void drawSystemImage(SystemImage&, const FloatRect&) final;
     void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& = { }) final;
-    ImageDrawResult drawImage(Image&, const FloatRect& destination, const FloatRect& source, const ImagePaintingOptions& = { ImageOrientation::FromImage }) final;
+    ImageDrawResult drawImage(Image&, const FloatRect& destination, const FloatRect& source, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage }) final;
     ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatPoint& source, const FloatSize& tileSize, const FloatSize& spacing, const ImagePaintingOptions& = { }) final;
     ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatRect& source, const FloatSize& tileScaleFactor, Image::TileRule, Image::TileRule, const ImagePaintingOptions& = { }) final;
 

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -156,9 +156,9 @@ RefPtr<NativeImage> BitmapImage::preTransformedNativeImageForCurrentFrame(bool r
     if (!image)
         return image;
 
-    auto orientation = respectOrientation ? orientationForCurrentFrame() : ImageOrientation(ImageOrientation::None);
+    auto orientation = respectOrientation ? orientationForCurrentFrame() : ImageOrientation(ImageOrientation::Orientation::None);
     auto correctedSize = m_source->densityCorrectedSize(orientation);
-    if (orientation == ImageOrientation::None && !correctedSize)
+    if (orientation == ImageOrientation::Orientation::None && !correctedSize)
         return image;
 
     auto correctedSizeFloat = correctedSize ? FloatSize(correctedSize.value()) : size();
@@ -318,7 +318,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
     }
 
     auto orientation = options.orientation();
-    if (orientation == ImageOrientation::FromImage) {
+    if (orientation == ImageOrientation::Orientation::FromImage) {
         orientation = frameOrientationAtIndex(m_currentFrame);
         drawNativeImage(*image, context, destRect, srcRect, IntSize(sourceSize(orientation)), { options, orientation });
     } else
@@ -342,7 +342,7 @@ void BitmapImage::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, 
         if (m_currentFrameDecodingStatus == DecodingStatus::Invalid)
             m_source->destroyIncompleteDecodedData();
         
-        Image::drawPattern(ctxt, destRect, tileRect, transform, phase, spacing, { options, ImageOrientation::FromImage });
+        Image::drawPattern(ctxt, destRect, tileRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });
         m_currentFrameDecodingStatus = frameDecodingStatusAtIndex(m_currentFrame);
         return;
     }
@@ -357,7 +357,7 @@ void BitmapImage::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, 
         // Temporarily reset image observer, we don't want to receive any changeInRect() calls due to this relayout.
         setImageObserver(nullptr);
 
-        draw(buffer->context(), tileRect, tileRect, { options, DecodingMode::Synchronous, ImageOrientation::FromImage });
+        draw(buffer->context(), tileRect, tileRect, { options, DecodingMode::Synchronous, ImageOrientation::Orientation::FromImage });
 
         setImageObserver(observer);
         buffer->convertToLuminanceMask();
@@ -368,7 +368,7 @@ void BitmapImage::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, 
     }
 
     ctxt.setDrawLuminanceMask(false);
-    m_cachedImage->drawPattern(ctxt, destRect, tileRect, transform, phase, spacing, { options, ImageOrientation::FromImage });
+    m_cachedImage->drawPattern(ctxt, destRect, tileRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });
 }
 
 bool BitmapImage::shouldAnimate() const

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -90,7 +90,7 @@ public:
     std::optional<IntPoint> hotSpot() const override { return m_source->hotSpot(); }
 
     // FloatSize due to override.
-    FloatSize size(ImageOrientation orientation = ImageOrientation::FromImage) const override { return m_source->size(orientation); }
+    FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const override { return m_source->size(orientation); }
     ImageOrientation orientation() const override { return m_source->orientation(); }
     Color singlePixelSolidColor() const override { return m_source->singlePixelSolidColor(); }
     bool frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(size_t index, const DecodingOptions& decodingOptions) const { return m_source->frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(index, decodingOptions); }
@@ -176,7 +176,7 @@ private:
     // |destroyAll| along.
     void destroyDecodedDataIfNecessary(bool destroyAll = true);
 
-    FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::FromImage) const final { return m_source->sourceSize(orientation); }
+    FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->sourceSize(orientation); }
     bool hasDensityCorrectedSize() const override { return m_source->hasDensityCorrectedSize(); }
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) override;

--- a/Source/WebCore/platform/graphics/CrossfadeGeneratedImage.h
+++ b/Source/WebCore/platform/graphics/CrossfadeGeneratedImage.h
@@ -44,7 +44,7 @@ public:
     bool hasRelativeWidth() const override { return false; }
     bool hasRelativeHeight() const override { return false; }
 
-    FloatSize size(ImageOrientation = ImageOrientation::FromImage) const override { return m_crossfadeSize; }
+    FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const override { return m_crossfadeSize; }
 
 private:
     ImageDrawResult draw(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) override;

--- a/Source/WebCore/platform/graphics/GeneratedImage.h
+++ b/Source/WebCore/platform/graphics/GeneratedImage.h
@@ -38,7 +38,7 @@ public:
     bool hasRelativeHeight() const override { return true; }
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) override;
 
-    FloatSize size(ImageOrientation = ImageOrientation::FromImage) const override { return m_size; }
+    FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const override { return m_size; }
 
     // Assume that generated content has no decoded data we need to worry about
     void destroyDecodedData(bool /*destroyAll*/ = true) override { }

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -613,7 +613,7 @@ void GraphicsContext::paintFrameForMedia(MediaPlayer& player, const FloatRect& d
 
 void GraphicsContext::paintVideoFrame(VideoFrame& frame, const FloatRect& destination, bool shouldDiscardAlpha)
 {
-    frame.paintInContext(*this, destination, ImageOrientation::None, shouldDiscardAlpha);
+    frame.paintInContext(*this, destination, ImageOrientation::Orientation::None, shouldDiscardAlpha);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -252,9 +252,9 @@ public:
 
     WEBCORE_EXPORT virtual void drawSystemImage(SystemImage&, const FloatRect&);
 
-    WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatPoint& destination, const ImagePaintingOptions& = { ImageOrientation::FromImage });
-    WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatRect& destination, const ImagePaintingOptions& = { ImageOrientation::FromImage });
-    WEBCORE_EXPORT virtual ImageDrawResult drawImage(Image&, const FloatRect& destination, const FloatRect& source, const ImagePaintingOptions& = { ImageOrientation::FromImage });
+    WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatPoint& destination, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage });
+    WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatRect& destination, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage });
+    WEBCORE_EXPORT virtual ImageDrawResult drawImage(Image&, const FloatRect& destination, const FloatRect& source, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage });
 
     WEBCORE_EXPORT virtual ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatPoint& source, const FloatSize& tileSize, const FloatSize& spacing, const ImagePaintingOptions& = { });
     WEBCORE_EXPORT virtual ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatRect& source, const FloatSize& tileScaleFactor, Image::TileRule, Image::TileRule, const ImagePaintingOptions& = { });

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -146,7 +146,7 @@ void Image::fillWithSolidColor(GraphicsContext& ctxt, const FloatRect& dstRect, 
 
 void Image::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform,  const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& options)
 {
-    auto tileImage = preTransformedNativeImageForCurrentFrame(options.orientation() == ImageOrientation::FromImage);
+    auto tileImage = preTransformedNativeImageForCurrentFrame(options.orientation() == ImageOrientation::Orientation::FromImage);
     if (!tileImage)
         return;
 

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -116,14 +116,14 @@ public:
     virtual bool hasRelativeHeight() const { return false; }
     virtual void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
-    virtual FloatSize size(ImageOrientation = ImageOrientation::FromImage) const = 0;
-    virtual FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::FromImage) const { return size(orientation); }
+    virtual FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const = 0;
+    virtual FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return size(orientation); }
     virtual bool hasDensityCorrectedSize() const { return false; }
     FloatRect rect() const { return FloatRect(FloatPoint(), size()); }
     float width() const { return size().width(); }
     float height() const { return size().height(); }
     virtual std::optional<IntPoint> hotSpot() const { return std::nullopt; }
-    virtual ImageOrientation orientation() const { return ImageOrientation::FromImage; }
+    virtual ImageOrientation orientation() const { return ImageOrientation::Orientation::FromImage; }
 
     WEBCORE_EXPORT EncodedDataStatus setData(RefPtr<FragmentedSharedBuffer>&& data, bool allDataReceived);
     virtual EncodedDataStatus dataChanged(bool /*allDataReceived*/) { return EncodedDataStatus::Unknown; }

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -98,7 +98,7 @@ private:
     SubsamplingLevel m_subsamplingLevel { SubsamplingLevel::Default };
     DecodingOptions m_decodingOptions;
 
-    ImageOrientation m_orientation { ImageOrientation::None };
+    ImageOrientation m_orientation { ImageOrientation::Orientation::None };
     std::optional<IntSize> m_densityCorrectedSize;
     Seconds m_duration;
     bool m_hasAlpha { true };

--- a/Source/WebCore/platform/graphics/ImagePaintingOptions.h
+++ b/Source/WebCore/platform/graphics/ImagePaintingOptions.h
@@ -28,6 +28,7 @@
 #include "DecodingOptions.h"
 #include "GraphicsTypes.h"
 #include "ImageOrientation.h"
+#include <wtf/ArgumentCoder.h>
 
 namespace WebCore {
 
@@ -63,10 +64,8 @@ struct ImagePaintingOptions {
     ImageOrientation orientation() const { return m_orientation; }
     InterpolationQuality interpolationQuality() const { return m_interpolationQuality; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ImagePaintingOptions> decode(Decoder&);
-
 private:
+    friend struct IPC::ArgumentCoder<ImagePaintingOptions, void>;
     template <typename First, typename... Rest>
     void setOption(First first, Rest... rest)
     {
@@ -84,49 +83,8 @@ private:
     CompositeOperator m_compositeOperator { CompositeOperator::SourceOver };
     BlendMode m_blendMode { BlendMode::Normal };
     DecodingMode m_decodingMode { DecodingMode::Synchronous };
-    ImageOrientation m_orientation { ImageOrientation::None };
+    ImageOrientation m_orientation { ImageOrientation::Orientation::None };
     InterpolationQuality m_interpolationQuality { InterpolationQuality::Default };
 };
-
-template<class Encoder>
-void ImagePaintingOptions::encode(Encoder& encoder) const
-{
-    encoder << m_compositeOperator;
-    encoder << m_blendMode;
-    encoder << m_decodingMode;
-    encoder << ImageOrientation::Orientation(m_orientation);
-    encoder << m_interpolationQuality;
-}
-
-template<class Decoder>
-std::optional<ImagePaintingOptions> ImagePaintingOptions::decode(Decoder& decoder)
-{
-    std::optional<CompositeOperator> compositeOperator;
-    decoder >> compositeOperator;
-    if (!compositeOperator)
-        return std::nullopt;
-
-    std::optional<BlendMode> blendMode;
-    decoder >> blendMode;
-    if (!blendMode)
-        return std::nullopt;
-
-    std::optional<DecodingMode> decodingMode;
-    decoder >> decodingMode;
-    if (!decodingMode)
-        return std::nullopt;
-
-    std::optional<ImageOrientation::Orientation> orientation;
-    decoder >> orientation;
-    if (!orientation)
-        return std::nullopt;
-
-    std::optional<InterpolationQuality> interpolationQuality;
-    decoder >> interpolationQuality;
-    if (!interpolationQuality)
-        return std::nullopt;
-
-    return ImagePaintingOptions { *compositeOperator, *blendMode, *decodingMode, *orientation, *interpolationQuality };
-}
 
 }

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -57,7 +57,7 @@ ImageSource::ImageSource(Ref<NativeImage>&& nativeImage)
     m_decodedSize = m_frames[0].frameBytes();
 
     m_size = m_frames[0].size();
-    m_orientation = ImageOrientation(ImageOrientation::None);
+    m_orientation = ImageOrientation(ImageOrientation::Orientation::None);
     m_cachedMetadata.add({ MetadataType::Orientation, MetadataType::Size });
 }
 
@@ -571,7 +571,7 @@ std::optional<IntSize> ImageSource::densityCorrectedSize(ImageOrientation orient
     if (!size)
         return std::nullopt;
 
-    if (orientation == ImageOrientation::FromImage)
+    if (orientation == ImageOrientation::Orientation::FromImage)
         orientation = this->orientation();
 
     return orientation.usesWidthAsHeight() ? std::optional<IntSize>(size.value().transposedSize()) : size;
@@ -595,7 +595,7 @@ IntSize ImageSource::sourceSize(ImageOrientation orientation)
 #endif
         size = firstFrameMetadataCacheIfNeeded(m_size, MetadataType::Size, &ImageFrame::size, ImageFrame::Caching::Metadata, SubsamplingLevel::Default);
     
-    if (orientation == ImageOrientation::FromImage)
+    if (orientation == ImageOrientation::Orientation::FromImage)
         orientation = this->orientation();
 
     return orientation.usesWidthAsHeight() ? size.transposedSize() : size;
@@ -713,7 +713,7 @@ void ImageSource::dump(TextStream& ts)
     ts.dumpProperty("solid-color", singlePixelSolidColor());
 
     ImageOrientation orientation = frameOrientationAtIndex(0);
-    if (orientation != ImageOrientation::None)
+    if (orientation != ImageOrientation::Orientation::None)
         ts.dumpProperty("orientation", orientation);
 }
 

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -93,14 +93,14 @@ public:
     String filenameExtension();
     String accessibilityDescription();
     std::optional<IntPoint> hotSpot();
-    std::optional<IntSize> densityCorrectedSize(ImageOrientation = ImageOrientation::FromImage);
+    std::optional<IntSize> densityCorrectedSize(ImageOrientation = ImageOrientation::Orientation::FromImage);
     bool hasDensityCorrectedSize() { return densityCorrectedSize().has_value(); }
 
     ImageOrientation orientation();
 
     // Image metadata which is calculated from the first ImageFrame.
-    WEBCORE_EXPORT IntSize size(ImageOrientation = ImageOrientation::FromImage);
-    IntSize sourceSize(ImageOrientation = ImageOrientation::FromImage);
+    WEBCORE_EXPORT IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage);
+    IntSize sourceSize(ImageOrientation = ImageOrientation::Orientation::FromImage);
     IntSize sizeRespectingOrientation();
     Color singlePixelSolidColor();
     SubsamplingLevel maximumSubsamplingLevel();

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -117,7 +117,7 @@ private:
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final { }
 
-    ImageDrawResult drawImage(Image&, const FloatRect&, const FloatRect&, const ImagePaintingOptions& = { ImageOrientation::FromImage }) final { return ImageDrawResult::DidNothing; }
+    ImageDrawResult drawImage(Image&, const FloatRect&, const FloatRect&, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage }) final { return ImageDrawResult::DidNothing; }
 
     ImageDrawResult drawTiledImage(Image&, const FloatRect&, const FloatPoint&, const FloatSize&, const FloatSize&, const ImagePaintingOptions& = { }) final { return ImageDrawResult::DidNothing; }
     ImageDrawResult drawTiledImage(Image&, const FloatRect&, const FloatRect&, const FloatSize&, Image::TileRule, Image::TileRule, const ImagePaintingOptions& = { }) final { return ImageDrawResult::DidNothing; }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -830,7 +830,7 @@ void drawPlatformImage(GraphicsContextCairo& platformContext, cairo_surface_t* s
         Cairo::State::setCompositeOperation(platformContext, options.compositeOperator(), options.blendMode());
 
     FloatRect dst = destRect;
-    if (options.orientation() != ImageOrientation::None) {
+    if (options.orientation() != ImageOrientation::Orientation::None) {
         // ImageOrientation expects the origin to be at (0, 0).
         Cairo::translate(platformContext, dst.x(), dst.y());
         dst.setLocation(FloatPoint());

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -262,7 +262,7 @@ void GraphicsContextCG::drawNativeImage(NativeImage& nativeImage, const FloatSiz
     auto getSubimage = [](CGImageRef image, const FloatSize& imageSize, const FloatRect& subimageRect, const ImagePaintingOptions& options) -> RetainPtr<CGImageRef> {
         auto physicalSubimageRect = subimageRect;
 
-        if (options.orientation() != ImageOrientation::None) {
+        if (options.orientation() != ImageOrientation::Orientation::None) {
             // subimageRect is in logical coordinates. getSubimage() deals with none-oriented
             // image. We need to convert subimageRect to physical image coordinates.
             if (auto transform = options.orientation().transformFromDefault(imageSize).inverse())
@@ -347,7 +347,7 @@ void GraphicsContextCG::drawNativeImage(NativeImage& nativeImage, const FloatSiz
     CGContextTranslateCTM(context, adjustedDestRect.x(), adjustedDestRect.y());
     adjustedDestRect.setLocation(FloatPoint::zero());
 
-    if (options.orientation() != ImageOrientation::None) {
+    if (options.orientation() != ImageOrientation::Orientation::None) {
         CGContextConcatCTM(context, options.orientation().transformFromDefault(adjustedDestRect.size()));
 
         // The destination rect will have its width and height already reversed for the orientation of

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -195,7 +195,7 @@ static ImageOrientation orientationFromProperties(CFDictionaryRef imagePropertie
     ASSERT(imageProperties);
     CFNumberRef orientationProperty = (CFNumberRef)CFDictionaryGetValue(imageProperties, kCGImagePropertyOrientation);
     if (!orientationProperty)
-        return ImageOrientation::None;
+        return ImageOrientation::Orientation::None;
     
     int exifValue;
     CFNumberGetValue(orientationProperty, kCFNumberIntType, &exifValue);

--- a/Source/WebCore/platform/graphics/cg/PDFDocumentImage.h
+++ b/Source/WebCore/platform/graphics/cg/PDFDocumentImage.h
@@ -73,7 +73,7 @@ private:
     void destroyDecodedData(bool /*destroyAll*/ = true) override;
 
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) override;
-    FloatSize size(ImageOrientation = ImageOrientation::FromImage) const override;
+    FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const override;
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) override;
 

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -367,7 +367,7 @@ void DrawGlyphsRecorder::recordDrawImage(CGRenderingStateRef, CGGStateRef gstate
     m_owner.scale(FloatSize(1, -1));
 
     auto image = NativeImage::create(cgImage);
-    m_owner.drawNativeImage(*image, image->size(), FloatRect(rect), FloatRect {{ }, image->size()}, ImagePaintingOptions { ImageOrientation::OriginTopLeft });
+    m_owner.drawNativeImage(*image, image->size(), FloatRect(rect), FloatRect { { }, image->size() }, ImagePaintingOptions { ImageOrientation::Orientation::OriginTopLeft });
 
     // Undo the above y-flip to restore the context.
     m_owner.scale(FloatSize(1, -1));

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
@@ -455,7 +455,7 @@ inline bool GraphicsContextGLCVCocoa::TextureContent::operator==(const TextureCo
         && format == other.format
         && type == other.type
         && unpackFlipY == other.unpackFlipY
-        && ImageOrientation::Orientation(orientation) == ImageOrientation::Orientation(other.orientation);
+        && orientation == other.orientation;
 }
 
 std::unique_ptr<GraphicsContextGLCVCocoa> GraphicsContextGLCVCocoa::create(GraphicsContextGLCocoa& context)
@@ -633,38 +633,38 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     bool flipY = false; // Flip y coordinate, i.e. mirrored along the x-axis.
     bool flipX = false; // Flip x coordinate, i.e. mirrored along the y-axis.
     bool swapXY = false;
-    switch (videoFrame.orientation()) {
-    case ImageOrientation::FromImage:
-    case ImageOrientation::OriginTopLeft:
+    switch (videoFrame.orientation().orientation()) {
+    case ImageOrientation::Orientation::FromImage:
+    case ImageOrientation::Orientation::OriginTopLeft:
         break;
-    case ImageOrientation::OriginTopRight:
+    case ImageOrientation::Orientation::OriginTopRight:
         flipX = true;
         break;
-    case ImageOrientation::OriginBottomRight:
+    case ImageOrientation::Orientation::OriginBottomRight:
         // Rotated 180 degrees.
         flipY = true;
         flipX = true;
         break;
-    case ImageOrientation::OriginBottomLeft:
+    case ImageOrientation::Orientation::OriginBottomLeft:
         // Mirrored along the x-axis.
         flipY = true;
         break;
-    case ImageOrientation::OriginLeftTop:
+    case ImageOrientation::Orientation::OriginLeftTop:
         // Mirrored along x-axis and rotated 270 degrees clock-wise.
         swapXY = true;
         break;
-    case ImageOrientation::OriginRightTop:
+    case ImageOrientation::Orientation::OriginRightTop:
         // Rotated 90 degrees clock-wise.
         flipX = true;
         swapXY = true;
         break;
-    case ImageOrientation::OriginRightBottom:
+    case ImageOrientation::Orientation::OriginRightBottom:
         // Mirror along x-axis and rotated 90 degrees clockwise.
         flipY = true;
         flipX = true;
         swapXY = true;
         break;
-    case ImageOrientation::OriginLeftBottom:
+    case ImageOrientation::Orientation::OriginLeftBottom:
         // Rotated 270 degrees clock-wise.
         flipY = true;
         swapXY = true;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -526,13 +526,13 @@ ImageOrientation VideoFrameCV::orientation() const
     // Sample transform first flips x-coordinates, then rotates.
     switch (rotation()) {
     case VideoFrame::Rotation::None:
-        return isMirrored() ? ImageOrientation::OriginTopRight : ImageOrientation::OriginTopLeft;
+        return isMirrored() ? ImageOrientation::Orientation::OriginTopRight : ImageOrientation::Orientation::OriginTopLeft;
     case VideoFrame::Rotation::Right:
-        return isMirrored() ? ImageOrientation::OriginRightBottom : ImageOrientation::OriginRightTop;
+        return isMirrored() ? ImageOrientation::Orientation::OriginRightBottom : ImageOrientation::Orientation::OriginRightTop;
     case VideoFrame::Rotation::UpsideDown:
-        return isMirrored() ? ImageOrientation::OriginBottomLeft : ImageOrientation::OriginBottomRight;
+        return isMirrored() ? ImageOrientation::Orientation::OriginBottomLeft : ImageOrientation::Orientation::OriginBottomRight;
     case VideoFrame::Rotation::Left:
-        return isMirrored() ? ImageOrientation::OriginLeftTop : ImageOrientation::OriginLeftBottom;
+        return isMirrored() ? ImageOrientation::Orientation::OriginLeftTop : ImageOrientation::Orientation::OriginLeftBottom;
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3305,27 +3305,27 @@ static ImageOrientation getVideoOrientation(const GstTagList* tagList)
     GUniqueOutPtr<gchar> tag;
     if (!gst_tag_list_get_string(tagList, GST_TAG_IMAGE_ORIENTATION, &tag.outPtr())) {
         GST_DEBUG("No image_orientation tag, applying no rotation.");
-        return ImageOrientation::None;
+        return ImageOrientation::Orientation::None;
     }
 
     GST_DEBUG("Found image_orientation tag: %s", tag.get());
     if (!g_strcmp0(tag.get(), "flip-rotate-0"))
-        return ImageOrientation::OriginTopRight;
+        return ImageOrientation::Orientation::OriginTopRight;
     if (!g_strcmp0(tag.get(), "rotate-180"))
-        return ImageOrientation::OriginBottomRight;
+        return ImageOrientation::Orientation::OriginBottomRight;
     if (!g_strcmp0(tag.get(), "flip-rotate-180"))
-        return ImageOrientation::OriginBottomLeft;
+        return ImageOrientation::Orientation::OriginBottomLeft;
     if (!g_strcmp0(tag.get(), "flip-rotate-270"))
-        return ImageOrientation::OriginLeftTop;
+        return ImageOrientation::Orientation::OriginLeftTop;
     if (!g_strcmp0(tag.get(), "rotate-90"))
-        return ImageOrientation::OriginRightTop;
+        return ImageOrientation::Orientation::OriginRightTop;
     if (!g_strcmp0(tag.get(), "flip-rotate-90"))
-        return ImageOrientation::OriginRightBottom;
+        return ImageOrientation::Orientation::OriginRightBottom;
     if (!g_strcmp0(tag.get(), "rotate-270"))
-        return ImageOrientation::OriginLeftBottom;
+        return ImageOrientation::Orientation::OriginLeftBottom;
 
     // Default rotation.
-    return ImageOrientation::None;
+    return ImageOrientation::Orientation::None;
 }
 
 void MediaPlayerPrivateGStreamer::updateVideoOrientation(const GstTagList* tagList)
@@ -3368,11 +3368,11 @@ void MediaPlayerPrivateGStreamer::updateVideoSizeAndOrientationFromCaps(const Gs
     auto pad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
     ASSERT(pad);
     auto tagsEvent = adoptGRef(gst_pad_get_sticky_event(pad.get(), GST_EVENT_TAG, 0));
-    auto orientation = ImageOrientation::None;
+    auto orientation = ImageOrientation::Orientation::None;
     if (tagsEvent) {
         GstTagList* tagList;
         gst_event_parse_tag(tagsEvent.get(), &tagList);
-        orientation = getVideoOrientation(tagList);
+        orientation = getVideoOrientation(tagList).orientation();
     }
 
     setVideoSourceOrientation(orientation);
@@ -3669,20 +3669,20 @@ bool MediaPlayerPrivateGStreamer::setVideoSourceOrientation(ImageOrientation ori
 #if USE(TEXTURE_MAPPER_GL)
 void MediaPlayerPrivateGStreamer::updateTextureMapperFlags()
 {
-    switch (m_videoSourceOrientation) {
-    case ImageOrientation::OriginTopLeft:
+    switch (m_videoSourceOrientation.orientation()) {
+    case ImageOrientation::Orientation::OriginTopLeft:
         m_textureMapperFlags = 0;
         break;
-    case ImageOrientation::OriginRightTop:
+    case ImageOrientation::Orientation::OriginRightTop:
         m_textureMapperFlags = TextureMapperGL::ShouldRotateTexture90;
         break;
-    case ImageOrientation::OriginBottomRight:
+    case ImageOrientation::Orientation::OriginBottomRight:
         m_textureMapperFlags = TextureMapperGL::ShouldRotateTexture180;
         break;
-    case ImageOrientation::OriginLeftBottom:
+    case ImageOrientation::Orientation::OriginLeftBottom:
         m_textureMapperFlags = TextureMapperGL::ShouldRotateTexture270;
         break;
-    case ImageOrientation::OriginBottomLeft:
+    case ImageOrientation::Orientation::OriginBottomLeft:
         m_textureMapperFlags = TextureMapperGL::ShouldFlipTexture;
         break;
     default:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.cpp
@@ -94,18 +94,18 @@ void VideoTextureCopierGStreamer::updateTextureSpaceMatrix()
 {
     m_textureSpaceMatrix.makeIdentity();
 
-    switch (m_orientation) {
-    case ImageOrientation::OriginTopLeft:
+    switch (m_orientation.orientation()) {
+    case ImageOrientation::Orientation::OriginTopLeft:
         break;
-    case ImageOrientation::OriginRightTop:
+    case ImageOrientation::Orientation::OriginRightTop:
         m_textureSpaceMatrix.rotate(-90);
         m_textureSpaceMatrix.translate(-1, 0);
         break;
-    case ImageOrientation::OriginBottomRight:
+    case ImageOrientation::Orientation::OriginBottomRight:
         m_textureSpaceMatrix.rotate(180);
         m_textureSpaceMatrix.translate(-1, -1);
         break;
-    case ImageOrientation::OriginLeftBottom:
+    case ImageOrientation::Orientation::OriginLeftBottom:
         m_textureSpaceMatrix.rotate(-270);
         m_textureSpaceMatrix.translate(0, -1);
         break;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -293,7 +293,7 @@ void ControlMac::drawListButton(GraphicsContext& context, const FloatRect& rect,
     comboBoxButtonContext.scale(desiredComboBoxButtonSize.width() / comboBoxButtonSize.width());
     comboBoxButtonContext.clipRoundedRect(FloatRoundedRect(FloatRect(FloatPoint::zero(), comboBoxButtonSize), FloatRoundedRect::Radii(comboBoxButtonCornerRadii)));
     comboBoxButtonContext.translate(comboBoxButtonInset.scaled(-1));
-    comboBoxButtonContext.drawConsumingImageBuffer(WTFMove(comboBoxImageBuffer), FloatPoint::zero(), ImagePaintingOptions { ImageOrientation::OriginBottomRight });
+    comboBoxButtonContext.drawConsumingImageBuffer(WTFMove(comboBoxImageBuffer), FloatPoint::zero(), ImagePaintingOptions { ImageOrientation::Orientation::OriginBottomRight });
 
     FloatPoint listButtonLocation;
     float listButtonY = rect.center().y() - desiredComboBoxButtonSize.height() / 2;

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.h
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.h
@@ -82,7 +82,7 @@ private:
     std::unique_ptr<ImageBackingStore> m_backingStore;
     DisposalMethod m_disposalMethod { DisposalMethod::Unspecified };
 
-    ImageOrientation m_orientation { ImageOrientation::None };
+    ImageOrientation m_orientation { ImageOrientation::Orientation::None };
     Seconds m_duration;
     bool m_hasAlpha { true };
 };

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -195,7 +195,7 @@ static ImageOrientation readImageOrientation(jpeg_decompress_struct* info)
         }
     }
 
-    return ImageOrientation::None;
+    return ImageOrientation::Orientation::None;
 }
 
 #if USE(LCMS)

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -401,7 +401,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
                 op == CompositeOperator::SourceOver ? bgLayer.compositeForPainting() : op,
                 bgLayer.blendMode(),
                 m_renderer.decodingModeForImageDraw(*image, m_paintInfo),
-                ImageOrientation::FromImage,
+                ImageOrientation::Orientation::FromImage,
                 m_renderer.chooseInterpolationQuality(context, *image, &bgLayer, geometry.tileSize)
             };
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1876,7 +1876,7 @@ bool RenderElement::checkForRepaintDuringLayout() const
 ImageOrientation RenderElement::imageOrientation() const
 {
     auto* imageElement = dynamicDowncast<HTMLImageElement>(element());
-    return (imageElement && !imageElement->allowsOrientationOverride()) ? ImageOrientation(ImageOrientation::FromImage) : style().imageOrientation();
+    return (imageElement && !imageElement->allowsOrientationOverride()) ? ImageOrientation(ImageOrientation::Orientation::FromImage) : style().imageOrientation();
 }
 
 void RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded(const RenderStyle& oldStyle, const RenderStyle& newStyle)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3002,7 +3002,7 @@ bool RenderLayerBacking::isDirectlyCompositedImage() const
         if (!is<BitmapImage>(image))
             return false;
 
-        if (downcast<BitmapImage>(*image).orientationForCurrentFrame() != ImageOrientation::None)
+        if (downcast<BitmapImage>(*image).orientationForCurrentFrame() != ImageOrientation::Orientation::None)
             return false;
 
 #if (PLATFORM(GTK) || PLATFORM(WPE))
@@ -3044,7 +3044,7 @@ bool RenderLayerBacking::isUnscaledBitmapOnly() const
             if (!is<BitmapImage>(image))
                 return false;
 
-            if (downcast<BitmapImage>(*image).orientationForCurrentFrame() != ImageOrientation::None)
+            if (downcast<BitmapImage>(*image).orientationForCurrentFrame() != ImageOrientation::Orientation::None)
                 return false;
 
             return contents.size() == image->size();

--- a/Source/WebCore/rendering/style/NinePieceImage.cpp
+++ b/Source/WebCore/rendering/style/NinePieceImage.cpp
@@ -223,13 +223,13 @@ void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement
             continue;
 
         if (isCornerPiece(piece)) {
-            graphicsContext.drawImage(*image, destinationRects[piece], sourceRects[piece], { op, ImageOrientation::FromImage });
+            graphicsContext.drawImage(*image, destinationRects[piece], sourceRects[piece], { op, ImageOrientation::Orientation::FromImage });
             continue;
         }
 
         Image::TileRule hRule = isHorizontalPiece(piece) ? static_cast<Image::TileRule>(horizontalRule()) : Image::StretchTile;
         Image::TileRule vRule = isVerticalPiece(piece) ? static_cast<Image::TileRule>(verticalRule()) : Image::StretchTile;
-        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::FromImage });
+        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::Orientation::FromImage });
     }
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1816,7 +1816,7 @@ public:
     static OptionSet<TextEmphasisPosition> initialTextEmphasisPosition() { return { TextEmphasisPosition::Over, TextEmphasisPosition::Right }; }
     static RubyPosition initialRubyPosition() { return RubyPosition::Before; }
     static OptionSet<LineBoxContain> initialLineBoxContain() { return { LineBoxContain::Block, LineBoxContain::Inline, LineBoxContain::Replaced }; }
-    static ImageOrientation initialImageOrientation() { return ImageOrientation::FromImage; }
+    static ImageOrientation initialImageOrientation() { return ImageOrientation::Orientation::FromImage; }
     static ImageRendering initialImageRendering() { return ImageRendering::Auto; }
     static ImageResolutionSource initialImageResolutionSource() { return ImageResolutionSource::Specified; }
     static ImageResolutionSnap initialImageResolutionSnap() { return ImageResolutionSnap::None; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -492,8 +492,8 @@ inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState&,
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.valueID() == CSSValueFromImage)
-        return ImageOrientation::FromImage;
-    return ImageOrientation::None;
+        return ImageOrientation::Orientation::FromImage;
+    return ImageOrientation::Orientation::None;
 }
 
 inline TransformOperations BuilderConverter::convertTransform(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -48,7 +48,7 @@ public:
     FrameView* frameView() const;
 
     bool isSVGImage() const final { return true; }
-    FloatSize size(ImageOrientation = ImageOrientation::FromImage) const final { return m_intrinsicSize; }
+    FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_intrinsicSize; }
 
     bool renderingTaintsOrigin() const final;
 

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.h
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.h
@@ -43,7 +43,7 @@ public:
 
     bool isSVGImageForContainer() const final { return true; }
 
-    FloatSize size(ImageOrientation = ImageOrientation::FromImage) const final;
+    FloatSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final;
 
     bool usesContainerSize() const final { return m_image->usesContainerSize(); }
     bool hasRelativeWidth() const final { return m_image->hasRelativeWidth(); }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3263,3 +3263,27 @@ header: <WebCore/DisplayListItems.h>
     uint8_t m_styleMode;
     bool m_styleShouldUseDarkAppearance;
 };
+
+[Nested] enum class WebCore::ImageOrientation::Orientation : int {
+    FromImage,
+    OriginTopLeft,
+    OriginTopRight,
+    OriginBottomRight,
+    OriginBottomLeft,
+    OriginLeftTop,
+    OriginRightTop,
+    OriginRightBottom,
+    OriginLeftBottom,
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ImageOrientation {
+    WebCore::ImageOrientation::Orientation orientation()
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ImagePaintingOptions {
+     WebCore::CompositeOperator m_compositeOperator;
+     WebCore::BlendMode m_blendMode;
+     WebCore::DecodingMode m_decodingMode;
+     WebCore::ImageOrientation m_orientation;
+     WebCore::InterpolationQuality m_interpolationQuality;
+};


### PR DESCRIPTION
#### 1e74777056c56506dc7ac1ff1015959b98295301
<pre>
Port ImageOrientation to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251270">https://bugs.webkit.org/show_bug.cgi?id=251270</a>
rdar://104745560

Reviewed by Alex Christensen.

This change refactors ImageOrientation::Orientation to use an enum class
so it can then be serialized over CoreIPC. It also includes the porting
over of the related types to the new serialization format, including:
    - ImagePaintingOptions
    - ImageOrientation
    - WebCore::ImageOrientation::Orientation

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp:
(WebCore::Display::BoxDecorationPainter::paintFillLayer const):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::createDragImage const):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createPromise):
(WebCore::ImageBitmap::createFromBuffer):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::imageSizeForRenderer const):
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageFromImage):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::preTransformedNativeImageForCurrentFrame):
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::drawPattern):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/CrossfadeGeneratedImage.h:
* Source/WebCore/platform/graphics/GeneratedImage.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::paintVideoFrame):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::drawImage):
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::drawPattern):
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::sourceSize const):
(WebCore::Image::orientation const):
* Source/WebCore/platform/graphics/ImageFrame.h:
* Source/WebCore/platform/graphics/ImageOrientation.h:
(WebCore::ImageOrientation::ImageOrientation):
(WebCore::ImageOrientation::fromEXIFValue):
(WebCore::ImageOrientation::operator int const):
(WebCore::ImageOrientation::operator==):
(WebCore::ImageOrientation::operator!=):
(WebCore::ImageOrientation::orientation const):
(WebCore::ImageOrientation::usesWidthAsHeight const):
(WebCore::ImageOrientation::transformFromDefault const):
(WebCore::ImageOrientation::withFlippedY const):
(WebCore::ImageOrientation::operator Orientation const): Deleted.
* Source/WebCore/platform/graphics/ImagePaintingOptions.h:
(WebCore::ImagePaintingOptions::encode const): Deleted.
(WebCore::ImagePaintingOptions::decode): Deleted.
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::ImageSource):
(WebCore::ImageSource::densityCorrectedSize):
(WebCore::ImageSource::sourceSize):
(WebCore::ImageSource::dump):
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
(WebCore::NullGraphicsContext::drawImage):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImage):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::orientationFromProperties):
* Source/WebCore/platform/graphics/cg/PDFDocumentImage.h:
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::recordDrawImage):
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp:
(WebCore::GraphicsContextGLCVCocoa::TextureContent::operator== const):
(WebCore::GraphicsContextGLCVCocoa::copyVideoSampleToTexture):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrameCV::orientation const):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawListButton):
* Source/WebCore/platform/image-decoders/ScalableImageDecoderFrame.h:
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::imageOrientation const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isDirectlyCompositedImage const):
(WebCore::RenderLayerBacking::isUnscaledBitmapOnly const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::paintAttachmentIcon):
* Source/WebCore/rendering/style/NinePieceImage.cpp:
(WebCore::NinePieceImage::paint const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::initialImageOrientation):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertImageOrientation):
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/svg/graphics/SVGImageForContainer.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259746@main">https://commits.webkit.org/259746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fac957edf31f22545d826d7a09436f08f76222fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114952 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175089 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6019 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97989 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39815 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26969 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8087 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4906 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6739 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10134 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->