### PR TITLE
Find on page intermittently fails to show results in PDFs in Safari

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -136,6 +136,7 @@
 #endif
 
 #if HAVE(UIFINDINTERACTION)
+#import <UIKit/UIFindSession_Private.h>
 #import <UIKit/_UIFindInteraction.h>
 #import <UIKit/_UITextSearching.h>
 #endif
@@ -362,6 +363,10 @@ typedef id<NSCoding, NSCopying> _UITextSearchDocumentIdentifier;
 
 @interface UIFindInteraction ()
 @property (class, nonatomic, copy, getter=_globalFindBuffer, setter=_setGlobalFindBuffer:) NSString *_globalFindBuffer;
+@end
+
+@interface UITextSearchingFindSession ()
+@property (nonatomic, readwrite, weak) id<UITextSearching> searchableObject;
 @end
 
 #endif // HAVE(UIFINDINTERACTION)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -818,8 +818,12 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
         [_scrollView _stopScrollingAndZoomingAnimations];
 
 #if HAVE(UIFINDINTERACTION)
-    if (_findInteractionEnabled)
+    if (_findInteractionEnabled) {
         [_findInteraction dismissFindNavigator];
+
+        if (auto *findSession = dynamic_objc_cast<UITextSearchingFindSession>([_findInteraction activeFindSession]))
+            findSession.searchableObject = [self _searchableObject];
+    }
 #endif
 }
 


### PR DESCRIPTION
#### dd929cd085dc7862b052721523e7b6ba97b98769
<pre>
Find on page intermittently fails to show results in PDFs in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=251311">https://bugs.webkit.org/show_bug.cgi?id=251311</a>
rdar://100155151

Reviewed by Aditya Keerthi.

When viewing a PDF in Safari, Find in Page fails after the following sequence
of events:

1. Open a PDF in Safari
2. Activate Find in Page and search for a string
3. Refresh the page
4. Activate Find in Page again

After the last step, Find In Page will continue to return zero results regardless
of the search string.

This is because the `WKPDFView` instance is used as the `UIFindSession`&apos;s &quot;searchable object&quot;
to process the search. When the page is refreshed, a new `WKPDFView` instance is created, but
not a new `UIFindSession`, and so the session has lost its searchable object.

This PR fixes this by setting the session&apos;s searchable object to the new `WKPDFView` in the
`_didCommitLoadForMainFrame` method, which is called after the new `WKPDFView` has been created.
This ensures that the session&apos;s searchable object is up to date.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLoadForMainFrame]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(swizzledPerformTextSearchWithQueryString):
(TEST):

Canonical link: <a href="https://commits.webkit.org/259655@main">https://commits.webkit.org/259655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df5ec1250ce442a7b7f5afe22adcafd3870e422c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114746 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174897 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5819 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97792 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39660 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8224 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4742 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6668 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9898 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->