### PR TITLE
REGRESSION (255355@main): HTML Notes: Attachment thumbnails are low resolution

### DIFF
--- a/Source/WebCore/platform/graphics/Icon.h
+++ b/Source/WebCore/platform/graphics/Icon.h
@@ -30,6 +30,15 @@
 #include "NativeImage.h"
 #include "PlatformImage.h"
 #include <CoreGraphics/CoreGraphics.h>
+
+#if USE(APPKIT)
+OBJC_CLASS NSImage;
+using CocoaImage = NSImage;
+#else
+OBJC_CLASS UIImage;
+using CocoaImage = UIImage;
+#endif
+
 #elif PLATFORM(WIN)
 typedef struct HICON__* HICON;
 #endif
@@ -53,8 +62,10 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT static RefPtr<Icon> createIconForImage(PlatformImagePtr&&);
-    RefPtr<NativeImage> image() const { return m_cgImage; }
+    WEBCORE_EXPORT static RefPtr<Icon> create(CocoaImage *);
+    WEBCORE_EXPORT static RefPtr<Icon> create(PlatformImagePtr&&);
+
+    RetainPtr<CocoaImage> image() const { return m_image; };
 #endif
 
 #if PLATFORM(MAC)
@@ -64,8 +75,8 @@ public:
 
 private:
 #if PLATFORM(COCOA)
-    Icon(RefPtr<NativeImage>&&);
-    RefPtr<NativeImage> m_cgImage;
+    Icon(CocoaImage *);
+    RetainPtr<CocoaImage> m_image;
 #elif PLATFORM(WIN)
     Icon(HICON);
     HICON m_hIcon;

--- a/Source/WebCore/platform/graphics/mac/IconMac.mm
+++ b/Source/WebCore/platform/graphics/mac/IconMac.mm
@@ -54,15 +54,13 @@ RefPtr<Icon> Icon::createIconForFiles(const Vector<String>& filenames)
         if (!image)
             return nullptr;
 
-        PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
-        return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
+        return adoptRef(new Icon(image));
     }
     NSImage *image = [NSImage imageNamed:NSImageNameMultipleDocuments];
     if (!image)
         return nullptr;
 
-    PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
-    return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
+    return adoptRef(new Icon(image));
 }
 
 RefPtr<Icon> Icon::createIconForFileExtension(const String& fileExtension)
@@ -73,8 +71,7 @@ RefPtr<Icon> Icon::createIconForFileExtension(const String& fileExtension)
     if (!image)
         return nullptr;
 
-    PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
-    return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
+    return adoptRef(new Icon(image));
 }
 
 RefPtr<Icon> Icon::createIconForUTI(const String& UTI)
@@ -85,8 +82,7 @@ RefPtr<Icon> Icon::createIconForUTI(const String& UTI)
     if (!image)
         return nullptr;
 
-    PlatformImagePtr platformImage = [image CGImageForProposedRect:nil context:nil hints:nil];
-    return adoptRef(new Icon(NativeImage::create(WTFMove(platformImage))));
+    return adoptRef(new Icon(image));
 }
 
 }

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1508,14 +1508,8 @@ RetainPtr<NSImage> RenderThemeMac::iconForAttachment(const String& fileName, con
     if (fileName.isNull() && attachmentType.isNull() && title.isNull())
         return nil;
 
-    if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title)) {
-        auto imageForIcon = adoptNS([[NSImage alloc] initWithCGImage:icon->image()->platformImage().get() size:NSZeroSize]);
-        // Need this because WebCore uses AppKit's flipped coordinate system exclusively.
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [imageForIcon setFlipped:YES];
-        ALLOW_DEPRECATED_DECLARATIONS_END
-        return imageForIcon;
-    }
+    if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title))
+        return icon->image();
 
     return nil;
 }
@@ -1585,7 +1579,7 @@ static void paintAttachmentIcon(const RenderAttachment& attachment, GraphicsCont
     if (!shouldDrawIcon(attachment.attachmentElement().attachmentTitleForDisplay()))
         return;
 
-    context.drawImage(*icon, layout.iconRect, { ImageOrientation::OriginBottomLeft });
+    context.drawImage(*icon, layout.iconRect);
 }
 
 static std::pair<RefPtr<Image>, float> createAttachmentPlaceholderImage(float deviceScaleFactor, const AttachmentLayout& layout)

--- a/Source/WebKit/Shared/Cocoa/WebIconUtilities.h
+++ b/Source/WebKit/Shared/Cocoa/WebIconUtilities.h
@@ -27,14 +27,15 @@
 
 #if PLATFORM(COCOA)
 
+#import "CocoaImage.h"
 #import <wtf/RetainPtr.h>
 
 namespace WebKit {
 
-WebCore::PlatformImagePtr fallbackIconForFile(NSURL *file);
-WebCore::PlatformImagePtr iconForImageFile(NSURL *file);
-WebCore::PlatformImagePtr iconForVideoFile(NSURL *file);
-WebCore::PlatformImagePtr iconForFiles(const Vector<String>& filenames);
+RetainPtr<CocoaImage> fallbackIconForFile(NSURL *file);
+RetainPtr<CocoaImage> iconForImageFile(NSURL *file);
+RetainPtr<CocoaImage> iconForVideoFile(NSURL *file);
+RetainPtr<CocoaImage> iconForFiles(const Vector<String>& filenames);
 
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -361,11 +361,7 @@ static RefPtr<WebKit::ShareableBitmap> convertPlatformImageToBitmap(CocoaImage *
         return nullptr;
 
     LocalCurrentGraphicsContext savedContext(*graphicsContext);
-#if PLATFORM(IOS_FAMILY)
     [image drawInRect:resultRect];
-#elif USE(APPKIT)
-    [image drawInRect:resultRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1 respectFlipped:YES hints:nil];
-#endif
 
     return bitmap;
 }
@@ -676,12 +672,7 @@ bool WebPageProxy::updateIconForDirectory(NSFileWrapper *fileWrapper, const Stri
     if (!image)
         return false;
 
-    auto flippedIcon = [NSImage imageWithSize:iconSize flipped:YES drawingHandler:^BOOL(NSRect destinationRect) {
-        [image drawInRect:destinationRect fromRect:NSMakeRect(0, 0, [image size].width, [image size].height) operation:NSCompositingOperationSourceOver fraction:1.0f];
-        return YES;
-    }];
-
-    auto convertedImage = convertPlatformImageToBitmap(flippedIcon, iconSize);
+    auto convertedImage = convertPlatformImageToBitmap(image, iconSize);
     if (!convertedImage)
         return false;
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -167,7 +167,7 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
 
 - (RetainPtr<UIImage>)displayImage
 {
-    return adoptNS([[UIImage alloc] initWithCGImage:WebKit::iconForImageFile(self.fileURL).get()]);
+    return WebKit::iconForImageFile(self.fileURL);
 }
 
 @end
@@ -185,7 +185,7 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
 
 - (RetainPtr<UIImage>)displayImage
 {
-    return adoptNS([[UIImage alloc] initWithCGImage:WebKit::iconForVideoFile(self.fileURL).get()]);
+    return WebKit::iconForVideoFile(self.fileURL);
 }
 
 @end
@@ -929,8 +929,7 @@ static NSString *displayStringForDocumentsAtURLs(NSArray<NSURL *> *urls)
 
         [retainedSelf->_view _removeTemporaryDirectoriesWhenDeallocated:std::exchange(retainedSelf->_temporaryUploadedFileURLs, { })];
         RunLoop::main().dispatch([retainedSelf = WTFMove(retainedSelf), maybeMovedURLs = WTFMove(maybeMovedURLs)] {
-            auto icon = adoptNS([[UIImage alloc] initWithCGImage:WebKit::iconForFiles({ [maybeMovedURLs firstObject].absoluteString }).get()]);
-            [retainedSelf _chooseFiles:maybeMovedURLs.get() displayString:displayStringForDocumentsAtURLs(maybeMovedURLs.get()) iconImage:icon.get()];
+            [retainedSelf _chooseFiles:maybeMovedURLs.get() displayString:displayStringForDocumentsAtURLs(maybeMovedURLs.get()) iconImage:WebKit::iconForFiles({ maybeMovedURLs.get()[0].absoluteString }).get()];
         });
     }).get());
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClientCocoa.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClientCocoa.mm
@@ -36,7 +36,7 @@ using namespace WebCore;
 
 RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames)
 {
-    return Icon::createIconForImage(iconForFiles(filenames).get());
+    return Icon::create(iconForFiles(filenames).get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5097,7 +5097,7 @@ void WebPage::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vector<St
         RetainPtr<CFDataRef> dataRef = adoptCF(CFDataCreate(nullptr, iconData.data(), iconData.size()));
         RetainPtr<CGDataProviderRef> imageProviderRef = adoptCF(CGDataProviderCreateWithCFData(dataRef.get()));
         RetainPtr<CGImageRef> imageRef = adoptCF(CGImageCreateWithPNGDataProvider(imageProviderRef.get(), nullptr, true, kCGRenderingIntentDefault));
-        icon = Icon::createIconForImage(WTFMove(imageRef));
+        icon = Icon::create(WTFMove(imageRef));
     }
 
     m_activeOpenPanelResultListener->didChooseFilesWithDisplayStringAndIcon(files, displayString, icon.get());

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm
@@ -82,7 +82,7 @@ using namespace WebCore;
     if (!_chooser)
         return;
 
-    _chooser->chooseMediaFiles(makeVector<String>(filenames), displayString, Icon::createIconForImage(imageRef).get());
+    _chooser->chooseMediaFiles(makeVector<String>(filenames), displayString, Icon::create(imageRef).get());
     _chooser = nullptr;
 }
 


### PR DESCRIPTION
#### bf1b77633553bff145d17d26ae7590851131db43
<pre>
REGRESSION (255355@main): HTML Notes: Attachment thumbnails are low resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=251293">https://bugs.webkit.org/show_bug.cgi?id=251293</a>
rdar://103533427

Reviewed by Wenson Hsieh.

In the process of supporting thumbnails for &lt;input type=file&gt; on macOS,
255355@main refactored `Icon` logic to share code between Cocoa platforms.

Prior to 255355@main, `Icon` was backed by `NSImage` on macOS, and `CGImageRef`
on other platforms. Following the change, `Icon` was backed by `CGImageRef` on
all platforms. To make this possible, `NSImage`s were converted to `CGImageRef`s
using `-[NSImage CGImageForProposedRect:context:hints]`, using a `nil` proposed
rect. This approach is problematic, as `NSImage`s are resolution-independent,
whereas `CGImageRef`s are not.

The `NSWorkspace` method used to get attachment thumbnails returns an `NSImage`
with multiple `NSImageRep`s. Before 255355@main, WebKit would draw the `NSImage`
into a 400x400 bitmap. Now, the `NSImage` is first converted into a `CGImageRef`,
defaulting to the smallest supported representation of 32x32. That image is then
drawn into a 400x400 bitmap, resulting in low resolution.

To fix, store images in `Icon` as `NSImage`/`UIImage` and only resolve them to
`CGImageRef` when it is time to paint them. An alternate solution would be to
pass in the proposed size through multiple layers, so that
`-[NSImage CGImageForProposedRect:context:hints]` could be called with the
correct rect following the retrieval of the image from `NSWorkspace`.
However, the approach in this patch was chosen since it reduces the amount of
plumbing required, avoids conversion to `UIImage` in multiple locations in
existing iOS code, and gives clients of `Icon` more control over how they want
to present the image.

Additionally, this change removes deprecated &quot;flippedness&quot; logic for images.
Attachment thumbnails unnecessarily modify the &quot;flippedness&quot; of the image in
the UIProcess, only to undo the effect in the WebProcess. &lt;input type=file&gt;
thumbnails already do the right thing. It does not make sense to reintroduce the
concept of &quot;flippedness&quot; to `Icon` (as was the case before 255355@main), since
it would break &lt;input type=file&gt; thumbnails and directory attachment thumbnails
(which have their own flipping logic, separate from files). Instead, the code
is refactored to ignore the concept of &quot;flippedness&quot; entirely, which AppKit
deprecated for images in macOS 10.6.

* Source/WebCore/platform/graphics/Icon.h:
(WebCore::Icon::image const):
* Source/WebCore/platform/graphics/cocoa/IconCocoa.mm:
(WebCore::Icon::Icon):
(WebCore::Icon::create):
(WebCore::Icon::paint):
(WebCore::Icon::createIconForImage): Deleted.
* Source/WebCore/platform/graphics/mac/IconMac.mm:
(WebCore::Icon::createIconForFiles):
(WebCore::Icon::createIconForFileExtension):
(WebCore::Icon::createIconForUTI):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::iconForAttachment):

Flipping the icon is no longer necessary, as the icon is drawn to a bitmap
context with a top-left origin in the UIProcess, and using a top-left origin in
the WebProcess.

(WebCore::paintAttachmentIcon):

Use the default origin, as attachment icons are no longer being flipped.

* Source/WebKit/Shared/Cocoa/WebIconUtilities.h:
* Source/WebKit/Shared/Cocoa/WebIconUtilities.mm:
(WebKit::thumbnailSizedImageForImage):
(WebKit::fallbackIconForFile):
(WebKit::iconForImageFile):
(WebKit::iconForVideoFile):
(WebKit::iconForFiles):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::convertPlatformImageToBitmap):

Use a simpler, equivalent AppKit method to share more code between Cocoa ports.

(WebKit::WebPageProxy::updateIconForDirectory):

Flipping the icon is no longer necessary, as the icon is drawn to a bitmap
context with a top-left origin in the UIProcess, and using a top-left origin in
the WebProcess.

* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[_WKImageFileUploadItem displayImage]):
(-[_WKVideoFileUploadItem displayImage]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClientCocoa.mm:
(WebKit::WebChromeClient::createIconForFiles):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
* Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm:
(-[WebOpenPanelResultListener chooseFilenames:displayString:iconImage:]):

Canonical link: <a href="https://commits.webkit.org/259598@main">https://commits.webkit.org/259598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/953f5174533b1c82e5dc36b9e9ed867a77a22567

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114554 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174750 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5300 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114473 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26647 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28007 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7804 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4592 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6621 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9592 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->