### PR TITLE
[GTK][WPE] Missing ENABLE(2022_GLIB_API ) in public headers after 259433@main

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in
@@ -124,6 +124,10 @@ WEBKIT_API GList *
 webkit_network_session_get_itp_summary_finish                    (WebKitNetworkSession         *session,
                                                                   GAsyncResult                 *result,
                                                                   GError                      **error);
+WEBKIT_API void
+webkit_network_session_prefetch_dns                              (WebKitNetworkSession         *session,
+                                                                  const char                   *hostname);
+
 WEBKIT_API WebKitDownload *
 webkit_network_session_download_uri                              (WebKitNetworkSession         *session,
                                                                   const char                   *uri);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -283,12 +283,12 @@ WEBKIT_API void
 webkit_web_context_set_web_extensions_initialization_user_data
                                                     (WebKitWebContext              *context,
                                                      GVariant                      *user_data);
-
+#if !ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_web_context_prefetch_dns                     (WebKitWebContext              *context,
                                                      const gchar                   *hostname);
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK)
 WEBKIT_DEPRECATED_FOR(webkit_web_context_new_with_website_data_manager) void
 webkit_web_context_set_disk_cache_directory         (WebKitWebContext              *context,
                                                      const gchar                   *directory);
@@ -299,7 +299,6 @@ webkit_web_context_allow_tls_certificate_for_host   (WebKitWebContext           
                                                      GTlsCertificate               *certificate,
                                                      const gchar                   *host);
 
-#if !ENABLE(2022_GLIB_API)
 WEBKIT_DEPRECATED void
 webkit_web_context_set_process_model                (WebKitWebContext              *context,
                                                      WebKitProcessModel             process_model);


### PR DESCRIPTION
#### 59fbc6d1ded1da728b00b0c49b9edaeb05d94e4d
<pre>
[GTK][WPE] Missing ENABLE(2022_GLIB_API ) in public headers after 259433@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=251354">https://bugs.webkit.org/show_bug.cgi?id=251354</a>

Reviewed by Michael Catanzaro.

webkit_web_context_allow_tls_certificate_for_host was moved to network session, but it&apos;s still listed in WebKitWebContext.h
webkit_web_context_prefetch_dns was moved to network session, but it&apos;s still listed in WebKitWebContext.h and not in WebKitNetworkSession.h

* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:

Canonical link: <a href="https://commits.webkit.org/259556@main">https://commits.webkit.org/259556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9965ff0be09dcb1676447add522845c9ec887284

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114511 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5252 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97566 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111007 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/94972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93854 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7666 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7760 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13812 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/47520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9549 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3518 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->