### PR TITLE
[WK2] Dispatch IPC messages through receivers' sequential message lists

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -47,12 +47,19 @@ namespace WebKit {
 void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
+
+    using AsyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithCVPixelBuffer*), TestWithCVPixelBuffer,
 #if USE(AVFOUNDATION)
-    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name())
-        return IPC::handleMessage<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::sendCVPixelBuffer);
-    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name())
-        return IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
+        IPC::MessageHandlerListEntry<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer, &TestWithCVPixelBuffer::receiveCVPixelBuffer>,
 #endif
+#if USE(AVFOUNDATION)
+        IPC::MessageHandlerListEntry<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer, &TestWithCVPixelBuffer::sendCVPixelBuffer>,
+#endif
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(AsyncMessageHandlerListType::valid());
+    if (auto handler = AsyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -48,8 +48,9 @@ class SendCVPixelBuffer {
 public:
     using Arguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit SendCVPixelBuffer(const RetainPtr<CVPixelBufferRef>& s0)
         : m_arguments(s0)
@@ -71,10 +72,11 @@ class ReceiveCVPixelBuffer {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
     const auto& arguments() const

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
@@ -45,8 +45,9 @@ class LoadURL {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
@@ -68,8 +69,9 @@ class LoadURL {
 public:
     using Arguments = std::tuple<String, int64_t>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     LoadURL(const String& url, int64_t value)
         : m_arguments(url, value)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -45,8 +45,9 @@ class SendImageData {
 public:
     using Arguments = std::tuple<RefPtr<WebCore::ImageData>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithImageData_SendImageData; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithImageData_SendImageData; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit SendImageData(const RefPtr<WebCore::ImageData>& s0)
         : m_arguments(s0)
@@ -66,10 +67,11 @@ class ReceiveImageData {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithImageData_ReceiveImageData; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithImageData_ReceiveImageData; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RefPtr<WebCore::ImageData>>;
     const auto& arguments() const

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -71,60 +71,49 @@ namespace WebKit {
 void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadURL>(connection, decoder, this, &TestWithLegacyReceiver::loadURL);
-#if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomething::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomething>(connection, decoder, this, &TestWithLegacyReceiver::loadSomething);
-#endif
-#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TouchEvent::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TouchEvent>(connection, decoder, this, &TestWithLegacyReceiver::touchEvent);
-#endif
+
+    using AsyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithLegacyReceiver*), TestWithLegacyReceiver,
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::AddEvent::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::AddEvent>(connection, decoder, this, &TestWithLegacyReceiver::addEvent);
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::AddEvent, &TestWithLegacyReceiver::addEvent>,
+#endif
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::Close, &TestWithLegacyReceiver::close>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::CreatePlugin, &TestWithLegacyReceiver::createPlugin>,
+#if ENABLE(DEPRECATED_FEATURE)
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::DeprecatedOperation, &TestWithLegacyReceiver::deprecatedOperation>,
+#endif
+#if PLATFORM(MAC)
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection, &TestWithLegacyReceiver::didCreateWebProcessConnection>,
+#endif
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision, &TestWithLegacyReceiver::didReceivePolicyDecision>,
+#if ENABLE(FEATURE_FOR_TESTING)
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::ExperimentalOperation, &TestWithLegacyReceiver::experimentalOperation>,
+#endif
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::GetPlugins, &TestWithLegacyReceiver::getPlugins>,
+#if PLATFORM(MAC)
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::InterpretKeyEvent, &TestWithLegacyReceiver::interpretKeyEvent>,
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomethingElse::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomethingElse>(connection, decoder, this, &TestWithLegacyReceiver::loadSomethingElse);
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::LoadSomething, &TestWithLegacyReceiver::loadSomething>,
 #endif
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision>(connection, decoder, this, &TestWithLegacyReceiver::didReceivePolicyDecision);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::Close::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::Close>(connection, decoder, this, &TestWithLegacyReceiver::close);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::PreferencesDidChange::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::PreferencesDidChange>(connection, decoder, this, &TestWithLegacyReceiver::preferencesDidChange);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendDoubleAndFloat::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendDoubleAndFloat>(connection, decoder, this, &TestWithLegacyReceiver::sendDoubleAndFloat);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendInts::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendInts>(connection, decoder, this, &TestWithLegacyReceiver::sendInts);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::CreatePlugin::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::CreatePlugin>(connection, decoder, this, &TestWithLegacyReceiver::createPlugin);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::RunJavaScriptAlert::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::RunJavaScriptAlert>(connection, decoder, this, &TestWithLegacyReceiver::runJavaScriptAlert);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPlugins::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::GetPlugins>(connection, decoder, this, &TestWithLegacyReceiver::getPlugins);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestParameterAttributes::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TestParameterAttributes>(connection, decoder, this, &TestWithLegacyReceiver::testParameterAttributes);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TemplateTest::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TemplateTest>(connection, decoder, this, &TestWithLegacyReceiver::templateTest);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SetVideoLayerID::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SetVideoLayerID>(connection, decoder, this, &TestWithLegacyReceiver::setVideoLayerID);
-#if PLATFORM(MAC)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::InterpretKeyEvent::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::InterpretKeyEvent>(connection, decoder, this, &TestWithLegacyReceiver::interpretKeyEvent);
+#if ENABLE(TOUCH_EVENTS)
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::LoadSomethingElse, &TestWithLegacyReceiver::loadSomethingElse>,
 #endif
-#if ENABLE(DEPRECATED_FEATURE)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DeprecatedOperation::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DeprecatedOperation>(connection, decoder, this, &TestWithLegacyReceiver::deprecatedOperation);
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::LoadURL, &TestWithLegacyReceiver::loadURL>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::PreferencesDidChange, &TestWithLegacyReceiver::preferencesDidChange>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::RunJavaScriptAlert, &TestWithLegacyReceiver::runJavaScriptAlert>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::SendDoubleAndFloat, &TestWithLegacyReceiver::sendDoubleAndFloat>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::SendInts, &TestWithLegacyReceiver::sendInts>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::SetVideoLayerID, &TestWithLegacyReceiver::setVideoLayerID>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::TemplateTest, &TestWithLegacyReceiver::templateTest>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::TestParameterAttributes, &TestWithLegacyReceiver::testParameterAttributes>,
+#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::TouchEvent, &TestWithLegacyReceiver::touchEvent>,
 #endif
-#if ENABLE(FEATURE_FOR_TESTING)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::ExperimentalOperation::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::ExperimentalOperation>(connection, decoder, this, &TestWithLegacyReceiver::experimentalOperation);
-#endif
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(AsyncMessageHandlerListType::valid());
+    if (auto handler = AsyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)
@@ -137,10 +126,15 @@ void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connec
 bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::getPluginProcessConnection);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
+
+    using SyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithLegacyReceiver*), TestWithLegacyReceiver,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::GetPluginProcessConnection, &TestWithLegacyReceiver::getPluginProcessConnection>,
+        IPC::MessageHandlerListEntry<Messages::TestWithLegacyReceiver::TestMultipleAttributes, &TestWithLegacyReceiver::testMultipleAttributes>,
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(SyncMessageHandlerListType::valid());
+    if (auto handler = SyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return handler({ connection, decoder, replyEncoder }, this);
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -66,8 +66,9 @@ class LoadURL {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadURL; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadURL; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
@@ -88,8 +89,9 @@ class LoadSomething {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadSomething; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadSomething; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadSomething(const String& url)
         : m_arguments(url)
@@ -111,8 +113,9 @@ class TouchEvent {
 public:
     using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TouchEvent; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TouchEvent; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit TouchEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
@@ -134,8 +137,9 @@ class AddEvent {
 public:
     using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_AddEvent; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_AddEvent; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit AddEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
@@ -157,8 +161,9 @@ class LoadSomethingElse {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadSomethingElse; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadSomethingElse; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadSomethingElse(const String& url)
         : m_arguments(url)
@@ -179,8 +184,9 @@ class DidReceivePolicyDecision {
 public:
     using Arguments = std::tuple<uint64_t, uint64_t, uint32_t>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     DidReceivePolicyDecision(uint64_t frameID, uint64_t listenerID, uint32_t policyAction)
         : m_arguments(frameID, listenerID, policyAction)
@@ -200,8 +206,9 @@ class Close {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_Close; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_Close; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     const auto& arguments() const
     {
@@ -216,8 +223,9 @@ class PreferencesDidChange {
 public:
     using Arguments = std::tuple<WebKit::WebPreferencesStore>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_PreferencesDidChange; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_PreferencesDidChange; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit PreferencesDidChange(const WebKit::WebPreferencesStore& store)
         : m_arguments(store)
@@ -237,8 +245,9 @@ class SendDoubleAndFloat {
 public:
     using Arguments = std::tuple<double, float>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendDoubleAndFloat; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendDoubleAndFloat; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     SendDoubleAndFloat(double d, float f)
         : m_arguments(d, f)
@@ -258,8 +267,9 @@ class SendInts {
 public:
     using Arguments = std::tuple<Vector<uint64_t>, Vector<Vector<uint64_t>>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendInts; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendInts; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     SendInts(const Vector<uint64_t>& ints, const Vector<Vector<uint64_t>>& intVectors)
         : m_arguments(ints, intVectors)
@@ -279,10 +289,11 @@ class CreatePlugin {
 public:
     using Arguments = std::tuple<uint64_t, WebKit::Plugin::Parameters>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_CreatePlugin; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_CreatePlugin; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_CreatePluginReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
     CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
@@ -303,10 +314,11 @@ class RunJavaScriptAlert {
 public:
     using Arguments = std::tuple<uint64_t, String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlert; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlert; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
     RunJavaScriptAlert(uint64_t frameID, const String& message)
@@ -327,10 +339,11 @@ class GetPlugins {
 public:
     using Arguments = std::tuple<bool>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_GetPlugins; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_GetPlugins; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginsReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
     explicit GetPlugins(bool refresh)
@@ -351,8 +364,9 @@ class GetPluginProcessConnection {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginProcessConnection; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginProcessConnection; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Connection::Handle>;
@@ -374,8 +388,9 @@ class TestMultipleAttributes {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TestMultipleAttributes; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TestMultipleAttributes; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
@@ -392,8 +407,9 @@ class TestParameterAttributes {
 public:
     using Arguments = std::tuple<uint64_t, double, double>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TestParameterAttributes; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TestParameterAttributes; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     TestParameterAttributes(uint64_t foo, double bar, double baz)
         : m_arguments(foo, bar, baz)
@@ -413,8 +429,9 @@ class TemplateTest {
 public:
     using Arguments = std::tuple<HashMap<String, std::pair<String, uint64_t>>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TemplateTest; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TemplateTest; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit TemplateTest(const HashMap<String, std::pair<String, uint64_t>>& a)
         : m_arguments(a)
@@ -434,8 +451,9 @@ class SetVideoLayerID {
 public:
     using Arguments = std::tuple<WebCore::GraphicsLayer::PlatformLayerID>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SetVideoLayerID; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SetVideoLayerID; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit SetVideoLayerID(const WebCore::GraphicsLayer::PlatformLayerID& videoLayerID)
         : m_arguments(videoLayerID)
@@ -456,8 +474,9 @@ class DidCreateWebProcessConnection {
 public:
     using Arguments = std::tuple<MachSendRight, OptionSet<WebKit::SelectionFlags>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     DidCreateWebProcessConnection(const MachSendRight& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
         : m_arguments(connectionIdentifier, flags)
@@ -479,10 +498,11 @@ class InterpretKeyEvent {
 public:
     using Arguments = std::tuple<uint32_t>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEvent; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEvent; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEventReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
     explicit InterpretKeyEvent(uint32_t type)
@@ -505,8 +525,9 @@ class DeprecatedOperation {
 public:
     using Arguments = std::tuple<IPC::DummyType>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DeprecatedOperation; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DeprecatedOperation; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit DeprecatedOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)
@@ -528,8 +549,9 @@ class ExperimentalOperation {
 public:
     using Arguments = std::tuple<IPC::DummyType>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_ExperimentalOperation; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_ExperimentalOperation; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit ExperimentalOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -44,8 +44,9 @@ class SendSemaphore {
 public:
     using Arguments = std::tuple<IPC::Semaphore>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSemaphore_SendSemaphore; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSemaphore_SendSemaphore; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit SendSemaphore(const IPC::Semaphore& s0)
         : m_arguments(s0)
@@ -65,10 +66,11 @@ class ReceiveSemaphore {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphore; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphore; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Semaphore>;
     const auto& arguments() const

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -39,8 +39,19 @@ namespace WebKit {
 
 void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
 {
-    if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name())
-        return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection.connection(), decoder, this, &TestWithStreamBatched::sendString);
+    using AsyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::StreamServerConnection>, TestWithStreamBatched*), TestWithStreamBatched,
+        IPC::MessageHandlerListEntry<Messages::TestWithStreamBatched::SendString, &TestWithStreamBatched::sendString>,
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(AsyncMessageHandlerListType::valid());
+    if (auto handler = AsyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
+    using SyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::StreamServerConnection>, TestWithStreamBatched*), TestWithStreamBatched,
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(SyncMessageHandlerListType::valid());
+    if (auto handler = SyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(connection);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -44,8 +44,9 @@ class SendString {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStreamBatched_SendString; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStreamBatched_SendString; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isStreamBatched = true;
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -39,8 +39,14 @@ namespace WebKit {
 void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithStreamBuffer::SendStreamBuffer::name())
-        return IPC::handleMessage<Messages::TestWithStreamBuffer::SendStreamBuffer>(connection, decoder, this, &TestWithStreamBuffer::sendStreamBuffer);
+
+    using AsyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithStreamBuffer*), TestWithStreamBuffer,
+        IPC::MessageHandlerListEntry<Messages::TestWithStreamBuffer::SendStreamBuffer, &TestWithStreamBuffer::sendStreamBuffer>,
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(AsyncMessageHandlerListType::valid());
+    if (auto handler = AsyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
@@ -46,8 +46,9 @@ class SendStreamBuffer {
 public:
     using Arguments = std::tuple<IPC::StreamConnectionBuffer>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStreamBuffer_SendStreamBuffer; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStreamBuffer_SendStreamBuffer; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit SendStreamBuffer(const IPC::StreamConnectionBuffer& stream)
         : m_arguments(stream)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -45,8 +45,9 @@ class SendString {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendString; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendString; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
 
@@ -68,13 +69,14 @@ class SendStringAsync {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringAsync; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringAsync; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringAsyncReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringAsyncReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<int64_t>;
     explicit SendStringAsync(const String& url)
@@ -95,8 +97,9 @@ class SendStringSync {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringSync; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringSync; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
@@ -122,8 +125,9 @@ class SendMachSendRight {
 public:
     using Arguments = std::tuple<MachSendRight>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendMachSendRight; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendMachSendRight; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
     static constexpr bool isStreamEncodable = false;
     static constexpr bool isStreamBatched = false;
 
@@ -147,8 +151,9 @@ class ReceiveMachSendRight {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_ReceiveMachSendRight; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStream_ReceiveMachSendRight; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = false;
     static constexpr bool isStreamBatched = false;
@@ -170,8 +175,9 @@ class SendAndReceiveMachSendRight {
 public:
     using Arguments = std::tuple<MachSendRight>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
     static constexpr bool isStreamEncodable = false;
     static constexpr bool isReplyStreamEncodable = false;
     static constexpr bool isStreamBatched = false;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -45,28 +45,41 @@ namespace WebKit {
 void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclass::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithSuperclass::LoadURL>(connection, decoder, this, &TestWithSuperclass::loadURL);
+
+    using AsyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithSuperclass*), TestWithSuperclass,
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::LoadURL, &TestWithSuperclass::loadURL>,
 #if ENABLE(TEST_FEATURE)
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessage::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessage>(connection, decoder, this, &TestWithSuperclass::testAsyncMessage);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithNoArguments);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::TestAsyncMessage, &TestWithSuperclass::testAsyncMessage>,
 #endif
+#if ENABLE(TEST_FEATURE)
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::TestAsyncMessageWithConnection, &TestWithSuperclass::testAsyncMessageWithConnection>,
+#endif
+#if ENABLE(TEST_FEATURE)
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments, &TestWithSuperclass::testAsyncMessageWithMultipleArguments>,
+#endif
+#if ENABLE(TEST_FEATURE)
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments, &TestWithSuperclass::testAsyncMessageWithNoArguments>,
+#endif
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(AsyncMessageHandlerListType::valid());
+    if (auto handler = AsyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
     WebPageBase::didReceiveMessage(connection, decoder);
 }
 
 bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSyncMessage);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestSynchronousMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSynchronousMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSynchronousMessage);
+
+    using SyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithSuperclass*), TestWithSuperclass,
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::TestSyncMessage, &TestWithSuperclass::testSyncMessage>,
+        IPC::MessageHandlerListEntry<Messages::TestWithSuperclass::TestSynchronousMessage, &TestWithSuperclass::testSynchronousMessage>,
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(SyncMessageHandlerListType::valid());
+    if (auto handler = SyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return handler({ connection, decoder, replyEncoder }, this);
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -49,8 +49,9 @@ class LoadURL {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_LoadURL; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_LoadURL; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
@@ -71,10 +72,11 @@ class TestAsyncMessage {
 public:
     using Arguments = std::tuple<WebKit::TestTwoStateEnum>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessage; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessage; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::MainThread;
     using ReplyArguments = std::tuple<uint64_t>;
     explicit TestAsyncMessage(WebKit::TestTwoStateEnum twoStateEnum)
@@ -97,10 +99,11 @@ class TestAsyncMessageWithNoArguments {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
     const auto& arguments() const
@@ -118,10 +121,11 @@ class TestAsyncMessageWithMultipleArguments {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool, uint64_t>;
     const auto& arguments() const
@@ -139,10 +143,11 @@ class TestAsyncMessageWithConnection {
 public:
     using Arguments = std::tuple<int>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnection; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnection; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
     explicit TestAsyncMessageWithConnection(const int& value)
@@ -164,8 +169,9 @@ class TestSyncMessage {
 public:
     using Arguments = std::tuple<uint32_t>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestSyncMessage; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestSyncMessage; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<uint8_t>;
@@ -187,8 +193,9 @@ class TestSynchronousMessage {
 public:
     using Arguments = std::tuple<bool>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestSynchronousMessage; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestSynchronousMessage; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<std::optional<WebKit::TestClassName>>;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -71,60 +71,49 @@ namespace WebKit {
 void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadURL>(connection, decoder, this, &TestWithoutAttributes::loadURL);
-#if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomething::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomething>(connection, decoder, this, &TestWithoutAttributes::loadSomething);
-#endif
-#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TouchEvent::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TouchEvent>(connection, decoder, this, &TestWithoutAttributes::touchEvent);
-#endif
+
+    using AsyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithoutAttributes*), TestWithoutAttributes,
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithoutAttributes::AddEvent::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::AddEvent>(connection, decoder, this, &TestWithoutAttributes::addEvent);
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::AddEvent, &TestWithoutAttributes::addEvent>,
+#endif
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::Close, &TestWithoutAttributes::close>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::CreatePlugin, &TestWithoutAttributes::createPlugin>,
+#if ENABLE(DEPRECATED_FEATURE)
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::DeprecatedOperation, &TestWithoutAttributes::deprecatedOperation>,
+#endif
+#if PLATFORM(MAC)
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::DidCreateWebProcessConnection, &TestWithoutAttributes::didCreateWebProcessConnection>,
+#endif
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::DidReceivePolicyDecision, &TestWithoutAttributes::didReceivePolicyDecision>,
+#if ENABLE(FEATURE_FOR_TESTING)
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::ExperimentalOperation, &TestWithoutAttributes::experimentalOperation>,
+#endif
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::GetPlugins, &TestWithoutAttributes::getPlugins>,
+#if PLATFORM(MAC)
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::InterpretKeyEvent, &TestWithoutAttributes::interpretKeyEvent>,
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomethingElse::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomethingElse>(connection, decoder, this, &TestWithoutAttributes::loadSomethingElse);
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::LoadSomething, &TestWithoutAttributes::loadSomething>,
 #endif
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DidReceivePolicyDecision::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DidReceivePolicyDecision>(connection, decoder, this, &TestWithoutAttributes::didReceivePolicyDecision);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::Close::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::Close>(connection, decoder, this, &TestWithoutAttributes::close);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::PreferencesDidChange::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::PreferencesDidChange>(connection, decoder, this, &TestWithoutAttributes::preferencesDidChange);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SendDoubleAndFloat::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SendDoubleAndFloat>(connection, decoder, this, &TestWithoutAttributes::sendDoubleAndFloat);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SendInts::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SendInts>(connection, decoder, this, &TestWithoutAttributes::sendInts);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::CreatePlugin::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::CreatePlugin>(connection, decoder, this, &TestWithoutAttributes::createPlugin);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::RunJavaScriptAlert::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::RunJavaScriptAlert>(connection, decoder, this, &TestWithoutAttributes::runJavaScriptAlert);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPlugins::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::GetPlugins>(connection, decoder, this, &TestWithoutAttributes::getPlugins);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TestParameterAttributes::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TestParameterAttributes>(connection, decoder, this, &TestWithoutAttributes::testParameterAttributes);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TemplateTest::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TemplateTest>(connection, decoder, this, &TestWithoutAttributes::templateTest);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SetVideoLayerID::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SetVideoLayerID>(connection, decoder, this, &TestWithoutAttributes::setVideoLayerID);
-#if PLATFORM(MAC)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithoutAttributes::didCreateWebProcessConnection);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::InterpretKeyEvent::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::InterpretKeyEvent>(connection, decoder, this, &TestWithoutAttributes::interpretKeyEvent);
+#if ENABLE(TOUCH_EVENTS)
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::LoadSomethingElse, &TestWithoutAttributes::loadSomethingElse>,
 #endif
-#if ENABLE(DEPRECATED_FEATURE)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DeprecatedOperation::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DeprecatedOperation>(connection, decoder, this, &TestWithoutAttributes::deprecatedOperation);
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::LoadURL, &TestWithoutAttributes::loadURL>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::PreferencesDidChange, &TestWithoutAttributes::preferencesDidChange>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::RunJavaScriptAlert, &TestWithoutAttributes::runJavaScriptAlert>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::SendDoubleAndFloat, &TestWithoutAttributes::sendDoubleAndFloat>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::SendInts, &TestWithoutAttributes::sendInts>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::SetVideoLayerID, &TestWithoutAttributes::setVideoLayerID>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::TemplateTest, &TestWithoutAttributes::templateTest>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::TestParameterAttributes, &TestWithoutAttributes::testParameterAttributes>,
+#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::TouchEvent, &TestWithoutAttributes::touchEvent>,
 #endif
-#if ENABLE(FEATURE_FOR_TESTING)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::ExperimentalOperation::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::ExperimentalOperation>(connection, decoder, this, &TestWithoutAttributes::experimentalOperation);
-#endif
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(AsyncMessageHandlerListType::valid());
+    if (auto handler = AsyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return std::void_t<>(handler({ connection, decoder }, this));
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)
@@ -137,10 +126,15 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
 bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPluginProcessConnection::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::getPluginProcessConnection);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
+
+    using SyncMessageHandlerListType = IPC::MessageHandlerList<bool(*)(IPC::HandleMessageContext<IPC::Connection>, TestWithoutAttributes*), TestWithoutAttributes,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::GetPluginProcessConnection, &TestWithoutAttributes::getPluginProcessConnection>,
+        IPC::MessageHandlerListEntry<Messages::TestWithoutAttributes::TestMultipleAttributes, &TestWithoutAttributes::testMultipleAttributes>,
+        IPC::MessageHandlerListEntry<void, nullptr>>;
+    static_assert(SyncMessageHandlerListType::valid());
+    if (auto handler = SyncMessageHandlerListType::messageHandler(decoder.messageName()))
+        return handler({ connection, decoder, replyEncoder }, this);
+
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(replyEncoder);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -66,8 +66,9 @@ class LoadURL {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadURL; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadURL; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
@@ -88,8 +89,9 @@ class LoadSomething {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadSomething; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadSomething; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadSomething(const String& url)
         : m_arguments(url)
@@ -111,8 +113,9 @@ class TouchEvent {
 public:
     using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TouchEvent; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TouchEvent; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit TouchEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
@@ -134,8 +137,9 @@ class AddEvent {
 public:
     using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_AddEvent; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_AddEvent; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit AddEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
@@ -157,8 +161,9 @@ class LoadSomethingElse {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadSomethingElse; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadSomethingElse; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit LoadSomethingElse(const String& url)
         : m_arguments(url)
@@ -179,8 +184,9 @@ class DidReceivePolicyDecision {
 public:
     using Arguments = std::tuple<uint64_t, uint64_t, uint32_t>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidReceivePolicyDecision; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidReceivePolicyDecision; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     DidReceivePolicyDecision(uint64_t frameID, uint64_t listenerID, uint32_t policyAction)
         : m_arguments(frameID, listenerID, policyAction)
@@ -200,8 +206,9 @@ class Close {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_Close; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_Close; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     const auto& arguments() const
     {
@@ -216,8 +223,9 @@ class PreferencesDidChange {
 public:
     using Arguments = std::tuple<WebKit::WebPreferencesStore>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_PreferencesDidChange; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_PreferencesDidChange; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit PreferencesDidChange(const WebKit::WebPreferencesStore& store)
         : m_arguments(store)
@@ -237,8 +245,9 @@ class SendDoubleAndFloat {
 public:
     using Arguments = std::tuple<double, float>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendDoubleAndFloat; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendDoubleAndFloat; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     SendDoubleAndFloat(double d, float f)
         : m_arguments(d, f)
@@ -258,8 +267,9 @@ class SendInts {
 public:
     using Arguments = std::tuple<Vector<uint64_t>, Vector<Vector<uint64_t>>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendInts; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendInts; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     SendInts(const Vector<uint64_t>& ints, const Vector<Vector<uint64_t>>& intVectors)
         : m_arguments(ints, intVectors)
@@ -279,10 +289,11 @@ class CreatePlugin {
 public:
     using Arguments = std::tuple<uint64_t, WebKit::Plugin::Parameters>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_CreatePlugin; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_CreatePlugin; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_CreatePluginReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
     CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
@@ -303,10 +314,11 @@ class RunJavaScriptAlert {
 public:
     using Arguments = std::tuple<uint64_t, String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlert; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlert; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlertReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
     RunJavaScriptAlert(uint64_t frameID, const String& message)
@@ -327,10 +339,11 @@ class GetPlugins {
 public:
     using Arguments = std::tuple<bool>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_GetPlugins; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_GetPlugins; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_GetPluginsReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
     explicit GetPlugins(bool refresh)
@@ -351,8 +364,9 @@ class GetPluginProcessConnection {
 public:
     using Arguments = std::tuple<String>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_GetPluginProcessConnection; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_GetPluginProcessConnection; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Connection::Handle>;
@@ -374,8 +388,9 @@ class TestMultipleAttributes {
 public:
     using Arguments = std::tuple<>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TestMultipleAttributes; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TestMultipleAttributes; }
     static constexpr bool isSync = true;
+    static constexpr bool isAsync = false;
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
@@ -392,8 +407,9 @@ class TestParameterAttributes {
 public:
     using Arguments = std::tuple<uint64_t, double, double>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TestParameterAttributes; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TestParameterAttributes; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     TestParameterAttributes(uint64_t foo, double bar, double baz)
         : m_arguments(foo, bar, baz)
@@ -413,8 +429,9 @@ class TemplateTest {
 public:
     using Arguments = std::tuple<HashMap<String, std::pair<String, uint64_t>>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TemplateTest; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TemplateTest; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit TemplateTest(const HashMap<String, std::pair<String, uint64_t>>& a)
         : m_arguments(a)
@@ -434,8 +451,9 @@ class SetVideoLayerID {
 public:
     using Arguments = std::tuple<WebCore::GraphicsLayer::PlatformLayerID>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SetVideoLayerID; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SetVideoLayerID; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit SetVideoLayerID(const WebCore::GraphicsLayer::PlatformLayerID& videoLayerID)
         : m_arguments(videoLayerID)
@@ -456,8 +474,9 @@ class DidCreateWebProcessConnection {
 public:
     using Arguments = std::tuple<MachSendRight, OptionSet<WebKit::SelectionFlags>>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidCreateWebProcessConnection; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidCreateWebProcessConnection; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     DidCreateWebProcessConnection(const MachSendRight& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
         : m_arguments(connectionIdentifier, flags)
@@ -479,10 +498,11 @@ class InterpretKeyEvent {
 public:
     using Arguments = std::tuple<uint32_t>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEvent; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEvent; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEventReply; }
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
     explicit InterpretKeyEvent(uint32_t type)
@@ -505,8 +525,9 @@ class DeprecatedOperation {
 public:
     using Arguments = std::tuple<IPC::DummyType>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DeprecatedOperation; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DeprecatedOperation; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit DeprecatedOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)
@@ -528,8 +549,9 @@ class ExperimentalOperation {
 public:
     using Arguments = std::tuple<IPC::DummyType>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_ExperimentalOperation; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_ExperimentalOperation; }
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
 
     explicit ExperimentalOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -93,12 +93,12 @@ void ProvisionalFrameProxy::didReceiveMessage(IPC::Connection& connection, IPC::
     ASSERT(decoder.messageReceiverName() == Messages::WebPageProxy::messageReceiverName());
 
     if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForResponse::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForResponse>(connection, decoder, this, &ProvisionalFrameProxy::decidePolicyForResponse);
+        IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForResponse, &ProvisionalFrameProxy::decidePolicyForResponse>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidCommitLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame>(connection, decoder, this, &ProvisionalFrameProxy::didCommitLoadForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame, &ProvisionalFrameProxy::didCommitLoadForFrame>({ connection, decoder }, this);
         return;
     }
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -505,115 +505,115 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
 
 #if PLATFORM(COCOA)
     if (decoder.messageName() == Messages::WebPageProxy::RegisterWebProcessAccessibilityToken::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::RegisterWebProcessAccessibilityToken>(connection, decoder, this, &ProvisionalPageProxy::registerWebProcessAccessibilityToken);
+        IPC::handleMessage<Messages::WebPageProxy::RegisterWebProcessAccessibilityToken, &ProvisionalPageProxy::registerWebProcessAccessibilityToken>({ connection, decoder }, this);
         return;
     }
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     if (decoder.messageName() == Messages::WebPageProxy::BindAccessibilityTree::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::BindAccessibilityTree>(connection, decoder, this, &ProvisionalPageProxy::bindAccessibilityTree);
+        IPC::handleMessage<Messages::WebPageProxy::BindAccessibilityTree, &ProvisionalPageProxy::bindAccessibilityTree>({ connection, decoder }, this);
         return;
     }
 #endif
 
     if (decoder.messageName() == Messages::WebPageProxy::BackForwardAddItem::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::BackForwardAddItem>(connection, decoder, this, &ProvisionalPageProxy::backForwardAddItem);
+        IPC::handleMessage<Messages::WebPageProxy::BackForwardAddItem, &ProvisionalPageProxy::backForwardAddItem>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess>(connection, decoder, this, &ProvisionalPageProxy::logDiagnosticMessageFromWebProcess);
+        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess, &ProvisionalPageProxy::logDiagnosticMessageFromWebProcess>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess>(connection, decoder, this, &ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess);
+        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess, &ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess>(connection, decoder, this, &ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess);
+        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess, &ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::StartURLSchemeTask::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::StartURLSchemeTask>(connection, decoder, this, &ProvisionalPageProxy::startURLSchemeTask);
+        IPC::handleMessage<Messages::WebPageProxy::StartURLSchemeTask, &ProvisionalPageProxy::startURLSchemeTask>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionAsync::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForNavigationActionAsync>(connection, decoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionAsync);
+        IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForNavigationActionAsync, &ProvisionalPageProxy::decidePolicyForNavigationActionAsync>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForResponse::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForResponse>(connection, decoder, this, &ProvisionalPageProxy::decidePolicyForResponse);
+        IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForResponse, &ProvisionalPageProxy::decidePolicyForResponse>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidChangeProvisionalURLForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidChangeProvisionalURLForFrame>(connection, decoder, this, &ProvisionalPageProxy::didChangeProvisionalURLForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidChangeProvisionalURLForFrame, &ProvisionalPageProxy::didChangeProvisionalURLForFrame>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidNavigateWithNavigationData::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidNavigateWithNavigationData>(connection, decoder, this, &ProvisionalPageProxy::didNavigateWithNavigationData);
+        IPC::handleMessage<Messages::WebPageProxy::DidNavigateWithNavigationData, &ProvisionalPageProxy::didNavigateWithNavigationData>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidPerformClientRedirect::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidPerformClientRedirect>(connection, decoder, this, &ProvisionalPageProxy::didPerformClientRedirect);
+        IPC::handleMessage<Messages::WebPageProxy::DidPerformClientRedirect, &ProvisionalPageProxy::didPerformClientRedirect>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidCreateMainFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCreateMainFrame>(connection, decoder, this, &ProvisionalPageProxy::didCreateMainFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidCreateMainFrame, &ProvisionalPageProxy::didCreateMainFrame>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidStartProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidStartProvisionalLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didStartProvisionalLoadForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidStartProvisionalLoadForFrame, &ProvisionalPageProxy::didStartProvisionalLoadForFrame>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidFailProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidFailProvisionalLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didFailProvisionalLoadForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidFailProvisionalLoadForFrame, &ProvisionalPageProxy::didFailProvisionalLoadForFrame>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidCommitLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didCommitLoadForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame, &ProvisionalPageProxy::didCommitLoadForFrame>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame, &ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame>({ connection, decoder }, this);
         return;
     }
 
     if (decoder.messageName() == Messages::WebPageProxy::DidPerformServerRedirect::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidPerformServerRedirect>(connection, decoder, this, &ProvisionalPageProxy::didPerformServerRedirect);
+        IPC::handleMessage<Messages::WebPageProxy::DidPerformServerRedirect, &ProvisionalPageProxy::didPerformServerRedirect>({ connection, decoder }, this);
         return;
     }
 
 #if USE(QUICK_LOOK)
     if (decoder.messageName() == Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame::name()) {
-        IPC::handleMessageAsync<Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame>(connection, decoder, this, &ProvisionalPageProxy::requestPasswordForQuickLookDocumentInMainFrame);
+        IPC::handleMessage<Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame, &ProvisionalPageProxy::requestPasswordForQuickLookDocumentInMainFrame>({ connection, decoder }, this);
         return;
     }
 #endif
 
 #if ENABLE(CONTENT_FILTERING)
     if (decoder.messageName() == Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::contentFilterDidBlockLoadForFrame);
+        IPC::handleMessage<Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame, &ProvisionalPageProxy::contentFilterDidBlockLoadForFrame>({ connection, decoder }, this);
         return;
     }
 #endif
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     if (decoder.messageName() == Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation>(connection, decoder, this, &ProvisionalPageProxy::didCreateContextInWebProcessForVisibilityPropagation);
+        IPC::handleMessage<Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation, &ProvisionalPageProxy::didCreateContextInWebProcessForVisibilityPropagation>({ connection, decoder }, this);
         return;
     }
 #endif
@@ -624,10 +624,10 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
 bool ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     if (decoder.messageName() == Messages::WebPageProxy::BackForwardGoToItem::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::BackForwardGoToItem>(connection, decoder, replyEncoder, this, &ProvisionalPageProxy::backForwardGoToItem);
+        return IPC::handleMessage<Messages::WebPageProxy::BackForwardGoToItem, &ProvisionalPageProxy::backForwardGoToItem>({ connection, decoder, replyEncoder }, this);
 
     if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, replyEncoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionSync);
+        return IPC::handleMessage<Messages::WebPageProxy::DecidePolicyForNavigationActionSync, &ProvisionalPageProxy::decidePolicyForNavigationActionSync>({ connection, decoder, replyEncoder }, this);
 
     return m_page.didReceiveSyncMessage(connection, decoder, replyEncoder);
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -48,12 +48,14 @@ struct MessageInfo {
 
 struct MockTestMessage1 {
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = false;
     static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
     std::tuple<> arguments() { return { }; }
 };
 
 struct MockTestMessageWithAsyncReply1 {
     static constexpr bool isSync = false;
+    static constexpr bool isAsync = true;
     static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(124); }
     // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.


### PR DESCRIPTION
#### 54a18c84c4018bd427ec1c8b209ef34463398c23
<pre>
[WK2] Dispatch IPC messages through receivers&apos; sequential message lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=251288">https://bugs.webkit.org/show_bug.cgi?id=251288</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::HandleMessageContext::HandleMessageContext):
(IPC::handleMessage):
(IPC::MessageHandlerList::valid):
(IPC::MessageHandlerList::messageHandler):
(IPC::handleMessageSynchronous): Deleted.
(IPC::handleMessageAsync): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
(handler_function):
(generate_message_handler.construct_message_handler_list):
(generate_message_handler):
(async_message_statement): Deleted.
(sync_message_statement): Deleted.
(generate_message_handler.collect_message_statements): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
(Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name):
(Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name):
(Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::asyncMessageReplyName):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
(WebKit::TestWithIfMessage::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h:
(Messages::TestWithIfMessage::LoadURL::name):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
(WebKit::TestWithImageData::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
(Messages::TestWithImageData::SendImageData::name):
(Messages::TestWithImageData::ReceiveImageData::name):
(Messages::TestWithImageData::ReceiveImageData::asyncMessageReplyName):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage):
(WebKit::TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
(Messages::TestWithLegacyReceiver::LoadURL::name):
(Messages::TestWithLegacyReceiver::LoadSomething::name):
(Messages::TestWithLegacyReceiver::TouchEvent::name):
(Messages::TestWithLegacyReceiver::AddEvent::name):
(Messages::TestWithLegacyReceiver::LoadSomethingElse::name):
(Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::name):
(Messages::TestWithLegacyReceiver::Close::name):
(Messages::TestWithLegacyReceiver::PreferencesDidChange::name):
(Messages::TestWithLegacyReceiver::SendDoubleAndFloat::name):
(Messages::TestWithLegacyReceiver::SendInts::name):
(Messages::TestWithLegacyReceiver::CreatePlugin::name):
(Messages::TestWithLegacyReceiver::CreatePlugin::asyncMessageReplyName):
(Messages::TestWithLegacyReceiver::RunJavaScriptAlert::name):
(Messages::TestWithLegacyReceiver::RunJavaScriptAlert::asyncMessageReplyName):
(Messages::TestWithLegacyReceiver::GetPlugins::name):
(Messages::TestWithLegacyReceiver::GetPlugins::asyncMessageReplyName):
(Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name):
(Messages::TestWithLegacyReceiver::TestMultipleAttributes::name):
(Messages::TestWithLegacyReceiver::TestParameterAttributes::name):
(Messages::TestWithLegacyReceiver::TemplateTest::name):
(Messages::TestWithLegacyReceiver::SetVideoLayerID::name):
(Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name):
(Messages::TestWithLegacyReceiver::InterpretKeyEvent::name):
(Messages::TestWithLegacyReceiver::InterpretKeyEvent::asyncMessageReplyName):
(Messages::TestWithLegacyReceiver::DeprecatedOperation::name):
(Messages::TestWithLegacyReceiver::ExperimentalOperation::name):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
(WebKit::TestWithSemaphore::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
(Messages::TestWithSemaphore::SendSemaphore::name):
(Messages::TestWithSemaphore::ReceiveSemaphore::name):
(Messages::TestWithSemaphore::ReceiveSemaphore::asyncMessageReplyName):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h:
(Messages::TestWithStreamBatched::SendString::name):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
(WebKit::TestWithStreamBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h:
(Messages::TestWithStreamBuffer::SendStreamBuffer::name):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
(Messages::TestWithStream::SendString::name):
(Messages::TestWithStream::SendStringAsync::name):
(Messages::TestWithStream::SendStringAsync::asyncMessageReplyName):
(Messages::TestWithStream::SendStringSync::name):
(Messages::TestWithStream::SendMachSendRight::name):
(Messages::TestWithStream::ReceiveMachSendRight::name):
(Messages::TestWithStream::SendAndReceiveMachSendRight::name):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveMessage):
(WebKit::TestWithSuperclass::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
(Messages::TestWithSuperclass::LoadURL::name):
(Messages::TestWithSuperclass::TestAsyncMessage::name):
(Messages::TestWithSuperclass::TestAsyncMessage::asyncMessageReplyName):
(Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name):
(Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::asyncMessageReplyName):
(Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name):
(Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::asyncMessageReplyName):
(Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name):
(Messages::TestWithSuperclass::TestAsyncMessageWithConnection::asyncMessageReplyName):
(Messages::TestWithSuperclass::TestSyncMessage::name):
(Messages::TestWithSuperclass::TestSynchronousMessage::name):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
(Messages::TestWithoutAttributes::LoadURL::name):
(Messages::TestWithoutAttributes::LoadSomething::name):
(Messages::TestWithoutAttributes::TouchEvent::name):
(Messages::TestWithoutAttributes::AddEvent::name):
(Messages::TestWithoutAttributes::LoadSomethingElse::name):
(Messages::TestWithoutAttributes::DidReceivePolicyDecision::name):
(Messages::TestWithoutAttributes::Close::name):
(Messages::TestWithoutAttributes::PreferencesDidChange::name):
(Messages::TestWithoutAttributes::SendDoubleAndFloat::name):
(Messages::TestWithoutAttributes::SendInts::name):
(Messages::TestWithoutAttributes::CreatePlugin::name):
(Messages::TestWithoutAttributes::CreatePlugin::asyncMessageReplyName):
(Messages::TestWithoutAttributes::RunJavaScriptAlert::name):
(Messages::TestWithoutAttributes::RunJavaScriptAlert::asyncMessageReplyName):
(Messages::TestWithoutAttributes::GetPlugins::name):
(Messages::TestWithoutAttributes::GetPlugins::asyncMessageReplyName):
(Messages::TestWithoutAttributes::GetPluginProcessConnection::name):
(Messages::TestWithoutAttributes::TestMultipleAttributes::name):
(Messages::TestWithoutAttributes::TestParameterAttributes::name):
(Messages::TestWithoutAttributes::TemplateTest::name):
(Messages::TestWithoutAttributes::SetVideoLayerID::name):
(Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name):
(Messages::TestWithoutAttributes::InterpretKeyEvent::name):
(Messages::TestWithoutAttributes::InterpretKeyEvent::asyncMessageReplyName):
(Messages::TestWithoutAttributes::DeprecatedOperation::name):
(Messages::TestWithoutAttributes::ExperimentalOperation::name):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::didReceiveMessage):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didReceiveMessage):
(WebKit::ProvisionalPageProxy::didReceiveSyncMessage):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54a18c84c4018bd427ec1c8b209ef34463398c23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105199 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114458 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174639 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5199 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97513 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114398 "Hash 54a18c84 for PR 9251 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39423 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108660 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7708 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4484 "Found 1 new test failure: fast/forms/fieldset/fieldset-flexbox.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47466 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9496 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->