### PR TITLE
[WebGPU] [Style] Inline members of Texture::m_descriptor

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -305,7 +305,7 @@ static bool refersToAllAspects(WGPUTextureFormat format, WGPUTextureAspect aspec
 
 static bool validateCopyBufferToTexture(const WGPUImageCopyBuffer& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize)
 {
-    const auto& dstTextureDesc = fromAPI(destination.texture).descriptor();
+    const auto& destinationTexture = fromAPI(destination.texture);
 
     if (!validateImageCopyBuffer(source))
         return false;
@@ -316,34 +316,34 @@ static bool validateCopyBufferToTexture(const WGPUImageCopyBuffer& source, const
     if (!Texture::validateImageCopyTexture(destination, copySize))
         return false;
 
-    if (!(dstTextureDesc.usage & WGPUTextureUsage_CopyDst))
+    if (!(destinationTexture.usage() & WGPUTextureUsage_CopyDst))
         return false;
 
-    if (dstTextureDesc.sampleCount != 1)
+    if (destinationTexture.sampleCount() != 1)
         return false;
 
-    WGPUTextureFormat aspectSpecificFormat = dstTextureDesc.format;
+    WGPUTextureFormat aspectSpecificFormat = destinationTexture.format();
 
-    if (Texture::isDepthOrStencilFormat(dstTextureDesc.format)) {
-        if (!Texture::refersToSingleAspect(dstTextureDesc.format, destination.aspect))
+    if (Texture::isDepthOrStencilFormat(destinationTexture.format())) {
+        if (!Texture::refersToSingleAspect(destinationTexture.format(), destination.aspect))
             return false;
 
-        if (!Texture::isValidImageCopyDestination(dstTextureDesc.format, destination.aspect))
+        if (!Texture::isValidImageCopyDestination(destinationTexture.format(), destination.aspect))
             return false;
 
-        aspectSpecificFormat = Texture::aspectSpecificFormat(dstTextureDesc.format, destination.aspect);
+        aspectSpecificFormat = Texture::aspectSpecificFormat(destinationTexture.format(), destination.aspect);
     }
 
     if (!Texture::validateTextureCopyRange(destination, copySize))
         return false;
 
-    if (!Texture::isDepthOrStencilFormat(dstTextureDesc.format)) {
-        auto texelBlockSize = Texture::texelBlockSize(dstTextureDesc.format);
+    if (!Texture::isDepthOrStencilFormat(destinationTexture.format())) {
+        auto texelBlockSize = Texture::texelBlockSize(destinationTexture.format());
         if (source.layout.offset % texelBlockSize)
             return false;
     }
 
-    if (Texture::isDepthOrStencilFormat(dstTextureDesc.format)) {
+    if (Texture::isDepthOrStencilFormat(destinationTexture.format())) {
         if (source.layout.offset % 4)
             return false;
     }
@@ -396,8 +396,8 @@ void CommandEncoder::copyBufferToTexture(const WGPUImageCopyBuffer& source, cons
     auto heightForMetal = std::min(copySize.height, logicalSize.height);
     auto depthForMetal = std::min(copySize.depthOrArrayLayers, logicalSize.depthOrArrayLayers);
 
-    auto& destinationDescriptor = fromAPI(destination.texture).descriptor();
-    switch (destinationDescriptor.dimension) {
+    const auto& destinationTexture = fromAPI(destination.texture);
+    switch (destinationTexture.dimension()) {
     case WGPUTextureDimension_1D: {
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400771-copyfrombuffer?language=objc
         // "When you copy to a 1D texture, height and depth must be 1."
@@ -467,27 +467,27 @@ void CommandEncoder::copyBufferToTexture(const WGPUImageCopyBuffer& source, cons
 
 static bool validateCopyTextureToBuffer(const WGPUImageCopyTexture& source, const WGPUImageCopyBuffer& destination, const WGPUExtent3D& copySize)
 {
-    const auto& srcTextureDesc = fromAPI(source.texture).descriptor();
+    const auto& sourceTexture = fromAPI(source.texture);
 
     if (!Texture::validateImageCopyTexture(source, copySize))
         return false;
 
-    if (!(srcTextureDesc.usage & WGPUBufferUsage_CopySrc))
+    if (!(sourceTexture.usage() & WGPUBufferUsage_CopySrc))
         return false;
 
-    if (srcTextureDesc.sampleCount != 1)
+    if (sourceTexture.sampleCount() != 1)
         return false;
 
-    WGPUTextureFormat aspectSpecificFormat = srcTextureDesc.format;
+    WGPUTextureFormat aspectSpecificFormat = sourceTexture.format();
 
-    if (Texture::isDepthOrStencilFormat(srcTextureDesc.format)) {
-        if (!Texture::refersToSingleAspect(srcTextureDesc.format, source.aspect))
+    if (Texture::isDepthOrStencilFormat(sourceTexture.format())) {
+        if (!Texture::refersToSingleAspect(sourceTexture.format(), source.aspect))
             return false;
 
-        if (!Texture::isValidImageCopySource(srcTextureDesc.format, source.aspect))
+        if (!Texture::isValidImageCopySource(sourceTexture.format(), source.aspect))
             return false;
 
-        aspectSpecificFormat = Texture::aspectSpecificFormat(srcTextureDesc.format, source.aspect);
+        aspectSpecificFormat = Texture::aspectSpecificFormat(sourceTexture.format(), source.aspect);
     }
 
     if (!validateImageCopyBuffer(destination))
@@ -499,13 +499,13 @@ static bool validateCopyTextureToBuffer(const WGPUImageCopyTexture& source, cons
     if (!Texture::validateTextureCopyRange(source, copySize))
         return false;
 
-    if (!Texture::isDepthOrStencilFormat(srcTextureDesc.format)) {
-        auto texelBlockSize = Texture::texelBlockSize(srcTextureDesc.format);
+    if (!Texture::isDepthOrStencilFormat(sourceTexture.format())) {
+        auto texelBlockSize = Texture::texelBlockSize(sourceTexture.format());
         if (destination.layout.offset % texelBlockSize)
             return false;
     }
 
-    if (Texture::isDepthOrStencilFormat(srcTextureDesc.format)) {
+    if (Texture::isDepthOrStencilFormat(sourceTexture.format())) {
         if (destination.layout.offset % 4)
             return false;
     }
@@ -558,8 +558,8 @@ void CommandEncoder::copyTextureToBuffer(const WGPUImageCopyTexture& source, con
     auto heightForMetal = std::min(copySize.height, logicalSize.height);
     auto depthForMetal = std::min(copySize.depthOrArrayLayers, logicalSize.depthOrArrayLayers);
 
-    auto& sourceDescriptor = fromAPI(source.texture).descriptor();
-    switch (sourceDescriptor.dimension) {
+    const auto& sourceTexture = fromAPI(source.texture);
+    switch (sourceTexture.dimension()) {
     case WGPUTextureDimension_1D: {
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copyfromtexture?language=objc
         // "When you copy to a 1D texture, height and depth must be 1."
@@ -639,31 +639,31 @@ static bool areCopyCompatible(WGPUTextureFormat format1, WGPUTextureFormat forma
 
 static bool validateCopyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize)
 {
-    const auto& srcTextureDesc = fromAPI(source.texture).descriptor();
+    const auto& sourceTexture = fromAPI(source.texture);
 
-    const auto& dstTextureDesc = fromAPI(destination.texture).descriptor();
+    const auto& destinationTexture = fromAPI(destination.texture);
 
     if (!Texture::validateImageCopyTexture(source, copySize))
         return false;
 
-    if (!(srcTextureDesc.usage & WGPUTextureUsage_CopySrc))
+    if (!(sourceTexture.usage() & WGPUTextureUsage_CopySrc))
         return false;
 
     if (!Texture::validateImageCopyTexture(destination, copySize))
         return false;
 
-    if (!(dstTextureDesc.usage & WGPUTextureUsage_CopyDst))
+    if (!(destinationTexture.usage() & WGPUTextureUsage_CopyDst))
         return false;
 
-    if (srcTextureDesc.sampleCount != dstTextureDesc.sampleCount)
+    if (sourceTexture.sampleCount() != destinationTexture.sampleCount())
         return false;
 
-    if (!areCopyCompatible(srcTextureDesc.format, dstTextureDesc.format))
+    if (!areCopyCompatible(sourceTexture.format(), destinationTexture.format()))
         return false;
 
-    if (Texture::isDepthOrStencilFormat(srcTextureDesc.format)) {
-        if (!refersToAllAspects(srcTextureDesc.format, source.aspect)
-            || !refersToAllAspects(dstTextureDesc.format, destination.aspect))
+    if (Texture::isDepthOrStencilFormat(sourceTexture.format())) {
+        if (!refersToAllAspects(sourceTexture.format(), source.aspect)
+            || !refersToAllAspects(destinationTexture.format(), destination.aspect))
             return false;
     }
 
@@ -677,7 +677,7 @@ static bool validateCopyTextureToTexture(const WGPUImageCopyTexture& source, con
     if (source.texture == destination.texture) {
         // Mip levels are never ranges.
         if (source.mipLevel == destination.mipLevel) {
-            switch (fromAPI(source.texture).descriptor().dimension) {
+            switch (fromAPI(source.texture).dimension()) {
             case WGPUTextureDimension_1D:
                 return false;
             case WGPUTextureDimension_2D: {
@@ -716,10 +716,10 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
 
     ensureBlitCommandEncoder();
 
-    auto& sourceDescriptor = fromAPI(source.texture).descriptor();
+    auto& sourceTexture = fromAPI(source.texture);
     // FIXME(PERFORMANCE): Is it actually faster to use the -[MTLBlitCommandEncoder copyFromTexture:...toTexture:...levelCount:]
     // variant, where possible, rather than calling the other variant in a loop?
-    switch (sourceDescriptor.dimension) {
+    switch (sourceTexture.dimension()) {
     case WGPUTextureDimension_1D: {
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400756-copyfromtexture?language=objc
         // "When you copy to a 1D texture, height and depth must be 1."

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -235,30 +235,30 @@ void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, const void*
         size:static_cast<NSUInteger>(size)];
 }
 
-static bool validateWriteTexture(const WGPUImageCopyTexture& destination, const WGPUTextureDataLayout& dataLayout, const WGPUExtent3D& size, size_t dataByteSize, const WGPUTextureDescriptor& textureDesc)
+static bool validateWriteTexture(const WGPUImageCopyTexture& destination, const WGPUTextureDataLayout& dataLayout, const WGPUExtent3D& size, size_t dataByteSize, const Texture& texture)
 {
     if (!Texture::validateImageCopyTexture(destination, size))
         return false;
 
-    if (!(textureDesc.usage & WGPUTextureUsage_CopyDst))
+    if (!(texture.usage() & WGPUTextureUsage_CopyDst))
         return false;
 
-    if (textureDesc.sampleCount != 1)
+    if (texture.sampleCount() != 1)
         return false;
 
     if (!Texture::validateTextureCopyRange(destination, size))
         return false;
 
-    if (!Texture::refersToSingleAspect(textureDesc.format, destination.aspect))
+    if (!Texture::refersToSingleAspect(texture.format(), destination.aspect))
         return false;
 
-    if (!Texture::isValidImageCopyDestination(textureDesc.format, destination.aspect))
+    if (!Texture::isValidImageCopyDestination(texture.format(), destination.aspect))
         return false;
 
-    auto aspectSpecificFormat = textureDesc.format;
+    auto aspectSpecificFormat = texture.format();
 
-    if (Texture::isDepthOrStencilFormat(textureDesc.format))
-        aspectSpecificFormat = Texture::aspectSpecificFormat(textureDesc.format, destination.aspect);
+    if (Texture::isDepthOrStencilFormat(texture.format()))
+        aspectSpecificFormat = Texture::aspectSpecificFormat(texture.format(), destination.aspect);
 
     if (!Texture::validateLinearTextureData(dataLayout, dataByteSize, aspectSpecificFormat, size))
         return false;
@@ -275,9 +275,9 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, const void* da
 
     auto dataByteSize = dataSize;
 
-    const auto& textureDesc = fromAPI(destination.texture).descriptor();
+    const auto& texture = fromAPI(destination.texture);
 
-    if (!validateWriteTexture(destination, dataLayout, size, dataByteSize, textureDesc)) {
+    if (!validateWriteTexture(destination, dataLayout, size, dataByteSize, texture)) {
         m_device.generateAValidationError("Validation failure."_s);
         return;
     }
@@ -314,7 +314,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, const void* da
         case MTLStorageModeManaged:
 #endif
             {
-                switch (textureDesc.dimension) {
+                switch (texture.dimension()) {
                 case WGPUTextureDimension_1D: {
                     auto region = MTLRegionMake1D(destination.origin.x, size.width);
                     for (uint32_t layer = 0; layer < size.depthOrArrayLayers; ++layer) {
@@ -384,7 +384,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, const void* da
     auto heightForMetal = std::min(size.height, logicalSize.height);
     auto depthForMetal = std::min(size.depthOrArrayLayers, logicalSize.depthOrArrayLayers);
 
-    switch (textureDesc.dimension) {
+    switch (texture.dimension()) {
     case WGPUTextureDimension_1D: {
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400771-copyfrombuffer?language=objc
         // "When you copy to a 1D texture, height and depth must be 1."

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,7 +84,15 @@ public:
     WGPUExtent3D physicalMiplevelSpecificTextureExtent(uint32_t mipLevel);
 
     id<MTLTexture> texture() const { return m_texture; }
-    const WGPUTextureDescriptor& descriptor() const { return m_descriptor; }
+
+    uint32_t width() const { return m_width; }
+    uint32_t height() const { return m_height; }
+    uint32_t depthOrArrayLayers() const { return m_depthOrArrayLayers; }
+    uint32_t mipLevelCount() const { return m_mipLevelCount; }
+    uint32_t sampleCount() const { return m_sampleCount; }
+    WGPUTextureDimension dimension() const { return m_dimension; }
+    WGPUTextureFormat format() const { return m_format; }
+    WGPUTextureUsageFlags usage() const { return m_usage; }
 
     Device& device() const { return m_device; }
 
@@ -98,7 +106,15 @@ private:
 
     id<MTLTexture> m_texture { nil };
 
-    const WGPUTextureDescriptor m_descriptor { };
+    const uint32_t m_width { 0 };
+    const uint32_t m_height { 0 };
+    const uint32_t m_depthOrArrayLayers { 0 };
+    const uint32_t m_mipLevelCount { 0 };
+    const uint32_t m_sampleCount { 0 };
+    const WGPUTextureDimension m_dimension { WGPUTextureDimension_2D };
+    const WGPUTextureFormat m_format { WGPUTextureFormat_Undefined };
+    const WGPUTextureUsageFlags m_usage { WGPUTextureUsage_None };
+
     const Vector<WGPUTextureFormat> m_viewFormats;
 
     const Ref<Device> m_device;


### PR DESCRIPTION
#### 81eb82843a2a882d22e932d3a773a679f7cf5ee7
<pre>
[WebGPU] [Style] Inline members of Texture::m_descriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=251325">https://bugs.webkit.org/show_bug.cgi?id=251325</a>
rdar://104786027

Reviewed by Tadeu Zagallo.

This is a purely stylistic change, to match our implementation to the nouns-and-verbs
that the spec uses. The spec for GPUTexture says it has internal slots for each of
the fields individually, rather than retaining the whole descriptor. I think it&apos;s
a good idea to match the spec, just stylistically.

No tests because there is no behavior change.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::validateCopyBufferToTexture):
(WebGPU::CommandEncoder::copyBufferToTexture):
(WebGPU::validateCopyTextureToBuffer):
(WebGPU::CommandEncoder::copyTextureToBuffer):
(WebGPU::validateCopyTextureToTexture):
(WebGPU::CommandEncoder::copyTextureToTexture):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::validateWriteTexture):
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/Texture.h:
(WebGPU::Texture::width const):
(WebGPU::Texture::height const):
(WebGPU::Texture::depthOrArrayLayers const):
(WebGPU::Texture::mipLevelCount const):
(WebGPU::Texture::sampleCount const):
(WebGPU::Texture::dimension const):
(WebGPU::Texture::format const):
(WebGPU::Texture::usage const):
(WebGPU::Texture::descriptor const): Deleted.
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::Texture):
(WebGPU::Texture::resolveTextureViewDescriptorDefaults const):
(WebGPU::Texture::arrayLayerCount const):
(WebGPU::Texture::validateCreateView const):
(WebGPU::Texture::createView):
(WebGPU::Texture::logicalMiplevelSpecificTextureExtent):
(WebGPU::Texture::physicalMiplevelSpecificTextureExtent):
(WebGPU::Texture::validateImageCopyTexture):
(WebGPU::Texture::validateTextureCopyRange):

Canonical link: <a href="https://commits.webkit.org/259565@main">https://commits.webkit.org/259565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eda1e65eca5ce550452a4c87bef6bb8a74278028

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114438 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5179 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114386 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7688 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4466 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6593 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9476 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->