### PR TITLE
[GTK][WPE] Bring back WebKitConsoleMessage API implementation

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2015 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "WebViewTest.h"
+
+class ConsoleMessageTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(ConsoleMessageTest);
+
+    // This should be keep in sync with the public enums in WebKitConsoleMessage.h.
+    enum class MessageSource { JavaScript, Network, ConsoleAPI, Security, Other };
+    enum class MessageLevel { Info, Log, Warning, Error, Debug };
+    struct ConsoleMessage {
+        bool operator==(const ConsoleMessage& other) const
+        {
+            return source == other.source
+                && level == other.level
+                && message == other.message
+                && lineNumber == other.lineNumber
+                && sourceID == other.sourceID;
+        }
+
+        MessageSource source;
+        MessageLevel level;
+        CString message;
+        unsigned lineNumber;
+        CString sourceID;
+    };
+
+    static void consoleMessageReceivedCallback(WebKitUserContentManager*, WebKitJavascriptResult* message, ConsoleMessageTest* test)
+    {
+        g_assert_nonnull(message);
+        GUniquePtr<char> messageString(WebViewTest::javascriptResultToCString(message));
+        GRefPtr<GVariant> variant = g_variant_parse(G_VARIANT_TYPE("(uusus)"), messageString.get(), nullptr, nullptr, nullptr);
+        g_assert_nonnull(variant.get());
+
+        unsigned source, level, lineNumber;
+        const char* messageText;
+        const char* sourceID;
+        g_variant_get(variant.get(), "(uu&su&s)", &source, &level, &messageText, &lineNumber, &sourceID);
+        test->m_consoleMessage = { static_cast<ConsoleMessageTest::MessageSource>(source), static_cast<ConsoleMessageTest::MessageLevel>(level), messageText, lineNumber, sourceID };
+
+        g_main_loop_quit(test->m_mainLoop);
+    }
+
+    ConsoleMessageTest()
+    {
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "console");
+        g_signal_connect(m_userContentManager.get(), "script-message-received::console", G_CALLBACK(consoleMessageReceivedCallback), this);
+    }
+
+    ~ConsoleMessageTest()
+    {
+        g_signal_handlers_disconnect_matched(m_userContentManager.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "console");
+    }
+
+    void waitUntilConsoleMessageReceived()
+    {
+        g_main_loop_run(m_mainLoop);
+    }
+
+    ConsoleMessage m_consoleMessage;
+};
+
+static void testWebKitConsoleMessageConsoleAPI(ConsoleMessageTest* test, gconstpointer)
+{
+    ConsoleMessageTest::ConsoleMessage referenceMessage = { ConsoleMessageTest::MessageSource::ConsoleAPI, ConsoleMessageTest::MessageLevel::Log, "Log Console Message", 1, "http://foo.com/bar" };
+    test->loadHtml("<html><body onload='console.log(\"Log Console Message\");'></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+
+    referenceMessage.level = ConsoleMessageTest::MessageLevel::Info;
+    referenceMessage.message = "Info Console Message";
+    test->loadHtml("<html><body onload='console.info(\"Info Console Message\");'></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+
+    referenceMessage.level = ConsoleMessageTest::MessageLevel::Warning;
+    referenceMessage.message = "Warning Console Message";
+    test->loadHtml("<html><body onload='console.warn(\"Warning Console Message\");'></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+
+    referenceMessage.level = ConsoleMessageTest::MessageLevel::Error;
+    referenceMessage.message = "Error Console Message";
+    test->loadHtml("<html><body onload='console.error(\"Error Console Message\");'></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+
+    referenceMessage.level = ConsoleMessageTest::MessageLevel::Debug;
+    referenceMessage.message = "Debug Console Message";
+    test->loadHtml("<html><body onload='console.debug(\"Debug Console Message\");'></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+}
+
+static void testWebKitConsoleMessageJavaScriptException(ConsoleMessageTest* test, gconstpointer)
+{
+    ConsoleMessageTest::ConsoleMessage referenceMessage = { ConsoleMessageTest::MessageSource::JavaScript, ConsoleMessageTest::MessageLevel::Error,
+        "ReferenceError: Can't find variable: foo", 1, "http://foo.com/bar" };
+    test->loadHtml("<html><body onload='foo()'></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+}
+
+static void testWebKitConsoleMessageNetworkError(ConsoleMessageTest* test, gconstpointer)
+{
+    ConsoleMessageTest::ConsoleMessage referenceMessage = { ConsoleMessageTest::MessageSource::Network, ConsoleMessageTest::MessageLevel::Error,
+        "Failed to load resource: The resource at “/org/webkit/glib/tests/not-found.css” does not exist", 0, "resource:///org/webkit/glib/tests/not-found.css" };
+    test->loadHtml("<html><head><link rel='stylesheet' href='not-found.css' type='text/css'></head><body></body></html>", "resource:///org/webkit/glib/tests/");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+}
+
+static void testWebKitConsoleMessageSecurityError(ConsoleMessageTest* test, gconstpointer)
+{
+    ConsoleMessageTest::ConsoleMessage referenceMessage = { ConsoleMessageTest::MessageSource::Security, ConsoleMessageTest::MessageLevel::Error,
+        "Not allowed to load local resource: file:///foo/bar/source.png", 1, "http://foo.com/bar" };
+    test->loadHtml("<html><body><img src=\"file:///foo/bar/source.png\"/></body></html>", "http://foo.com/bar");
+    test->waitUntilConsoleMessageReceived();
+    g_assert_true(test->m_consoleMessage == referenceMessage);
+}
+
+void beforeAll()
+{
+    ConsoleMessageTest::add("WebKitConsoleMessage", "console-api", testWebKitConsoleMessageConsoleAPI);
+    ConsoleMessageTest::add("WebKitConsoleMessage", "js-exception", testWebKitConsoleMessageJavaScriptException);
+    ConsoleMessageTest::add("WebKitConsoleMessage", "network-error", testWebKitConsoleMessageNetworkError);
+    ConsoleMessageTest::add("WebKitConsoleMessage", "security-error", testWebKitConsoleMessageSecurityError);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -171,6 +171,8 @@ ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/
 
 if (ENABLE_2022_GLIB_API)
     ADD_WK2_TEST(TestWebKitNetworkSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp)
+else ()
+    ADD_WK2_TEST(TestConsoleMessage ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp)
 endif ()
 
 macro(ADD_WPE_QT_TEST test_name)


### PR DESCRIPTION
#### 91955d0ab066432662bddfc48d7d6b9388aec222
<pre>
[GTK][WPE] Bring back WebKitConsoleMessage API implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=251315">https://bugs.webkit.org/show_bug.cgi?id=251315</a>

Reviewed by Michael Catanzaro.

I deprecated the API in 257010@main and removed the functionality
assuming nobody was actually using it, but I was wrong. So, keep the API
deprecated, but bring back the implementation for backwards
compatibility.

* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(webkitWebPageDidSendConsoleMessage):
(webkit_web_page_class_init):
(webkitWebPageCreate):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp: Added.
(ConsoleMessageTest::ConsoleMessage::operator== const):
(ConsoleMessageTest::consoleMessageReceivedCallback):
(ConsoleMessageTest::ConsoleMessageTest):
(ConsoleMessageTest::~ConsoleMessageTest):
(ConsoleMessageTest::waitUntilConsoleMessageReceived):
(testWebKitConsoleMessageConsoleAPI):
(testWebKitConsoleMessageJavaScriptException):
(testWebKitConsoleMessageNetworkError):
(testWebKitConsoleMessageSecurityError):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp:
(consoleMessageSentCallback):
(pageCreatedCallback):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/259535@main">https://commits.webkit.org/259535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e7ac5772d9a47adb697eec42c46d1f0bc3db868

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114405 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174583 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5150 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97459 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39378 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81043 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27869 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4445 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47424 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9442 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3513 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->