### PR TITLE
REGRESSION (256863@main): [ iOS ] imported/w3c/web-platform-tests/webstorage/storage_local_window_open.window.html is a consistent timeout

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3879,8 +3879,6 @@ webkit.org/b/249486 media/audioSession/audioSessionType.html [ Failure ]
 # webkit.org/b/250885 CSS3/filters/effect-contrast-hw.html is a constant image failure
 [ Release arm64 ] css3/filters/effect-contrast-hw.html [ ImageOnlyFailure ]
 
-webkit.org/b/250922 imported/w3c/web-platform-tests/webstorage/storage_local_window_open.window.html [ Pass Timeout ]
-
 webkit.org/b/251040 [ Debug ] fast/forms/ios/remove-view-after-focus.html [ Pass Crash ]
 
 webkit.org/b/251047 [ Debug ] fast/loader/crash-replacing-location-before-load.html [ Pass Crash ]

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -175,8 +175,11 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
         return false;
     }
 
-    if (quota() != WebCore::StorageMap::noQuota)
-        m_database->setMaximumSize(quota());
+    if (quota() != WebCore::StorageMap::noQuota) {
+        // Value is upconverted and stored as blob in database, so we need to make database file limit
+        // bigger than quota.
+        m_database->setMaximumSize(quota() * 2);
+    }
 
     return true;
 }


### PR DESCRIPTION
#### 4590ce7d98b4a3761aba90e33a04c73fa51c37ca
<pre>
REGRESSION (256863@main): [ iOS ] imported/w3c/web-platform-tests/webstorage/storage_local_window_open.window.html is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=250922">https://bugs.webkit.org/show_bug.cgi?id=250922</a>
rdar://104498135

Reviewed by Chris Dumez.

Currently quota check of LocalStorage is performed in both web process (StorageAreaMap) and network process
(SQLiteStorageArea). Web process only sends a setting item request to network process when the local quota check passes.
The issue they calculate usage differently: web process calculates usage based on size of string (WebCore::StorageMap)
and network process uses database file size. Also network process stores upconverted characters in database
(SQLiteStorageArea stores value as blob and SQLiteStatement::bindBlob upconverts characters). The result is web process
may send more requests to network process than it is supposed to.

For example, in the failing test, web process can send about 5000 setItem requests to network process, and network
process will start return error after finishing about 2500 requests. Since 256863@main, network process will include all
stored items in the request reply when a request fails, so that web process can sync its local cache and two processes
have a consistent view of data. The reason the test starts to fail is reading all items takes time, and there are too
many failed requests.

To fix this issue, this patch increases database size limit to 10MB (double of quota), which should make quota check
results in different processes to be more closer.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::prepareDatabase):

Canonical link: <a href="https://commits.webkit.org/259571@main">https://commits.webkit.org/259571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a716dc6c2be1747028525adabd44995b1a6ddae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114327 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174511 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5065 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114318 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39317 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80982 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7481 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27801 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7575 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4384 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47354 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6596 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9364 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->