### PR TITLE
[ iOS Release ] imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html  is a constant text only failure.

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL texImage2D with 48x36 srgb VideoFrame. assert_equals: expected 150 but got 151
+PASS texSubImage2D with 48x36 srgb VideoFrame.
+FAIL texImage2D with 480x360 srgb VideoFrame. assert_equals: expected 150 but got 151
+PASS texSubImage2D with 480x360 srgb VideoFrame.
+PASS texImage2D with a closed VideoFrame.
+PASS texSubImage2D with a closed VideoFrame.
+


### PR DESCRIPTION
#### 0bada1b982e0c5efbb3f7b246ece8e1e163c9c07
<pre>
[ iOS Release ] imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html  is a constant text only failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251234">https://bugs.webkit.org/show_bug.cgi?id=251234</a>
rdar://problem/104720207

Unreviewed test gardening.

Rebaselining test.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/259511@main">https://commits.webkit.org/259511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6311d30e27e8689ab39438057e90fccfa73c9eb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/105096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114355 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5096 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/110852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13660 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9392 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3497 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->