### PR TITLE
[JSC] Add strength reduction for SIMD Vector logic operations

### DIFF
--- a/Source/JavaScriptCore/b3/B3Const128Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const128Value.cpp
@@ -32,6 +32,30 @@ namespace JSC { namespace B3 {
 
 Const128Value::~Const128Value() = default;
 
+Value* Const128Value::vectorAndConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasV128())
+        return nullptr;
+    v128_t result = vectorAnd(m_value, other->asV128());
+    return proc.add<Const128Value>(origin(), result);
+}
+
+Value* Const128Value::vectorOrConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasV128())
+        return nullptr;
+    v128_t result = vectorOr(m_value, other->asV128());
+    return proc.add<Const128Value>(origin(), result);
+}
+
+Value* Const128Value::vectorXorConstant(Procedure& proc, const Value* other) const
+{
+    if (!other->hasV128())
+        return nullptr;
+    v128_t result = vectorXor(m_value, other->asV128());
+    return proc.add<Const128Value>(origin(), result);
+}
+
 void Const128Value::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {
     out.print(comma, m_value.u64x2[0], comma, m_value.u64x2[1]);

--- a/Source/JavaScriptCore/b3/B3Const128Value.h
+++ b/Source/JavaScriptCore/b3/B3Const128Value.h
@@ -39,6 +39,10 @@ public:
 
     inline v128_t value() const { return m_value; }
 
+    Value* vectorAndConstant(Procedure&, const Value* other) const final;
+    Value* vectorOrConstant(Procedure&, const Value* other) const final;
+    Value* vectorXorConstant(Procedure&, const Value* other) const final;
+
     B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
 
 protected:

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -1317,7 +1317,7 @@ private:
             }
 
             // Turn this: BitOr(BitOr(value, constant1), constant2)
-            // Into this: BitOr(value, constant1 & constant2).
+            // Into this: BitOr(value, constant1 | constant2).
             if (m_value->child(0)->opcode() == BitOr) {
                 Value* newConstant = m_value->child(1)->bitOrConstant(m_proc, m_value->child(0)->child(1));
                 if (newConstant) {
@@ -2445,15 +2445,228 @@ private:
             break;
         }
 
-        case VectorSwizzle: {
-            if constexpr (isARM64()) {
-                if (m_value->numChildren() == 2 && m_value->child(1)->isConstant()) {
-                    v128_t pattern = m_value->child(1)->as<Const128Value>()->value();
-                    if (SIMDShuffle::isIdentity(pattern)) {
-                        replaceWithIdentity(m_value->child(0));
+        case VectorOr: {
+            handleCommutativity();
+
+            // Turn this: VectorOr(constant1, constant2)
+            // Into this: constant1 | constant2
+            if (Value* constantVectorOr = m_value->child(0)->vectorOrConstant(m_proc, m_value->child(1))) {
+                replaceWithNewValue(constantVectorOr);
+                break;
+            }
+
+            // Turn this: VectorOr(VectorOr(value, constant1), constant2)
+            // Into this: VectorOr(value, constant1 | constant2).
+            if (m_value->child(0)->opcode() == VectorOr) {
+                Value* newConstant = m_value->child(1)->vectorOrConstant(m_proc, m_value->child(0)->child(1));
+                if (newConstant) {
+                    m_insertionSet.insertValue(m_index, newConstant);
+                    m_value->child(0) = m_value->child(0)->child(0);
+                    m_value->child(1) = newConstant;
+                    m_changed = true;
+                }
+            }
+
+            // Turn this: VectorOr(valueX, valueX)
+            // Into this: valueX.
+            if (m_value->child(0) == m_value->child(1)) {
+                replaceWithIdentity(m_value->child(0));
+                break;
+            }
+
+            // Turn this: VectorOr(value, zero-constant)
+            // Into this: value.
+            if (m_value->child(1)->isV128(vectorAllZeros())) {
+                replaceWithIdentity(m_value->child(0));
+                break;
+            }
+
+            // Turn this: VectorOr(value, all-ones)
+            // Into this: all-ones.
+            if (m_value->child(1)->isV128(vectorAllOnes())) {
+                replaceWithIdentity(m_value->child(1));
+                break;
+            }
+
+            // Turn this: VectorOr(VectorXor(x1, allOnes), VectorXor(x2, allOnes)
+            // Into this: VectorXor(VectorAnd(x1, x2), allOnes)
+            // By applying De Morgan laws
+            if (m_value->child(0)->opcode() == VectorXor
+                && m_value->child(1)->opcode() == VectorXor
+                && m_value->child(0)->child(1)->isV128(vectorAllOnes())
+                && m_value->child(1)->child(1)->isV128(vectorAllOnes())) {
+                Value* vectorAnd = m_insertionSet.insert<SIMDValue>(m_index, m_value->origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, m_value->child(0)->child(0), m_value->child(1)->child(0));
+                replaceWithNew<SIMDValue>(m_value->origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, vectorAnd, m_value->child(1)->child(1));
+                break;
+            }
+
+            // Turn this: VectorOr(VectorXor(x, allOnes), c)
+            // Into this: VectorXor(VectorAnd(x, ~c), allOnes)
+            // This is a variation on the previous optimization, treating c as if it were VectorXor(~c, allOnes)
+            // It does not reduce the number of operations, but provides some normalization (we try to get VectorXor by allOnes at the outermost point), and some chance to float Xors to a place where they might get eliminated.
+            if (m_value->child(0)->opcode() == VectorXor
+                && m_value->child(1)->hasV128()
+                && m_value->child(0)->child(1)->isV128(vectorAllOnes())) {
+                Value* newConstant = m_value->child(1)->vectorXorConstant(m_proc, m_value->child(0)->child(1));
+                ASSERT(newConstant);
+                m_insertionSet.insertValue(m_index, newConstant);
+                Value* vectorAnd = m_insertionSet.insert<SIMDValue>(m_index, m_value->origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, m_value->child(0)->child(0), newConstant);
+                replaceWithNew<SIMDValue>(m_value->origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, vectorAnd, m_value->child(0)->child(1));
+                break;
+            }
+            break;
+        }
+
+        case VectorAnd: {
+            handleCommutativity();
+
+            // Turn this: VectorAnd(constant1, constant2)
+            // Into this: constant1 & constant2
+            if (Value* constantVectorAnd = m_value->child(0)->vectorAndConstant(m_proc, m_value->child(1))) {
+                replaceWithNewValue(constantVectorAnd);
+                break;
+            }
+
+            // Turn this: VectorAnd(VectorAnd(value, constant1), constant2)
+            // Into this: VectorAnd(value, constant1 & constant2).
+            if (m_value->child(0)->opcode() == VectorAnd) {
+                Value* newConstant = m_value->child(1)->vectorAndConstant(m_proc, m_value->child(0)->child(1));
+                if (newConstant) {
+                    m_insertionSet.insertValue(m_index, newConstant);
+                    m_value->child(0) = m_value->child(0)->child(0);
+                    m_value->child(1) = newConstant;
+                    m_changed = true;
+                }
+            }
+
+            // Turn this: VectorAnd(valueX, valueX)
+            // Into this: valueX.
+            if (m_value->child(0) == m_value->child(1)) {
+                replaceWithIdentity(m_value->child(0));
+                break;
+            }
+
+            // Turn this: VectorAnd(value, zero-constant)
+            // Into this: zero-constant.
+            if (m_value->child(1)->isV128(vectorAllZeros())) {
+                replaceWithIdentity(m_value->child(1));
+                break;
+            }
+
+            // Turn this: VectorAnd(value, all-ones)
+            // Into this: value.
+            if (m_value->child(1)->isV128(vectorAllOnes())) {
+                replaceWithIdentity(m_value->child(0));
+                break;
+            }
+
+            // Turn this: VectorAnd(Op(value, constant1), constant2)
+            //     where !(constant1 & constant2)
+            //       and Op is VectorOr or VectorXor
+            // into this: VectorAnd(value, constant2)
+            if (m_value->child(1)->hasV128()) {
+                bool replaced = false;
+                v128_t constant2 = m_value->child(1)->asV128();
+                switch (m_value->child(0)->opcode()) {
+                case VectorOr:
+                case VectorXor:
+                    if (m_value->child(0)->child(1)->hasV128()
+                        && bitEquals(vectorAnd(m_value->child(0)->child(1)->asV128(), constant2), vectorAllZeros())) {
+                        m_value->child(0) = m_value->child(0)->child(0);
+                        m_changed = true;
+                        replaced = true;
                         break;
                     }
+                    break;
+                default:
+                    break;
+                }
+                if (replaced)
+                    break;
+            }
 
+            // Turn this: VectorAnd(VectorXor(x1, allOnes), VectorXor(x2, allOnes))
+            // Into this: VectorXor(VectorOr(x1, x2), allOnes)
+            // By applying De Morgan laws
+            if (m_value->child(0)->opcode() == VectorXor
+                && m_value->child(1)->opcode() == VectorXor
+                && (m_value->child(0)->child(1)->isV128(vectorAllOnes()) && m_value->child(1)->child(1)->isV128(vectorAllOnes()))) {
+                Value* vectorOr = m_insertionSet.insert<SIMDValue>(m_index, m_value->origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, m_value->child(0)->child(0), m_value->child(1)->child(0));
+                replaceWithNew<SIMDValue>(m_value->origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, vectorOr, m_value->child(1)->child(1));
+                break;
+            }
+
+            // Turn this: VectorAnd(VectorXor(x, allOnes), c)
+            // Into this: VectorXor(VectorOr(x, ~c), allOnes)
+            // This is a variation on the previous optimization, treating c as if it were VectorXor(~c, allOnes)
+            // It does not reduce the number of operations, but provides some normalization (we try to get VectorXor by allOnes at the outermost point), and some chance to float Xors to a place where they might get eliminated.
+            if (m_value->child(0)->opcode() == VectorXor
+                && m_value->child(1)->hasV128()
+                && m_value->child(0)->child(1)->isV128(vectorAllOnes())) {
+                Value* newConstant = m_value->child(1)->vectorXorConstant(m_proc, m_value->child(0)->child(1));
+                ASSERT(newConstant);
+                m_insertionSet.insertValue(m_index, newConstant);
+                Value* vectorOr = m_insertionSet.insert<SIMDValue>(m_index, m_value->origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, m_value->child(0)->child(0), newConstant);
+                replaceWithNew<SIMDValue>(m_value->origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, vectorOr, m_value->child(0)->child(1));
+                break;
+            }
+
+            break;
+        }
+
+        case VectorXor: {
+            handleCommutativity();
+
+            // Turn this: VectorXor(constant1, constant2)
+            // Into this: constant1 ^ constant2
+            if (Value* constantVectorXor = m_value->child(0)->vectorXorConstant(m_proc, m_value->child(1))) {
+                replaceWithNewValue(constantVectorXor);
+                break;
+            }
+
+            // Turn this: VectorXor(VectorXor(value, constant1), constant2)
+            // Into this: VectorXor(value, constant1 ^ constant2).
+            if (m_value->child(0)->opcode() == VectorXor) {
+                Value* newConstant = m_value->child(1)->vectorXorConstant(m_proc, m_value->child(0)->child(1));
+                if (newConstant) {
+                    m_insertionSet.insertValue(m_index, newConstant);
+                    m_value->child(0) = m_value->child(0)->child(0);
+                    m_value->child(1) = newConstant;
+                    m_changed = true;
+                }
+            }
+
+            // Turn this: VectorXor(valueX, valueX)
+            // Into this: zero-constant.
+            if (m_value->child(0) == m_value->child(1)) {
+                replaceWithNewValue(m_proc.addConstant(m_value->origin(), B3::V128, vectorAllZeros()));
+                break;
+            }
+
+            // Turn this: VectorXor(value, zero-constant)
+            // Into this: value.
+            if (m_value->child(1)->isV128(vectorAllZeros())) {
+                replaceWithIdentity(m_value->child(0));
+                break;
+            }
+
+            break;
+        }
+
+        case VectorSwizzle: {
+            if (m_value->numChildren() == 2 && m_value->child(1)->isConstant()) {
+                v128_t pattern = m_value->child(1)->as<Const128Value>()->value();
+                if (SIMDShuffle::isIdentity(pattern)) {
+                    replaceWithIdentity(m_value->child(0));
+                    break;
+                }
+
+                if (SIMDShuffle::isAllOutOfBoundsForUnaryShuffle(pattern)) {
+                    replaceWithNewValue(m_proc.addConstant(m_value->origin(), B3::V128, vectorAllZeros()));
+                    break;
+                }
+
+                if constexpr (isARM64()) {
                     if (auto lane = SIMDShuffle::isI64x2DupElement(pattern)) {
                         replaceWithNew<SIMDValue>(m_value->origin(), VectorDupElement, B3::V128, SIMDLane::i64x2, SIMDSignMode::None, lane.value(), m_value->child(0));
                         break;
@@ -2475,7 +2688,9 @@ private:
                     }
                     break;
                 }
+            }
 
+            if constexpr (isARM64()) {
                 if (m_value->numChildren() == 3 && m_value->child(2)->isConstant()) {
                     v128_t pattern = m_value->child(2)->as<Const128Value>()->value();
                     if (auto child = SIMDShuffle::isOnlyOneSideMask(pattern)) {

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -426,6 +426,21 @@ Value* Value::sqrtConstant(Procedure&) const
     return nullptr;
 }
 
+Value* Value::vectorAndConstant(Procedure&, const Value*) const
+{
+    return nullptr;
+}
+
+Value* Value::vectorOrConstant(Procedure&, const Value*) const
+{
+    return nullptr;
+}
+
+Value* Value::vectorXorConstant(Procedure&, const Value*) const
+{
+    return nullptr;
+}
+
 TriState Value::equalConstant(const Value*) const
 {
     return TriState::Indeterminate;

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -240,6 +240,10 @@ public:
     virtual Value* floorConstant(Procedure&) const;
     virtual Value* sqrtConstant(Procedure&) const;
 
+    virtual Value* vectorAndConstant(Procedure&, const Value* other) const;
+    virtual Value* vectorOrConstant(Procedure&, const Value* other) const;
+    virtual Value* vectorXorConstant(Procedure&, const Value* other) const;
+
     virtual TriState equalConstant(const Value* other) const;
     virtual TriState notEqualConstant(const Value* other) const;
     virtual TriState lessThanConstant(const Value* other) const;
@@ -251,7 +255,7 @@ public:
     virtual TriState aboveEqualConstant(const Value* other) const;
     virtual TriState belowEqualConstant(const Value* other) const;
     virtual TriState equalOrUnorderedConstant(const Value* other) const;
-    
+
     // If the value is a comparison then this returns the inverted form of that comparison, if
     // possible. It can be impossible for double comparisons, where for example LessThan and
     // GreaterEqual behave differently. If this returns a value, it is a new value, which must be
@@ -283,6 +287,7 @@ public:
 
     bool hasV128() const;
     v128_t asV128() const;
+    bool isV128(v128_t) const;
 
     bool hasNumber() const;
     template<typename T> bool isRepresentableAs() const;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -384,6 +384,11 @@ inline v128_t Value::asV128() const
     return as<Const128Value>()->value();
 }
 
+inline bool Value::isV128(v128_t value) const
+{
+    return hasV128() && bitEquals(asV128(), value);
+}
+
 inline bool Value::hasNumber() const
 {
     return hasInt() || hasDouble() || hasFloat();

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -272,6 +272,7 @@ struct B3Operand {
     Type value;
 };
 
+typedef B3Operand<v128_t> V128Operand;
 typedef B3Operand<int64_t> Int64Operand;
 typedef B3Operand<int32_t> Int32Operand;
 typedef B3Operand<int16_t> Int16Operand;
@@ -314,6 +315,30 @@ Vector<B3Operand<FloatType>> floatingPointOperands()
     populateWithInterestingValues(operands);
     return operands;
 };
+
+inline Vector<V128Operand> v128Operands()
+{
+    Vector<V128Operand> operands;
+    operands.append({ "0,0", v128_t { 0, 0 } });
+    operands.append({ "1,0", v128_t { 1, 0 } });
+    operands.append({ "0,1", v128_t { 0, 1 } });
+    operands.append({ "42,0", v128_t { 42, 0 } });
+    operands.append({ "0,42", v128_t { 0, 42 } });
+    operands.append({ "42,42", v128_t { 42, 42 } });
+    operands.append({ "-42,-42", v128_t { static_cast<uint64_t>(-42), static_cast<uint64_t>(-42) } });
+    operands.append({ "0,-42", v128_t { 0, static_cast<uint64_t>(-42) } });
+    operands.append({ "-42,0", v128_t { static_cast<uint64_t>(-42), 0 } });
+    operands.append({ "int64-max,int64-max", v128_t { static_cast<uint64_t>(std::numeric_limits<int64_t>::max()), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) } });
+    operands.append({ "int64-min,int64-min", v128_t { static_cast<uint64_t>(std::numeric_limits<int64_t>::min()), static_cast<uint64_t>(std::numeric_limits<int64_t>::min()) } });
+    operands.append({ "int32-max,int32-max", v128_t { static_cast<uint64_t>(std::numeric_limits<int32_t>::max()), static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) } });
+    operands.append({ "int32-min,int32-min", v128_t { static_cast<uint64_t>(std::numeric_limits<int32_t>::min()), static_cast<uint64_t>(std::numeric_limits<int32_t>::min()) } });
+    operands.append({ "uint64-max,uint64-max", v128_t { static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()), static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()) } });
+    operands.append({ "uint64-min,uint64-min", v128_t { static_cast<uint64_t>(std::numeric_limits<uint64_t>::min()), static_cast<uint64_t>(std::numeric_limits<uint64_t>::min()) } });
+    operands.append({ "uint32-max,uint32-max", v128_t { static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()), static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) } });
+    operands.append({ "uint32-min,uint32-min", v128_t { static_cast<uint64_t>(std::numeric_limits<uint32_t>::min()), static_cast<uint64_t>(std::numeric_limits<uint32_t>::min()) } });
+
+    return operands;
+}
 
 inline Vector<Int64Operand> int64Operands()
 {
@@ -1176,5 +1201,17 @@ void testStoreAfterClobberExitsSideways();
 void testStoreAfterClobberDifferentWidth();
 void testStoreAfterClobberDifferentWidthSuccessor();
 void testStoreAfterClobberExitsSidewaysSuccessor();
+
+void testVectorOrConstants(v128_t, v128_t);
+void testVectorAndConstants(v128_t, v128_t);
+void testVectorXorConstants(v128_t, v128_t);
+void testVectorOrSelf();
+void testVectorAndSelf();
+void testVectorXorSelf();
+void testVectorXorOrAllOnesToVectorAndXor();
+void testVectorXorAndAllOnesToVectorOrXor();
+void testVectorXorOrAllOnesConstantToVectorAndXor(v128_t);
+void testVectorXorAndAllOnesConstantToVectorOrXor(v128_t);
+void testVectorAndConstantConstant(v128_t, v128_t);
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -865,6 +865,20 @@ void run(const char* filter)
 
     RUN(testReportUsedRegistersLateUseFollowedByEarlyDefDoesNotMarkUseAsDead());
 
+    if (isARM64() || isX86()) {
+        RUN(testVectorXorOrAllOnesToVectorAndXor());
+        RUN(testVectorXorAndAllOnesToVectorOrXor());
+        RUN(testVectorOrSelf());
+        RUN(testVectorAndSelf());
+        RUN(testVectorXorSelf());
+        RUN_UNARY(testVectorXorOrAllOnesConstantToVectorAndXor, v128Operands());
+        RUN_UNARY(testVectorXorAndAllOnesConstantToVectorOrXor, v128Operands());
+        RUN_BINARY(testVectorOrConstants, v128Operands(), v128Operands());
+        RUN_BINARY(testVectorAndConstants, v128Operands(), v128Operands());
+        RUN_BINARY(testVectorXorConstants, v128Operands(), v128Operands());
+        RUN_BINARY(testVectorAndConstantConstant, v128Operands(), v128Operands());
+    }
+
     if (tasks.isEmpty())
         usage();
 

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -2024,4 +2024,333 @@ void testDoubleMaxMin()
     testFMaxMin<double>();
 }
 
+void testVectorOrConstants(v128_t lhs, v128_t rhs)
+{
+    alignas(16) v128_t vector;
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* lhsConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* rhsConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, lhsConstant, rhsConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+
+        compileAndRun<void>(proc, &vector);
+        CHECK(bitEquals(vector, vectorOr(lhs, rhs)));
+    }
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* lhsConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* rhsConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* first = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, lhsConstant);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, first, rhsConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+        auto code = compileProc(proc);
+
+        for (auto& operand : v128Operands()) {
+            vector = operand.value;
+            invoke<void>(*code, &vector);
+            CHECK(bitEquals(vector, vectorOr(vectorOr(lhs, operand.value), rhs)));
+        }
+    }
+}
+
+void testVectorOrSelf()
+{
+    alignas(16) v128_t vector;
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, input);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand : v128Operands()) {
+        vector = operand.value;
+        invoke<void>(*code, &vector);
+        CHECK(bitEquals(vector, vectorOr(operand.value, operand.value)));
+    }
+}
+
+void testVectorXorOrAllOnesToVectorAndXor()
+{
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* constant = root->appendNew<Const128Value>(proc, Origin(), vectorAllOnes());
+    Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, sizeof(v128_t));
+    Value* result0 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input0, constant);
+    Value* result1 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input1, constant);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, result0, result1);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand0 : v128Operands()) {
+        for (auto& operand1 : v128Operands()) {
+            vectors[0] = operand0.value;
+            vectors[1] = operand1.value;
+            invoke<void>(*code, vectors);
+            CHECK(bitEquals(vectors[0], vectorOr(vectorXor(operand0.value, vectorAllOnes()), vectorXor(operand1.value, vectorAllOnes()))));
+        }
+    }
+}
+
+void testVectorXorAndAllOnesToVectorOrXor()
+{
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* constant = root->appendNew<Const128Value>(proc, Origin(), vectorAllOnes());
+    Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* input1 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, sizeof(v128_t));
+    Value* result0 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input0, constant);
+    Value* result1 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input1, constant);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, result0, result1);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand0 : v128Operands()) {
+        for (auto& operand1 : v128Operands()) {
+            vectors[0] = operand0.value;
+            vectors[1] = operand1.value;
+            invoke<void>(*code, vectors);
+            CHECK(bitEquals(vectors[0], vectorAnd(vectorXor(operand0.value, vectorAllOnes()), vectorXor(operand1.value, vectorAllOnes()))));
+        }
+    }
+}
+
+void testVectorXorOrAllOnesConstantToVectorAndXor(v128_t constant)
+{
+    alignas(16) v128_t vector;
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* allOnes = root->appendNew<Const128Value>(proc, Origin(), vectorAllOnes());
+    Value* constant0 = root->appendNew<Const128Value>(proc, Origin(), constant);
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* result0 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, allOnes);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, result0, constant0);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand : v128Operands()) {
+        vector = operand.value;
+        invoke<void>(*code, &vector);
+        CHECK(bitEquals(vector, vectorOr(vectorXor(operand.value, vectorAllOnes()), constant)));
+    }
+}
+
+void testVectorXorAndAllOnesConstantToVectorOrXor(v128_t constant)
+{
+    alignas(16) v128_t vector;
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* allOnes = root->appendNew<Const128Value>(proc, Origin(), vectorAllOnes());
+    Value* constant0 = root->appendNew<Const128Value>(proc, Origin(), constant);
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* result0 = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, allOnes);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, result0, constant0);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand : v128Operands()) {
+        vector = operand.value;
+        invoke<void>(*code, &vector);
+        CHECK(bitEquals(vector, vectorAnd(vectorXor(operand.value, vectorAllOnes()), constant)));
+    }
+}
+
+void testVectorAndConstants(v128_t lhs, v128_t rhs)
+{
+    alignas(16) v128_t vector;
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* lhsConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* rhsConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, lhsConstant, rhsConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+
+        compileAndRun<void>(proc, &vector);
+        CHECK(bitEquals(vector, vectorAnd(lhs, rhs)));
+    }
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* lhsConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* rhsConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* first = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, lhsConstant);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, first, rhsConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+        auto code = compileProc(proc);
+
+        for (auto& operand : v128Operands()) {
+            vector = operand.value;
+            invoke<void>(*code, &vector);
+            CHECK(bitEquals(vector, vectorAnd(vectorAnd(lhs, operand.value), rhs)));
+        }
+    }
+}
+
+void testVectorAndSelf()
+{
+    alignas(16) v128_t vector;
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, input);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand : v128Operands()) {
+        vector = operand.value;
+        invoke<void>(*code, &vector);
+        CHECK(bitEquals(vector, vectorAnd(operand.value, operand.value)));
+    }
+}
+
+void testVectorXorConstants(v128_t lhs, v128_t rhs)
+{
+    alignas(16) v128_t vector;
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* lhsConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* rhsConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, lhsConstant, rhsConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+
+        compileAndRun<void>(proc, &vector);
+        CHECK(bitEquals(vector, vectorXor(lhs, rhs)));
+    }
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* lhsConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* rhsConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* first = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, lhsConstant);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, first, rhsConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+        auto code = compileProc(proc);
+
+        for (auto& operand : v128Operands()) {
+            vector = operand.value;
+            invoke<void>(*code, &vector);
+            CHECK(bitEquals(vector, vectorXor(vectorXor(lhs, operand.value), rhs)));
+        }
+    }
+}
+
+void testVectorXorSelf()
+{
+    alignas(16) v128_t vector;
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, input);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    for (auto& operand : v128Operands()) {
+        vector = operand.value;
+        invoke<void>(*code, &vector);
+        CHECK(bitEquals(vector, vectorXor(operand.value, operand.value)));
+    }
+}
+
+void testVectorAndConstantConstant(v128_t lhs, v128_t rhs)
+{
+    alignas(16) v128_t vector;
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* firstConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* secondConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* first = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, firstConstant);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, first, secondConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+        auto code = compileProc(proc);
+
+        for (auto& operand : v128Operands()) {
+            vector = operand.value;
+            invoke<void>(*code, &vector);
+            CHECK(bitEquals(vector, vectorAnd(vectorXor(operand.value, lhs), rhs)));
+        }
+    }
+    {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+
+        Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+        Value* firstConstant = root->appendNew<Const128Value>(proc, Origin(), lhs);
+        Value* secondConstant = root->appendNew<Const128Value>(proc, Origin(), rhs);
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* first = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, input, firstConstant);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorAnd, B3::V128, SIMDLane::v128, SIMDSignMode::None, first, secondConstant);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address);
+        root->appendNewControlValue(proc, Return, Origin());
+        auto code = compileProc(proc);
+
+        for (auto& operand : v128Operands()) {
+            vector = operand.value;
+            invoke<void>(*code, &vector);
+            CHECK(bitEquals(vector, vectorAnd(vectorOr(operand.value, lhs), rhs)));
+        }
+    }
+}
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -36,13 +36,42 @@ typedef union v128_u {
     uint16_t u16x8[8];
     uint32_t u32x4[4];
     uint64_t u64x2[2] = { 0, 0 };
-    v128_u() = default;
+
+    constexpr v128_u() = default;
+    constexpr v128_u(uint64_t first, uint64_t second)
+        : u64x2 { first, second }
+    { }
 } v128_t;
 
+constexpr v128_t vectorAllOnes()
+{
+    return v128_t { UINT64_MAX, UINT64_MAX };
+}
+
+constexpr v128_t vectorAllZeros()
+{
+    return v128_t { 0, 0 };
+}
+
 // Comparing based on bits. Not using float/double comparison.
-inline bool bitEquals(const v128_t& lhs, const v128_t rhs)
+constexpr bool bitEquals(const v128_t& lhs, const v128_t rhs)
 {
     return lhs.u64x2[0] == rhs.u64x2[0] && lhs.u64x2[1] == rhs.u64x2[1];
+}
+
+constexpr v128_t vectorOr(v128_t lhs, v128_t rhs)
+{
+    return v128_t { lhs.u64x2[0] | rhs.u64x2[0], lhs.u64x2[1] | rhs.u64x2[1] };
+}
+
+constexpr v128_t vectorAnd(v128_t lhs, v128_t rhs)
+{
+    return v128_t { lhs.u64x2[0] & rhs.u64x2[0], lhs.u64x2[1] & rhs.u64x2[1] };
+}
+
+constexpr v128_t vectorXor(v128_t lhs, v128_t rhs)
+{
+    return v128_t { lhs.u64x2[0] ^ rhs.u64x2[0], lhs.u64x2[1] ^ rhs.u64x2[1] };
 }
 
 enum class SIMDLane : uint8_t {


### PR DESCRIPTION
#### 3f2afe08ec3b95cfc159ff1770687130f3dcbe07
<pre>
[JSC] Add strength reduction for SIMD Vector logic operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=251284">https://bugs.webkit.org/show_bug.cgi?id=251284</a>
rdar://104754015

Reviewed by Keith Miller.

On x64, we generate B3 nodes for wasm i8x16.shuffle

    @lhs = VectorSwizzle(@input0, @constantMask0)
    @rhs = VectorSwizzle(@input1, @constantMask1)
    @result = VectorOr(@lhs, @rhs)

We found that the hottest function in tfjs is using only one side of operand on shuffle.
This is because wasm i8x16.shuffle always takes 2 operands, and actual use of tfjs is only needing one operand.
As a result, one of the above constantMask becomes all 0xff on x64. And the resulted one is,

    @lhs = VectorSwizzle(@input0, @constantMask0)
    @rhs = VectorSwizzle(@input1, 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff) # It is always 0
    @result = VectorOr(@lhs, @rhs)

This should be converted to

    @result = VectorSwizzle(@input0, @constantMask0)

because (1) @rhs is always all-zeros and (2) we should optimize VectorOr(@lhs, all-zeros) to @lhs.

This patch adds

1. Bit logic strength reduction for VectorOr, VectorAnd, and VectorXor.
2. Add strength reduction for VectorSwizzle when the mask is all OOB.

This imporoves JetStream3/tfjs by 10% on x64 device.

* Source/JavaScriptCore/b3/B3Const128Value.cpp:
(JSC::B3::Const128Value::vectorAndConstant const):
(JSC::B3::Const128Value::vectorOrConstant const):
(JSC::B3::Const128Value::vectorXorConstant const):
* Source/JavaScriptCore/b3/B3Const128Value.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::vectorAndConstant const):
(JSC::B3::Value::vectorOrConstant const):
(JSC::B3::Value::vectorXorConstant const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
(JSC::B3::Value::isV128 const):
* Source/JavaScriptCore/jit/SIMDInfo.h:
(JSC::vectorAllOnes):
(JSC::vectorAllZeros):
(JSC::vectorOr):
(JSC::vectorAnd):
(JSC::vectorXor):
* Source/JavaScriptCore/jit/SIMDShuffle.h:
(JSC::SIMDShuffle::isAllOutOfBoundsForUnaryShuffle):
(JSC::SIMDShuffle::isAllOutOfBoundsForBinaryShuffle):

Canonical link: <a href="https://commits.webkit.org/259514@main">https://commits.webkit.org/259514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d893fb092bdda255d8e46d6079befff8c4d362c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105070 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114333 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5071 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97390 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110826 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26452 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/80992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94915 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27811 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92955 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5217 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7581 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30286 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47364 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101651 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9370 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25360 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3498 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->