### PR TITLE
Add WKApplicationManifest API

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -306,6 +306,7 @@ UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
 UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
 UIProcess/API/Cocoa/LegacyBundleForClass.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
+UIProcess/API/Cocoa/WKApplicationManifest.mm
 UIProcess/API/Cocoa/WKBackForwardList.mm
 UIProcess/API/Cocoa/WKBackForwardListItem.mm
 UIProcess/API/Cocoa/WKBrowsingContextController.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKInspectorPrivate.h"
+#import <WebKit/WKFoundation.h>
 
-#import "WKObject.h"
-#import "WebInspectorUIProxy.h"
-#import <wtf/WeakObjCPtr.h>
+NS_ASSUME_NONNULL_BEGIN
 
-namespace WebKit {
+/*! @abstract WKApplicationManifest represents the Web App Manifest data described by a web page currently displayed in a WKWebView.
+@discussion You do not create instances of WKApplicationManifest yourself. Instead, they are created by calling the getApplicationManifestWithCompletionHandler:
+method on WKWebView.
+An instance of WKApplicationManifest is a snapshot of the Web App Manifest data described by a web page at the time getApplicationManifestWithCompletionHandler: was called, and is not a live object.
+*/
 
-template<> struct WrapperTraits<WebInspectorUIProxy> {
-    using WrapperClass = _WKInspector;
-};
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface WKApplicationManifest : NSObject
 
-}
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
-@interface _WKInspector () <WKObject> {
-@package
-    API::ObjectStorage<WebKit::WebInspectorUIProxy> _inspector;
-    WeakObjCPtr<id <_WKInspectorDelegate> > _delegate;
-}
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifest.mm
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKApplicationManifestInternal.h"
+
+#import <WebCore/ColorCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
+@interface _WKApplicationManifestIcon ()
+- (instancetype)initWithCoreIcon:(const WebCore::ApplicationManifest::Icon *)icon;
+@end
+
+@implementation WKApplicationManifest
+
+- (API::Object&)_apiObject
+{
+    return *_applicationManifest;
+}
+
+- (instancetype)initWithApplicationManifest:(Ref<API::ApplicationManifest>&&)applicationManifest
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    _applicationManifest = WTFMove(applicationManifest);
+
+    return self;
+}
+
+static NSString *nullableNSString(const WTF::String& string)
+{
+    return string.isNull() ? nil : (NSString *)string;
+}
+
+- (NSString *)_name
+{
+    return nullableNSString(_applicationManifest->applicationManifest().name);
+}
+
+- (NSString *)_shortName
+{
+    return nullableNSString(_applicationManifest->applicationManifest().shortName);
+}
+
+- (NSString *)_applicationDescription
+{
+    return nullableNSString(_applicationManifest->applicationManifest().description);
+}
+
+- (NSURL *)_scope
+{
+    return _applicationManifest->applicationManifest().scope;
+}
+
+- (NSURL *)_startURL
+{
+    return _applicationManifest->applicationManifest().startURL;
+}
+
+- (WebCore::CocoaColor *)_themeColor
+{
+    return cocoaColor(_applicationManifest->applicationManifest().themeColor).autorelease();
+}
+
+- (_WKApplicationManifestDisplayMode)_displayMode
+{
+    switch (_applicationManifest->applicationManifest().display) {
+    case WebCore::ApplicationManifest::Display::Browser:
+        return _WKApplicationManifestDisplayModeBrowser;
+    case WebCore::ApplicationManifest::Display::MinimalUI:
+        return _WKApplicationManifestDisplayModeMinimalUI;
+    case WebCore::ApplicationManifest::Display::Standalone:
+        return _WKApplicationManifestDisplayModeStandalone;
+    case WebCore::ApplicationManifest::Display::Fullscreen:
+        return _WKApplicationManifestDisplayModeFullScreen;
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
+- (NSArray<_WKApplicationManifestIcon *> *)_icons
+{
+    return createNSArray(_applicationManifest->applicationManifest().icons, [] (auto& coreIcon) -> id {
+        return adoptNS([[_WKApplicationManifestIcon alloc] initWithCoreIcon:&coreIcon]).autorelease();
+    }).autorelease();
+}
+
+- (NSURL *)_manifestId
+{
+    return _applicationManifest->applicationManifest().id;
+}
+
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifestInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifestInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKInspectorPrivate.h"
+#import "APIApplicationManifest.h"
+#import "WKApplicationManifestPrivate.h"
 
-#import "WKObject.h"
-#import "WebInspectorUIProxy.h"
-#import <wtf/WeakObjCPtr.h>
-
-namespace WebKit {
-
-template<> struct WrapperTraits<WebInspectorUIProxy> {
-    using WrapperClass = _WKInspector;
-};
-
-}
-
-@interface _WKInspector () <WKObject> {
+@interface WKApplicationManifest () {
 @package
-    API::ObjectStorage<WebKit::WebInspectorUIProxy> _inspector;
-    WeakObjCPtr<id <_WKInspectorDelegate> > _delegate;
+    RefPtr<API::ApplicationManifest> _applicationManifest;
 }
+
+- (instancetype)initWithApplicationManifest:(Ref<API::ApplicationManifest>&&)applicationManifest;
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifestPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifestPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,28 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKInspectorPrivate.h"
+#import <WebKit/WKApplicationManifest.h>
+#import <WebKit/_WKApplicationManifest.h>
 
-#import "WKObject.h"
-#import "WebInspectorUIProxy.h"
-#import <wtf/WeakObjCPtr.h>
+NS_ASSUME_NONNULL_BEGIN
 
-namespace WebKit {
+@interface WKApplicationManifest (WKPrivate)
 
-template<> struct WrapperTraits<WebInspectorUIProxy> {
-    using WrapperClass = _WKInspector;
-};
+@property (nonatomic, readonly, nullable, copy) NSString *_name;
+@property (nonatomic, readonly, nullable, copy) NSString *_shortName;
+@property (nonatomic, readonly, nullable, copy) NSString *_applicationDescription;
+@property (nonatomic, readonly, nullable, copy) NSURL *_scope;
+@property (nonatomic, readonly, copy) NSURL *_startURL;
+@property (nonatomic, readonly, copy) NSURL *_manifestId;
+@property (nonatomic, readonly) _WKApplicationManifestDisplayMode _displayMode;
+@property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestIcon *> *_icons;
 
-}
+#if TARGET_OS_IPHONE
+@property (nonatomic, readonly, nullable, copy) UIColor *_themeColor;
+#else
+@property (nonatomic, readonly, nullable, copy) NSColor *_themeColor;
+#endif
 
-@interface _WKInspector () <WKObject> {
-@package
-    API::ObjectStorage<WebKit::WebInspectorUIProxy> _inspector;
-    WeakObjCPtr<id <_WKInspectorDelegate> > _delegate;
-}
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class UIFindInteraction;
 #endif
 
+@class WKApplicationManifest;
 @class WKBackForwardList;
 @class WKBackForwardListItem;
 @class WKContentWorld;
@@ -663,6 +664,13 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 @discussion The default value is NO.
 */
 @property (nonatomic, setter=setInspectable:) BOOL inspectable NS_SWIFT_NAME(isInspectable) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*!
+@abstract Gets Web Application Manifest data from the WKWebView to be used with UIActivityViewController
+@param completionHandler A block to invoke with the available WKApplicationManifest data.
+The WKApplicationManifest argument to this block may be nil if the web page does not specify the bare minimum Web Application Manifest data.
+*/
+- (void)getApplicationManifestWithCompletionHandler:(void (^)(WKApplicationManifest * _Nullable applicationManifest))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -58,6 +58,7 @@
 #import "UIDelegate.h"
 #import "VideoFullscreenManagerProxy.h"
 #import "ViewGestureController.h"
+#import "WKApplicationManifestInternal.h"
 #import "WKBackForwardListInternal.h"
 #import "WKBackForwardListItemInternal.h"
 #import "WKBrowsingContextHandleInternal.h"
@@ -1962,6 +1963,24 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
     _minimumViewportInset = minimumViewportInset;
     _maximumViewportInset = maximumViewportInset;
+}
+
+- (void)getApplicationManifestWithCompletionHandler:(void (^)(WKApplicationManifest *))completionHandler
+{
+    THROW_IF_SUSPENDED;
+#if ENABLE(APPLICATION_MANIFEST)
+    _page->getApplicationManifest([completionHandler = makeBlockPtr(completionHandler)](const std::optional<WebCore::ApplicationManifest>& manifest) {
+        if (manifest) {
+            auto apiManifest = API::ApplicationManifest::create(*manifest);
+            auto wkManifest = adoptNS([[WKApplicationManifest alloc] initWithApplicationManifest:WTFMove(apiManifest)]);
+            completionHandler(wkManifest.get());
+        } else
+            completionHandler(nil);
+    });
+#else
+    if (completionHandler)
+        completionHandler(nil);
+#endif
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -37,6 +37,7 @@
 #import "_WKInspectorPrivateForTesting.h"
 #import "_WKRemoteObjectRegistry.h"
 #import <WebCore/FrameIdentifier.h>
+#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -40,6 +40,7 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/ElementContext.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/SortedArrayMap.h>
 #import <wtf/text/TextStream.h>
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -989,6 +989,9 @@
 		4A3CC18F19B07B8A00D14AEF /* WKUserMediaPermissionRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F3619AF7AC3002EBAB5 /* WKUserMediaPermissionRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4CAECB6627465AE400AB78D0 /* UnifiedSource114.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CAECB5E27465AE300AB78D0 /* UnifiedSource114.cpp */; };
 		4F601432155C5AA2001FBDE0 /* BlockingResponseMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F601430155C5A32001FBDE0 /* BlockingResponseMap.h */; };
+		510081B3298376C000BC75F9 /* WKApplicationManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 510081B2298376B600BC75F9 /* WKApplicationManifest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		510081B4298376C600BC75F9 /* WKApplicationManifestInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 510081B1298376B600BC75F9 /* WKApplicationManifestInternal.h */; };
+		510081B629845DD500BC75F9 /* WKApplicationManifestPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 510081B529845DD500BC75F9 /* WKApplicationManifestPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		510523741C73D38B007993CB /* WebIDBConnectionToServerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 510523731C73D37B007993CB /* WebIDBConnectionToServerMessages.h */; };
 		510523751C73D38F007993CB /* WebIDBConnectionToServerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 510523721C73D37B007993CB /* WebIDBConnectionToServerMessageReceiver.cpp */; };
 		5106D7C418BDBE73000AB166 /* ContextMenuContextData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5106D7C018BDBE73000AB166 /* ContextMenuContextData.h */; };
@@ -4970,6 +4973,10 @@
 		4A410F4919AF7B80002EBAB5 /* WebUserMediaClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebUserMediaClient.h; sourceTree = "<group>"; };
 		4CAECB5E27465AE300AB78D0 /* UnifiedSource114.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource114.cpp; sourceTree = "<group>"; };
 		4F601430155C5A32001FBDE0 /* BlockingResponseMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockingResponseMap.h; sourceTree = "<group>"; };
+		510081B0298376B500BC75F9 /* WKApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKApplicationManifest.mm; sourceTree = "<group>"; };
+		510081B1298376B600BC75F9 /* WKApplicationManifestInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKApplicationManifestInternal.h; sourceTree = "<group>"; };
+		510081B2298376B600BC75F9 /* WKApplicationManifest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKApplicationManifest.h; sourceTree = "<group>"; };
+		510081B529845DD500BC75F9 /* WKApplicationManifestPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKApplicationManifestPrivate.h; sourceTree = "<group>"; };
 		51021E9B12B16788005C033C /* WebContextMenuClientMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContextMenuClientMac.mm; sourceTree = "<group>"; };
 		5104F5A11F19D7CF004CF821 /* CookieStorageUtilsCF.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CookieStorageUtilsCF.mm; sourceTree = "<group>"; };
 		510523711C73D22B007993CB /* WebIDBConnectionToServer.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebIDBConnectionToServer.messages.in; sourceTree = "<group>"; };
@@ -10401,6 +10408,10 @@
 				1C20935E22318CB000026A39 /* NSAttributedString.h */,
 				1C20935F22318CB000026A39 /* NSAttributedString.mm */,
 				1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */,
+				510081B2298376B600BC75F9 /* WKApplicationManifest.h */,
+				510081B0298376B500BC75F9 /* WKApplicationManifest.mm */,
+				510081B1298376B600BC75F9 /* WKApplicationManifestInternal.h */,
+				510081B529845DD500BC75F9 /* WKApplicationManifestPrivate.h */,
 				37C4C08B1814AC5C003688B9 /* WKBackForwardList.h */,
 				37C4C08A1814AC5C003688B9 /* WKBackForwardList.mm */,
 				37C4C08E1814AF3A003688B9 /* WKBackForwardListInternal.h */,
@@ -15913,6 +15924,9 @@
 				2D12DAB520662C73006F00FB /* WKAnimationDelegate.h in Headers */,
 				BCDDB32D124EC2E10048D13C /* WKAPICast.h in Headers */,
 				512E34E5130B4D0500ABD19A /* WKApplicationCacheManager.h in Headers */,
+				510081B3298376C000BC75F9 /* WKApplicationManifest.h in Headers */,
+				510081B4298376C600BC75F9 /* WKApplicationManifestInternal.h in Headers */,
+				510081B629845DD500BC75F9 /* WKApplicationManifestPrivate.h in Headers */,
 				A13DC682207AA6B20066EF72 /* WKApplicationStateTrackingView.h in Headers */,
 				BC4075F4124FF0270068F20A /* WKArray.h in Headers */,
 				577739952580388F0059348B /* WKASCAuthorizationPresenterDelegate.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -33,6 +33,7 @@
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import <WebCore/ApplicationManifest.h>
+#import <WebKit/WKApplicationManifestPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKApplicationManifest.h>
@@ -74,8 +75,22 @@ TEST(ApplicationManifest, Basic)
     Util::run(&done);
 
     done = false;
+    [webView.get() getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        EXPECT_NULL(manifest);
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
     [webView synchronouslyLoadHTMLString:@"<link rel=\"manifest\" href=\"invalidurl://path\">"];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
+        EXPECT_NULL(manifest);
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView.get() getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
         EXPECT_NULL(manifest);
         done = true;
     }];
@@ -86,6 +101,13 @@ TEST(ApplicationManifest, Basic)
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
         EXPECT_TRUE([manifest.name isEqualToString:@"Test"]);
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView.get() getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        EXPECT_TRUE([manifest._name isEqualToString:@"Test"]);
         done = true;
     }];
     Util::run(&done);
@@ -112,6 +134,22 @@ TEST(ApplicationManifest, Basic)
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
         auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
+
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView.get() getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        EXPECT_TRUE([manifest._name isEqualToString:@"A Web Application"]);
+        EXPECT_TRUE([manifest._shortName isEqualToString:@"WebApp"]);
+        EXPECT_TRUE([manifest._applicationDescription isEqualToString:@"Hello."]);
+        EXPECT_TRUE([manifest._startURL isEqual:[NSURL URLWithString:@"http://example.com/app/start"]]);
+        EXPECT_TRUE([manifest._scope isEqual:[NSURL URLWithString:@"http://example.com/app"]]);
+
+        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        EXPECT_TRUE(CGColorEqualToColor(manifest._themeColor.CGColor, redColor.get()));
 
         done = true;
     }];
@@ -173,6 +211,16 @@ TEST(ApplicationManifest, AlwaysFetch)
         done = true;
     }];
     Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        EXPECT_TRUE(CGColorEqualToColor(manifest._themeColor.CGColor, redColor.get()));
+
+        done = true;
+    }];
+    Util::run(&done);
 }
 
 TEST(ApplicationManifest, OnlyFirstManifest)
@@ -199,6 +247,16 @@ TEST(ApplicationManifest, OnlyFirstManifest)
         done = true;
     }];
     Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        EXPECT_TRUE(CGColorEqualToColor(manifest._themeColor.CGColor, redColor.get()));
+
+        done = true;
+    }];
+    Util::run(&done);
 }
 
 TEST(ApplicationManifest, NoManifest)
@@ -211,6 +269,14 @@ TEST(ApplicationManifest, NoManifest)
 
     __block bool done = false;
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
+        EXPECT_NULL(manifest);
+
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
         EXPECT_NULL(manifest);
 
         done = true;
@@ -242,6 +308,16 @@ TEST(ApplicationManifest, MediaAttriute)
         done = true;
     }];
     Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        EXPECT_TRUE(CGColorEqualToColor(manifest._themeColor.CGColor, redColor.get()));
+
+        done = true;
+    }];
+    Util::run(&done);
 }
 
 TEST(ApplicationManifest, DoesNotExist)
@@ -254,6 +330,14 @@ TEST(ApplicationManifest, DoesNotExist)
 
     __block bool done = false;
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
+        EXPECT_NULL(manifest);
+
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
         EXPECT_NULL(manifest);
 
         done = true;
@@ -272,6 +356,14 @@ TEST(ApplicationManifest, Blocked)
 
     __block bool done = false;
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
+        EXPECT_NULL(manifest);
+
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
         EXPECT_NULL(manifest);
 
         done = true;
@@ -325,6 +417,56 @@ TEST(ApplicationManifest, Icons)
 
         size_t iconIndex = 0;
         for (_WKApplicationManifestIcon *icon in manifest.icons) {
+            NSDictionary *expectedIcon = expectedIcons[iconIndex];
+            NSString *expectedURLString = [expectedIcon objectForKey:@"src"];
+            EXPECT_TRUE([icon.src isEqual:[NSURL URLWithString:expectedURLString]]);
+            EXPECT_TRUE([icon.type isEqual:[expectedIcon objectForKey:@"type"]]);
+
+            switch (iconIndex) {
+            case 0:
+                EXPECT_EQ(icon.sizes.count, 1ul);
+                EXPECT_TRUE([icon.sizes[0] isEqual:[expectedIcon objectForKey:@"sizes"]]);
+                EXPECT_EQ(icon.purposes.count, 1ul);
+                EXPECT_EQ(icon.purposes[0].unsignedLongValue, 1ul);
+                break;
+
+            case 1:
+                EXPECT_EQ(icon.sizes.count, 1ul);
+                EXPECT_TRUE([icon.sizes[0] isEqual:[expectedIcon objectForKey:@"sizes"]]);
+                EXPECT_EQ(icon.purposes.count, 2ul);
+                EXPECT_EQ(icon.purposes[0].unsignedLongValue, 2ul);
+                EXPECT_EQ(icon.purposes[1].unsignedLongValue, 4ul);
+                break;
+
+            case 2:
+                EXPECT_EQ(icon.sizes.count, 2ul);
+                EXPECT_TRUE([icon.sizes[0] isEqual:@"96x96"]);
+                EXPECT_TRUE([icon.sizes[1] isEqual:@"128x128"]);
+                EXPECT_EQ(icon.purposes.count, 1ul);
+                EXPECT_EQ(icon.purposes[0].unsignedLongValue, 2ul);
+                break;
+            }
+
+            ++iconIndex;
+        }
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    [webView getApplicationManifestWithCompletionHandler:^(WKApplicationManifest *manifest) {
+        EXPECT_TRUE([manifest._name isEqualToString:@"A Web Application"]);
+        EXPECT_TRUE([manifest._shortName isEqualToString:@"WebApp"]);
+        EXPECT_TRUE([manifest._applicationDescription isEqualToString:@"Hello."]);
+        EXPECT_TRUE([manifest._startURL isEqual:[NSURL URLWithString:@"http://example.com/app/start"]]);
+        EXPECT_TRUE([manifest._scope isEqual:[NSURL URLWithString:@"http://example.com/app"]]);
+
+        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        EXPECT_TRUE(CGColorEqualToColor(manifest._themeColor.CGColor, redColor.get()));
+
+        size_t iconIndex = 0;
+        for (_WKApplicationManifestIcon *icon in manifest._icons) {
             NSDictionary *expectedIcon = expectedIcons[iconIndex];
             NSString *expectedURLString = [expectedIcon objectForKey:@"src"];
             EXPECT_TRUE([icon.src isEqual:[NSURL URLWithString:expectedURLString]]);


### PR DESCRIPTION
#### 275b520c94280c07ae81e2769ae4f71a6c1e301b
<pre>
Add WKApplicationManifest API
<a href="https://bugs.webkit.org/show_bug.cgi?id=251298">https://bugs.webkit.org/show_bug.cgi?id=251298</a>
rdar://104630943

Reviewed by Andy Estes.

WKApplicationManifest directly reflects how the _WKApplicationManifest SPI works, but with a few differences:
1 - It is not constructible by the API client, only accessible from a WKWebView instance
2 - API-wise it is an opaque token, instead of having accessible properties
3 - It will have more private properties added to it in a followup patch that _WKApplicationManifest doesn&apos;t need

So I&apos;m creating a new object instead of just promoting the older SPI.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifest.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h.
* Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifest.mm: Added.
(-[WKApplicationManifest _apiObject]):
(-[WKApplicationManifest initWithApplicationManifest:]):
(nullableNSString):
(-[WKApplicationManifest _name]):
(-[WKApplicationManifest _shortName]):
(-[WKApplicationManifest _applicationDescription]):
(-[WKApplicationManifest _scope]):
(-[WKApplicationManifest _startURL]):
(-[WKApplicationManifest _themeColor]):
(-[WKApplicationManifest _displayMode]):
(-[WKApplicationManifest _icons]):
(-[WKApplicationManifest _manifestId]):
* Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifestInternal.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h.
* Source/WebKit/UIProcess/API/Cocoa/WKApplicationManifestPrivate.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView getApplicationManifestWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/259523@main">https://commits.webkit.org/259523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e24a19324ad4b12cd374713397d4c9f5f6d68902

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105129 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114388 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5131 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97446 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26502 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7542 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6559 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9424 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->