### PR TITLE
imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-computed.html crashes (libc++ assertions)

### DIFF
--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -211,7 +211,7 @@ public:
         if (!m_stepPosition && *otherSteps.m_stepPosition == StepPosition::End)
             return true;
 
-        if (*m_stepPosition == StepPosition::End && !otherSteps.m_stepPosition)
+        if (!otherSteps.m_stepPosition && *m_stepPosition == StepPosition::End)
             return true;
 
         return false;


### PR DESCRIPTION
#### 8f690bd4d72836915fb0c82775e16f1bf01caf59
<pre>
imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-computed.html crashes (libc++ assertions)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251352">https://bugs.webkit.org/show_bug.cgi?id=251352</a>

Reviewed by Antti Koivisto and Chris Dumez.

We have a `m_stepPosition == otherSteps.m_stepPosition` check in TimingFunction::operator==(const TimingFunction&amp;) which would
catch the case where both m_stepPosition and otherSteps.m_stepPosition, which are std::optional&lt;&gt;, would not hold a value.

However, we would hit a recently-enabled libc++ assertion (see bug 245692) because of the check
`*m_stepPosition == StepPosition::End &amp;&amp; !otherSteps.m_stepPosition`. Indeed, it is possible for otherSteps.m_stepPosition to
hold a value while m_stepPosition does not.

We simply reverse the two clauses such that we test `!otherSteps.m_stepPosition` first since we already know from earlier
that `otherSteps.m_stepPosition` and `m_stepPosition` cannot both not hold a value.

* Source/WebCore/platform/animation/TimingFunction.h:

Canonical link: <a href="https://commits.webkit.org/259559@main">https://commits.webkit.org/259559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15383d6253713870fc2c680576ddcbfe060ab1d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114503 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174692 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5244 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97558 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39471 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81139 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7658 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7753 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4530 "Found 1 new test failure: fast/forms/fieldset/fieldset-elements.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47514 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9541 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3522 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->