### PR TITLE
[JSC] Add I64 support for Wasm IC and FTL Wasm fast call

### DIFF
--- a/JSTests/wasm/stress/js-to-wasm-i64-register.js
+++ b/JSTests/wasm/stress/js-to-wasm-i64-register.js
@@ -1,0 +1,42 @@
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+async function test() {
+    let params = [];
+    for (let i = 0; i < 1; ++i)
+        params.push('i64');
+
+    let cont = (new Builder())
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("foo")
+        .End()
+        .Code()
+        .Function("foo", { params: params, ret: "i64" });
+    for (let i = 0; i < 1; ++i)
+        cont = cont.GetLocal(i);
+    let builder = cont.Return()
+        .End()
+        .End();
+
+    const bin = builder.WebAssembly().get();
+    const {instance} = await WebAssembly.instantiate(bin, {});
+
+    for (let i = 0; i < 100000; i++) {
+        assert.eq(instance.exports.foo(0n), 0n);
+        assert.eq(instance.exports.foo(-1n), -1n);
+        assert.eq(instance.exports.foo(0xffffffffn), 0xffffffffn);
+        assert.eq(instance.exports.foo(0xffffffffffffffffn), -1n);
+        assert.eq(instance.exports.foo(0xffffffffffffffffffffn), -1n);
+        assert.eq(instance.exports.foo(-0xffffffffn), -0xffffffffn);
+        assert.eq(instance.exports.foo(-0xffffffffffffffffn), 1n);
+        assert.eq(instance.exports.foo(-0xffffffffffffffffffffn), 1n);
+        assert.eq(instance.exports.foo(0x80000000n), 0x80000000n);
+        assert.eq(instance.exports.foo(-0x80000000n), -0x80000000n);
+        assert.eq(instance.exports.foo(0x8000000000000000n), -9223372036854775808n);
+        assert.eq(instance.exports.foo(-0x8000000000000000n), -0x8000000000000000n);
+    }
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/js-to-wasm-i64-stack.js
+++ b/JSTests/wasm/stress/js-to-wasm-i64-stack.js
@@ -1,0 +1,44 @@
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+async function test() {
+    let params = [];
+    for (let i = 0; i < 50; ++i)
+        params.push('i64');
+
+    let cont = (new Builder())
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("foo")
+        .End()
+        .Code()
+        .Function("foo", { params: params, ret: "i64" });
+    for (let i = 0; i < 50; ++i)
+        cont = cont.GetLocal(i);
+    for (let i = 0; i < 49; ++i)
+        cont = cont.I64Add();
+    let builder = cont.Return()
+        .End()
+        .End();
+
+    const bin = builder.WebAssembly().get();
+    const {instance} = await WebAssembly.instantiate(bin, {});
+
+    for (let i = 0; i < 100000; i++) {
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n), 0n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, -1n), -1n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0xffffffffn), 0xffffffffn);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0xffffffffffffffffn), -1n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0xffffffffffffffffffffn), -1n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, -0xffffffffn), -0xffffffffn);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, -0xffffffffffffffffn), 1n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, -0xffffffffffffffffffffn), 1n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0x80000000n), 0x80000000n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, -0x80000000n), -0x80000000n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0x8000000000000000n), -9223372036854775808n);
+        assert.eq(instance.exports.foo(0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, -0x8000000000000000n), -0x8000000000000000n);
+    }
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/js-to-wasm-many-double-from-js.js
+++ b/JSTests/wasm/stress/js-to-wasm-many-double-from-js.js
@@ -1,0 +1,39 @@
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+async function test() {
+    let params = [];
+    for (let i = 0; i < 50; ++i)
+        params.push('f64');
+
+    let cont = (new Builder())
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("foo")
+        .End()
+        .Code()
+        .Function("foo", { params: params, ret: "f64" });
+    for (let i = 0; i < 50; ++i)
+        cont = cont.GetLocal(i);
+    for (let i = 0; i < 49; ++i)
+        cont = cont.F64Add();
+    let builder = cont.Return()
+        .End()
+        .End();
+
+    const bin = builder.WebAssembly().get();
+    const {instance} = await WebAssembly.instantiate(bin, {});
+
+    for (let i = 0; i < 1000000; i++) {
+        assert.eq(instance.exports.foo(
+            0.1,1.1,2.1,3.1,4.1,5.1,6.1,7.1,8.1,9.1,
+            10.1,11.1,12.1,13.1,14.1,15.1,16.1,17.1,18.1,19.1,
+            20.1,21.1,22.1,23.1,24.1,25.1,26.1,27.1,28.1,29.1,
+            30.1,31.1,32.1,33.1,34.1,35.1,36.1,37.1,38.1,39.1,
+            40.1,41.1,42.1,43.1,44.1,45.1,46.1,47.1,48.1,49.1,
+        ), 1229.9999999999986);
+    }
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/js-to-wasm-many-i64.js
+++ b/JSTests/wasm/stress/js-to-wasm-many-i64.js
@@ -1,0 +1,39 @@
+import * as assert from '../assert.js';
+import Builder from '../Builder.js';
+
+async function test() {
+    let params = [];
+    for (let i = 0; i < 50; ++i)
+        params.push('i64');
+
+    let cont = (new Builder())
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("foo")
+        .End()
+        .Code()
+        .Function("foo", { params: params, ret: "i64" });
+    for (let i = 0; i < 50; ++i)
+        cont = cont.GetLocal(i);
+    for (let i = 0; i < 49; ++i)
+        cont = cont.I64Add();
+    let builder = cont.Return()
+        .End()
+        .End();
+
+    const bin = builder.WebAssembly().get();
+    const {instance} = await WebAssembly.instantiate(bin, {});
+
+    for (let i = 0; i < 1000000; i++) {
+        assert.eq(instance.exports.foo(
+             0n, 1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n,
+            10n,11n,12n,13n,14n,15n,16n,17n,18n,19n,
+            20n,21n,22n,23n,24n,25n,26n,27n,28n,29n,
+            30n,31n,32n,33n,34n,35n,36n,37n,38n,39n,
+            40n,41n,42n,43n,44n,45n,46n,47n,48n,49n,
+        ), 1225n);
+    }
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4668,6 +4668,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             setNonCellTypeForNode(node, SpecInt32Only);
             break;
         }
+        case Wasm::TypeKind::I64: {
+            setTypeForNode(node, SpecBigInt);
+            break;
+        }
         case Wasm::TypeKind::Ref:
         case Wasm::TypeKind::RefNull:
         case Wasm::TypeKind::Funcref:

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3895,6 +3895,14 @@ JSC_DEFINE_JIT_OPERATION(operationDateGetYear, EncodedJSValue, (VM* vmPointer, D
     return JSValue::encode(jsNumber(gregorianDateTime->year() - 1900));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationInt64ToBigInt, EncodedJSValue, (JSGlobalObject* globalObject, int64_t value))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    return JSValue::encode(JSBigInt::makeHeapBigIntOrBigInt32(globalObject, value));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationThrowDFG, void, (JSGlobalObject* globalObject, EncodedJSValue valueToThrow))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -360,6 +360,8 @@ JSC_DECLARE_JIT_OPERATION(operationDateGetUTCSeconds, EncodedJSValue, (VM*, Date
 JSC_DECLARE_JIT_OPERATION(operationDateGetTimezoneOffset, EncodedJSValue, (VM*, DateInstance*));
 JSC_DECLARE_JIT_OPERATION(operationDateGetYear, EncodedJSValue, (VM*, DateInstance*));
 
+JSC_DECLARE_JIT_OPERATION(operationInt64ToBigInt, EncodedJSValue, (JSGlobalObject*, int64_t));
+
 JSC_DECLARE_JIT_OPERATION(operationProcessTypeProfilerLogDFG, void, (VM*));
 
 JSC_DECLARE_JIT_OPERATION(operationTriggerReoptimizationNow, void, (CodeBlock* baselineCodeBlock, CodeBlock* optimizedCodeBlock, OSRExitBase*));

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -980,6 +980,22 @@ public:
 #endif
     }
 
+#if USE(JSVALUE64)
+    void toBigInt64(GPRReg cellGPR, GPRReg destGPR, GPRReg scratchGPR, GPRReg scratch2GPR)
+    {
+        ASSERT(noOverlap(cellGPR, destGPR, scratchGPR, scratch2GPR));
+        load32(Address(cellGPR, JSBigInt::offsetOfLength()), destGPR);
+        JumpList doneCases;
+        doneCases.append(branchTest32(Zero, destGPR));
+        loadPtr(Address(cellGPR, JSBigInt::offsetOfData()), scratchGPR);
+        cageConditionallyAndUntag(Gigacage::Primitive, scratchGPR, destGPR, scratch2GPR, false, false);
+        load64(Address(scratchGPR), destGPR);
+        doneCases.append(branchTest8(Zero, Address(cellGPR, JSBigInt::offsetOfSign())));
+        neg64(destGPR);
+        doneCases.link(this);
+    }
+#endif
+
     void isNotEmpty(GPRReg gpr, GPRReg dst)
     {
 #if USE(JSVALUE64)

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -86,6 +86,16 @@ public:
         return OBJECT_OFFSETOF(JSBigInt, m_length);
     }
 
+    static size_t offsetOfSign()
+    {
+        return OBJECT_OFFSETOF(JSBigInt, m_sign);
+    }
+
+    inline static size_t offsetOfData()
+    {
+        return OBJECT_OFFSETOF(JSBigInt, m_data);
+    }
+
     DECLARE_EXPORT_INFO;
 
     JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
@@ -609,17 +619,12 @@ private:
 
     JS_EXPORT_PRIVATE static uint64_t toBigUInt64Heap(JSBigInt*);
 
-    inline static size_t offsetOfData()
-    {
-        return OBJECT_OFFSETOF(JSBigInt, m_data);
-    }
-
     inline Digit* dataStorage() { return m_data.get(m_length); }
     inline Digit* dataStorageUnsafe() { return m_data.getUnsafe(); }
 
     const unsigned m_length;
     unsigned m_hash { 0 };
-    bool m_sign { false };
+    uint8_t m_sign { false };
     CagedBarrierPtr<Gigacage::Primitive, Digit, tagCagedPtr> m_data;
 };
 


### PR DESCRIPTION
#### da3929b44d5a8519cabe8f8c39954e1c1eb59f5f
<pre>
[JSC] Add I64 support for Wasm IC and FTL Wasm fast call
<a href="https://bugs.webkit.org/show_bug.cgi?id=251332">https://bugs.webkit.org/show_bug.cgi?id=251332</a>
rdar://104794806

Reviewed by Tadeu Zagallo.

This patch adds I64 support for Wasm IC and FTL Wasm fast call. This makes it possible to accept all major wasm types in IC and Wasm fast calls,
so we can reasonably assume that we will always go to this IC or fast call when the callsite is performance enough.

What we need is extracting I64 from HeapBigInt. This patch adds AssemblyHelpers::toBigInt64, which takes JSBigInt and extract I64 for wasm.

Microbenchmark showed 10x improvement (following script&apos;s iteration count is modified to make the core part running longer for measurement).

    DYLD_FRAMEWORK_PATH=$VM $VM/jsc -m js-to-wasm-many-i64.js  0.62s user 0.05s system 102% cpu 0.653 total
    DYLD_FRAMEWORK_PATH=$VM $VM/jsc -m js-to-wasm-many-i64.js  5.11s user 0.09s system 83% cpu 6.184 total

* JSTests/wasm/stress/js-to-wasm-many-double-from-js.js: Added.
(async test):
* JSTests/wasm/stress/js-to-wasm-many-i64.js: Added.
(async test):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::toBigInt64):
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):

Canonical link: <a href="https://commits.webkit.org/259584@main">https://commits.webkit.org/259584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/649b4323d3e38a5b55148cb290900ee6b53910d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114473 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174656 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5214 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114408 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39441 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81108 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95034 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7628 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27926 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93096 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5358 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4499 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30330 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47481 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/101798 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9511 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25406 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->