### PR TITLE
Move Opaque Origin Identifier from SecurityOrigin to SecurityOriginData

### DIFF
--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -36,6 +36,7 @@
 
 #include <optional>
 #include <type_traits>
+#include <wtf/Hasher.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -153,6 +154,11 @@ public:
 private:
     T m_value;
 };
+
+template <typename T, typename Traits> inline void add(Hasher& hasher, const Markable<T, Traits>& value)
+{
+    add(hasher, value.asOptional());
+}
 
 template <typename T, typename Traits> constexpr bool operator==(const Markable<T, Traits>& x, const Markable<T, Traits>& y)
 {

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -52,14 +52,6 @@ namespace WebCore {
 
 constexpr unsigned maximumURLSize = 0x04000000;
 
-static bool schemeRequiresHost(const URL& url)
-{
-    // We expect URLs with these schemes to have authority components. If the
-    // URL lacks an authority component, we get concerned and mark the origin
-    // as opaque.
-    return url.protocolIsInHTTPFamily() || url.protocolIs("ftp"_s);
-}
-
 bool SecurityOrigin::shouldIgnoreHost(const URL& url)
 {
     return url.protocolIsData() || url.protocolIsAbout() || url.protocolIsJavaScript() || url.protocolIs("file"_s);
@@ -89,46 +81,6 @@ static RefPtr<SecurityOrigin> getCachedOrigin(const URL& url)
     if (url.protocolIsBlob())
         return ThreadableBlobRegistry::getCachedOrigin(url);
     return nullptr;
-}
-
-static bool shouldTreatAsOpaqueOrigin(const URL& url)
-{
-    if (!url.isValid())
-        return true;
-
-    // FIXME: Do we need to unwrap the URL further?
-    URL innerURL = SecurityOrigin::shouldUseInnerURL(url) ? SecurityOrigin::extractInnerURL(url) : url;
-    if (!innerURL.isValid())
-        return true;
-
-    // For edge case URLs that were probably misparsed, make sure that the origin is opaque.
-    // This is an additional safety net against bugs in URL parsing, and for network back-ends that parse URLs differently,
-    // and could misinterpret another component for hostname.
-    if (schemeRequiresHost(innerURL) && innerURL.host().isEmpty())
-        return true;
-
-    if (LegacySchemeRegistry::shouldTreatURLSchemeAsNoAccess(innerURL.protocol()))
-        return true;
-
-    // https://url.spec.whatwg.org/#origin with some additions
-    if (url.hasSpecialScheme()
-#if PLATFORM(COCOA)
-        || !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NullOriginForNonSpecialSchemedURLs)
-        || url.protocolIs("applewebdata"_s)
-        || url.protocolIs("x-apple-ql-id"_s)
-        || url.protocolIs("x-apple-ql-id2"_s)
-        || url.protocolIs("x-apple-ql-magic"_s)
-#endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
-        || url.protocolIs("resource"_s)
-#endif
-#if ENABLE(PDFJS)
-        || url.protocolIs("webkit-pdfjs-viewer"_s)
-#endif
-        || url.protocolIs("blob"_s))
-        return false;
-
-    return !LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol());
 }
 
 static bool isLoopbackIPAddress(StringView host)
@@ -175,10 +127,10 @@ bool shouldTreatAsPotentiallyTrustworthy(const URL& url)
     return shouldTreatAsPotentiallyTrustworthy(url.protocol(), url.host());
 }
 
-SecurityOrigin::SecurityOrigin(const URL& url)
-    : m_data(SecurityOriginData::fromURL(url))
-    , m_isLocal(LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(m_data.protocol))
+void SecurityOrigin::initializeShared(const URL& url)
 {
+    m_isLocal = LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(m_data.protocol);
+
     // document.domain starts as m_data.host, but can be set by the DOM.
     m_domain = m_data.host;
 
@@ -192,10 +144,21 @@ SecurityOrigin::SecurityOrigin(const URL& url)
         m_filePath = url.fileSystemPath(); // In case enforceFilePathSeparation() is called.
 }
 
+SecurityOrigin::SecurityOrigin(const URL& url)
+    : m_data(SecurityOriginData::fromURL(url))
+{
+    initializeShared(url);
+}
+
+SecurityOrigin::SecurityOrigin(SecurityOriginData&& data)
+    : m_data(WTFMove(data))
+{
+    initializeShared(m_data.toURL());
+}
+
 SecurityOrigin::SecurityOrigin()
-    : m_data { emptyString(), emptyString(), std::nullopt }
+    : m_data { SecurityOriginData::createOpaque() }
     , m_domain { emptyString() }
-    , m_opaqueOriginIdentifier { OpaqueOriginIdentifier::generateThreadSafe() }
     , m_isPotentiallyTrustworthy { false }
 {
 }
@@ -204,7 +167,6 @@ SecurityOrigin::SecurityOrigin(const SecurityOrigin* other)
     : m_data { other->m_data.isolatedCopy() }
     , m_domain { other->m_domain.isolatedCopy() }
     , m_filePath { other->m_filePath.isolatedCopy() }
-    , m_opaqueOriginIdentifier { other->m_opaqueOriginIdentifier }
     , m_universalAccess { other->m_universalAccess }
     , m_domainWasSetInDOM { other->m_domainWasSetInDOM }
     , m_canLoadLocalResources { other->m_canLoadLocalResources }
@@ -220,7 +182,7 @@ Ref<SecurityOrigin> SecurityOrigin::create(const URL& url)
     if (RefPtr<SecurityOrigin> cachedOrigin = getCachedOrigin(url))
         return cachedOrigin.releaseNonNull();
 
-    if (shouldTreatAsOpaqueOrigin(url))
+    if (SecurityOriginData::shouldTreatAsOpaqueOrigin(url))
         return adoptRef(*new SecurityOrigin);
 
     if (shouldUseInnerURL(url))
@@ -277,7 +239,7 @@ bool SecurityOrigin::isSameOriginDomain(const SecurityOrigin& other) const
         return true;
 
     if (isOpaque() || other.isOpaque())
-        return m_opaqueOriginIdentifier == other.m_opaqueOriginIdentifier;
+        return data().opaqueOriginIdentifier == other.data().opaqueOriginIdentifier;
 
     // Here are two cases where we should permit access:
     //
@@ -435,7 +397,7 @@ bool SecurityOrigin::isSameOriginAs(const SecurityOrigin& other) const
         return true;
 
     if (isOpaque() || other.isOpaque())
-        return m_opaqueOriginIdentifier == other.m_opaqueOriginIdentifier;
+        return data().opaqueOriginIdentifier == other.data().opaqueOriginIdentifier;
 
     return isSameSchemeHostPort(other);
 }
@@ -596,13 +558,17 @@ Ref<SecurityOrigin> SecurityOrigin::create(const String& protocol, const String&
     return origin;
 }
 
-Ref<SecurityOrigin> SecurityOrigin::create(WebCore::SecurityOriginData&& data, String&& domain, String&& filePath, Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>&& opaqueOriginIdentifier, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal)
+Ref<SecurityOrigin> SecurityOrigin::create(SecurityOriginData&& data)
+{
+    return adoptRef(*new SecurityOrigin(WTFMove(data)));
+}
+
+Ref<SecurityOrigin> SecurityOrigin::create(WebCore::SecurityOriginData&& data, String&& domain, String&& filePath, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal)
 {
     auto origin = adoptRef(*new SecurityOrigin);
     origin->m_data = WTFMove(data);
     origin->m_domain = WTFMove(domain);
     origin->m_filePath = WTFMove(filePath);
-    origin->m_opaqueOriginIdentifier = WTFMove(opaqueOriginIdentifier);
     origin->m_universalAccess = universalAccess;
     origin->m_domainWasSetInDOM = domainWasSetInDOM;
     origin->m_canLoadLocalResources = canLoadLocalResources;
@@ -619,7 +585,7 @@ bool SecurityOrigin::equal(const SecurityOrigin* other) const
         return true;
 
     if (isOpaque() || other->isOpaque())
-        return m_opaqueOriginIdentifier == other->m_opaqueOriginIdentifier;
+        return data().opaqueOriginIdentifier == other->data().opaqueOriginIdentifier;
     
     if (!isSameSchemeHostPort(*other))
         return false;

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -28,19 +28,14 @@
 
 #pragma once
 
-#include "ProcessQualified.h"
 #include "SecurityOriginData.h"
 #include <wtf/ArgumentCoder.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/Hasher.h>
-#include <wtf/Markable.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-enum OpaqueOriginIdentifierType { };
-using OpaqueOriginIdentifier = ProcessQualified<ObjectIdentifier<OpaqueOriginIdentifierType>>;
 
 class SecurityOrigin : public ThreadSafeRefCounted<SecurityOrigin> {
 public:
@@ -55,7 +50,8 @@ public:
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> createFromString(const String&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const String& protocol, const String& host, std::optional<uint16_t> port);
-    WEBCORE_EXPORT static Ref<SecurityOrigin> create(WebCore::SecurityOriginData&&, String&& domain, String&& filePath, Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>&&, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> create(SecurityOriginData&&);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> create(WebCore::SecurityOriginData&&, String&& domain, String&& filePath, bool universalAccess, bool domainWasSetInDOM, bool canLoadLocalResources, bool enforcesFilePathSeparation, bool needsStorageAccessFromFileURLsQuirk, std::optional<bool> isPotentiallyTrustworthy, bool isLocal);
 
     // QuickLook documents are in non-local origins even when loaded from file: URLs. They need to
     // be allowed to display their own file: URLs in order to perform reloads and same-document
@@ -162,7 +158,7 @@ public:
     // There's a subtle difference between an opaque origin and an origin that
     // has the SandboxOrigin flag set. The latter implies the former, and, in
     // addition, the SandboxOrigin flag is inherited by iframes.
-    bool isOpaque() const { return !!m_opaqueOriginIdentifier; }
+    bool isOpaque() const { return m_data.isOpaque(); }
 
     // Marks a file:// origin as being in a domain defined by its path.
     // FIXME 81578: The naming of this is confusing. Files with restricted access to other local files
@@ -226,6 +222,8 @@ private:
     WEBCORE_EXPORT SecurityOrigin();
     explicit SecurityOrigin(const URL&);
     explicit SecurityOrigin(const SecurityOrigin*);
+    explicit SecurityOrigin(SecurityOriginData&&);
+    void initializeShared(const URL&);
 
     // FIXME: Rename this function to something more semantic.
     bool passesFileCheck(const SecurityOrigin&) const;
@@ -240,7 +238,6 @@ private:
     SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
-    Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
     bool m_universalAccess { false };
     bool m_domainWasSetInDOM { false };
     bool m_canLoadLocalResources { false };
@@ -258,7 +255,7 @@ bool serializedOriginsMatch(const SecurityOrigin*, const SecurityOrigin*);
 
 inline void add(Hasher& hasher, const SecurityOrigin& origin)
 {
-    add(hasher, origin.protocol(), origin.host(), origin.port());
+    add(hasher, origin.data());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#include "ProcessQualified.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Hasher.h>
+#include <wtf/Markable.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -34,6 +37,10 @@ class Frame;
 class SecurityOrigin;
 
 struct SecurityOriginData {
+    enum OpaqueOriginIdentifierType { };
+    using OpaqueOriginIdentifier = ProcessQualified<ObjectIdentifier<OpaqueOriginIdentifierType>>;
+    using MarkableOpaqueOriginIdentifier = Markable<OpaqueOriginIdentifier, OpaqueOriginIdentifier::MarkableTraits>;
+
     SecurityOriginData() = default;
     SecurityOriginData(const String& protocol, const String& host, std::optional<uint16_t> port)
         : protocol(protocol)
@@ -42,19 +49,24 @@ struct SecurityOriginData {
     {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isHashTableDeletedValue());
     }
+    explicit SecurityOriginData(OpaqueOriginIdentifier opaqueOriginIdentifier)
+        : protocol(emptyString())
+        , host(emptyString())
+        , opaqueOriginIdentifier(opaqueOriginIdentifier)
+    {
+    }
     SecurityOriginData(WTF::HashTableDeletedValueType)
         : protocol(WTF::HashTableDeletedValue)
     {
     }
     
     WEBCORE_EXPORT static SecurityOriginData fromFrame(Frame*);
-    static SecurityOriginData fromURL(const URL& url)
+    WEBCORE_EXPORT static SecurityOriginData fromURL(const URL&);
+    WEBCORE_EXPORT static SecurityOriginData fromURLWithoutStrictOpaqueness(const URL&);
+
+    static SecurityOriginData createOpaque()
     {
-        return SecurityOriginData {
-            url.protocol().isNull() ? emptyString() : url.protocol().convertToASCIILowercase(),
-            url.host().isNull() ? emptyString() : url.host().convertToASCIILowercase(),
-            url.port()
-        };
+        return SecurityOriginData { OpaqueOriginIdentifier::generateThreadSafe() };
     }
 
     WEBCORE_EXPORT Ref<SecurityOrigin> securityOrigin() const;
@@ -65,6 +77,7 @@ struct SecurityOriginData {
     String protocol;
     String host;
     std::optional<uint16_t> port;
+    MarkableOpaqueOriginIdentifier opaqueOriginIdentifier;
 
     WEBCORE_EXPORT SecurityOriginData isolatedCopy() const &;
     WEBCORE_EXPORT SecurityOriginData isolatedCopy() &&;
@@ -80,7 +93,7 @@ struct SecurityOriginData {
     }
     bool isOpaque() const
     {
-        return protocol == emptyString() && host == emptyString() && !port;
+        return !!opaqueOriginIdentifier;
     }
 
     bool isHashTableDeletedValue() const
@@ -90,19 +103,59 @@ struct SecurityOriginData {
     
     WEBCORE_EXPORT String toString() const;
 
-    URL toURL() const;
+    WEBCORE_EXPORT URL toURL() const;
 
 #if !LOG_DISABLED
     String debugString() const { return toString(); }
 #endif
+
+    static bool shouldTreatAsOpaqueOrigin(const URL&);
+
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<SecurityOriginData> decode(Decoder&);
 };
+
+template<class Encoder>
+void SecurityOriginData::encode(Encoder& encoder) const
+{
+    encoder << opaqueOriginIdentifier;
+    if (opaqueOriginIdentifier)
+        return;
+    encoder << protocol << host << port;
+}
+
+template<class Decoder>
+std::optional<SecurityOriginData> SecurityOriginData::decode(Decoder& decoder)
+{
+    std::optional<SecurityOriginData::MarkableOpaqueOriginIdentifier> opaqueOriginIdentifier;
+    decoder >> opaqueOriginIdentifier;
+    if (!opaqueOriginIdentifier)
+        return std::nullopt;
+    if (*opaqueOriginIdentifier)
+        return SecurityOriginData(**opaqueOriginIdentifier);
+    std::optional<String> protocol;
+    decoder >> protocol;
+    if (!protocol)
+        return std::nullopt;
+    if (protocol->isHashTableDeletedValue())
+        return std::nullopt;
+    std::optional<String> host;
+    decoder >> host;
+    if (!host)
+        return std::nullopt;
+    std::optional<std::optional<uint16_t>> port;
+    decoder >> port;
+    if (!port)
+        return std::nullopt;
+    return SecurityOriginData(WTFMove(*protocol), WTFMove(*host), *port);
+}
 
 WEBCORE_EXPORT bool operator==(const SecurityOriginData&, const SecurityOriginData&);
 inline bool operator!=(const SecurityOriginData& first, const SecurityOriginData& second) { return !(first == second); }
 
 inline void add(Hasher& hasher, const SecurityOriginData& data)
 {
-    add(hasher, data.protocol, data.host, data.port);
+    add(hasher, data.protocol, data.host, data.port, data.opaqueOriginIdentifier);
 }
 
 struct SecurityOriginDataHashTraits : SimpleClassHashTraits<SecurityOriginData> {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -301,8 +301,8 @@ public:
     void resetStoragePersistedState(PAL::SessionID, CompletionHandler<void()>&&);
     void cloneSessionStorageForWebPage(PAL::SessionID, WebPageProxyIdentifier fromIdentifier, WebPageProxyIdentifier toIdentifier);
     void didIncreaseQuota(PAL::SessionID, WebCore::ClientOrigin&&, QuotaIncreaseRequestIdentifier, std::optional<uint64_t> newQuota);
-    void renameOriginInWebsiteData(PAL::SessionID, const URL&, const URL&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
-    void websiteDataOriginDirectoryForTesting(PAL::SessionID, const URL&, const URL&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
+    void renameOriginInWebsiteData(PAL::SessionID, WebCore::SecurityOriginData&&, WebCore::SecurityOriginData&&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
+    void websiteDataOriginDirectoryForTesting(PAL::SessionID, WebCore::ClientOrigin&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
 
 #if PLATFORM(IOS_FAMILY)
     bool parentProcessHasServiceWorkerEntitlement() const;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -47,8 +47,8 @@ messages -> NetworkProcess LegacyReceiver {
     FetchWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, OptionSet<WebKit::WebsiteDataFetchOption> fetchOptions) -> (struct WebKit::WebsiteData websiteData)
     DeleteWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, WallTime modifiedSince) -> ()
     DeleteWebsiteDataForOrigins(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, Vector<WebCore::SecurityOriginData> origins, Vector<String> cookieHostNames, Vector<String> HSTSCacheHostNames, Vector<WebCore::RegistrableDomain> registrableDomains) -> ()
-    RenameOriginInWebsiteData(PAL::SessionID sessionID, URL oldDomain, URL newDomain, OptionSet<WebKit::WebsiteDataType> websiteDataTypes) -> ()
-    WebsiteDataOriginDirectoryForTesting(PAL::SessionID sessionID, URL origin, URL topOrigin, enum:uint32_t WebKit::WebsiteDataType websiteDataType) -> (String directory)
+    RenameOriginInWebsiteData(PAL::SessionID sessionID, struct WebCore::SecurityOriginData oldOrigin, struct WebCore::SecurityOriginData newOrigin, OptionSet<WebKit::WebsiteDataType> websiteDataTypes) -> ()
+    WebsiteDataOriginDirectoryForTesting(PAL::SessionID sessionID, struct WebCore::ClientOrigin origin, enum:uint32_t WebKit::WebsiteDataType websiteDataType) -> (String directory)
 
     DownloadRequest(PAL::SessionID sessionID, WebKit::DownloadID downloadID, WebCore::ResourceRequest request, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, String suggestedFilename)
     ResumeDownload(PAL::SessionID sessionID, WebKit::DownloadID downloadID, IPC::DataReference resumeData, String path, WebKit::SandboxExtension::Handle sandboxExtensionHandle, enum:bool WebKit::CallDownloadDidStart callDownloadDidStart)

--- a/Source/WebKit/Shared/API/APISecurityOrigin.h
+++ b/Source/WebKit/Shared/API/APISecurityOrigin.h
@@ -35,7 +35,7 @@ class SecurityOrigin : public API::ObjectImpl<API::Object::Type::SecurityOrigin>
 public:
     static Ref<SecurityOrigin> createFromString(const WTF::String& string)
     {
-        return adoptRef(*new SecurityOrigin(WebCore::SecurityOriginData::fromURL(WTF::URL { string })));
+        return adoptRef(*new SecurityOrigin(WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(WTF::URL { string })));
     }
 
     static Ref<SecurityOrigin> create(const WTF::String& protocol, const WTF::String& host, std::optional<uint16_t> port)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1604,12 +1604,6 @@ struct WebCore::DataListSuggestionInformation {
 };
 #endif
 
-struct WebCore::SecurityOriginData {
-    [Validator='!protocol->isHashTableDeletedValue()'] String protocol;
-    String host;
-    std::optional<uint16_t> port;
-};
-
 struct WebCore::ClientOrigin {
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData topOrigin;
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData clientOrigin;
@@ -2863,7 +2857,6 @@ struct WebCore::SameSiteInfo {
     WebCore::SecurityOriginData m_data;
     String m_domain;
     String m_filePath;
-    Markable<WebCore::OpaqueOriginIdentifier, WebCore::OpaqueOriginIdentifier::MarkableTraits> m_opaqueOriginIdentifier;
     bool m_universalAccess;
     bool m_domainWasSetInDOM;
     bool m_canLoadLocalResources;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -739,7 +739,9 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     if (![dataTypes isSubsetOfSet:supportedTypes])
         [NSException raise:NSInvalidArgumentException format:@"_renameOrigin can only be called with WKWebsiteDataTypeLocalStorage and WKWebsiteDataTypeIndexedDBDatabases right now."];
 
-    _websiteDataStore->renameOriginInWebsiteData(oldName, newName, WebKit::toWebsiteDataTypes(dataTypes), [completionHandler = makeBlockPtr(completionHandler)] {
+    auto oldOrigin = WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(oldName);
+    auto newOrigin = WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(newName);
+    _websiteDataStore->renameOriginInWebsiteData(WTFMove(oldOrigin), WTFMove(newOrigin), WebKit::toWebsiteDataTypes(dataTypes), [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -1002,7 +1004,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         return completionHandler(nil);
 
     auto completionHandlerCopy = makeBlockPtr(completionHandler);
-    _websiteDataStore->originDirectoryForTesting(origin, topOrigin, *websiteDataType, [completionHandlerCopy = WTFMove(completionHandlerCopy)](auto result) {
+    _websiteDataStore->originDirectoryForTesting(WebCore::ClientOrigin { WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(topOrigin), WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(origin) }, *websiteDataType, [completionHandlerCopy = WTFMove(completionHandlerCopy)](auto result) {
         completionHandlerCopy(result);
     });
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
@@ -112,7 +112,7 @@ WebKitSecurityOrigin* webkit_security_origin_new_for_uri(const gchar* uri)
 {
     g_return_val_if_fail(uri, nullptr);
 
-    return webkitSecurityOriginCreate(WebCore::SecurityOriginData::fromURL(URL { String::fromUTF8(uri) }));
+    return webkitSecurityOriginCreate(WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(URL { String::fromUTF8(uri) }));
 }
 
 /**

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -411,14 +411,14 @@ void NetworkProcessProxy::deleteWebsiteDataForOrigins(PAL::SessionID sessionID, 
     sendWithAsyncReply(Messages::NetworkProcess::DeleteWebsiteDataForOrigins(sessionID, dataTypes, origins, cookieHostNames, HSTSCacheHostNames, registrableDomains), WTFMove(completionHandler));
 }
 
-void NetworkProcessProxy::renameOriginInWebsiteData(PAL::SessionID sessionID, const URL& oldName, const URL& newName, OptionSet<WebsiteDataType> dataTypes, CompletionHandler<void()>&& completionHandler)
+void NetworkProcessProxy::renameOriginInWebsiteData(PAL::SessionID sessionID, const SecurityOriginData& oldOrigin, const SecurityOriginData& newOrigin, OptionSet<WebsiteDataType> dataTypes, CompletionHandler<void()>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::NetworkProcess::RenameOriginInWebsiteData(sessionID, oldName, newName, dataTypes), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::NetworkProcess::RenameOriginInWebsiteData(sessionID, oldOrigin, newOrigin, dataTypes), WTFMove(completionHandler));
 }
 
-void NetworkProcessProxy::websiteDataOriginDirectoryForTesting(PAL::SessionID sessionID, URL&& origin, URL&& topOrigin, WebsiteDataType type, CompletionHandler<void(const String&)>&& completionHandler)
+void NetworkProcessProxy::websiteDataOriginDirectoryForTesting(PAL::SessionID sessionID, ClientOrigin&& origin, WebsiteDataType type, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::NetworkProcess::WebsiteDataOriginDirectoryForTesting(sessionID, WTFMove(origin), WTFMove(topOrigin), type), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::NetworkProcess::WebsiteDataOriginDirectoryForTesting(sessionID, WTFMove(origin), type), WTFMove(completionHandler));
 }
 
 void NetworkProcessProxy::networkProcessDidTerminate(ProcessTerminationReason reason)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -132,8 +132,8 @@ public:
     void fetchWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, CompletionHandler<void(WebsiteData)>&&);
     void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, CompletionHandler<void()>&& completionHandler);
     void deleteWebsiteDataForOrigins(PAL::SessionID, OptionSet<WebKit::WebsiteDataType>, const Vector<WebCore::SecurityOriginData>& origins, const Vector<String>& cookieHostNames, const Vector<String>& HSTSCacheHostNames, const Vector<RegistrableDomain>&, CompletionHandler<void()>&&);
-    void renameOriginInWebsiteData(PAL::SessionID, const URL&, const URL&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
-    void websiteDataOriginDirectoryForTesting(PAL::SessionID, URL&&, URL&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
+    void renameOriginInWebsiteData(PAL::SessionID, const WebCore::SecurityOriginData&, const WebCore::SecurityOriginData&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
+    void websiteDataOriginDirectoryForTesting(PAL::SessionID, WebCore::ClientOrigin&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
 
     void preconnectTo(PAL::SessionID, WebPageProxyIdentifier, WebCore::PageIdentifier, const URL&, const String&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>, LastNavigationWasAppInitiated);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -153,7 +153,7 @@ void ProvisionalPageProxy::cancel()
     FrameInfoData frameInfo {
         true, // isMainFrame
         m_request,
-        SecurityOriginData::fromURL(m_request.url()),
+        SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url()),
         { },
         m_mainFrame->frameID(),
         std::nullopt,

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -678,7 +678,7 @@ void UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionR
     // If page navigated, there is no need to call the page client for authorization.
     auto* webFrame = WebFrameProxy::webFrame(m_currentUserMediaRequest->frameID());
 
-    if (!webFrame || !SecurityOrigin::createFromString(m_page.pageLoadState().activeURL())->isSameSchemeHostPort(m_currentUserMediaRequest->topLevelDocumentSecurityOrigin())) {
+    if (!webFrame || !protocolHostAndPortAreEqual(URL(m_page.pageLoadState().activeURL()), m_currentUserMediaRequest->topLevelDocumentSecurityOrigin().data().toURL())) {
         denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints, emptyString());
         return;
     }
@@ -692,7 +692,7 @@ void UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionR
 void UserMediaPermissionRequestManagerProxy::checkUserMediaPermissionForSpeechRecognition(WebCore::FrameIdentifier frameIdentifier, const WebCore::SecurityOrigin& requestingOrigin, const WebCore::SecurityOrigin& topOrigin, const WebCore::CaptureDevice& device, CompletionHandler<void(bool)>&& completionHandler)
 {
     auto* frame = WebFrameProxy::webFrame(frameIdentifier);
-    if (!frame || !SecurityOrigin::createFromString(m_page.pageLoadState().activeURL())->isSameSchemeHostPort(topOrigin)) {
+    if (!frame || !protocolHostAndPortAreEqual(URL(m_page.pageLoadState().activeURL()), topOrigin.data().toURL())) {
         completionHandler(false);
         return;
     }
@@ -720,7 +720,7 @@ void UserMediaPermissionRequestManagerProxy::checkUserMediaPermissionForSpeechRe
 
 bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera(const ClientOrigin& origin) const
 {
-    if (!SecurityOrigin::createFromString(m_page.pageLoadState().activeURL())->isSameSchemeHostPort(origin.topOrigin.securityOrigin().get()))
+    if (!protocolHostAndPortAreEqual(URL(m_page.pageLoadState().activeURL()), origin.topOrigin.toURL()))
         return true;
 
     return !anyOf(m_deniedRequests, [](auto& request) { return request.isVideoDenied; })
@@ -730,7 +730,7 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera
 
 bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone(const ClientOrigin& origin) const
 {
-    if (!SecurityOrigin::createFromString(m_page.pageLoadState().activeURL())->isSameSchemeHostPort(origin.topOrigin.securityOrigin().get()))
+    if (!protocolHostAndPortAreEqual(URL(m_page.pageLoadState().activeURL()), origin.topOrigin.toURL()))
         return true;
 
     return !anyOf(m_deniedRequests, [](auto& request) { return request.isAudioDenied; })
@@ -758,7 +758,7 @@ void UserMediaPermissionRequestManagerProxy::requestSystemValidation(const WebPa
 void UserMediaPermissionRequestManagerProxy::getUserMediaPermissionInfo(FrameIdentifier frameID, Ref<SecurityOrigin>&& userMediaDocumentOrigin, Ref<SecurityOrigin>&& topLevelDocumentOrigin, CompletionHandler<void(PermissionInfo)>&& handler)
 {
     auto* webFrame = WebFrameProxy::webFrame(frameID);
-    if (!webFrame || !SecurityOrigin::createFromString(m_page.pageLoadState().activeURL())->isSameSchemeHostPort(topLevelDocumentOrigin.get())) {
+    if (!webFrame || !protocolHostAndPortAreEqual(URL(m_page.pageLoadState().activeURL()), topLevelDocumentOrigin->data().toURL())) {
         handler({ });
         return;
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3583,7 +3583,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
 
 #if ENABLE(DEVICE_ORIENTATION)
     if (navigation && (!navigation->websitePolicies() || navigation->websitePolicies()->deviceOrientationAndMotionAccessState() == WebCore::DeviceOrientationOrMotionPermissionState::Prompt)) {
-        auto deviceOrientationPermission = websiteDataStore->deviceOrientationAndMotionAccessController().cachedDeviceOrientationPermission(SecurityOriginData::fromURL(navigation->currentRequest().url()));
+        auto deviceOrientationPermission = websiteDataStore->deviceOrientationAndMotionAccessController().cachedDeviceOrientationPermission(SecurityOriginData::fromURLWithoutStrictOpaqueness(navigation->currentRequest().url()));
         if (deviceOrientationPermission != WebCore::DeviceOrientationOrMotionPermissionState::Prompt) {
             if (!navigation->websitePolicies())
                 navigation->setWebsitePolicies(API::WebsitePolicies::create());
@@ -5484,7 +5484,7 @@ void WebPageProxy::didChangeMainDocument(FrameIdentifier frameID)
 #if ENABLE(GPU_PROCESS)
         if (auto* gpuProcess = m_process->processPool().gpuProcess()) {
             if (auto* frame = WebFrameProxy::webFrame(frameID))
-                gpuProcess->updateCaptureOrigin(SecurityOriginData::fromURL(frame->url()), m_process->coreProcessIdentifier());
+                gpuProcess->updateCaptureOrigin(SecurityOriginData::fromURLWithoutStrictOpaqueness(frame->url()), m_process->coreProcessIdentifier());
         }
 #endif
     }
@@ -8974,7 +8974,7 @@ void WebPageProxy::makeStorageSpaceRequest(FrameIdentifier frameID, const String
     MESSAGE_CHECK(m_process, frame);
 
     auto originData = SecurityOriginData::fromDatabaseIdentifier(originIdentifier);
-    if (originData != SecurityOriginData::fromURL(URL { currentURL() })) {
+    if (originData != SecurityOriginData::fromURLWithoutStrictOpaqueness(URL { currentURL() })) {
         completionHandler(currentQuota);
         return;
     }

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -77,7 +77,7 @@ RefPtr<WebPageProxy> WebPermissionControllerProxy::mostReasonableWebPageProxy(co
             for (auto& potentialWebPageProxy : getPtr(process)->pages()) {
                 if (!potentialWebPageProxy)
                     continue;
-                if (WebCore::SecurityOriginData::fromURL(URL { potentialWebPageProxy->currentURL() }) != topOrigin)
+                if (SecurityOriginData::fromURLWithoutStrictOpaqueness(URL { potentialWebPageProxy->currentURL() }) != topOrigin)
                     continue;
                 // The most reasonable webPageProxy is the newest one (the one with the greatest identifier).
                 if (webPageProxy && webPageProxy->identifier() > potentialWebPageProxy->identifier())

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -191,7 +191,7 @@ Vector<RefPtr<WebPageProxy>> WebProcessProxy::pages() const
 void WebProcessProxy::forWebPagesWithOrigin(PAL::SessionID sessionID, const SecurityOriginData& origin, const Function<void(WebPageProxy&)>& callback)
 {
     for (auto& page : globalPages()) {
-        if (!page || page->sessionID() != sessionID || SecurityOriginData::fromURL(URL { page->currentURL() }) != origin)
+        if (!page || page->sessionID() != sessionID || SecurityOriginData::fromURLWithoutStrictOpaqueness(URL { page->currentURL() }) != origin)
             continue;
         callback(*page);
     }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2011,14 +2011,14 @@ String WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(const String&)
 }
 #endif
 
-void WebsiteDataStore::renameOriginInWebsiteData(URL&& oldName, URL&& newName, OptionSet<WebsiteDataType> dataTypes, CompletionHandler<void()>&& completionHandler)
+void WebsiteDataStore::renameOriginInWebsiteData(WebCore::SecurityOriginData&& oldOrigin, WebCore::SecurityOriginData&& newOrigin, OptionSet<WebsiteDataType> dataTypes, CompletionHandler<void()>&& completionHandler)
 {
-    networkProcess().renameOriginInWebsiteData(m_sessionID, oldName, newName, dataTypes, WTFMove(completionHandler));
+    networkProcess().renameOriginInWebsiteData(m_sessionID, oldOrigin, newOrigin, dataTypes, WTFMove(completionHandler));
 }
 
-void WebsiteDataStore::originDirectoryForTesting(URL&& origin, URL&& topOrigin, WebsiteDataType type, CompletionHandler<void(const String&)>&& completionHandler)
+void WebsiteDataStore::originDirectoryForTesting(WebCore::ClientOrigin&& origin, WebsiteDataType type, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    networkProcess().websiteDataOriginDirectoryForTesting(m_sessionID, WTFMove(origin), WTFMove(topOrigin), type, WTFMove(completionHandler));
+    networkProcess().websiteDataOriginDirectoryForTesting(m_sessionID, WTFMove(origin), type, WTFMove(completionHandler));
 }
 
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -337,8 +337,8 @@ public:
     API::HTTPCookieStore& cookieStore();
     WebCore::LocalWebLockRegistry& webLockRegistry() { return m_webLockRegistry.get(); }
 
-    void renameOriginInWebsiteData(URL&&, URL&&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
-    void originDirectoryForTesting(URL&&, URL&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
+    void renameOriginInWebsiteData(WebCore::SecurityOriginData&&, WebCore::SecurityOriginData&&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
+    void originDirectoryForTesting(WebCore::ClientOrigin&&, WebsiteDataType, CompletionHandler<void(const String&)>&&);
 
     bool networkProcessHasEntitlementForTesting(const String&);
 

--- a/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
@@ -204,7 +204,7 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
     }
 
     auto policyListener = adoptNS([[WKWebAllowDenyPolicyListener alloc] initWithCompletionHandler:WTFMove(decisionHandler)]);
-    [[WKWebGeolocationPolicyDecider sharedPolicyDecider] decidePolicyForGeolocationRequestFromOrigin:WebCore::SecurityOriginData::fromURL(request.url) requestingURL:request.url view:request.view.get() listener:policyListener.get()];
+    [[WKWebGeolocationPolicyDecider sharedPolicyDecider] decidePolicyForGeolocationRequestFromOrigin:WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url) requestingURL:request.url view:request.view.get() listener:policyListener.get()];
 }
 
 - (void)geolocationAuthorizationDenied

--- a/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp
@@ -29,6 +29,7 @@
 #include "Test.h"
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/FileSystem.h>
+#include <wtf/HashSet.h>
 #include <wtf/MainThread.h>
 #include <wtf/URL.h>
 
@@ -91,6 +92,8 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     auto o10 = SecurityOrigin::createFromString("x-apple-ql-magic://host"_s);
     auto o11 = SecurityOrigin::createFromString("x-apple-ql-id2://host"_s);
 #endif
+    auto o12 = SecurityOrigin::createOpaque();
+    auto o13 = SecurityOrigin::createOpaque();
 
     EXPECT_EQ(String("http"_s), o1->protocol());
     EXPECT_EQ(String("http"_s), o2->protocol());
@@ -105,6 +108,8 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     EXPECT_EQ(String("x-apple-ql-magic"_s), o10->protocol());
     EXPECT_EQ(String("x-apple-ql-id2"_s), o11->protocol());
 #endif
+    EXPECT_EQ(emptyString(), o12->protocol());
+    EXPECT_EQ(emptyString(), o13->protocol());
 
     EXPECT_EQ(String("example.com"_s), o1->host());
     EXPECT_EQ(String("example.com"_s), o2->host());
@@ -119,6 +124,8 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     EXPECT_EQ(String("host"_s), o10->host());
     EXPECT_EQ(String("host"_s), o11->host());
 #endif
+    EXPECT_EQ(emptyString(), o12->host());
+    EXPECT_EQ(emptyString(), o13->host());
 
     EXPECT_FALSE(o1->port());
     EXPECT_FALSE(o2->port());
@@ -133,6 +140,8 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     EXPECT_FALSE(o10->port());
     EXPECT_FALSE(o11->port());
 #endif
+    EXPECT_FALSE(o12->port());
+    EXPECT_FALSE(o13->port());
 
     EXPECT_EQ("http://example.com"_s, o1->toString());
     EXPECT_EQ("http://example.com"_s, o2->toString());
@@ -147,6 +156,8 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     EXPECT_EQ("x-apple-ql-magic://host"_s, o10->toString());
     EXPECT_EQ("x-apple-ql-id2://host"_s, o11->toString());
 #endif
+    EXPECT_EQ("null"_s, o12->toString());
+    EXPECT_EQ("null"_s, o13->toString());
 
     EXPECT_TRUE(o1->isSameOriginAs(o2.get()));
     EXPECT_TRUE(o1->isSameOriginAs(o3.get()));
@@ -160,6 +171,10 @@ TEST_F(SecurityOriginTest, SecurityOriginConstructors)
     EXPECT_FALSE(o1->isSameOriginAs(o10.get()));
     EXPECT_FALSE(o1->isSameOriginAs(o11.get()));
 #endif
+    EXPECT_FALSE(o12->isSameOriginAs(o13.get()));
+
+    EXPECT_TRUE(o12->isOpaque());
+    EXPECT_TRUE(o13->isOpaque());
 }
 
 TEST_F(SecurityOriginTest, SecurityOriginFileBasedConstructors)
@@ -275,4 +290,35 @@ TEST_F(SecurityOriginTest, IsRegistrableDomainSuffix)
     EXPECT_TRUE(comOrigin->isMatchingRegistrableDomainSuffix("com"_s));
 }
 
+TEST_F(SecurityOriginTest, SecurityOriginHash)
+{
+    auto o1 = SecurityOrigin::create("http"_s, "example.com"_s, std::nullopt);
+    auto o2 = SecurityOrigin::create("http"_s, "example.com"_s, std::optional<uint16_t>(80));
+    auto o3 = SecurityOrigin::create(URL { "file:///" + tempFilePath() });
+    auto o4 = SecurityOrigin::createOpaque();
+    auto o5 = SecurityOrigin::createOpaque();
+
+    EXPECT_TRUE(o1->isSameOriginAs(o2.get()));
+    EXPECT_EQ(o1->data(), o2->data());
+
+    HashSet<SecurityOriginData> set;
+    EXPECT_EQ(set.size(), 0u);
+    set.add(o1->data());
+    EXPECT_EQ(set.size(), 1u);
+    set.add(o2->data());
+    EXPECT_EQ(set.size(), 1u);
+    set.add(o3->data());
+    EXPECT_EQ(set.size(), 2u);
+    set.add(o4->data());
+    EXPECT_EQ(set.size(), 3u);
+    set.add(o5->data());
+    EXPECT_EQ(set.size(), 4u);
+
+    EXPECT_TRUE(set.remove(o4->data()));
+    EXPECT_EQ(set.size(), 3u);
+    EXPECT_TRUE(set.contains(o5->data()));
+    EXPECT_FALSE(set.contains(o4->data()));
+    EXPECT_TRUE(set.remove(o2->data()));
+    EXPECT_FALSE(set.contains(o1->data()));
+}
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
@@ -1076,12 +1076,12 @@ static void testWebViewUserMediaEnumerateDevicesPermissionCheck(UIClientTest* te
 
     // Test denying a permission request.
     test->m_allowPermissionRequests = false;
-    test->loadHtml(userMediaRequestHTML, nullptr);
+    test->loadHtml(userMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilTitleChangedTo("Permission denied");
 
     // Test allowing a permission request.
     test->m_allowPermissionRequests = true;
-    test->loadHtml(userMediaRequestHTML, nullptr);
+    test->loadHtml(userMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilTitleChangedTo("OK");
 
     webkit_settings_set_enable_media_stream(settings, enabled);
@@ -1119,7 +1119,7 @@ static void testWebViewUserMediaPermissionRequests(UIClientTest* test, gconstpoi
 
     // Test denying a permission request.
     test->m_allowPermissionRequests = false;
-    test->loadHtml(userMediaRequestHTML, nullptr);
+    test->loadHtml(userMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilTitleChangedTo("NotAllowedError");
     g_assert_cmpuint(webkit_web_view_get_display_capture_state(test->m_webView), ==, WEBKIT_MEDIA_CAPTURE_STATE_NONE);
     g_assert_cmpuint(webkit_web_view_get_microphone_capture_state(test->m_webView), ==, WEBKIT_MEDIA_CAPTURE_STATE_NONE);
@@ -1127,7 +1127,7 @@ static void testWebViewUserMediaPermissionRequests(UIClientTest* test, gconstpoi
 
     // Test allowing a permission request.
     test->m_allowPermissionRequests = true;
-    test->loadHtml(userMediaRequestHTML, nullptr);
+    test->loadHtml(userMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilTitleChangedTo("OK");
     g_assert_cmpuint(webkit_web_view_get_display_capture_state(test->m_webView), ==, WEBKIT_MEDIA_CAPTURE_STATE_NONE);
     g_assert_cmpuint(webkit_web_view_get_microphone_capture_state(test->m_webView), ==, WEBKIT_MEDIA_CAPTURE_STATE_ACTIVE);
@@ -1189,7 +1189,7 @@ static void testWebViewAudioOnlyUserMediaPermissionRequests(UIClientTest* test, 
 
     // Test denying a permission request.
     test->m_allowPermissionRequests = false;
-    test->loadHtml(userMediaRequestHTML, nullptr);
+    test->loadHtml(userMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilTitleChangedTo("NotAllowedError");
     g_assert_cmpuint(webkit_web_view_get_display_capture_state(test->m_webView), ==, WEBKIT_MEDIA_CAPTURE_STATE_NONE);
     g_assert_cmpuint(webkit_web_view_get_microphone_capture_state(test->m_webView), ==, WEBKIT_MEDIA_CAPTURE_STATE_NONE);
@@ -1231,7 +1231,7 @@ static void testWebViewDisplayUserMediaPermissionRequests(UIClientTest* test, gc
 
     // Test denying a permission request.
     test->m_allowPermissionRequests = false;
-    test->loadHtml(displayMediaRequestHTML, nullptr);
+    test->loadHtml(displayMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilLoadFinished();
     test->clickMouseButton(5, 5);
     test->waitUntilTitleChangedTo("NotAllowedError");
@@ -1241,7 +1241,7 @@ static void testWebViewDisplayUserMediaPermissionRequests(UIClientTest* test, gc
 
     // Test allowing a permission request.
     test->m_allowPermissionRequests = true;
-    test->loadHtml(displayMediaRequestHTML, nullptr);
+    test->loadHtml(displayMediaRequestHTML, "https://foo.com/bar");
     test->waitUntilLoadFinished();
     test->clickMouseButton(5, 5);
     test->waitUntilTitleChangedTo("OK");


### PR DESCRIPTION
#### 7fde32c36b521c0b98efa92eb57a635018f8355f
<pre>
Move Opaque Origin Identifier from SecurityOrigin to SecurityOriginData
<a href="https://bugs.webkit.org/show_bug.cgi?id=251048">https://bugs.webkit.org/show_bug.cgi?id=251048</a>
rdar://104578586

Reviewed by Youenn Fablet, Sihui Liu and Chris Dumez.

This change is a pre-patch for later work. The motivation for this change is
that SecurityOriginData will be used in a HashMap and the key in that mapping
must correctly take the opaqueOriginIdentifier into account.

There are some unintended side-effects from this change, so we make some
relevant changes, as well. We modify some permissions checks in WebKit&apos;s
UIProcess and NetworkProcess because the expectations of the existing logic
fall into two categories:
  - converting a SecurityOriginData into a SecurityOrigin should consider
    creating an opaque origin
  - converting a URL into a SecurityOriginData should not consider creating an
    opaque origin.

Now with this patch neither of these actions are true. In the first case, now
we instantiate a SecurityOrigin directly with a SecurityOriginData, and in that
constructor we don&apos;t re-evaluate if an opaque origin should be created.
Therefore, that check must happen when creating the SecurityOriginData. In the
other case, we consider creating an opaque SecurityOriginData from a URL
instead of directly mapping the URL&apos;s scheme+host+port to the same fields in
the SecurityOriginData.

As a result of this, we now directly compare the scheme, host, and port of URLs
in some places instead of relying on SecurityOrigin::isSameSchemeHostPort. For
other cases, we introduce a new function
SecurityOriginData::fromURLWithoutStrictOpaqueness where we skip most Opaque
Origin checks.

We also explicitly set the URL in WebKitGLib&apos;s MediaStream tests because they
use about:blank as the default and that creates a discrepancy between the
Page&apos;s active URL and the top document&apos;s SecurityOrigin.

* Source/WTF/wtf/Markable.h:
(WTF::add):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::initializeShared):
(WebCore::SecurityOrigin::SecurityOrigin):
(WebCore::SecurityOrigin::create):
(WebCore::SecurityOrigin::isSameOriginDomain const):
(WebCore::SecurityOrigin::isSameOriginAs const):
(WebCore::SecurityOrigin::equal const):
(WebCore::schemeRequiresHost): Deleted.
(WebCore::shouldTreatAsOpaqueOrigin): Deleted.
* Source/WebCore/page/SecurityOrigin.h:
(WebCore::SecurityOrigin::isOpaque const):
(WebCore::add):
* Source/WebCore/page/SecurityOriginData.cpp:
(WebCore::SecurityOriginData::fromURL):
(WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness):
(WebCore::SecurityOriginData::securityOrigin const):
(WebCore::SecurityOriginData::isolatedCopy const):
(WebCore::SecurityOriginData::isolatedCopy):
(WebCore::operator==):
(WebCore::schemeRequiresHost):
(WebCore::SecurityOriginData::shouldTreatAsOpaqueOrigin):
* Source/WebCore/page/SecurityOriginData.h:
(WebCore::SecurityOriginData::SecurityOriginData):
(WebCore::SecurityOriginData::createOpaque):
(WebCore::SecurityOriginData::isOpaque const):
(WebCore::SecurityOriginData::encode const):
(WebCore::SecurityOriginData::decode):
(WebCore::add):
(WebCore::SecurityOriginData::fromURL): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::deleteWebsiteDataForOrigin):
(WebKit::NetworkProcess::renameOriginInWebsiteData):
(WebKit::NetworkProcess::websiteDataOriginDirectoryForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::createFetchTask):
(WebKit::WebSWServerConnection::registerServiceWorkerClient):
* Source/WebKit/Shared/API/APISecurityOrigin.h:
(API::SecurityOrigin::createFromString):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _renameOrigin:to:forDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore _originDirectoryForTesting:topOrigin:type:completionHandler:]):
* Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp:
(webkit_security_origin_new_for_uri):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::renameOriginInWebsiteData):
(WebKit::NetworkProcessProxy::websiteDataOriginDirectoryForTesting):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::cancel):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::checkUserMediaPermissionForSpeechRecognition):
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera const):
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone const):
(WebKit::UserMediaPermissionRequestManagerProxy::getUserMediaPermissionInfo):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
(WebKit::WebPageProxy::didChangeMainDocument):
(WebKit::WebPageProxy::makeStorageSpaceRequest):
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
(WebKit::WebPermissionControllerProxy::mostReasonableWebPageProxy const):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::forWebPagesWithOrigin):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::renameOriginInWebsiteData):
(WebKit::WebsiteDataStore::originDirectoryForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm:
(-[WKGeolocationProviderIOS geolocationAuthorizationGranted]):
* Tools/TestWebKitAPI/Tests/WebCore/SecurityOrigin.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp:
(testWebViewUserMediaEnumerateDevicesPermissionCheck):
(testWebViewUserMediaPermissionRequests):
(testWebViewAudioOnlyUserMediaPermissionRequests):
(testWebViewDisplayUserMediaPermissionRequests):

Canonical link: <a href="https://commits.webkit.org/260214@main">https://commits.webkit.org/260214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbcb0ad99921a7d658823c93a588966428d69224

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/111058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/7404 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99337 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/13346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40955 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28039 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82721 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/editable (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/96584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29380 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/96020 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/7261 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6375 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30755 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48959 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/104835 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7060 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/11442 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25979 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->