### PR TITLE
Unnecessarily using std::variant and std::monostate when we could just use nullptr instead

### DIFF
--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -31,14 +31,12 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallFrame.h>
 #include <JavaScriptCore/ScriptCallStack.h>
-#include <initializer_list>
 #include <variant>
 #include <wtf/HashSet.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+class CSSStyleImageValue;
 class CanvasGradient;
 class CanvasPattern;
 class Element;
@@ -47,10 +45,7 @@ class HTMLImageElement;
 class HTMLVideoElement;
 class ImageBitmap;
 class ImageData;
-#if ENABLE(OFFSCREEN_CANVAS)
 class OffscreenCanvas;
-#endif
-class CSSStyleImageValue;
 
 class InspectorCanvas final : public RefCounted<InspectorCanvas> {
 public:
@@ -58,7 +53,7 @@ public:
 
     const String& identifier() const { return m_identifier; }
 
-    CanvasRenderingContext* canvasContext() const;
+    CanvasRenderingContext& canvasContext() const { return m_context; }
     HTMLCanvasElement* canvasElement() const;
 
     ScriptExecutionContext* scriptExecutionContext() const;
@@ -101,7 +96,7 @@ public:
     String getCanvasContentAsDataURL(Inspector::Protocol::ErrorString&);
 
 private:
-    InspectorCanvas(CanvasRenderingContext&);
+    explicit InspectorCanvas(CanvasRenderingContext&);
 
     void appendActionSnapshotIfNeeded();
 
@@ -136,10 +131,7 @@ private:
 
     String m_identifier;
 
-    std::variant<
-        std::reference_wrapper<CanvasRenderingContext>,
-        std::monostate
-    > m_context;
+    CanvasRenderingContext& m_context;
 
     RefPtr<Inspector::Protocol::Recording::InitialState> m_initialState;
     RefPtr<JSON::ArrayOf<Inspector::Protocol::Recording::Frame>> m_frames;

--- a/Source/WebCore/inspector/InspectorShaderProgram.h
+++ b/Source/WebCore/inspector/InspectorShaderProgram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc.  All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,33 +28,19 @@
 #if ENABLE(WEBGL)
 
 #include <JavaScriptCore/InspectorProtocolObjects.h>
-#include <variant>
-#include <wtf/Forward.h>
-#include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class InspectorCanvas;
-
-#if ENABLE(WEBGL)
 class WebGLProgram;
-class WebGLRenderingContextBase;
-#endif
 
 class InspectorShaderProgram final : public RefCounted<InspectorShaderProgram> {
 public:
-#if ENABLE(WEBGL)
     static Ref<InspectorShaderProgram> create(WebGLProgram&, InspectorCanvas&);
-#endif
 
     const String& identifier() const { return m_identifier; }
     InspectorCanvas& canvas() const { return m_canvas; }
-
-#if ENABLE(WEBGL)
-    WebGLProgram* program() const;
-#endif
+    WebGLProgram& program() const { return m_program; }
 
     String requestShaderSource(Inspector::Protocol::Canvas::ShaderType);
     bool updateShader(Inspector::Protocol::Canvas::ShaderType, const String& source);
@@ -68,20 +54,11 @@ public:
     Ref<Inspector::Protocol::Canvas::ShaderProgram> buildObjectForShaderProgram();
 
 private:
-#if ENABLE(WEBGL)
     InspectorShaderProgram(WebGLProgram&, InspectorCanvas&);
-#endif
 
     String m_identifier;
     InspectorCanvas& m_canvas;
-
-    std::variant<
-#if ENABLE(WEBGL)
-        std::reference_wrapper<WebGLProgram>,
-#endif
-        std::monostate
-    > m_program;
-
+    WebGLProgram& m_program;
     bool m_disabled { false };
     bool m_highlighted { false };
 };

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -787,12 +787,12 @@ void WebsiteDataStore::getManagedDomains(CompletionHandler<void(const HashSet<We
     });
 }
 
-std::optional<std::reference_wrapper<HashSet<WebCore::RegistrableDomain>>> WebsiteDataStore::managedDomainsIfInitialized()
+const HashSet<WebCore::RegistrableDomain>* WebsiteDataStore::managedDomainsIfInitialized()
 {
     ASSERT(RunLoop::isMain());
     if (!hasInitializedManagedDomains)
-        return std::nullopt;
-    return managedDomains();
+        return nullptr;
+    return &managedDomains();
 }
 
 void WebsiteDataStore::setManagedDomainsForTesting(HashSet<WebCore::RegistrableDomain>&& domains, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2068,7 +2068,7 @@ void WebsiteDataStore::forwardManagedDomainsToITPIfInitialized(CompletionHandler
 {
     auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
     auto managedDomains = managedDomainsIfInitialized();
-    if (!managedDomains || managedDomains->get().isEmpty())
+    if (!managedDomains || managedDomains->isEmpty())
         return;
 
     auto propagateManagedDomains = [callbackAggregator] (WebsiteDataStore* store, const HashSet<WebCore::RegistrableDomain>& domains) {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -478,7 +478,7 @@ private:
 #endif
 
 #if ENABLE(MANAGED_DOMAINS)
-    static std::optional<std::reference_wrapper<HashSet<WebCore::RegistrableDomain>>> managedDomainsIfInitialized();
+    static const HashSet<WebCore::RegistrableDomain>* managedDomainsIfInitialized();
     static void forwardManagedDomainsToITPIfInitialized(CompletionHandler<void()>&&);
     void setManagedDomainsForITP(const HashSet<WebCore::RegistrableDomain>&, CompletionHandler<void()>&&);
 #endif


### PR DESCRIPTION
#### 37f282e65d2edf8c3c72614ad822ac26cfa8a062
<pre>
Unnecessarily using std::variant and std::monostate when we could just use nullptr instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=251346">https://bugs.webkit.org/show_bug.cgi?id=251346</a>
rdar://problem/104809022

Reviewed by Patrick Angle.

Using std::variant, std::reference_wrapper, and std::monostate is like a pointer, but less
efficient. Using std::optional and std::reference_wrapper is the same. Found places in our
code where we did that and removed them. Also updated one place that used std::reference_wrapper
where a reference would work just as well.

* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::canvasContext const): Moved to the header since it&apos;s now trivial.
(WebCore::InspectorCanvas::canvasElement const): Removed the switchOn since m_context is now
a reference rather than a variant.
(WebCore::InspectorCanvas::scriptExecutionContext const): Ditto.
(WebCore::InspectorCanvas::resolveContext const): Ditto.
(WebCore::InspectorCanvas::clientNodes const): Ditto.
(WebCore::InspectorCanvas::canvasChanged): Ditto.
(WebCore::InspectorCanvas::resetRecordingData): Ditto.
(WebCore::InspectorCanvas::recordAction): Ditto.
(WebCore::InspectorCanvas::buildObjectForCanvas): Ditto.
(WebCore::InspectorCanvas::releaseObjectForRecording): Ditto.
(WebCore::InspectorCanvas::buildInitialState): Ditto.

* Source/WebCore/inspector/InspectorCanvas.h: Removed some unneded includes. Use
CanvasRenderingContext&amp; for m_context.

* Source/WebCore/inspector/InspectorShaderProgram.cpp: Removed redundant checks of
(WebCore::InspectorShaderProgram::program const): Moved to the header since it&apos;s now
trivial.
(WebCore::InspectorShaderProgram::requestShaderSource): Removed the switchOn since m_program
is now a reference rather than a variant. Also changed to use early return, WebKit style.
(WebCore::InspectorShaderProgram::updateShader): Ditto.
(WebCore::InspectorShaderProgram::buildObjectForShaderProgram): Removed the code that looked
at m_program entirely, since it did&apos;t do anything.

* Source/WebCore/inspector/InspectorShaderProgram.h: Removed redundant checks of
m_program.

* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::startRecording): Updated since InspectorCanvas::canvasContext
now returns a reference.
(WebCore::InspectorCanvasAgent::stopRecording): Ditto.
(WebCore::InspectorCanvasAgent::recordAction): Ditto.
(WebCore::InspectorCanvasAgent::reset): Ditto.
(WebCore::InspectorCanvasAgent::unbindCanvas): Ditto.
(WebCore::InspectorCanvasAgent::findInspectorCanvas): Ditto.
(WebCore::InspectorCanvasAgent::findInspectorProgram): Updated since
InspectorShaderProgram::program now returns a reference.

* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::managedDomainsIfInitialized): Return a pointer.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized): Updated since
managedDomainsIfInitialized now returns a pointer.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h: Updated.

Canonical link: <a href="https://commits.webkit.org/259572@main">https://commits.webkit.org/259572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afccf28f8dfadf55d7c97821bbbd086f81639a00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114546 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5291 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97604 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95006 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26640 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7700 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7796 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47544 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6586 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9584 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->