### PR TITLE
[ews-build.webkit.org] Delete BugzillaMixin.create_bug

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1559,28 +1559,6 @@ class BugzillaMixin(AddToLogMixin):
             return FAILURE
         return SUCCESS
 
-    def create_bug(self, bug_title, bug_description, component='Tools / Tests', cc_list=None):
-        bug_url = '{}rest/bug'.format(BUG_SERVER_URL)
-        if not (bug_title and bug_description):
-            return FAILURE
-
-        try:
-            response = requests.post(bug_url, data={'product': 'WebKit',
-                                                    'component': component,
-                                                    'version': 'WebKit Nightly Build',
-                                                    'summary': bug_title,
-                                                    'description': bug_description,
-                                                    'cc': cc_list,
-                                                    'Bugzilla_api_key': self.get_bugzilla_api_key()})
-            if response.status_code not in [200, 201]:
-                self._addToLog('stdio', 'Unable to file bug. Unexpected response code from bugzilla: {}'.format(response.status_code))
-                return FAILURE
-        except Exception as e:
-            self._addToLog('stdio', 'Error in creating bug: {}'.format(bug_title))
-            return FAILURE
-        self._addToLog('stdio', 'Filed bug: {}'.format(bug_title))
-        return SUCCESS
-
 
 class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
     name = 'validate-change'


### PR DESCRIPTION
#### 9283f7bed93a52fa7668843c9f57ed43f39c6be9
<pre>
[ews-build.webkit.org] Delete BugzillaMixin.create_bug
<a href="https://bugs.webkit.org/show_bug.cgi?id=251280">https://bugs.webkit.org/show_bug.cgi?id=251280</a>
rdar://104751558

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(BugzillaMixin.create_bug): Deleted.

Canonical link: <a href="https://commits.webkit.org/259502@main">https://commits.webkit.org/259502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d5c402f3312b29173dea730e240746af0b03bfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114314 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5052 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/113327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110807 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7468 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/103850 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13617 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3495 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->