### PR TITLE
Clean up collectScreenProperties()

### DIFF
--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -186,20 +186,26 @@ ScreenProperties collectScreenProperties()
 {
     ScreenProperties screenProperties;
 
+    // FIXME: This displayID doesn't match the synthetic displayIDs we use in iOS WebKit (see WebPageProxy::generateDisplayIDFromPageID()).
     PlatformDisplayID displayID = 0;
 
     for (UIScreen *screen in [PAL::getUIScreenClass() screens]) {
-        FloatRect screenAvailableRect = screen.bounds;
-        screenAvailableRect.setY(NSMaxY(screen.bounds) - (screenAvailableRect.y() + screenAvailableRect.height())); // flip
-        FloatRect screenRect = screen._referenceBounds;
-        DestinationColorSpace colorSpace { screenColorSpace(nullptr) };
-        int screenDepth = WebCore::screenDepth(nullptr);
-        int screenDepthPerComponent = WebCore::screenDepthPerComponent(nullptr);
-        bool screenSupportsExtendedColor = WebCore::screenSupportsExtendedColor(nullptr);
-        bool screenHasInvertedColors = WebCore::screenHasInvertedColors();
-        float scaleFactor = WebCore::screenPPIFactor();
+        ScreenData screenData;
 
-        screenProperties.screenDataMap.set(++displayID, ScreenData { screenAvailableRect, screenRect, WTFMove(colorSpace), screenDepth, screenDepthPerComponent, screenSupportsExtendedColor, screenHasInvertedColors, false, scaleFactor });
+        auto screenAvailableRect = FloatRect { screen.bounds };
+        screenAvailableRect.setY(NSMaxY(screen.bounds) - (screenAvailableRect.y() + screenAvailableRect.height())); // flip
+        screenData.screenAvailableRect = screenAvailableRect;
+        
+        screenData.screenRect = screen._referenceBounds;
+        screenData.colorSpace = { screenColorSpace(nullptr) };
+        screenData.screenDepth = WebCore::screenDepth(nullptr);
+        screenData.screenDepthPerComponent = WebCore::screenDepthPerComponent(nullptr);
+        screenData.screenSupportsExtendedColor = WebCore::screenSupportsExtendedColor(nullptr);
+        screenData.screenHasInvertedColors = WebCore::screenHasInvertedColors();
+        screenData.screenSupportsHighDynamicRange = false; // FIXME: Some iOS devices do have HDR displays.
+        screenData.scaleFactor = WebCore::screenPPIFactor();
+
+        screenProperties.screenDataMap.set(++displayID, WTFMove(screenData));
         
         if (screen == [PAL::getUIScreenClass() mainScreen])
             screenProperties.primaryDisplayID = displayID;


### PR DESCRIPTION
#### 91da502c75ce04d454197a360eefa760d09ca59e
<pre>
Clean up collectScreenProperties()
<a href="https://bugs.webkit.org/show_bug.cgi?id=251291">https://bugs.webkit.org/show_bug.cgi?id=251291</a>
rdar://104761082

Reviewed by Tim Horton.

Tidy up the collectScreenProperties() code for macOS and iOS.

Instead of lots of local variables, just fill in a `ScreenData` and WTFMove() it into the hash map.
Move complex code that gets supportsHighDynamicRange on macOS into a lambda.

* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::collectScreenProperties):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):

Canonical link: <a href="https://commits.webkit.org/259527@main">https://commits.webkit.org/259527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6d2bc01660ea609004aa7caeb85f2fcb6ff5e47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114341 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174529 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5080 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97399 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39332 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80997 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27814 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7589 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4400 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47367 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6560 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9378 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->