### PR TITLE
[WebGPU] Simplify the lifetime of GPUPresentationContext within GPUCanvasContextCocoa

### DIFF
--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -67,10 +67,17 @@ std::unique_ptr<GPUCanvasContextCocoa> GPUCanvasContextCocoa::create(CanvasBase&
     return std::unique_ptr<GPUCanvasContextCocoa>(new GPUCanvasContextCocoa(canvas, gpu));
 }
 
+static GPUPresentationContextDescriptor presentationContextDescriptor()
+{
+    return GPUPresentationContextDescriptor {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250955 Add integration with the compositor here.
+    };
+}
+
 GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, GPU& gpu)
     : GPUCanvasContext(canvas)
     , m_layerContentsDisplayDelegate(DisplayBufferDisplayDelegate::create())
-    , m_gpu(gpu)
+    , m_presentationContext(gpu.createPresentationContext(presentationContextDescriptor()))
 {
 }
 
@@ -81,9 +88,9 @@ void GPUCanvasContextCocoa::reshape(int width, int height)
 
     m_width = width;
     m_height = height;
-    m_presentationContext = nullptr;
+    unconfigurePresentationContextIfNeeded();
 
-    createPresentationContextIfNeeded();
+    configurePresentationContextIfNeeded();
 }
 
 GPUCanvasContext::CanvasType GPUCanvasContextCocoa::canvas()
@@ -99,17 +106,22 @@ void GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& configuration)
     reshape(canvasSize.width(), canvasSize.height());
 }
 
-void GPUCanvasContextCocoa::createPresentationContextIfNeeded()
+void GPUCanvasContextCocoa::unconfigurePresentationContextIfNeeded()
 {
-    if (!m_configuration)
+    if (!m_presentationContextIsConfigured)
         return;
 
-    GPUPresentationContextDescriptor presentationContextDescriptor = {
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250955 Add integration with the compositor here.
-    };
+    m_presentationContext->unconfigure();
+    m_presentationContextIsConfigured = false;
+}
 
-    m_presentationContext = m_gpu->createPresentationContext(presentationContextDescriptor);
-    ASSERT(m_presentationContext);
+void GPUCanvasContextCocoa::configurePresentationContextIfNeeded()
+{
+    if (m_presentationContextIsConfigured)
+        return;
+
+    if (!m_configuration)
+        return;
 
     GPUPresentationConfiguration configuration = {
         m_configuration->device, // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250995 This is definitely a UAF
@@ -123,6 +135,7 @@ void GPUCanvasContextCocoa::createPresentationContextIfNeeded()
     };
 
     m_presentationContext->configure(configuration);
+    m_presentationContextIsConfigured = true;
 }
 
 RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
@@ -130,7 +143,7 @@ RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
     if (!m_configuration)
         return nullptr;
 
-    createPresentationContextIfNeeded();
+    configurePresentationContextIfNeeded();
 
     GPUTextureDescriptor descriptor = {
         { "WebGPU Display texture"_s },
@@ -144,7 +157,7 @@ RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
     };
 
     markContextChangedAndNotifyCanvasObservers();
-    return m_configuration->device->createSurfaceTexture(descriptor, *m_presentationContext);
+    return m_configuration->device->createSurfaceTexture(descriptor, m_presentationContext);
 }
 
 PixelFormat GPUCanvasContextCocoa::pixelFormat() const

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -128,15 +128,16 @@ private:
     explicit GPUCanvasContextCocoa(CanvasBase&, GPU&);
 
     void markContextChangedAndNotifyCanvasObservers();
-    void createPresentationContextIfNeeded();
+    void configurePresentationContextIfNeeded();
+    void unconfigurePresentationContextIfNeeded();
 
     std::optional<GPUCanvasConfiguration> m_configuration;
     Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
-    RefPtr<GPUPresentationContext> m_presentationContext;
-    Ref<GPU> m_gpu; // FIXME: https://bugs.webkit.org/show_bug.cgi?id=251067 We shouldn't need to retain this.
+    Ref<GPUPresentationContext> m_presentationContext;
 
     int m_width { 0 };
     int m_height { 0 };
+    bool m_presentationContextIsConfigured { false };
     bool m_compositingResultsNeedsUpdating { false };
 };
 


### PR DESCRIPTION
#### 2f4084835f4b881444e57f4f16eb4425fa5a92e6
<pre>
[WebGPU] Simplify the lifetime of GPUPresentationContext within GPUCanvasContextCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=251067">https://bugs.webkit.org/show_bug.cgi?id=251067</a>
rdar://104784569

Reviewed by Tadeu Zagallo.

There&apos;s no reason to lazily create the GPUPresentationContext; we can just create
it eagerly, which allows us to use a Ref instead of a RefPtr for the object,
thereby eliminating one potential state in the class.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::presentationContextDescriptor):
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
(WebCore::GPUCanvasContextCocoa::reshape):
(WebCore::GPUCanvasContextCocoa::unconfigurePresentationContextIfNeeded):
(WebCore::GPUCanvasContextCocoa::configurePresentationContextIfNeeded):
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
(WebCore::GPUCanvasContextCocoa::createPresentationContextIfNeeded): Deleted.
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:

Canonical link: <a href="https://commits.webkit.org/259564@main">https://commits.webkit.org/259564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b1cabe3405e51ee0c5d1a119904350eb692bcaf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114433 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174611 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5176 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114384 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39398 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81064 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7588 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7683 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4462 "Found 1 new test failure: fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6591 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9471 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->