### PR TITLE
Function constructor should format arguments differently

### DIFF
--- a/JSTests/ChakraCore/test/Lib/noargs_2.baseline-jsc
+++ b/JSTests/ChakraCore/test/Lib/noargs_2.baseline-jsc
@@ -10,7 +10,8 @@ encodeURI = undefined
 decodeURIComponent = undefined
 encodeURIComponent = undefined
 Object = [object Object]
-Function = function anonymous() {
+Function = function anonymous(
+) {
 
 }
 Array = 

--- a/JSTests/stress/function-cache-with-parameters-end-position.js
+++ b/JSTests/stress/function-cache-with-parameters-end-position.js
@@ -22,7 +22,8 @@ for (var i = 0; i < 10; ++i) {
     var f = Function('/*) {\n*/', 'return 42');
     shouldBe(f.toString(),
 `function anonymous(/*) {
-*/) {
+*/
+) {
 return 42
 }`);
 }
@@ -33,7 +34,8 @@ for (var i = 0; i < 10; ++i) {
     var f = Function('/*) {\n*/', 'return 43');
     shouldBe(f.toString(),
 `function anonymous(/*) {
-*/) {
+*/
+) {
 return 43
 }`);
 }

--- a/JSTests/stress/function-constructor-name.js
+++ b/JSTests/stress/function-constructor-name.js
@@ -10,27 +10,31 @@ var AsyncGeneratorFunction = async function*(){}.constructor;
 var f = Function(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(f.toString(),
-`function anonymous() {
+`function anonymous(
+) {
 return 42
 }`);
 
 var gf = GeneratorFunction(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(gf.toString(),
-`function* anonymous() {
+`function* anonymous(
+) {
 return 42
 }`);
 
 var af = AsyncFunction(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(af.toString(),
-`async function anonymous() {
+`async function anonymous(
+) {
 return 42
 }`);
 
 var agf = AsyncGeneratorFunction(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(agf.toString(),
-`async function* anonymous() {
+`async function* anonymous(
+) {
 return 42
 }`);

--- a/JSTests/stress/function-constructor-semantics.js
+++ b/JSTests/stress/function-constructor-semantics.js
@@ -45,8 +45,8 @@ testError("a=20", "'use strict';");
 testError("{a}", "'use strict';");
 testError("...args", "'use strict';");
 testError("...args", "b", "");
-testError("//", "b", "");
 
+testOK("//", "b", "");
 testOK("/*", "*/", "");
 testOK("a", "/*b", "*/", "'use strict'; let b");
 testOK("{a}", "return a;");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1,10 +1,4 @@
 ---
-test/annexB/built-ins/Function/createdynfn-html-close-comment-params.js:
-  default: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
-  strict mode: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
-test/annexB/built-ins/Function/createdynfn-html-open-comment-params.js:
-  default: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
-  strict mode: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
 test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js:
   default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
 test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js:
@@ -615,18 +609,6 @@ test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
 test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
   default: 'Test262Error: Expected a ReferenceError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a ReferenceError but got a different error constructor with the same name'
-test/built-ins/Function/prototype/toString/AsyncFunction.js:
-  default: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-test/built-ins/Function/prototype/toString/AsyncGenerator.js:
-  default: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-test/built-ins/Function/prototype/toString/Function.js:
-  default: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-test/built-ins/Function/prototype/toString/GeneratorFunction.js:
-  default: "SyntaxError: Unexpected keyword 'yield'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected keyword 'yield'. Expected a ')' or a ',' after a parameter declaration."
 test/built-ins/Function/prototype/toString/async-arrow-function.js:
   default: 'Test262Error: Conforms to NativeFunction Syntax: "async ( /* b */ a /* c */ , /* d */ b /* e */ ) /* f */ => /* g */ { /* h */ ; /* i */ }" (async /* a */ ( /* b */ a /* c */ , /* d */ b /* e */ ) /* f */ => /* g */ { /* h */ ; /* i */ })'
   strict mode: 'Test262Error: Conforms to NativeFunction Syntax: "async ( /* b */ a /* c */ , /* d */ b /* e */ ) /* f */ => /* g */ { /* h */ ; /* i */ }" (async /* a */ ( /* b */ a /* c */ , /* d */ b /* e */ ) /* f */ => /* g */ { /* h */ ; /* i */ })'

--- a/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
@@ -66,7 +66,7 @@ int testFunctionOverrides()
         "'function f1() { /* Overridden f1 */ }\\n"
         "function () { /* Overridden f2 */ }\\n"
         "function () { /* Overridden f3 */ }\\n"
-        "function anonymous() { /* Overridden f4 */ }\\n';"
+        "function anonymous(\\n) { /* Overridden f4 */ }\\n';"
         "var result = (str == expectedStr);" "\n"
         "result";
 

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1799,7 +1799,7 @@ int main(int argc, char* argv[])
     ASSERT(!JSObjectMakeFunction(context, NULL, 0, NULL, functionBody, NULL, 1, &exception));
     ASSERT(JSValueIsObject(context, exception));
     v = JSObjectGetProperty(context, JSValueToObject(context, exception, NULL), line, NULL);
-    assertEqualsAsNumber(v, 2);
+    assertEqualsAsNumber(v, 3);
     JSStringRelease(functionBody);
     JSStringRelease(line);
 
@@ -1809,7 +1809,7 @@ int main(int argc, char* argv[])
     ASSERT(!JSObjectMakeFunction(context, NULL, 0, NULL, functionBody, NULL, -42, &exception));
     ASSERT(JSValueIsObject(context, exception));
     v = JSObjectGetProperty(context, JSValueToObject(context, exception, NULL), line, NULL);
-    assertEqualsAsNumber(v, 2);
+    assertEqualsAsNumber(v, 3);
     JSStringRelease(functionBody);
     JSStringRelease(line);
 
@@ -1819,7 +1819,7 @@ int main(int argc, char* argv[])
     ASSERT(!JSObjectMakeFunction(context, NULL, 0, NULL, functionBody, NULL, 1, &exception));
     ASSERT(JSValueIsObject(context, exception));
     v = JSObjectGetProperty(context, JSValueToObject(context, exception, NULL), line, NULL);
-    assertEqualsAsNumber(v, 3);
+    assertEqualsAsNumber(v, 4);
     JSStringRelease(functionBody);
     JSStringRelease(line);
 
@@ -1853,7 +1853,7 @@ int main(int argc, char* argv[])
     JSStringRelease(functionBody);
     
     string = JSValueToStringCopy(context, function, NULL);
-    assertEqualsAsUTF8String(JSValueMakeString(context, string), "function foo(foo) {\nreturn foo;\n}");
+    assertEqualsAsUTF8String(JSValueMakeString(context, string), "function foo(foo\n) {\nreturn foo;\n}");
     JSStringRelease(string);
 
     JSStringRef print = JSStringCreateWithUTF8CString("print");

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -87,11 +87,11 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
     String program;
     functionConstructorParametersEndPosition = std::nullopt;
     if (args.isEmpty())
-        program = makeString(prefix, functionName.string(), "() {\n\n}");
+        program = makeString(prefix, functionName.string(), "(\n) {\n\n}");
     else if (args.size() == 1) {
         auto body = args.at(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        program = tryMakeString(prefix, functionName.string(), "() {\n", body, "\n}");
+        program = tryMakeString(prefix, functionName.string(), "(\n) {\n", body, "\n}");
         if (UNLIKELY(!program)) {
             throwOutOfMemoryError(globalObject, scope);
             return { };
@@ -110,20 +110,20 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
             RETURN_IF_EXCEPTION(scope, { });
             auto viewWithString = jsString->viewWithUnderlyingString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
-            builder.append(", ", viewWithString.view);
+            builder.append(",", viewWithString.view);
         }
         if (UNLIKELY(builder.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
 
-        functionConstructorParametersEndPosition = builder.length() + 1;
+        functionConstructorParametersEndPosition = builder.length() + sizeof("\n)") - 1;
 
         auto* bodyString = args.at(args.size() - 1).toString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         auto body = bodyString->viewWithUnderlyingString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        builder.append(") {\n", body.view, "\n}");
+        builder.append("\n) {\n", body.view, "\n}");
         if (UNLIKELY(builder.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
             return { };


### PR DESCRIPTION
#### 223fdc7df199b3f887fbce41b3d67ba044de8409
<pre>
Function constructor should format arguments differently
<a href="https://bugs.webkit.org/show_bug.cgi?id=251304">https://bugs.webkit.org/show_bug.cgi?id=251304</a>

Reviewed by NOBODY (OOPS!).

The current spec says that parameters should be separated by just a &quot;,&quot; and not &quot;, &quot;. Also the closing &quot;)&quot; should have a new line before it.

From <a href="https://tc39.es/ecma262/#sec-createdynamicfunction">https://tc39.es/ecma262/#sec-createdynamicfunction</a> :

10. d. iii. Set P to the string-concatenation of P, &quot;,&quot; (a comma), and nextArgString.

and

12. Let sourceString be the string-concatenation of prefix, &quot; anonymous(&quot;, P, 0x000A (LINE FEED), &quot;) {&quot;, bodyString, and &quot;}&quot;.

* JSTests/ChakraCore/test/Lib/noargs_2.baseline-jsc:
* JSTests/stress/function-cache-with-parameters-end-position.js:
(i.anonymous):
* JSTests/stress/function-constructor-name.js:
(async var):
* JSTests/stress/function-constructor-semantics.js:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp:
(testFunctionOverrides):
* Source/JavaScriptCore/API/tests/testapi.c:
(main):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/223fdc7df199b3f887fbce41b3d67ba044de8409

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114372 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174563 "Found 2 new test failures: js/dom/function-names.html, js/dom/script-start-end-locations.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5115 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114354 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110870 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11856 "Found 4 new test failures: fast/events/event-function-toString.html, imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext.html, js/dom/function-names.html, js/dom/script-start-end-locations.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94856 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39358 "Found 6 new test failures: fast/events/event-function-toString.html, imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext.html, inspector/console/messageAdded-from-named-evaluations.html, inspector/debugger/search-scripts.html, js/dom/function-names.html, js/dom/script-start-end-locations.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93723 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26484 "Found 6 new test failures: fast/events/event-function-toString.html, imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext.html, inspector/console/messageAdded-from-named-evaluations.html, inspector/debugger/search-scripts.html, js/dom/function-names.html, js/dom/script-start-end-locations.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81023 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94950 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7526 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27843 "Found 6 new test failures: fast/events/event-function-toString.html, imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext.html, inspector/console/messageAdded-from-named-evaluations.html, inspector/debugger/search-scripts.html, js/dom/function-names.html, js/dom/script-start-end-locations.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/92998 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5260 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7624 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4426 "Found 6 new test failures: fast/events/event-function-toString.html, fast/forms/fieldset/fieldset-elements.html, imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext.html, inspector/console/messageAdded-from-named-evaluations.html, js/dom/function-names.html, js/dom/script-start-end-locations.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30295 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47396 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101696 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9409 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25368 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->