### PR TITLE
[GStreamer][MSE] Replace raw pointer with GRefPtr in GStreamerMediaDescription constructor

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -508,7 +508,7 @@ void AppendPipeline::didReceiveInitializationSegment()
             ASSERT(track->webKitTrack);
             SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation info;
             info.track = static_cast<AudioTrackPrivateGStreamer*>(track->webKitTrack.get());
-            info.description = GStreamerMediaDescription::create(track->caps.get());
+            info.description = GStreamerMediaDescription::create(track->caps);
             initializationSegment.audioTracks.append(info);
             break;
         }
@@ -516,7 +516,7 @@ void AppendPipeline::didReceiveInitializationSegment()
             ASSERT(track->webKitTrack);
             SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation info;
             info.track = static_cast<VideoTrackPrivateGStreamer*>(track->webKitTrack.get());
-            info.description = GStreamerMediaDescription::create(track->caps.get());
+            info.description = GStreamerMediaDescription::create(track->caps);
             initializationSegment.videoTracks.append(info);
             break;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class GStreamerMediaDescription : public MediaDescription {
 public:
-    static Ref<GStreamerMediaDescription> create(GstCaps* caps)
+    static Ref<GStreamerMediaDescription> create(const GRefPtr<GstCaps>& caps)
     {
         return adoptRef(*new GStreamerMediaDescription(caps));
     }
@@ -45,7 +45,7 @@ public:
     bool isText() const override;
 
 private:
-    GStreamerMediaDescription(GstCaps* caps)
+    GStreamerMediaDescription(const GRefPtr<GstCaps>& caps)
         : MediaDescription()
         , m_caps(caps)
     {


### PR DESCRIPTION
#### 13ac0f7d87c8d065c1e07bc13a8792ac9256fdb5
<pre>
[GStreamer][MSE] Replace raw pointer with GRefPtr in GStreamerMediaDescription constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=251360">https://bugs.webkit.org/show_bug.cgi?id=251360</a>

Reviewed by Xabier Rodriguez-Calvar.

The caps are already stored internally as a GRefPtr, so it&apos;s safer to pass a GRefPtr to the
constructor as well.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h:
(WebCore::GStreamerMediaDescription::create):
(WebCore::GStreamerMediaDescription::GStreamerMediaDescription):

Canonical link: <a href="https://commits.webkit.org/259620@main">https://commits.webkit.org/259620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/151de2b268a0548760240143c035690f5647a1e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114534 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174726 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5268 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114455 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39502 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81164 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27988 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4568 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47531 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6635 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9565 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->