### PR TITLE
REGRESSION(256180@main): Enabling accelerated drawing caused some ImageOnly Failures (248018)

### DIFF
--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <html>
 <head>
-<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=111; totalPixels=848-853" />
+<meta name="fuzzy" content="maxDifference=110; totalPixels=853" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/gradients/spreadMethodAlpha.svg
+++ b/LayoutTests/svg/gradients/spreadMethodAlpha.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=1;totalPixels=28400-29700" />
+    <meta name="fuzzy" content="maxDifference=1;totalPixels=27684-29700" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="0">
         <stop stop-color="rgba(0,0,255,0.5)" offset="0"/>
         <stop stop-color="rgba(0,0,255,0.5)" offset="0.5"/>


### PR DESCRIPTION
#### bb5fff6456b051fdbfc60d714b21f3fbb9d0ecb7
<pre>
REGRESSION(256180@main): Enabling accelerated drawing caused some ImageOnly Failures (248018)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248018">https://bugs.webkit.org/show_bug.cgi?id=248018</a>
rdar://102449694

Unreviewed test gardening.

Adjusting pixel tolerance on tests that broke when accelrated drawing was enabled.

* LayoutTests/svg/compositing/outermost-svg-with-border-padding.html:
* LayoutTests/svg/gradients/spreadMethodAlpha.svg:

Canonical link: <a href="https://commits.webkit.org/259518@main">https://commits.webkit.org/259518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71c0536d2277c4e41849a1c2c83a5850c5c33ea9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114370 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5113 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110868 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3502 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->