### PR TITLE
Align 'Screen' IDL interface with Web-Specs

### DIFF
--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2007 Apple Inc.  All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,24 +53,24 @@ Screen::Screen(DOMWindow& window)
 
 Screen::~Screen() = default;
 
-unsigned Screen::height() const
+int Screen::height() const
 {
     auto* frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Height);
-    return static_cast<unsigned>(frame->screenSize().height());
+    return static_cast<int>(frame->screenSize().height());
 }
 
-unsigned Screen::width() const
+int Screen::width() const
 {
     auto* frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::Width);
-    return static_cast<unsigned>(frame->screenSize().width());
+    return static_cast<int>(frame->screenSize().width());
 }
 
 unsigned Screen::colorDepth() const
@@ -117,24 +118,24 @@ int Screen::availTop() const
     return static_cast<int>(screenAvailableRect(frame->view()).y());
 }
 
-unsigned Screen::availHeight() const
+int Screen::availHeight() const
 {
     auto* frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailHeight);
-    return static_cast<unsigned>(screenAvailableRect(frame->view()).height());
+    return static_cast<int>(screenAvailableRect(frame->view()).height());
 }
 
-unsigned Screen::availWidth() const
+int Screen::availWidth() const
 {
     auto* frame = this->frame();
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::AvailWidth);
-    return static_cast<unsigned>(screenAvailableRect(frame->view()).width());
+    return static_cast<int>(screenAvailableRect(frame->view()).width());
 }
 
 ScreenOrientation& Screen::orientation()

--- a/Source/WebCore/page/Screen.h
+++ b/Source/WebCore/page/Screen.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2007 Apple Inc.  All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,14 +45,14 @@ public:
     static Ref<Screen> create(DOMWindow& window) { return adoptRef(*new Screen(window)); }
     ~Screen();
 
-    unsigned height() const;
-    unsigned width() const;
+    int height() const;
+    int width() const;
     unsigned colorDepth() const;
     unsigned pixelDepth() const;
     int availLeft() const;
     int availTop() const;
-    unsigned availHeight() const;
-    unsigned availWidth() const;
+    int availHeight() const;
+    int availWidth() const;
 
     ScreenOrientation& orientation();
 

--- a/Source/WebCore/page/Screen.idl
+++ b/Source/WebCore/page/Screen.idl
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2007 Apple Inc.  All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,19 +27,20 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.csswg.org/cssom-view/#the-screen-interface
 
 [
     GenerateIsReachable=ReachableFromDOMWindow,
     Exposed=Window
 ] interface Screen {
-    readonly attribute unsigned long height;
-    readonly attribute unsigned long width;
+    readonly attribute long height;
+    readonly attribute long width;
     readonly attribute unsigned long colorDepth;
     readonly attribute unsigned long pixelDepth;
     readonly attribute long availLeft;
     readonly attribute long availTop;
-    readonly attribute unsigned long availHeight;
-    readonly attribute unsigned long availWidth;
+    readonly attribute long availHeight;
+    readonly attribute long availWidth;
 
     // https://w3c.github.io/screen-orientation/#extensions-to-the-screen-interface
     [SameObject, EnabledBySetting=ScreenOrientationAPIEnabled] readonly attribute ScreenOrientation orientation;


### PR DESCRIPTION
#### c51d404521b83f41bc0c7a4e968d496903438721
<pre>
Align &apos;Screen&apos; IDL interface with Web-Specs

Align &apos;Screen&apos; IDL interface with Web-Specs
<a href="https://bugs.webkit.org/show_bug.cgi?id=249183">https://bugs.webkit.org/show_bug.cgi?id=249183</a>

Reviewed by Chris Dumez.

This patch is to align WebKit with Blink / Chromium, Gecko / Firefox and Web-Specification.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/b583366b60a014dfbd1d76e1e6217cf2605c8ca3">https://chromium.googlesource.com/chromium/blink/+/b583366b60a014dfbd1d76e1e6217cf2605c8ca3</a>

This patch is to align Screen IDL interfaces of &quot;height&quot;, &quot;width&quot;, &quot;availWidth&quot;
and &quot;availHeight&quot; from unsigned non-negative integers to just integers as per
Web-Specification.

* Source/WebCore/page/Screen.cpp:
(Screen::height): Change from &apos;unsigned&apos; to &apos;int&apos;
(Screen::width): Ditto
(Screen::availWidth): Ditto
(Screen::availHeight): Ditto
* Source/WebCore/page/Screen.h: Ditto
* Source/WebCore/page/Screen.idl: Ditto

Canonical link: <a href="https://commits.webkit.org/259560@main">https://commits.webkit.org/259560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/662e39522adf73ebd37ed24505182663e7315dd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114471 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174654 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5212 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114406 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39437 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7626 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27924 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4496 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47479 "Passed tests") | | 
| [💥 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6583 "An unexpected error occured. Recent messages:Validated commiter and reviewer (exception)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9509 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3523 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->