### PR TITLE
[ New Test ] (258407@main): [ iOS MacOS Debug ] imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.html is a consistent failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Attempt to create a sync access handle. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: file_system_type"
+FAIL Attempt to create a sync access handle. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.js
@@ -2,7 +2,3 @@
 // META: script=resources/sandboxed-fs-test-helpers.js
 // META: script=resources/messaging-helpers.js
 // META: script=script-tests/FileSystemFileHandle-create-sync-access-handle.js
-
-// This variable allows the test to differentiate between local and sandboxed
-// file systems, since createSyncAccessHandle() behavior is different each one.
-const file_system_type = 'sandboxed';

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-create-sync-access-handle.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-create-sync-access-handle.js
@@ -5,11 +5,6 @@
 //    /fs/resources/test-helpers.js
 
 directory_test(async (t, root_dir) => {
-  assert_true(
-      file_system_type == 'sandboxed' || file_system_type == 'local',
-      'File system type should be sandboxed or local.');
-  const expect_success = file_system_type == 'sandboxed';
-
   const dedicated_worker =
       create_dedicated_worker(t, kDedicatedWorkerMessageTarget);
   const file_handle =
@@ -22,5 +17,5 @@ directory_test(async (t, root_dir) => {
   const message_event = await event_watcher.wait_for('message');
   const response = message_event.data;
 
-  assert_equals(response.success, expect_success);
+  assert_true(response.success);
 }, 'Attempt to create a sync access handle.');

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3891,8 +3891,6 @@ webkit.org/b/251216 imported/w3c/web-platform-tests/fetch/metadata/generated/css
 
 webkit.org/b/251234 imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.worker.html [ Failure ]
 
-webkit.org/b/251274 [ Debug ] imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.html [ Pass Failure ]
-
 webkit.org/b/251302 accessibility/ios-simulator/table-cell-ranges.html [ Failure ]
 
 webkit.org/b/251312 fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html [ Pass Failure ]


### PR DESCRIPTION
#### a489862bf7057dd278c8287926c64aacefa0d2e8
<pre>
[ New Test ] (258407@main): [ iOS MacOS Debug ] imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=251274">https://bugs.webkit.org/show_bug.cgi?id=251274</a>
rdar://problem/104747460

Reviewed by Youenn Fablet.

The test is flaky because the variable file_system_type might be not be when test runs. As the test is the only user of
FileSystemFileHandle-create-sync-access-handle.js, there is no need to check file system type and we can just remove
file_system_type.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.js:
* LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-create-sync-access-handle.js:
(directory_test.async t):
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259575@main">https://commits.webkit.org/259575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a15b85322a68b977a604e64225e2e707e03f4f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114383 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174567 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5126 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114359 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4431 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6602 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9420 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->