### PR TITLE
WebDriver: [iPadOS] Synthetic tap events are not dispatched to the window

### DIFF
--- a/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
+++ b/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
@@ -209,15 +209,17 @@ void WebAutomationSession::platformSimulateTouchInteraction(WebPageProxy& page, 
     });
 
     _WKTouchEventGenerator *generator = [_WKTouchEventGenerator sharedTouchEventGenerator];
+    UIWindow *window = [page.cocoaView() window];
+
     switch (interaction) {
     case TouchInteraction::TouchDown:
-        [generator touchDown:locationOnScreen completionBlock:interactionFinished.get()];
+        [generator touchDown:locationOnScreen window:window completionBlock:interactionFinished.get()];
         break;
     case TouchInteraction::LiftUp:
-        [generator liftUp:locationOnScreen completionBlock:interactionFinished.get()];
+        [generator liftUp:locationOnScreen window:window completionBlock:interactionFinished.get()];
         break;
     case TouchInteraction::MoveTo:
-        [generator moveToPoint:locationOnScreen duration:duration.value_or(0_s).seconds() completionBlock:interactionFinished.get()];
+        [generator moveToPoint:locationOnScreen duration:duration.value_or(0_s).seconds() window:window completionBlock:interactionFinished.get()];
         break;
     }
 }

--- a/Source/WebKit/UIProcess/_WKTouchEventGenerator.h
+++ b/Source/WebKit/UIProcess/_WKTouchEventGenerator.h
@@ -30,6 +30,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class UIWindow;
 typedef struct __IOHIDEvent * IOHIDEventRef;
 
 WK_CLASS_AVAILABLE(ios(13.0))
@@ -37,9 +38,9 @@ WK_CLASS_AVAILABLE(ios(13.0))
 + (_WKTouchEventGenerator *)sharedTouchEventGenerator;
 
 // The 'location' parameter is in screen coordinates, as used by IOHIDEvent.
-- (void)touchDown:(CGPoint)location completionBlock:(void (^)(void))completionBlock;
-- (void)liftUp:(CGPoint)location completionBlock:(void (^)(void))completionBlock;
-- (void)moveToPoint:(CGPoint)location duration:(NSTimeInterval)seconds completionBlock:(void (^)(void))completionBlock;
+- (void)touchDown:(CGPoint)location window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock;
+- (void)liftUp:(CGPoint)location window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock;
+- (void)moveToPoint:(CGPoint)location duration:(NSTimeInterval)seconds window:(UIWindow *)window completionBlock:(void (^)(void))completionBlock;
 
 // Clients must call this method whenever a HID event is delivered to the UIApplication.
 // It is used to detect when all synthesized touch events have been successfully delivered.


### PR DESCRIPTION
#### a670e7900b4af016dcd0871284712c9dea1e7d60
<pre>
WebDriver: [iPadOS] Synthetic tap events are not dispatched to the window
<a href="https://bugs.webkit.org/show_bug.cgi?id=251299">https://bugs.webkit.org/show_bug.cgi?id=251299</a>
rdar://102439701

Reviewed by BJ Burg.

On iPadOS, the UIApplication.sharedApplication.keyWindow does not take Scenes into account, and can therefore result in
unexpected behavior when used to determine the frontmost window, namely that the returned window may not even be visible
on screen, but instead might be the &quot;key&quot; window from another Scene that the application has. This causes us to be
unable to get the `contextId` of the correct window, which means touch events were not being dispatched to the window
under automation. Instead of relying on the window under automation being implicitly the key window, clients should
instead provide the window in which they expect an event to take place so that _WKTouchEventGenerator can use that
window&apos;s `contextId` for created events, ensuring they are dispatched to the correct window.

iOS was unaffected because Safari does not spawn multiple scenes on that platform, which means the key window was
already accurate for that platform.

* Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm:
- Provide the window that is the target for the touch events.

(WebKit::WebAutomationSession::platformSimulateTouchInteraction):
* Source/WebKit/UIProcess/_WKTouchEventGenerator.h:
* Source/WebKit/UIProcess/_WKTouchEventGenerator.mm:
(-[_WKTouchEventGenerator _sendHIDEvent:window:]):
(-[_WKTouchEventGenerator _sendMarkerHIDEventInWindow:completionBlock:]):
- Get the `contextId` from the provided window, instead of always using the `keyWindow`.

(-[_WKTouchEventGenerator _updateTouchPoints:count:window:]):
(-[_WKTouchEventGenerator touchDownAtPoints:touchCount:window:]):
(-[_WKTouchEventGenerator touchDown:touchCount:window:]):
(-[_WKTouchEventGenerator liftUpAtPoints:touchCount:window:]):
(-[_WKTouchEventGenerator liftUp:touchCount:window:]):
(-[_WKTouchEventGenerator moveToPoints:touchCount:duration:window:]):
(-[_WKTouchEventGenerator touchDown:window:completionBlock:]):
(-[_WKTouchEventGenerator liftUp:window:completionBlock:]):
(-[_WKTouchEventGenerator moveToPoint:duration:window:completionBlock:]):
- Plumb the window through.

(-[_WKTouchEventGenerator touchDown:]): Deleted.
(-[_WKTouchEventGenerator liftUp:]): Deleted.
- Remove unused methods.

Canonical link: <a href="https://commits.webkit.org/259576@main">https://commits.webkit.org/259576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/280136cb621fa08b6ac8168bcf73f918df6c70c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114351 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5092 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114338 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39368 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81033 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7505 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27823 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7601 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4408 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47376 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6604 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9388 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->