### PR TITLE
Refactor some lookalike character string replacement logic

### DIFF
--- a/Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h
+++ b/Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h
@@ -26,13 +26,18 @@
 #pragma once
 
 #import <wtf/CompletionHandler.h>
+#import <wtf/Function.h>
+#import <wtf/Ref.h>
+#import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/text/WTFString.h>
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
 #import <WebCore/LookalikeCharactersSanitizationData.h>
 #endif
 
+OBJC_CLASS WKNetworkConnectionIntegrityNotificationListener;
 OBJC_CLASS NSURLSession;
 
 namespace WebKit {
@@ -40,9 +45,50 @@ namespace WebKit {
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
 
 void configureForNetworkConnectionIntegrity(NSURLSession *);
-void requestLookalikeCharacterStrings(CompletionHandler<void(const Vector<String>&)>&&);
 void requestAllowedLookalikeCharacterStrings(CompletionHandler<void(const Vector<WebCore::LookalikeCharactersSanitizationData>&)>&&);
 
-#endif
+class LookalikeCharacters {
+public:
+    static LookalikeCharacters& shared();
+
+    const Vector<String>& cachedStrings() const { return m_cachedStrings; }
+    void updateStrings(CompletionHandler<void()>&&);
+
+    class Observer : public RefCounted<Observer>, public CanMakeWeakPtr<Observer> {
+    public:
+        ~Observer() = default;
+
+    private:
+        friend class LookalikeCharacters;
+
+        Observer(Function<void()>&& callback)
+            : m_callback { WTFMove(callback) }
+        {
+        }
+
+        static Ref<Observer> create(Function<void()>&& callback)
+        {
+            return adoptRef(*new Observer(WTFMove(callback)));
+        }
+
+        void invokeCallback() { m_callback(); }
+
+        Function<void()> m_callback;
+    };
+
+    Ref<Observer> observeUpdates(Function<void()>&&);
+
+private:
+    LookalikeCharacters() = default;
+    void setCachedStrings(Vector<String>&&);
+
+    RetainPtr<WKNetworkConnectionIntegrityNotificationListener> m_notificationListener;
+    Vector<String> m_cachedStrings;
+    WeakHashSet<Observer> m_observers;
+};
+
+void configureForNetworkConnectionIntegrity(NSURLSession *);
+
+#endif // ENABLE(NETWORK_CONNECTION_INTEGRITY)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -159,6 +159,7 @@
 #endif
 
 #if PLATFORM(COCOA)
+#include "NetworkConnectionIntegrityHelpers.h"
 #include "PlaybackSessionContextIdentifier.h"
 #include "RemoteLayerTreeNode.h"
 #include <wtf/WeakObjCPtr.h>
@@ -2737,7 +2738,6 @@ private:
     void waitForInitialLookalikeCharacterStrings(WebFramePolicyListenerProxy&);
     void sendCachedLookalikeCharacterStrings();
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    static Vector<String>& cachedLookalikeStrings();
     static Vector<WebCore::LookalikeCharactersSanitizationData>& cachedAllowedLookalikeStrings();
     void updateAllowedLookalikeCharacterStringsIfNeeded();
 #endif
@@ -3359,6 +3359,7 @@ private:
     bool m_isLockdownModeExplicitlySet { false };
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    RefPtr<LookalikeCharacters::Observer> m_lookalikeCharacterUpdateObserver;
     bool m_needsInitialLookalikeCharacterStrings { true };
     bool m_shouldUpdateAllowedLookalikeCharacterStrings { false };
 #endif


### PR DESCRIPTION
#### ce3796e77e74f8bc09b40944a74ac1b094b0daef
<pre>
Refactor some lookalike character string replacement logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=251335">https://bugs.webkit.org/show_bug.cgi?id=251335</a>
rdar://104801247

Reviewed by Tim Horton.

Refactor some existing logic around lookalike characters strings; see below for more details.

* Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h:
(WebKit::LookalikeCharacters::cachedStrings const):
(WebKit::LookalikeCharacters::Observer::Observer):
(WebKit::LookalikeCharacters::Observer::create):
(WebKit::LookalikeCharacters::Observer::invokeCallback):

Consolidate some static helper functions in WebPageProxy into a separate singleton object in
`NetworkConnectionIntegrityHelpers`.

* Source/WebKit/UIProcess/WebPageProxy.cpp:

Additionally begin observing lookalike character string updates upon initialization.

(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::creationParameters):

Use the new helper class above.

(WebKit::WebPageProxy::sendCachedLookalikeCharacterStrings):
(WebKit::WebPageProxy::waitForInitialLookalikeCharacterStrings):
(WebKit::WebPageProxy::cachedLookalikeStrings): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/259589@main">https://commits.webkit.org/259589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22c1644e631cc954b9252770380204e8c20ebe84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114480 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5221 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114421 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39445 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27933 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4506 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6613 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9518 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->