### PR TITLE
Add some new network connection integrity flags

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -522,4 +522,8 @@ WTF_EXTERN_C_END
 @property (nonatomic) BOOL _skipsStackTraceCapture;
 @end
 
+@interface NSMutableURLRequest (Staging_103362732)
+@property (setter=_setWebSearchContent:) BOOL _isWebSearchContent;
+@end
+
 #endif // defined(__OBJC__)

--- a/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
+++ b/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
@@ -33,6 +33,8 @@ enum class NetworkConnectionIntegrity : uint8_t {
     HTTPSOnly = 1 << 2,
     HTTPSOnlyExplicitlyBypassedForDomain = 1 << 3,
     FailClosed = 1 << 4,
+    WebSearchContent = 1 << 5,
+    EnhancedTelemetry = 1 << 6,
 };
 
 }
@@ -46,7 +48,9 @@ template<> struct EnumTraits<WebCore::NetworkConnectionIntegrity> {
         WebCore::NetworkConnectionIntegrity::HTTPSFirst,
         WebCore::NetworkConnectionIntegrity::HTTPSOnly,
         WebCore::NetworkConnectionIntegrity::HTTPSOnlyExplicitlyBypassedForDomain,
-        WebCore::NetworkConnectionIntegrity::FailClosed
+        WebCore::NetworkConnectionIntegrity::FailClosed,
+        WebCore::NetworkConnectionIntegrity::WebSearchContent,
+        WebCore::NetworkConnectionIntegrity::EnhancedTelemetry
     >;
 };
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -400,13 +400,17 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
         [mutableRequest _setProhibitPrivacyProxy:YES];
 #endif
 
-    if (parameters.networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::Enabled))
+    auto networkConnectionIntegrityPolicy = parameters.networkConnectionIntegrityPolicy;
+    if (networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::Enabled))
         enableNetworkConnectionIntegrity(mutableRequest.get(), NetworkSession::needsAdditionalNetworkConnectionIntegritySettings(request));
 
 #if HAVE(PRIVACY_PROXY_FAIL_CLOSED_FOR_UNREACHABLE_HOSTS)
-    if ([mutableRequest respondsToSelector:@selector(_setPrivacyProxyFailClosedForUnreachableHosts:)] && parameters.networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::FailClosed))
+    if ([mutableRequest respondsToSelector:@selector(_setPrivacyProxyFailClosedForUnreachableHosts:)] && networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::FailClosed))
         [mutableRequest _setPrivacyProxyFailClosedForUnreachableHosts:YES];
 #endif
+
+    if ([mutableRequest respondsToSelector:@selector(_setWebSearchContent:)] && networkConnectionIntegrityPolicy.contains(WebCore::NetworkConnectionIntegrity::WebSearchContent))
+        [mutableRequest _setWebSearchContent:YES];
 
 #if ENABLE(APP_PRIVACY_REPORT)
     mutableRequest.get().attribution = request.isAppInitiated() ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -618,6 +618,12 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::FailClosed))
         policy |= _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed;
 
+    if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::WebSearchContent))
+        policy |= _WKWebsiteNetworkConnectionIntegrityPolicyWebSearchContent;
+
+    if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::EnhancedTelemetry))
+        policy |= _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry;
+
     return policy;
 }
 
@@ -639,6 +645,12 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
     if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed)
         webCorePolicy.add(WebCore::NetworkConnectionIntegrity::FailClosed);
+
+    if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyWebSearchContent)
+        webCorePolicy.add(WebCore::NetworkConnectionIntegrity::WebSearchContent);
+
+    if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry)
+        webCorePolicy.add(WebCore::NetworkConnectionIntegrity::EnhancedTelemetry);
 
     _websitePolicies->setNetworkConnectionIntegrityPolicy(webCorePolicy);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -82,6 +82,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
     _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly = 1 << 2,
     _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnlyExplicitlyBypassedForDomain = 1 << 3,
     _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed = 1 << 4,
+    _WKWebsiteNetworkConnectionIntegrityPolicyWebSearchContent = 1 << 5,
+    _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry = 1 << 6,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @class _WKCustomHeaderFields;


### PR DESCRIPTION
#### 2e940ac01eb0f71a1df868f3cf7acf654c5cda9b
<pre>
Add some new network connection integrity flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=251337">https://bugs.webkit.org/show_bug.cgi?id=251337</a>
rdar://103369330

Reviewed by Aditya Keerthi.

Add a couple of new flags to `WebCore::NetworkConnectionIntegrity`, and expose it through new
corresponding SPI policy flags.

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/platform/network/NetworkConnectionIntegrity.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):

Call `-_setWebSearchContent:` if the policy flag is set, and
`-[NSMutableURLRequest _setWebSearchContent:]` is available.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _networkConnectionIntegrityPolicy]):
(-[WKWebpagePreferences _setNetworkConnectionIntegrityPolicy:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/259569@main">https://commits.webkit.org/259569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b326b910593e1a09a72348c89d56fedfbb01cfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114483 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174668 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5224 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114424 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/110980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/11957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39448 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7733 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4508 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6597 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9521 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->