### PR TITLE
[WebGPU] GPUTexture::destroy() and RemoteDeviceProxy::destroy() do nothing

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
@@ -66,6 +66,7 @@ Ref<GPUTextureView> GPUTexture::createView(const std::optional<GPUTextureViewDes
 
 void GPUTexture::destroy()
 {
+    m_backing->destroy();
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -68,6 +68,8 @@ PAL::WebGPU::Queue& RemoteDeviceProxy::queue()
 
 void RemoteDeviceProxy::destroy()
 {
+    auto sendResult = send(Messages::RemoteDevice::Destroy());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::Buffer> RemoteDeviceProxy::createBuffer(const PAL::WebGPU::BufferDescriptor& descriptor)


### PR DESCRIPTION
#### 16a66f7561b54ca47761eabaea1b6ddbfa5e03ae
<pre>
[WebGPU] GPUTexture::destroy() and RemoteDeviceProxy::destroy() do nothing
<a href="https://bugs.webkit.org/show_bug.cgi?id=251326">https://bugs.webkit.org/show_bug.cgi?id=251326</a>
rdar://104786514

Reviewed by Tadeu Zagallo.

We must have just forgotten to hook them up. All the other destroy() methods are already hooked up.

* Source/WebCore/Modules/WebGPU/GPUTexture.cpp:
(WebCore::GPUTexture::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::destroy):

Canonical link: <a href="https://commits.webkit.org/259539@main">https://commits.webkit.org/259539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/701b60568a4a73cc339e1c7c6bcbb43ea5b06c46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114442 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174624 "Failed to checkout and rebase branch from PR 9288") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5183 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97497 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39408 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81074 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7692 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4469 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6566 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9480 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->