### PR TITLE
Exclude PushDatabase from backup

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -211,6 +211,8 @@ static Expected<UniqueRef<SQLiteDatabase>, ShouldDeleteAndRetry> openAndMigrateD
     }
 
     if (version < currentPushDatabaseVersion) {
+        FileSystem::setExcludedFromBackup(FileSystem::parentPath(path), true);
+
         SQLiteTransaction transaction(db);
         transaction.begin();
 


### PR DESCRIPTION
#### b97e13eff45f7fa73d7bcc69331cc059dcd06d0c
<pre>
Exclude PushDatabase from backup
<a href="https://bugs.webkit.org/show_bug.cgi?id=251343">https://bugs.webkit.org/show_bug.cgi?id=251343</a>
rdar://104806715

Reviewed by Youenn Fablet.

We should avoid backing up the web push database since it contains state like endpoints and keys
that shouldn&apos;t be shared across devices.

We do this at migration time to avoid calling setExcludedFromBackup on every DB open operation.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::openAndMigrateDatabaseImpl):

Canonical link: <a href="https://commits.webkit.org/259563@main">https://commits.webkit.org/259563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1f1c0597f4412fe2ac4c5d18c7fd38e46f7b31a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114479 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174664 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5220 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114420 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39444 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81110 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7634 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27932 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4505 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47487 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6587 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9517 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->