### PR TITLE
Remote CA platform layers don't ever call setUsesWebKitBehavior.

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -79,6 +79,7 @@ public:
     CALayer *layerWithIDForTesting(WebCore::GraphicsLayer::PlatformLayerID) const;
 
     bool replayCGDisplayListsIntoBackingStore() const;
+    bool css3DTransformInteroperabilityEnabled() const;
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     const HashSet<WebCore::GraphicsLayer::PlatformLayerID>& overlayRegionIDs() const { return m_overlayRegionIDs; }
     void updateOverlayRegionIDs(const HashSet<WebCore::GraphicsLayer::PlatformLayerID> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -91,6 +91,11 @@ bool RemoteLayerTreeHost::replayCGDisplayListsIntoBackingStore() const
 #endif
 }
 
+bool RemoteLayerTreeHost::css3DTransformInteroperabilityEnabled() const
+{
+    return m_drawingArea->page().preferences().css3DTransformInteroperabilityEnabled();
+}
+
 bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& transaction, float indicatorScaleFactor)
 {
     if (!m_drawingArea)
@@ -289,6 +294,16 @@ void RemoteLayerTreeHost::createLayer(const RemoteLayerTreeTransaction::LayerCre
     ASSERT(!m_nodes.contains(properties.layerID));
 
     auto node = makeNode(properties);
+
+#if HAVE(CALAYER_USES_WEBKIT_BEHAVIOR)
+    if (css3DTransformInteroperabilityEnabled() && [node->layer() respondsToSelector:@selector(setUsesWebKitBehavior:)]) {
+        [node->layer() setUsesWebKitBehavior:YES];
+        if ([node->layer() isKindOfClass:[CATransformLayer class]])
+            [node->layer() setSortsSublayers:YES];
+        else
+            [node->layer() setSortsSublayers:NO];
+    }
+#endif
 
     m_nodes.add(properties.layerID, WTFMove(node));
 }


### PR DESCRIPTION
#### 907c2373af16165072a9b48aec8d5315fb68f9ae
<pre>
Remote CA platform layers don&apos;t ever call setUsesWebKitBehavior.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251339">https://bugs.webkit.org/show_bug.cgi?id=251339</a>

Reviewed by NOBODY (OOPS!).

We set this in PlatformCALayer for in-process layers, we need to set it for remote ones too.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::css3DTransformInteroperabilityEnabled const):
(WebKit::RemoteLayerTreeHost::createLayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/907c2373af16165072a9b48aec8d5315fb68f9ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114474 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5215 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114416 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39440 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26568 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81105 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/title-change, /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7629 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7724 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4500 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47482 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6615 "Failed to update pull request") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9512 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->