### PR TITLE
[UI-Side compositing] Move ScrollerPairMac to ScrollingTreeScrollingNodeDelegateMac

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -236,6 +236,8 @@ page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
 page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
 page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
 page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+page/scrolling/mac/ScrollerMac.mm
+page/scrolling/mac/ScrollerPairMac.mm
 page/scrolling/mac/ScrollingCoordinatorMac.mm
 page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
 page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -46,6 +46,12 @@ public:
     virtual void serviceScrollAnimation(MonotonicTime) = 0;
 
     virtual void updateFromStateNode(const ScrollingStateScrollingNode&) { }
+    
+    virtual bool handleWheelEventForScrollbars(const PlatformWheelEvent&) { return false; }
+    virtual bool handleMouseEventForScrollbars(const PlatformMouseEvent&) { return false; }
+    
+    virtual void updateScrollbarLayers() { }
+    virtual void initScrollbars() { }
 
     virtual void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&) { }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -32,9 +32,9 @@
 
 OBJC_CLASS CALayer;
 OBJC_CLASS NSScrollerImp;
-OBJC_CLASS WKScrollerImpDelegate;
+OBJC_CLASS WebScrollerImpDelegateMac;
 
-namespace WebKit {
+namespace WebCore {
 
 class ScrollerPairMac;
 
@@ -55,7 +55,10 @@ public:
     CALayer *hostLayer() const { return m_hostLayer.get(); }
     void setHostLayer(CALayer *);
 
+    RetainPtr<NSScrollerImp> takeScrollerImp() { return std::exchange(m_scrollerImp, { }); }
     NSScrollerImp *scrollerImp() { return m_scrollerImp.get(); }
+    void setscrollerImp(NSScrollerImp *imp) { m_scrollerImp = imp; }
+
 
     WebCore::FloatPoint convertFromContent(const WebCore::FloatPoint&) const;
 
@@ -67,7 +70,7 @@ private:
 
     RetainPtr<CALayer> m_hostLayer;
     RetainPtr<NSScrollerImp> m_scrollerImp;
-    RetainPtr<WKScrollerImpDelegate> m_scrollerImpDelegate;
+    RetainPtr<WebScrollerImpDelegateMac> m_scrollerImpDelegate;
 };
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -44,18 +44,18 @@ enum class FeatureToAnimate {
     ExpansionTransition
 };
 
-@interface WKScrollbarPartAnimation : NSAnimation {
-    WebKit::ScrollerMac* _scroller;
+@interface WebScrollbarPartAnimationMac : NSAnimation {
+    WebCore::ScrollerMac* _scroller;
     FeatureToAnimate _featureToAnimate;
     CGFloat _startValue;
     CGFloat _endValue;
 }
-- (id)initWithScroller:(WebKit::ScrollerMac*)scroller featureToAnimate:(FeatureToAnimate)featureToAnimate animateFrom:(CGFloat)startValue animateTo:(CGFloat)endValue duration:(NSTimeInterval)duration;
+- (id)initWithScroller:(WebCore::ScrollerMac*)scroller featureToAnimate:(FeatureToAnimate)featureToAnimate animateFrom:(CGFloat)startValue animateTo:(CGFloat)endValue duration:(NSTimeInterval)duration;
 @end
 
-@implementation WKScrollbarPartAnimation
+@implementation WebScrollbarPartAnimationMac
 
-- (id)initWithScroller:(WebKit::ScrollerMac*)scroller featureToAnimate:(FeatureToAnimate)featureToAnimate animateFrom:(CGFloat)startValue animateTo:(CGFloat)endValue duration:(NSTimeInterval)duration
+- (id)initWithScroller:(WebCore::ScrollerMac*)scroller featureToAnimate:(FeatureToAnimate)featureToAnimate animateFrom:(CGFloat)startValue animateTo:(CGFloat)endValue duration:(NSTimeInterval)duration
 {
     self = [super initWithDuration:duration animationCurve:NSAnimationEaseInOut];
     if (!self)
@@ -124,21 +124,21 @@ enum class FeatureToAnimate {
 
 @end
 
-@interface WKScrollerImpDelegate : NSObject<NSAnimationDelegate, NSScrollerImpDelegate> {
-    WebKit::ScrollerMac* _scroller;
+@interface WebScrollerImpDelegateMac : NSObject<NSAnimationDelegate, NSScrollerImpDelegate> {
+    WebCore::ScrollerMac* _scroller;
 
-    RetainPtr<WKScrollbarPartAnimation> _knobAlphaAnimation;
-    RetainPtr<WKScrollbarPartAnimation> _trackAlphaAnimation;
-    RetainPtr<WKScrollbarPartAnimation> _uiStateTransitionAnimation;
-    RetainPtr<WKScrollbarPartAnimation> _expansionTransitionAnimation;
+    RetainPtr<WebScrollbarPartAnimationMac> _knobAlphaAnimation;
+    RetainPtr<WebScrollbarPartAnimationMac> _trackAlphaAnimation;
+    RetainPtr<WebScrollbarPartAnimationMac> _uiStateTransitionAnimation;
+    RetainPtr<WebScrollbarPartAnimationMac> _expansionTransitionAnimation;
 }
-- (id)initWithScroller:(WebKit::ScrollerMac*)scroller;
+- (id)initWithScroller:(WebCore::ScrollerMac*)scroller;
 - (void)cancelAnimations;
 @end
 
-@implementation WKScrollerImpDelegate
+@implementation WebScrollerImpDelegateMac
 
-- (id)initWithScroller:(WebKit::ScrollerMac*)scroller
+- (id)initWithScroller:(WebCore::ScrollerMac*)scroller
 {
     self = [super init];
     if (!self)
@@ -214,7 +214,7 @@ enum class FeatureToAnimate {
 }
 #endif
 
-- (void)setUpAlphaAnimation:(RetainPtr<WKScrollbarPartAnimation>&)scrollbarPartAnimation featureToAnimate:(FeatureToAnimate)featureToAnimate animateAlphaTo:(CGFloat)newAlpha duration:(NSTimeInterval)duration
+- (void)setUpAlphaAnimation:(RetainPtr<WebScrollbarPartAnimationMac>&)scrollbarPartAnimation featureToAnimate:(FeatureToAnimate)featureToAnimate animateAlphaTo:(CGFloat)newAlpha duration:(NSTimeInterval)duration
 {
     // If we are currently animating,  stop
     if (scrollbarPartAnimation) {
@@ -222,7 +222,7 @@ enum class FeatureToAnimate {
         scrollbarPartAnimation = nil;
     }
 
-    scrollbarPartAnimation = adoptNS([[WKScrollbarPartAnimation alloc] initWithScroller:_scroller
+    scrollbarPartAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller
         featureToAnimate:featureToAnimate
         animateFrom:featureToAnimate == FeatureToAnimate::KnobAlpha ? [_scroller->scrollerImp() knobAlpha] : [_scroller->scrollerImp() trackAlpha]
         animateTo:newAlpha
@@ -259,7 +259,7 @@ enum class FeatureToAnimate {
     [scrollerImp setUiStateTransitionProgress:1 - [scrollerImp uiStateTransitionProgress]];
 
     if (!_uiStateTransitionAnimation) {
-        _uiStateTransitionAnimation = adoptNS([[WKScrollbarPartAnimation alloc] initWithScroller:_scroller
+        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller
             featureToAnimate:FeatureToAnimate::UIStateTransition
             animateFrom:[scrollerImp uiStateTransitionProgress]
             animateTo:1.0
@@ -284,7 +284,7 @@ enum class FeatureToAnimate {
     [scrollerImp setExpansionTransitionProgress:1 - [scrollerImp expansionTransitionProgress]];
 
     if (!_expansionTransitionAnimation) {
-        _expansionTransitionAnimation = adoptNS([[WKScrollbarPartAnimation alloc] initWithScroller:_scroller
+        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller
             featureToAnimate:FeatureToAnimate::ExpansionTransition
             animateFrom:[scrollerImp expansionTransitionProgress]
             animateTo:1.0
@@ -317,7 +317,7 @@ enum class FeatureToAnimate {
 
 @end
 
-namespace WebKit {
+namespace WebCore {
 
 ScrollerMac::ScrollerMac(ScrollerPairMac& pair, Orientation orientation)
     : m_pair(pair)
@@ -333,7 +333,7 @@ ScrollerMac::~ScrollerMac()
 
 void ScrollerMac::attach()
 {
-    m_scrollerImpDelegate = adoptNS([[WKScrollerImpDelegate alloc] initWithScroller:this]);
+    m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
 
     NSScrollerStyle newStyle = [m_pair.scrollerImpPair() scrollerStyle];
     m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:newStyle controlSize:NSControlSizeRegular horizontal:m_orientation == Orientation::Horizontal replacingScrollerImp:nil];

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -32,7 +32,7 @@
 #include <WebCore/FloatSize.h>
 
 OBJC_CLASS NSScrollerImpPair;
-OBJC_CLASS WKScrollerImpPairDelegate;
+OBJC_CLASS WebScrollerImpPairDelegateMac;
 
 namespace WebCore {
 class PlatformMouseEvent;
@@ -40,12 +40,13 @@ class PlatformWheelEvent;
 class ScrollingTreeScrollingNode;
 }
 
-namespace WebKit {
+namespace WebCore {
 
 class ScrollerPairMac {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     ScrollerPairMac(WebCore::ScrollingTreeScrollingNode&);
+    void init();
 
     ~ScrollerPairMac();
 
@@ -68,6 +69,12 @@ public:
     Values valuesForOrientation(ScrollerMac::Orientation);
 
     NSScrollerImpPair *scrollerImpPair() { return m_scrollerImpPair.get(); }
+    NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }
+    NSScrollerImp *scrollerImpVertical() { return verticalScroller().scrollerImp(); }
+    
+    void releaseReferencesToScrollerImpsOnTheMainThread();
+    
+    bool hasScrollerImp();
 
 private:
     WebCore::ScrollingTreeScrollingNode& m_scrollingNode;
@@ -82,7 +89,7 @@ private:
     std::optional<WebCore::FloatPoint> m_lastScrollPosition;
 
     RetainPtr<NSScrollerImpPair> m_scrollerImpPair;
-    RetainPtr<WKScrollerImpPairDelegate> m_scrollerImpPairDelegate;
+    RetainPtr<WebScrollerImpPairDelegateMac> m_scrollerImpPairDelegate;
 };
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
+#include "ScrollerPairMac.h"
 #include "ScrollingEffectsController.h"
 #include "ThreadedScrollingTreeScrollingNodeDelegate.h"
 #include <wtf/RunLoop.h>
@@ -41,7 +42,6 @@ class IntPoint;
 class ScrollingStateScrollingNode;
 class ScrollingTreeScrollingNode;
 class ScrollingTree;
-class ScrollerPairMac;
 
 class ScrollingTreeScrollingNodeDelegateMac final : public ThreadedScrollingTreeScrollingNodeDelegate {
 public:
@@ -58,6 +58,12 @@ public:
     bool isRubberBandInProgress() const;
 
     void updateScrollbarPainters();
+    void updateScrollbarLayers() final;
+    
+    bool handleWheelEventForScrollbars(const PlatformWheelEvent&) final;
+    bool handleMouseEventForScrollbars(const PlatformMouseEvent&) final;
+    
+    void initScrollbars() final;
 
 private:
     void updateFromStateNode(const ScrollingStateScrollingNode&) final;
@@ -74,10 +80,7 @@ private:
     void rubberBandingStateChanged(bool) final;
     bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;
 
-    void releaseReferencesToScrollerImpsOnTheMainThread();
-
-    RetainPtr<NSScrollerImp> m_verticalScrollerImp;
-    RetainPtr<NSScrollerImp> m_horizontalScrollerImp;
+    ScrollerPairMac m_scrollerPair;
 
     bool m_inMomentumPhase { false };
 };

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -552,8 +552,6 @@ UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
-UIProcess/RemoteLayerTree/mac/ScrollerMac.mm
-UIProcess/RemoteLayerTree/mac/ScrollerPairMac.mm
 UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
 UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -29,15 +29,14 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include "RemoteScrollingTree.h"
-#include "ScrollerPairMac.h"
 
 namespace WebKit {
 using namespace WebCore;
 
 ScrollingTreeFrameScrollingNodeRemoteMac::ScrollingTreeFrameScrollingNodeRemoteMac(ScrollingTree& tree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
     : ScrollingTreeFrameScrollingNodeMac(tree, nodeType, nodeID)
-    , m_scrollerPair(makeUnique<ScrollerPairMac>(*this))
 {
+    m_delegate->initScrollbars();
 }
 
 ScrollingTreeFrameScrollingNodeRemoteMac::~ScrollingTreeFrameScrollingNodeRemoteMac()
@@ -53,43 +52,25 @@ void ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren(const S
 {
     ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(stateNode);
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
-    
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer) && horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
-        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
-    
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer) && verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
-        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
-        if (scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair->horizontalScroller().setHostLayer(nullptr);
-        if (scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair->verticalScroller().setHostLayer(nullptr);
-    }
-
-    m_scrollerPair->updateValues();
+    m_delegate->updateFromStateNode(scrollingStateNode);
 }
 
 void ScrollingTreeFrameScrollingNodeRemoteMac::repositionRelatedLayers()
 {
     ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers();
-
-    if (m_scrollerPair)
-        m_scrollerPair->updateValues();
+    m_delegate->updateScrollbarLayers();
 }
 
 WheelEventHandlingResult ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
 {
     auto result = ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
-    m_scrollerPair->handleWheelEvent(wheelEvent);
+    m_delegate->handleWheelEventForScrollbars(wheelEvent);
     return result;
 }
 
 bool ScrollingTreeFrameScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)
 {
-    if (!m_scrollerPair)
-        return false;
-    return m_scrollerPair->handleMouseEvent(mouseEvent);
+    return m_delegate->handleMouseEventForScrollbars(mouseEvent);
 }
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -46,8 +46,6 @@ private:
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     WebCore::WheelEventHandlingResult handleWheelEvent(const WebCore::PlatformWheelEvent&, WebCore::EventTargeting) override;
     void repositionRelatedLayers() override;
-
-    std::unique_ptr<ScrollerPairMac> m_scrollerPair;
 };
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
 
 #include "RemoteScrollingTree.h"
-#include "ScrollerPairMac.h"
 #include <WebCore/ScrollingStateOverflowScrollingNode.h>
 
 namespace WebKit {
@@ -42,8 +41,8 @@ Ref<ScrollingTreeOverflowScrollingNodeRemoteMac> ScrollingTreeOverflowScrollingN
 
 ScrollingTreeOverflowScrollingNodeRemoteMac::ScrollingTreeOverflowScrollingNodeRemoteMac(ScrollingTree& tree, ScrollingNodeID nodeID)
     : ScrollingTreeOverflowScrollingNodeMac(tree, nodeID)
-    , m_scrollerPair(makeUnique<ScrollerPairMac>(*this))
 {
+    m_delegate->initScrollbars();
 }
 
 ScrollingTreeOverflowScrollingNodeRemoteMac::~ScrollingTreeOverflowScrollingNodeRemoteMac()
@@ -54,40 +53,25 @@ void ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren(cons
 {
     ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(stateNode);
     const auto& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(stateNode);
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer) && horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
-        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
-    
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer) && verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
-        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
-
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
-        if (scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair->horizontalScroller().setHostLayer(nullptr);
-        if (scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair->verticalScroller().setHostLayer(nullptr);
-    }
-
-    m_scrollerPair->updateValues();
+    m_delegate->updateFromStateNode(scrollingStateNode);
 }
 
 void ScrollingTreeOverflowScrollingNodeRemoteMac::repositionRelatedLayers()
 {
     ScrollingTreeOverflowScrollingNodeMac::repositionRelatedLayers();
-
-    m_scrollerPair->updateValues();
+    m_delegate->updateScrollbarLayers();
 }
 
 WheelEventHandlingResult ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
 {
     auto result = ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
-    m_scrollerPair->handleWheelEvent(wheelEvent);
+    m_delegate->handleWheelEventForScrollbars(wheelEvent);
     return result;
 }
 
 bool ScrollingTreeOverflowScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)
 {
-    return m_scrollerPair->handleMouseEvent(mouseEvent);
+    return m_delegate->handleMouseEventForScrollbars(mouseEvent);
 }
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
@@ -46,8 +46,6 @@ private:
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     WebCore::WheelEventHandlingResult handleWheelEvent(const WebCore::PlatformWheelEvent&, WebCore::EventTargeting) override;
     void repositionRelatedLayers() override;
-
-    std::unique_ptr<ScrollerPairMac> m_scrollerPair;
 };
 
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7539,12 +7539,8 @@
 		E3CAAA432413278A00CED2E2 /* AccessibilitySupportSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilitySupportSPI.h; sourceTree = "<group>"; };
 		E3EFB02C2550617C003C2F96 /* WebSystemSoundDelegate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSystemSoundDelegate.cpp; sourceTree = "<group>"; };
 		E3EFB02D2550617C003C2F96 /* WebSystemSoundDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSystemSoundDelegate.h; sourceTree = "<group>"; };
-		E404907021DE65F70037F0DB /* ScrollerPairMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollerPairMac.h; sourceTree = "<group>"; };
 		E404907121DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollingTreeFrameScrollingNodeRemoteMac.cpp; sourceTree = "<group>"; };
-		E404907221DE65F70037F0DB /* ScrollerPairMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollerPairMac.mm; sourceTree = "<group>"; };
 		E404907321DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeFrameScrollingNodeRemoteMac.h; sourceTree = "<group>"; };
-		E404907421DE65F70037F0DB /* ScrollerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollerMac.mm; sourceTree = "<group>"; };
-		E404907521DE65F70037F0DB /* ScrollerMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollerMac.h; sourceTree = "<group>"; };
 		E40C1F9321F0B96E00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeFrameScrollingNodeRemoteIOS.h; sourceTree = "<group>"; };
 		E40C1F9521F0B97F00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingTreeFrameScrollingNodeRemoteIOS.mm; sourceTree = "<group>"; };
 		E413F59B1AC1ADB600345360 /* NetworkCacheEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkCacheEntry.h; sourceTree = "<group>"; };
@@ -14458,10 +14454,6 @@
 				0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */,
 				0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */,
 				0FF7CE8B2901FDAD00EA62D6 /* RemoteScrollingTreeMac.mm */,
-				E404907521DE65F70037F0DB /* ScrollerMac.h */,
-				E404907421DE65F70037F0DB /* ScrollerMac.mm */,
-				E404907021DE65F70037F0DB /* ScrollerPairMac.h */,
-				E404907221DE65F70037F0DB /* ScrollerPairMac.mm */,
 				E404907121DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.cpp */,
 				E404907321DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.h */,
 				0F73B767222B38C600805316 /* ScrollingTreeOverflowScrollingNodeRemoteMac.cpp */,


### PR DESCRIPTION
#### 20982a6f9b4d0fe71fefa63225ce1383995a3126
<pre>
[UI-Side compositing] Move ScrollerPairMac to ScrollingTreeScrollingNodeDelegateMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=251297">https://bugs.webkit.org/show_bug.cgi?id=251297</a>
rdar://104762822

Reviewed by Simon Fraser.

Move ScrollerPairMac and ScrollerMac to WebCore so they can be used in ScrollingTreeScrollingNodeDelegateMac. Move the
scrollbar code in ScrollingTreeFrameScrollingNodeRemoteMac and ScrollingTreeOverflowScrollingNodeRemoteMac to
ScrollingTreeScrollingNodeDelegateMac. Remove m_verticalScrollerImp and m_horizontalScrollerImp so that
the non UI-side compositing code uses ScrollerPairMac as well.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h: Renamed from Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerMac.h.
(WebCore::ScrollerMac::pair):
(WebCore::ScrollerMac::orientation const):
(WebCore::ScrollerMac::hostLayer const):
(WebCore::ScrollerMac::scrollerImp):
(WebCore::ScrollerMac::setscrollerImp):
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm: Renamed from Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerMac.mm.
(-[WebScrollbarPartAnimationMac initWithScroller:featureToAnimate:animateFrom:animateTo:duration:]):
(-[WebScrollbarPartAnimationMac startAnimation]):
(-[WebScrollbarPartAnimationMac setStartValue:]):
(-[WebScrollbarPartAnimationMac setEndValue:]):
(-[WebScrollbarPartAnimationMac setCurrentProgress:]):
(-[WebScrollbarPartAnimationMac invalidate]):
(-[WebScrollerImpDelegateMac initWithScroller:]):
(-[WebScrollerImpDelegateMac cancelAnimations]):
(-[WebScrollerImpDelegateMac convertRectToBacking:]):
(-[WebScrollerImpDelegateMac convertRectFromBacking:]):
(-[WebScrollerImpDelegateMac layer]):
(-[WebScrollerImpDelegateMac mouseLocationInScrollerForScrollerImp:]):
(-[WebScrollerImpDelegateMac convertRectToLayer:]):
(-[WebScrollerImpDelegateMac shouldUseLayerPerPartForScrollerImp:]):
(-[WebScrollerImpDelegateMac effectiveAppearanceForScrollerImp:]):
(-[WebScrollerImpDelegateMac setUpAlphaAnimation:featureToAnimate:animateAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateKnobAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateTrackAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateUIStateTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateExpansionTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac scrollerImp:overlayScrollerStateChangedTo:]):
(-[WebScrollerImpDelegateMac invalidate]):
(WebCore::ScrollerMac::ScrollerMac):
(WebCore::ScrollerMac::~ScrollerMac):
(WebCore::ScrollerMac::attach):
(WebCore::ScrollerMac::setHostLayer):
(WebCore::ScrollerMac::updateValues):
(WebCore::ScrollerMac::convertFromContent const):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h: Renamed from Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerPairMac.h.
(WebCore::ScrollerPairMac::verticalScroller):
(WebCore::ScrollerPairMac::horizontalScroller):
(WebCore::ScrollerPairMac::lastKnownMousePosition const):
(WebCore::ScrollerPairMac::scrollerImpPair):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm: Renamed from Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollerPairMac.mm.
(-[WebScrollerImpPairDelegateMac initWithScrollerPair:]):
(-[WebScrollerImpPairDelegateMac invalidate]):
(-[WebScrollerImpPairDelegateMac contentAreaRectForScrollerImpPair:]):
(-[WebScrollerImpPairDelegateMac inLiveResizeForScrollerImpPair:]):
(-[WebScrollerImpPairDelegateMac mouseLocationInContentAreaForScrollerImpPair:]):
(-[WebScrollerImpPairDelegateMac scrollerImpPair:convertContentPoint:toScrollerImp:]):
(-[WebScrollerImpPairDelegateMac scrollerImpPair:setContentAreaNeedsDisplayInRect:]):
(-[WebScrollerImpPairDelegateMac scrollerImpPair:updateScrollerStyleForNewRecommendedScrollerStyle:]):
(WebCore::ScrollerPairMac::ScrollerPairMac):
(WebCore::ScrollerPairMac::init):
(WebCore::ScrollerPairMac::~ScrollerPairMac):
(WebCore::ScrollerPairMac::handleWheelEvent):
(WebCore::ScrollerPairMac::handleMouseEvent):
(WebCore::ScrollerPairMac::updateValues):
(WebCore::ScrollerPairMac::visibleSize const):
(WebCore::ScrollerPairMac::useDarkAppearance const):
(WebCore::ScrollerPairMac::valuesForOrientation):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::releaseReferencesToScrollerImpsOnTheMainThread):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::initScrollbars):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateScrollbarLayers):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEventForScrollbars):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleMouseEventForScrollbars):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::ScrollingTreeFrameScrollingNodeRemoteMac):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::repositionRelatedLayers):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEvent):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::handleMouseEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::ScrollingTreeOverflowScrollingNodeRemoteMac):
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren):
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::repositionRelatedLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259592@main">https://commits.webkit.org/259592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b23c61f42422b152aa0c705791290d59d94b36ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114586 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5334 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97638 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111087 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95034 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26668 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7730 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7839 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47572 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9626 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3535 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->