### PR TITLE
Prevent construction of String, StringView objects with native string literals

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -397,8 +397,8 @@ public:
         //       StringImpl::hash() only sets a new hash iff !hasHash().
         //       Additionally, StringImpl::setHash() asserts hasHash() and !isStatic().
 
-        template<unsigned characterCount> constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
-        template<unsigned characterCount> constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
+        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
+        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
         operator StringImpl&();
     };
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -73,6 +73,13 @@ public:
 
     ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
 
+    // Explicitly deleting these constructors prevents construction of StringView objects with
+    // native string literals by using implicit converting constructors of String and Span types.
+    template<typename CharacterType, size_t N>
+    StringView(CharacterType(&)[N]) = delete;
+    template<typename CharacterType, size_t N>
+    StringView(const CharacterType(&)[N]) = delete;
+
     static StringView empty();
 
     unsigned length() const;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -81,6 +81,13 @@ public:
     // Construct a string from a constant string literal.
     String(ASCIILiteral);
 
+    // Explicitly deleting these constructors prevents construction of String objects with
+    // native string literals by using implicit converting constructors of StaticStringImpl and Span types.
+    template<typename CharacterType, size_t N>
+    String(CharacterType(&)[N]) = delete;
+    template<typename CharacterType, size_t N>
+    String(const CharacterType(&)[N]) = delete;
+
     String(const String&) = default;
     String(String&&) = default;
     String& operator=(const String&) = default;

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -224,7 +224,7 @@ static String generateTemporaryPath(const Function<bool(const String&)>& action)
 
         ASSERT(wcslen(tempFile) == std::size(tempFile) - 1);
 
-        proposedPath = pathByAppendingComponent(String(tempPath), String(tempFile));
+        proposedPath = pathByAppendingComponent(String(std::data(tempPath)), String(std::data(tempFile)));
         if (proposedPath.isEmpty())
             break;
     } while (!action(proposedPath));

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -968,7 +968,7 @@ sub printTagNameCppFile
     print F "static constexpr StringImpl::StaticStringImpl unadjustedTagNames[] = {\n";
     for my $elementKey (sort byElementNameOrder keys %allElements) {
         next if $allElements{$elementKey}{unadjustedTagEnumValue} eq "";
-        print F "    \"$allElements{$elementKey}{parsedTagName}\",\n";
+        print F "    StringImpl::StaticStringImpl { \"$allElements{$elementKey}{parsedTagName}\" },\n";
     }
     print F "};\n";
     print F "\n";

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -310,7 +310,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
         SelectObject(hdc, hfont);
         WCHAR name[LF_FACESIZE];
         GetTextFace(hdc, LF_FACESIZE, name);
-        familyName = String(name);
+        familyName = String(std::data(name));
 
         if (containsCharacter || currentFontContainsCharacter(hdc, characters, length))
             break;

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -83,10 +83,10 @@ static bool getWebLocData(IDataObject* dataObject, String& url, String* title)
     
     if (title) {
         PathRemoveExtension(filename);
-        *title = String(filename);
+        *title = String(std::data(filename));
     }
     
-    url = String(urlBuffer);
+    url = String(std::data(urlBuffer));
     succeeded = true;
 
 exit:
@@ -113,10 +113,10 @@ static bool getWebLocData(const DragDataMap* dataObject, String& url, String* ti
 
     if (title) {
         PathRemoveExtension(filename);
-        *title = String(filename);
+        *title = String(std::data(filename));
     }
     
-    url = String(urlBuffer);
+    url = String(std::data(urlBuffer));
     return true;
 }
 
@@ -382,7 +382,7 @@ void getFileDescriptorData(IDataObject* dataObject, int& size, String& pathname)
 
     FILEGROUPDESCRIPTOR* fgd = static_cast<FILEGROUPDESCRIPTOR*>(GlobalLock(store.hGlobal));
     size = fgd->fgd[0].nFileSizeLow;
-    pathname = String(fgd->fgd[0].cFileName);
+    pathname = String(std::data(fgd->fgd[0].cFileName));
 
     GlobalUnlock(store.hGlobal);
     ::ReleaseStgMedium(&store);
@@ -720,7 +720,7 @@ void getHDropData(IDataObject* data, FORMATETC* format, Vector<String>& dataStri
     for (UINT i = 0; i < fileCount; i++) {
         if (!DragQueryFileW(hdrop, i, filename, std::size(filename)))
             continue;
-        dataStrings.append(filename);
+        dataStrings.append(String(std::data(filename)));
     }
 
     GlobalUnlock(store.hGlobal);

--- a/Source/WebCore/platform/win/DragDataWin.cpp
+++ b/Source/WebCore/platform/win/DragDataWin.cpp
@@ -148,7 +148,7 @@ Vector<String> DragData::asFilenames() const
         for (unsigned i = 0; i < numFiles; i++) {
             if (!DragQueryFileW(hdrop, i, filename, std::size(filename)))
                 continue;
-            result.append(filename);
+            result.append(String(std::data(filename)));
         }
 
         // Free up memory from drag

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -385,7 +385,7 @@ void Pasteboard::read(PasteboardFileReader& reader, std::optional<size_t>)
         for (UINT i = 0; i < fileCount; i++) {
             if (!DragQueryFileW(hdrop, i, filename, std::size(filename)))
                 continue;
-            reader.readFilename(filename);
+            reader.readFilename(String(std::data(filename)));
         }
 
         GlobalUnlock(medium.hGlobal);

--- a/Source/WebKitLegacy/win/WebLocalizableStrings.cpp
+++ b/Source/WebKitLegacy/win/WebLocalizableStrings.cpp
@@ -127,7 +127,7 @@ static void createWebKitBundle()
     if (wcscat_s(pathStr, MAX_PATH, L"\\WebKit.resources"))
         return;
 
-    String bundlePathString(pathStr);
+    String bundlePathString(std::data(pathStr));
     if (!bundlePathString)
         return;
 

--- a/Tools/DumpRenderTree/win/DumpRenderTree.cpp
+++ b/Tools/DumpRenderTree/win/DumpRenderTree.cpp
@@ -1112,7 +1112,7 @@ static String findFontFallback(const char* pathOrUrl)
     if (!::PathIsDirectoryW(fullPath))
         return emptyString();
 
-    String pathToCheck = fullPath;
+    String pathToCheck(std::data(fullPath));
     StringView pathToCheckView { pathToCheck };
 
     static const String layoutTests = "LayoutTests"_s;


### PR DESCRIPTION
#### 207f44268eae5a6a1bcf3a80f203514926202b15
<pre>
Prevent construction of String, StringView objects with native string literals
<a href="https://bugs.webkit.org/show_bug.cgi?id=251317">https://bugs.webkit.org/show_bug.cgi?id=251317</a>

Reviewed by NOBODY (OOPS!).

Explicitly delete constructors on String and StringView classes that would
accept fixed-length character arrays. This completely disallows construction
of objects of these types with native string literals, whose type is deduced to
a fixed-length array.

This avoids the possible misuse of stirng literals and buffer-purpose arrays
that might contain the terminating null character before the last character in
that array. That would mean that the length of the null-terminated string would
be actually smaller than the length deduced from the fixed-length array type.

Deletion of these constructors is necessary to prevent other constructors taking
and handling the fixed-length array value implicitly. One such example is the
Span-handling constructor, where the Span object can be implicitly constructed
with the fixed-length array, again taking the array&apos;s length as the length of
the resulting Span, regardless of possible null characters in the string data.

Another example of such converting constructor being used implicitly is on the
StaticStringImpl class. Besides the deleted constructors, the constructors on
the StaticStringImpl class are also marked as explicit, preventing any implicit
conversion to occur.

On Windows, the String constructor accepting a wchar_t pointer is regularly used
with a wchar_t fixed-length array buffer. std::data() is used in those cases,
converting the fixed-length array buffer to a wchar_t pointer pointing to that
array data.

* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::generateTemporaryPath):
* Source/WebCore/dom/make_names.pl:
(printTagNameCppFile):
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::FontCache::systemFallbackForCharacters):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::getWebLocData):
(WebCore::getFileDescriptorData):
(WebCore::getHDropData):
* Source/WebCore/platform/win/DragDataWin.cpp:
(WebCore::DragData::asFilenames const):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::read):
* Source/WebKitLegacy/win/WebLocalizableStrings.cpp:
(createWebKitBundle):
* Tools/DumpRenderTree/win/DumpRenderTree.cpp:
(findFontFallback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/207f44268eae5a6a1bcf3a80f203514926202b15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114494 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174686 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5235 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97549 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114430 "Hash 207f4426 for PR 9282 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39460 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81126 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27947 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93117 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5379 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7744 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4521 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30335 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47502 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101819 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9532 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25412 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->