### PR TITLE
[WebGPU] Flesh out PresentationContext's API

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -41,10 +41,18 @@ void GPUPresentationContext::unconfigure()
     m_backing->unconfigure();
 }
 
-GPUTexture* GPUPresentationContext::getCurrentTexture()
+GPUTexture& GPUPresentationContext::getCurrentTexture()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250958 Figure out how the lifetime of these objects should behave.
-    return nullptr;
+    if (!m_currentTexture)
+        m_currentTexture = GPUTexture::create(m_backing->getCurrentTexture()).ptr();
+
+    return *m_currentTexture;
+}
+
+void GPUPresentationContext::present()
+{
+    m_backing->present();
+    m_currentTexture = nullptr;
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUTexture.h"
 #include <pal/graphics/WebGPU/WebGPUPresentationContext.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
@@ -48,7 +49,9 @@ public:
     void configure(const GPUPresentationConfiguration&);
     void unconfigure();
 
-    GPUTexture* getCurrentTexture();
+    GPUTexture& getCurrentTexture();
+
+    void present();
 
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
@@ -64,6 +67,7 @@ private:
     }
 
     Ref<PAL::WebGPU::PresentationContext> m_backing;
+    RefPtr<GPUTexture> m_currentTexture;
 };
 
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp
@@ -66,6 +66,8 @@ void PresentationContextImpl::configure(const PresentationConfiguration& present
     if (m_swapChain)
         wgpuSwapChainRelease(m_swapChain);
 
+    m_format = presentationConfiguration.format;
+
     WGPUSwapChainDescriptor backingDescriptor {
         nullptr,
         nullptr,
@@ -88,10 +90,22 @@ void PresentationContextImpl::unconfigure()
     m_swapChain = nullptr;
 }
 
-Texture* PresentationContextImpl::getCurrentTexture()
+Texture& PresentationContextImpl::getCurrentTexture()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250958 Figure out how the lifetime of these objects should behave.
-    return nullptr;
+    // FIXME: If m_swapChain is nullptr, return an invalid texture.
+
+    if (!m_currentTexture) {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250958 This is wrong; these objects are +0, but our Impl wrappers treat them as +1 objects.
+        m_currentTexture = TextureImpl::create(wgpuSwapChainGetCurrentTexture(m_swapChain), m_format, TextureDimension::_2d, m_convertToBackingContext).ptr();
+    }
+
+    return *m_currentTexture;
+}
+
+void PresentationContextImpl::present()
+{
+    wgpuSwapChainPresent(m_swapChain);
+    m_currentTexture = nullptr;
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h
@@ -37,6 +37,7 @@
 namespace PAL::WebGPU {
 
 class ConvertToBackingContext;
+class TextureImpl;
 
 class PresentationContextImpl final : public PresentationContext {
     WTF_MAKE_FAST_ALLOCATED;
@@ -65,15 +66,20 @@ private:
     void configure(const PresentationConfiguration&) final;
     void unconfigure() final;
 
-    Texture* getCurrentTexture() final;
+    Texture& getCurrentTexture() final;
+
+    void present() final;
 
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
 #endif
 
+    TextureFormat m_format { TextureFormat::Bgra8unorm };
+
     WGPUSurface m_backing { nullptr };
     WGPUSwapChain m_swapChain { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
+    RefPtr<TextureImpl> m_currentTexture;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h
@@ -46,7 +46,9 @@ public:
     virtual void configure(const PresentationConfiguration&) = 0;
     virtual void unconfigure() = 0;
 
-    virtual Texture* getCurrentTexture() = 0;
+    virtual Texture& getCurrentTexture() = 0;
+
+    virtual void present() = 0;
 
 #if PLATFORM(COCOA)
     virtual void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -157,6 +157,7 @@ RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
     };
 
     markContextChangedAndNotifyCanvasObservers();
+    // FIXME: This should use PresentationContext::getCurrentTexture() instead.
     return m_configuration->device->createSurfaceTexture(descriptor, m_presentationContext);
 }
 

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@ namespace WebGPU {
 
 class Adapter;
 class Device;
+class Texture;
 class TextureView;
 
 class PresentationContext : public WGPUSurfaceImpl, public WGPUSwapChainImpl, public RefCounted<PresentationContext> {
@@ -59,6 +60,7 @@ public:
     virtual void configure(Device&, const WGPUSwapChainDescriptor&);
 
     virtual void present();
+    virtual Texture* getCurrentTexture(); // FIXME: This should return a Texture&.
     virtual TextureView* getCurrentTextureView(); // FIXME: This should return a TextureView&.
 
     virtual bool isPresentationContextIOSurface() const { return false; }

--- a/Source/WebGPU/WebGPU/PresentationContext.mm
+++ b/Source/WebGPU/WebGPU/PresentationContext.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,6 +71,11 @@ void PresentationContext::present()
 {
 }
 
+Texture* PresentationContext::getCurrentTexture()
+{
+    return nullptr;
+}
+
 TextureView* PresentationContext::getCurrentTextureView()
 {
     return nullptr;
@@ -93,6 +98,11 @@ void wgpuSwapChainRelease(WGPUSwapChain swapChain)
 WGPUTextureFormat wgpuSurfaceGetPreferredFormat(WGPUSurface surface, WGPUAdapter adapter)
 {
     return WebGPU::fromAPI(surface).getPreferredFormat(WebGPU::fromAPI(adapter));
+}
+
+WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain)
+{
+    return WebGPU::fromAPI(swapChain).getCurrentTexture();
 }
 
 WGPUTextureView wgpuSwapChainGetCurrentTextureView(WGPUSwapChain swapChain)

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,9 +33,6 @@
 
 namespace WebGPU {
 
-class Device;
-class TextureView;
-
 class PresentationContextCoreAnimation : public PresentationContext {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -49,6 +46,7 @@ public:
     void configure(Device&, const WGPUSwapChainDescriptor&) override;
 
     void present() override;
+    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
 
     bool isPresentationContextCoreAnimation() const override { return true; }
@@ -57,9 +55,10 @@ private:
     PresentationContextCoreAnimation(const WGPUSurfaceDescriptor&);
 
     struct Configuration {
-        Configuration(uint32_t width, uint32_t height, String&& label, WGPUTextureFormat format, Device& device)
+        Configuration(uint32_t width, uint32_t height, WGPUTextureUsageFlags usage, String&& label, WGPUTextureFormat format, Device& device)
             : width(width)
             , height(height)
+            , usage(usage)
             , label(WTFMove(label))
             , format(format)
             , device(device)
@@ -68,6 +67,7 @@ private:
 
         struct FrameState {
             id<CAMetalDrawable> currentDrawable;
+            RefPtr<Texture> currentTexture;
             RefPtr<TextureView> currentTextureView;
         };
 
@@ -76,6 +76,7 @@ private:
         std::optional<FrameState> currentFrameState;
         uint32_t width { 0 };
         uint32_t height { 0 };
+        WGPUTextureUsageFlags usage { WGPUTextureUsage_None };
         String label;
         WGPUTextureFormat format { WGPUTextureFormat_Undefined };
         Ref<Device> device;

--- a/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #import "APIConversions.h"
 #import "Texture.h"
+#import "TextureView.h"
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebGPU {
@@ -68,7 +69,7 @@ void PresentationContextCoreAnimation::configure(Device& device, const WGPUSwapC
         return;
     }
 
-    m_configuration = Configuration(descriptor.width, descriptor.height, fromAPI(descriptor.label), descriptor.format, device);
+    m_configuration = Configuration(descriptor.width, descriptor.height, descriptor.usage, fromAPI(descriptor.label), descriptor.format, device);
 
     m_layer.pixelFormat = Texture::pixelFormat(descriptor.format);
     if (descriptor.usage == WGPUTextureUsage_RenderAttachment)
@@ -82,7 +83,22 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
     auto label = this->label.utf8();
 
     id<CAMetalDrawable> currentDrawable = [layer nextDrawable];
-    id<MTLTexture> texture = currentDrawable.texture;
+    id<MTLTexture> backingTexture = currentDrawable.texture;
+
+    WGPUTextureDescriptor textureDescriptor {
+        nullptr,
+        label.data(),
+        usage,
+        WGPUTextureDimension_2D, {
+            width,
+            height,
+            1,
+        },
+        format,
+        1,
+        1,
+    };
+    auto texture = Texture::create(backingTexture, textureDescriptor, { format }, device);
 
     WGPUTextureViewDescriptor textureViewDescriptor {
         nullptr,
@@ -95,8 +111,8 @@ auto PresentationContextCoreAnimation::Configuration::generateCurrentFrameState(
         1,
         WGPUTextureAspect_All,
     };
-    auto textureView = TextureView::create(texture, textureViewDescriptor, { { width, height, 1 } }, device);
-    return { currentDrawable, textureView.ptr() };
+    auto textureView = TextureView::create(backingTexture, textureViewDescriptor, { { width, height, 1 } }, device);
+    return { currentDrawable, texture.ptr(), textureView.ptr() };
 }
 
 void PresentationContextCoreAnimation::present()
@@ -110,6 +126,17 @@ void PresentationContextCoreAnimation::present()
     [m_configuration->currentFrameState->currentDrawable present];
 
     m_configuration->currentFrameState = std::nullopt;
+}
+
+Texture* PresentationContextCoreAnimation::getCurrentTexture()
+{
+    if (!m_configuration)
+        return nullptr;
+
+    if (!m_configuration->currentFrameState)
+        m_configuration->currentFrameState = m_configuration->generateCurrentFrameState(m_layer);
+
+    return m_configuration->currentFrameState->currentTexture.get();
 }
 
 TextureView* PresentationContextCoreAnimation::getCurrentTextureView()

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,6 @@
 
 namespace WebGPU {
 
-class Device;
-class TextureView;
-
 class PresentationContextIOSurface : public PresentationContext {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -45,6 +42,7 @@ public:
     void configure(Device&, const WGPUSwapChainDescriptor&) override;
 
     void present() override;
+    Texture* getCurrentTexture() override; // FIXME: This should return a Texture&.
     TextureView* getCurrentTextureView() override; // FIXME: This should return a TextureView&.
 
     RetainPtr<IOSurfaceRef> displayBuffer() const { return m_displayBuffer; }

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -90,6 +90,11 @@ void PresentationContextIOSurface::present()
     nextDrawable();
 }
 
+Texture* PresentationContextIOSurface::getCurrentTexture()
+{
+    return nullptr;
+}
+
 TextureView* PresentationContextIOSurface::getCurrentTextureView()
 {
     return nullptr;

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -151,6 +151,9 @@ typedef void (*WGPUProcInstanceRequestAdapterWithBlock)(WGPUInstance instance, W
 typedef void (*WGPUProcQueueOnSubmittedWorkDoneWithBlock)(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneBlockCallback callback);
 typedef void (*WGPUProcShaderModuleGetCompilationInfoWithBlock)(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
 
+// FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
+typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChain);
+
 #endif  // !defined(WGPU_SKIP_PROCS)
 
 #if !defined(WGPU_SKIP_DECLARATIONS)
@@ -210,6 +213,9 @@ WGPU_EXPORT void wgpuShaderModuleGetCompilationInfoWithBlock(WGPUShaderModule sh
 
 WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDisplayBuffer(WGPUSurface);
 WGPU_EXPORT IOSurfaceRef wgpuSurfaceCocoaCustomSurfaceGetDrawingBuffer(WGPUSurface);
+
+// FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
+WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);
 
 #endif  // !defined(WGPU_SKIP_DECLARATIONS)
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -77,6 +77,8 @@ private:
 
     void getCurrentTexture(WebGPUIdentifier);
 
+    void present();
+
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&);
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in
@@ -27,6 +27,7 @@ messages -> RemotePresentationContext NotRefCounted Stream {
     void Configure(WebKit::WebGPU::PresentationConfiguration configuration)
     void Unconfigure()
     void GetCurrentTexture(WebKit::WebGPUIdentifier identifier)
+    void Present()
 #if PLATFORM(COCOA)
     void PrepareForDisplay() -> (MachSendRight displayBuffer) Synchronous NotStreamEncodableReply
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -92,14 +92,14 @@ Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createTexture(const PAL::WebGPU::Te
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
     if (!convertedDescriptor) {
         // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateTexture(*convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createSurfaceTexture(const PAL::WebGPU::TextureDescriptor& descriptor, const PAL::WebGPU::PresentationContext& presentationContext)
@@ -107,14 +107,14 @@ Ref<PAL::WebGPU::Texture> RemoteDeviceProxy::createSurfaceTexture(const PAL::Web
     auto convertedDescriptor = m_convertToBackingContext->convertToBacking(descriptor);
     if (!convertedDescriptor) {
         // FIXME: Implement error handling.
-        return RemoteTextureProxy::create(*this, m_convertToBackingContext, WebGPUIdentifier::generate());
+        return RemoteTextureProxy::create(root(), m_convertToBackingContext, WebGPUIdentifier::generate());
     }
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = send(Messages::RemoteDevice::CreateSurfaceTexture(m_convertToBackingContext->convertToBacking(presentationContext), *convertedDescriptor, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteTextureProxy::create(*this, m_convertToBackingContext, identifier);
+    return RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
 }
 
 Ref<PAL::WebGPU::Sampler> RemoteDeviceProxy::createSampler(const PAL::WebGPU::SamplerDescriptor& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemotePresentationContextMessages.h"
+#include "RemoteTextureProxy.h"
 #include "WebGPUConvertToBackingContext.h"
 #include "WebGPUPresentationConfiguration.h"
 
@@ -61,10 +62,24 @@ void RemotePresentationContextProxy::unconfigure()
     UNUSED_VARIABLE(sendResult);
 }
 
-PAL::WebGPU::Texture* RemotePresentationContextProxy::getCurrentTexture()
+PAL::WebGPU::Texture& RemotePresentationContextProxy::getCurrentTexture()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250958 Figure out how the lifetime of these objects should behave.
-    return nullptr;
+    if (!m_currentTexture) {
+        auto identifier = WebGPUIdentifier::generate();
+        auto sendResult = send(Messages::RemotePresentationContext::GetCurrentTexture(identifier));
+        UNUSED_VARIABLE(sendResult);
+
+        m_currentTexture = RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
+    }
+
+    return *m_currentTexture;
+}
+
+void RemotePresentationContextProxy::present()
+{
+    auto sendResult = send(Messages::RemotePresentationContext::Present());
+    UNUSED_VARIABLE(sendResult);
+    m_currentTexture = nullptr;
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -35,6 +35,7 @@
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
+class RemoteTextureProxy;
 
 class RemotePresentationContextProxy final : public PAL::WebGPU::PresentationContext {
     WTF_MAKE_FAST_ALLOCATED;
@@ -76,7 +77,9 @@ private:
     void configure(const PAL::WebGPU::PresentationConfiguration&) final;
     void unconfigure() final;
 
-    PAL::WebGPU::Texture* getCurrentTexture() final;
+    PAL::WebGPU::Texture& getCurrentTexture() final;
+
+    void present() final;
 
 #if PLATFORM(COCOA)
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
@@ -85,6 +88,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteGPUProxy> m_parent;
+    RefPtr<RemoteTextureProxy> m_currentTexture;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,10 +35,10 @@
 
 namespace WebKit::WebGPU {
 
-RemoteTextureProxy::RemoteTextureProxy(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+RemoteTextureProxy::RemoteTextureProxy(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     : m_backing(identifier)
     , m_convertToBackingContext(convertToBackingContext)
-    , m_parent(parent)
+    , m_root(root)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,20 +42,19 @@ class ConvertToBackingContext;
 class RemoteTextureProxy final : public PAL::WebGPU::Texture {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteTextureProxy> create(RemoteDeviceProxy& parent, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
+    static Ref<RemoteTextureProxy> create(RemoteGPUProxy& root, ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier)
     {
-        return adoptRef(*new RemoteTextureProxy(parent, convertToBackingContext, identifier));
+        return adoptRef(*new RemoteTextureProxy(root, convertToBackingContext, identifier));
     }
 
     virtual ~RemoteTextureProxy();
 
-    RemoteDeviceProxy& parent() { return m_parent; }
-    RemoteGPUProxy& root() { return m_parent->root(); }
+    RemoteGPUProxy& root() { return m_root; }
 
 private:
     friend class DowncastConvertToBackingContext;
 
-    RemoteTextureProxy(RemoteDeviceProxy&, ConvertToBackingContext&, WebGPUIdentifier);
+    RemoteTextureProxy(RemoteGPUProxy&, ConvertToBackingContext&, WebGPUIdentifier);
 
     RemoteTextureProxy(const RemoteTextureProxy&) = delete;
     RemoteTextureProxy(RemoteTextureProxy&&) = delete;
@@ -84,7 +83,7 @@ private:
 
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
-    Ref<RemoteDeviceProxy> m_parent;
+    Ref<RemoteGPUProxy> m_root;
 };
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### 7d48787400be8e0bc45e3bf0c0817d510341347f
<pre>
[WebGPU] Flesh out PresentationContext&apos;s API
<a href="https://bugs.webkit.org/show_bug.cgi?id=250990">https://bugs.webkit.org/show_bug.cgi?id=250990</a>
rdar://104537242

Reviewed by Tadeu Zagallo.

This patch does 3 things:
1. Migrates getCurrentTextureView() to getCurrentTexture(). GPUCanvasContext uses
       getCurrentTexture(), but WebGPU.h exposes getCurrentTextureView(). GPUCanvasContext
       represents the source of truth; WebGPU.h is outdated, so we should use
       getCurrentTexture(). webgpu-native/webgpu-headers#89 is
       about updating WebGPU.h.
2. Implements getCurrentTexture(). These are a little tricky because they&apos;re supposed to be
       +0 getters. However, that&apos;s only relevant for calling directly into WebGPU.framework;
       everywhere else in WebKit we use owning Refs, so in WebKit, a +0 object is really just
       an object whose creator has a ref to it. The tricky parts about dealing with
       WebGPU.framework will be fixed in <a href="https://bugs.webkit.org/show_bug.cgi?id=250958">https://bugs.webkit.org/show_bug.cgi?id=250958</a>; this
       patch hooks just those parts up intentionally incorrectly and adds a FIXME with a link
       to that bug. These functions aren&apos;t called yet (that&apos;s for
       <a href="https://bugs.webkit.org/show_bug.cgi?id=250995)">https://bugs.webkit.org/show_bug.cgi?id=250995)</a> so it&apos;s okay that this part doesn&apos;t
       actually work yet. WebGPU.framework continues to implement getCurrentTextureView()
       just for completeness.
3. Adds present(), and hooks it up to wgpuSwapChainPresent(). This part is super
       straightforward.

* Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp:
(WebCore::GPUPresentationContext::getCurrentTexture):
(WebCore::GPUPresentationContext::present):
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp:
(PAL::WebGPU::PresentationContextImpl::configure):
(PAL::WebGPU::PresentationContextImpl::getCurrentTexture):
(PAL::WebGPU::PresentationContextImpl::present):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContext.h:
* Source/WebGPU/WebGPU/PresentationContext.mm:
(WebGPU::PresentationContext::getCurrentTexture):
(wgpuSwapChainGetCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.h:
(WebGPU::PresentationContextCoreAnimation::Configuration::Configuration):
* Source/WebGPU/WebGPU/PresentationContextCoreAnimation.mm:
(WebGPU::PresentationContextCoreAnimation::configure):
(WebGPU::PresentationContextCoreAnimation::Configuration::generateCurrentFrameState):
(WebGPU::PresentationContextCoreAnimation::getCurrentTexture):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::getCurrentTexture):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::getCurrentTexture):
(WebKit::RemotePresentationContext::present):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createSurfaceTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
(WebKit::WebGPU::RemotePresentationContextProxy::getCurrentTexture):
(WebKit::WebGPU::RemotePresentationContextProxy::present):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::RemoteTextureProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:

Canonical link: <a href="https://commits.webkit.org/259585@main">https://commits.webkit.org/259585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e2506e9d2fa548082be2005316935f43fe60a8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114584 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109230 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/15594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5332 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97636 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111085 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/15594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/15594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26666 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7837 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6606 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9624 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->