### PR TITLE
[WebGPU] Make objects with weak getters be internally retained by their owner

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUComputePipeline.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,8 @@ void GPUComputePipeline::setLabel(String&& label)
 
 Ref<GPUBindGroupLayout> GPUComputePipeline::getBindGroupLayout(uint32_t index)
 {
+    // "A new GPUBindGroupLayout wrapper is returned each time"
     return GPUBindGroupLayout::create(m_backing->getBindGroupLayout(index));
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUComputePipeline.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUBindGroupLayout.h"
 #include <cstdint>
 #include <pal/graphics/WebGPU/WebGPUComputePipeline.h>
 #include <wtf/Ref.h>
@@ -32,8 +33,6 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-class GPUBindGroupLayout;
 
 class GPUComputePipeline : public RefCounted<GPUComputePipeline> {
 public:

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -98,7 +98,7 @@ Ref<GPUSupportedLimits> GPUDevice::limits() const
     return GPUSupportedLimits::create(m_backing->limits());
 }
 
-GPUQueue& GPUDevice::queue() const
+Ref<GPUQueue> GPUDevice::queue() const
 {
     return m_queue;
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -91,7 +91,7 @@ public:
     Ref<GPUSupportedFeatures> features() const;
     Ref<GPUSupportedLimits> limits() const;
 
-    GPUQueue& queue() const;
+    Ref<GPUQueue> queue() const;
 
     void destroy();
 

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -41,12 +41,14 @@ void GPUPresentationContext::unconfigure()
     m_backing->unconfigure();
 }
 
-GPUTexture& GPUPresentationContext::getCurrentTexture()
+RefPtr<GPUTexture> GPUPresentationContext::getCurrentTexture()
 {
-    if (!m_currentTexture)
-        m_currentTexture = GPUTexture::create(m_backing->getCurrentTexture()).ptr();
+    if (!m_currentTexture) {
+        if (auto currentTexture = m_backing->getCurrentTexture())
+            m_currentTexture = GPUTexture::create(*currentTexture).ptr();
+    }
 
-    return *m_currentTexture;
+    return m_currentTexture;
 }
 
 void GPUPresentationContext::present()

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -50,7 +50,7 @@ public:
     void configure(const GPUPresentationConfiguration&);
     void unconfigure();
 
-    GPUTexture& getCurrentTexture();
+    RefPtr<GPUTexture> getCurrentTexture();
 
     void present();
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipeline.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@ void GPURenderPipeline::setLabel(String&& label)
 
 Ref<GPUBindGroupLayout> GPURenderPipeline::getBindGroupLayout(uint32_t index)
 {
+    // "A new GPUBindGroupLayout wrapper is returned each time"
     return GPUBindGroupLayout::create(m_backing->getBindGroupLayout(index));
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipeline.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUBindGroupLayout.h"
 #include <cstdint>
 #include <pal/graphics/WebGPU/WebGPURenderPipeline.h>
 #include <wtf/Ref.h>
@@ -32,8 +33,6 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-class GPUBindGroupLayout;
 
 class GPURenderPipeline : public RefCounted<GPURenderPipeline> {
 public:

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,7 +47,9 @@ ComputePipelineImpl::~ComputePipelineImpl()
 
 Ref<BindGroupLayout> ComputePipelineImpl::getBindGroupLayout(uint32_t index)
 {
-    return BindGroupLayoutImpl::create(wgpuComputePipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
+    return m_bindGroupLayouts.ensure(index, [this, index] {
+        return BindGroupLayoutImpl::create(wgpuComputePipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
+    }).iterator->value;
 }
 
 void ComputePipelineImpl::setLabelInternal(const String& label)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,11 @@
 
 #include "WebGPUComputePipeline.h"
 #include <WebGPU/WebGPU.h>
+#include <wtf/HashMap.h>
 
 namespace PAL::WebGPU {
 
+class BindGroupLayoutImpl;
 class ConvertToBackingContext;
 
 class ComputePipelineImpl final : public ComputePipeline {
@@ -62,6 +64,7 @@ private:
 
     WGPUComputePipeline m_backing { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
+    HashMap<uint32_t, Ref<BindGroupLayoutImpl>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -74,7 +74,7 @@ DeviceImpl::DeviceImpl(WGPUDevice device, Ref<SupportedFeatures>&& features, Ref
 
 DeviceImpl::~DeviceImpl() = default;
 
-Queue& DeviceImpl::queue()
+Ref<Queue> DeviceImpl::queue()
 {
     return m_queue;
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
@@ -59,7 +59,7 @@ private:
 
     WGPUDevice backing() const { return m_deviceHolder->backingDevice(); }
 
-    Queue& queue() final;
+    Ref<Queue> queue() final;
 
     void destroy() final;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.cpp
@@ -90,7 +90,7 @@ void PresentationContextImpl::unconfigure()
     m_swapChain = nullptr;
 }
 
-Texture& PresentationContextImpl::getCurrentTexture()
+RefPtr<Texture> PresentationContextImpl::getCurrentTexture()
 {
     // FIXME: If m_swapChain is nullptr, return an invalid texture.
 
@@ -99,7 +99,7 @@ Texture& PresentationContextImpl::getCurrentTexture()
         m_currentTexture = TextureImpl::create(wgpuSwapChainGetCurrentTexture(m_swapChain), m_format, TextureDimension::_2d, m_convertToBackingContext).ptr();
     }
 
-    return *m_currentTexture;
+    return m_currentTexture;
 }
 
 void PresentationContextImpl::present()

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPresentationContextImpl.h
@@ -66,7 +66,7 @@ private:
     void configure(const PresentationConfiguration&) final;
     void unconfigure() final;
 
-    Texture& getCurrentTexture() final;
+    RefPtr<Texture> getCurrentTexture() final;
 
     void present() final;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,7 +47,9 @@ RenderPipelineImpl::~RenderPipelineImpl()
 
 Ref<BindGroupLayout> RenderPipelineImpl::getBindGroupLayout(uint32_t index)
 {
-    return BindGroupLayoutImpl::create(wgpuRenderPipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
+    return m_bindGroupLayouts.ensure(index, [this, index] {
+        return BindGroupLayoutImpl::create(wgpuRenderPipelineGetBindGroupLayout(m_backing, index), m_convertToBackingContext);
+    }).iterator->value;
 }
 
 void RenderPipelineImpl::setLabelInternal(const String& label)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,11 @@
 
 #include "WebGPURenderPipeline.h"
 #include <WebGPU/WebGPU.h>
+#include <wtf/HashMap.h>
 
 namespace PAL::WebGPU {
 
+class BindGroupLayoutImpl;
 class ConvertToBackingContext;
 
 class RenderPipelineImpl final : public RenderPipeline {
@@ -62,6 +64,7 @@ private:
 
     WGPURenderPipeline m_backing { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
+    HashMap<uint32_t, Ref<BindGroupLayoutImpl>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUComputePipeline.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUComputePipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
@@ -93,7 +93,7 @@ public:
     SupportedLimits& limits() { return m_limits; }
     const SupportedLimits& limits() const { return m_limits; }
 
-    virtual Queue& queue() = 0;
+    virtual Ref<Queue> queue() = 0;
 
     virtual void destroy() = 0;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContext.h
@@ -46,7 +46,7 @@ public:
     virtual void configure(const PresentationConfiguration&) = 0;
     virtual void unconfigure() = 0;
 
-    virtual Texture& getCurrentTexture() = 0;
+    virtual RefPtr<Texture> getCurrentTexture() = 0;
 
     virtual void present() = 0;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPipeline.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp
@@ -140,6 +140,9 @@ void GPUCanvasContextCocoa::configurePresentationContextIfNeeded()
 
 RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
 {
+    if (m_currentTexture)
+        return m_currentTexture;
+
     if (!m_configuration)
         return nullptr;
 
@@ -158,7 +161,8 @@ RefPtr<GPUTexture> GPUCanvasContextCocoa::getCurrentTexture()
 
     markContextChangedAndNotifyCanvasObservers();
     // FIXME: This should use PresentationContext::getCurrentTexture() instead.
-    return m_configuration->device->createSurfaceTexture(descriptor, m_presentationContext);
+    m_currentTexture = m_configuration->device->createSurfaceTexture(descriptor, m_presentationContext);
+    return m_currentTexture;
 }
 
 PixelFormat GPUCanvasContextCocoa::pixelFormat() const
@@ -189,6 +193,7 @@ void GPUCanvasContextCocoa::prepareForDisplay()
         protectedThis->m_compositingResultsNeedsUpdating = false;
     });
 #endif
+    m_currentTexture = nullptr;
 }
 
 void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -134,6 +134,7 @@ private:
     std::optional<GPUCanvasConfiguration> m_configuration;
     Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
     Ref<GPUPresentationContext> m_presentationContext;
+    RefPtr<GPUTexture> m_currentTexture;
 
     int m_width { 0 };
     int m_height { 0 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,14 @@ void RemoteComputePipeline::stopListeningForIPC()
 void RemoteComputePipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
     auto bindGroupLayout = m_backing->getBindGroupLayout(index);
+    // We're creating a new resource here, because we don't want the GetBindGroupLayout message to be sync.
+    // If the message is async, then the WebGPUIdentifier goes from the Web process to the GPU Process, which
+    // means the Web Process is going to proceed and interact with the bind group layout as-if it has this identifier.
+    // So we need to make sure the bind group layout has this identifier.
+    // Maybe one day we could add the same bind group layout into the ObjectHeap multiple times under multiple identifiers,
+    // but for now let's just create a new RemoteBindGroupLayout object with the expected identifier, just for simplicity.
+    // The Web Process should already be caching these current bind group layout internally, so it's unlikely that we'll
+    // actually run into a problem here.
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteBindGroupLayout);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -37,6 +37,7 @@
 #include "RemoteExternalTexture.h"
 #include "RemotePipelineLayout.h"
 #include "RemoteQuerySet.h"
+#include "RemoteQueue.h"
 #include "RemoteRenderBundleEncoder.h"
 #include "RemoteRenderPipeline.h"
 #include "RemoteSampler.h"
@@ -64,6 +65,7 @@
 #include <pal/graphics/WebGPU/WebGPUPipelineLayoutDescriptor.h>
 #include <pal/graphics/WebGPU/WebGPUQuerySet.h>
 #include <pal/graphics/WebGPU/WebGPUQuerySetDescriptor.h>
+#include <pal/graphics/WebGPU/WebGPUQueue.h>
 #include <pal/graphics/WebGPU/WebGPURenderBundleEncoder.h>
 #include <pal/graphics/WebGPU/WebGPURenderBundleEncoderDescriptor.h>
 #include <pal/graphics/WebGPU/WebGPURenderPipeline.h>
@@ -94,7 +96,7 @@ void RemoteDevice::stopListeningForIPC()
     m_streamConnection->stopReceivingMessages(Messages::RemoteDevice::messageReceiverName(), m_identifier.toUInt64());
 }
 
-RemoteQueue& RemoteDevice::queue()
+Ref<RemoteQueue> RemoteDevice::queue()
 {
     return m_queue;
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -75,7 +75,7 @@ public:
 
     void stopListeningForIPC();
 
-    RemoteQueue& queue();
+    Ref<RemoteQueue> queue();
 
 private:
     friend class WebGPU::ObjectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -34,6 +34,7 @@
 #include "WebGPUObjectHeap.h"
 #include <pal/graphics/WebGPU/WebGPUPresentationConfiguration.h>
 #include <pal/graphics/WebGPU/WebGPUPresentationContext.h>
+#include <pal/graphics/WebGPU/WebGPUTexture.h>
 
 namespace WebKit {
 
@@ -70,7 +71,7 @@ void RemotePresentationContext::unconfigure()
 
 void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
 {
-    auto& texture = m_backing->getCurrentTexture();
+    auto texture = m_backing->getCurrentTexture();
     // We're creating a new resource here, because we don't want the GetCurrentTexture message to be sync.
     // If the message is async, then the WebGPUIdentifier goes from the Web process to the GPU Process, which
     // means the Web Process is going to proceed and interact with the texture as-if it has this identifier.
@@ -79,7 +80,8 @@ void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
     // but for now let's just create a new RemoteTexture object with the expected identifier, just for simplicity.
     // The Web Process should already be caching these current textures internally, so it's unlikely that we'll
     // actually run into a problem here.
-    auto remoteTexture = RemoteTexture::create(texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
+    // FIXME: Handle the situation where texture is nullptr.
+    auto remoteTexture = RemoteTexture::create(*texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteTexture);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,14 @@ void RemoteRenderPipeline::stopListeningForIPC()
 void RemoteRenderPipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
     auto bindGroupLayout = m_backing->getBindGroupLayout(index);
+    // We're creating a new resource here, because we don't want the GetBindGroupLayout message to be sync.
+    // If the message is async, then the WebGPUIdentifier goes from the Web process to the GPU Process, which
+    // means the Web Process is going to proceed and interact with the bind group layout as-if it has this identifier.
+    // So we need to make sure the bind group layout has this identifier.
+    // Maybe one day we could add the same bind group layout into the ObjectHeap multiple times under multiple identifiers,
+    // but for now let's just create a new RemoteBindGroupLayout object with the expected identifier, just for simplicity.
+    // The Web Process should already be caching these current bind group layout internally, so it's unlikely that we'll
+    // actually run into a problem here.
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteBindGroupLayout);
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,11 +47,13 @@ RemoteComputePipelineProxy::~RemoteComputePipelineProxy()
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteComputePipelineProxy::getBindGroupLayout(uint32_t index)
 {
-    auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = send(Messages::RemoteComputePipeline::GetBindGroupLayout(index, identifier));
-    UNUSED_VARIABLE(sendResult);
+    return m_bindGroupLayouts.ensure(index, [this, index] {
+        auto identifier = WebGPUIdentifier::generate();
+        auto sendResult = send(Messages::RemoteComputePipeline::GetBindGroupLayout(index, identifier));
+        UNUSED_VARIABLE(sendResult);
 
-    return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
+        return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
+    }).iterator->value;
 }
 
 void RemoteComputePipelineProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,12 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <pal/graphics/WebGPU/WebGPUComputePipeline.h>
+#include <wtf/HashMap.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
+class RemoteBindGroupLayoutProxy;
 
 class RemoteComputePipelineProxy final : public PAL::WebGPU::ComputePipeline {
     WTF_MAKE_FAST_ALLOCATED;
@@ -79,6 +81,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    HashMap<uint32_t, Ref<RemoteBindGroupLayoutProxy>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -61,7 +61,7 @@ RemoteDeviceProxy::~RemoteDeviceProxy()
 {
 }
 
-PAL::WebGPU::Queue& RemoteDeviceProxy::queue()
+Ref<PAL::WebGPU::Queue> RemoteDeviceProxy::queue()
 {
     return m_queue;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -75,7 +75,7 @@ private:
         return root().streamClientConnection().sendSync(WTFMove(message), backing(), defaultSendTimeout);
     }
 
-    PAL::WebGPU::Queue& queue() final;
+    Ref<PAL::WebGPU::Queue> queue() final;
 
     void destroy() final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -62,7 +62,7 @@ void RemotePresentationContextProxy::unconfigure()
     UNUSED_VARIABLE(sendResult);
 }
 
-PAL::WebGPU::Texture& RemotePresentationContextProxy::getCurrentTexture()
+RefPtr<PAL::WebGPU::Texture> RemotePresentationContextProxy::getCurrentTexture()
 {
     if (!m_currentTexture) {
         auto identifier = WebGPUIdentifier::generate();
@@ -72,7 +72,7 @@ PAL::WebGPU::Texture& RemotePresentationContextProxy::getCurrentTexture()
         m_currentTexture = RemoteTextureProxy::create(root(), m_convertToBackingContext, identifier);
     }
 
-    return *m_currentTexture;
+    return m_currentTexture;
 }
 
 void RemotePresentationContextProxy::present()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -77,7 +77,7 @@ private:
     void configure(const PAL::WebGPU::PresentationConfiguration&) final;
     void unconfigure() final;
 
-    PAL::WebGPU::Texture& getCurrentTexture() final;
+    RefPtr<PAL::WebGPU::Texture> getCurrentTexture() final;
 
     void present() final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,11 +47,13 @@ RemoteRenderPipelineProxy::~RemoteRenderPipelineProxy()
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteRenderPipelineProxy::getBindGroupLayout(uint32_t index)
 {
-    auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = send(Messages::RemoteRenderPipeline::GetBindGroupLayout(index, identifier));
-    UNUSED_VARIABLE(sendResult);
+    return m_bindGroupLayouts.ensure(index, [this, index] {
+        auto identifier = WebGPUIdentifier::generate();
+        auto sendResult = send(Messages::RemoteRenderPipeline::GetBindGroupLayout(index, identifier));
+        UNUSED_VARIABLE(sendResult);
 
-    return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
+        return RemoteBindGroupLayoutProxy::create(m_parent, m_convertToBackingContext, identifier);
+    }).iterator->value;
 }
 
 void RemoteRenderPipelineProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,12 @@
 #include "RemoteDeviceProxy.h"
 #include "WebGPUIdentifier.h"
 #include <pal/graphics/WebGPU/WebGPURenderPipeline.h>
+#include <wtf/HashMap.h>
 
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
+class RemoteBindGroupLayoutProxy;
 
 class RemoteRenderPipelineProxy final : public PAL::WebGPU::RenderPipeline {
     WTF_MAKE_FAST_ALLOCATED;
@@ -79,6 +81,7 @@ private:
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteDeviceProxy> m_parent;
+    HashMap<uint32_t, Ref<RemoteBindGroupLayoutProxy>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupLayouts;
 };
 
 } // namespace WebKit::WebGPU


### PR DESCRIPTION
#### 742f4888b2d333248c2c80b3a01685a581d2b135
<pre>
[WebGPU] Make objects with weak getters be internally retained by their owner
<a href="https://bugs.webkit.org/show_bug.cgi?id=251324">https://bugs.webkit.org/show_bug.cgi?id=251324</a>
rdar://104785462

Reviewed by Tadeu Zagallo.

This patch has 2 effects overall:
1. Our internal interfaces more closely match the semantics of the API
2. The results of getters are cached internally, thereby making subsequent calls faster

* Source/WebCore/Modules/WebGPU/GPUComputePipeline.cpp:
(WebCore::GPUComputePipeline::getBindGroupLayout):
* Source/WebCore/Modules/WebGPU/GPUComputePipeline.h:
* Source/WebCore/Modules/WebGPU/GPURenderPipeline.cpp:
(WebCore::GPURenderPipeline::getBindGroupLayout):
* Source/WebCore/Modules/WebGPU/GPURenderPipeline.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.cpp:
(PAL::WebGPU::ComputePipelineImpl::getBindGroupLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUComputePipelineImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.cpp:
(PAL::WebGPU::RenderPipelineImpl::getBindGroupLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPipelineImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUComputePipeline.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPipeline.h:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::GPUCanvasContextCocoa::getCurrentTexture):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::getBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
(WebKit::WebGPU::RemoteComputePipelineProxy::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
(WebKit::WebGPU::RemoteRenderPipelineProxy::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:

Canonical link: <a href="https://commits.webkit.org/259609@main">https://commits.webkit.org/259609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f949608ffcdad01bb77e35b3a363bd1f14756b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114677 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5429 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97727 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111180 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95099 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26734 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7801 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7923 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6626 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9715 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->