### PR TITLE
[GStreamer][WebRTC] Don't attempt to parse colorspace information on incoming RTP video buffers

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -273,7 +273,15 @@ static inline void setBufferFields(GstBuffer* buffer, const MediaTime& presentat
 
 Ref<VideoFrameGStreamer> VideoFrameGStreamer::create(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize, const MediaTime& presentationTime, Rotation videoRotation, bool videoMirrored, std::optional<VideoFrameTimeMetadata>&& metadata, std::optional<PlatformVideoColorSpace>&& colorSpace)
 {
-    auto platformColorSpace = colorSpace.value_or(videoColorSpaceFromCaps(gst_sample_get_caps(sample.get())));
+    PlatformVideoColorSpace platformColorSpace;
+    if (colorSpace)
+        platformColorSpace = *colorSpace;
+    else {
+        auto* caps = gst_sample_get_caps(sample.get());
+        if (doCapsHaveType(caps, GST_VIDEO_CAPS_TYPE_PREFIX))
+            platformColorSpace = videoColorSpaceFromCaps(caps);
+    }
+
     return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), presentationSize, presentationTime, videoRotation, videoMirrored, WTFMove(metadata), WTFMove(platformColorSpace)));
 }
 


### PR DESCRIPTION
#### 3e1dc777d5946a4e787c0b54eeb7efda943201db
<pre>
[GStreamer][WebRTC] Don&apos;t attempt to parse colorspace information on incoming RTP video buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=251361">https://bugs.webkit.org/show_bug.cgi?id=251361</a>

Reviewed by Xabier Rodriguez-Calvar.

Incoming video frames are wrapped in RTP payloads, so we can&apos;t use the usual caps-&gt;VideoInfo code
paths. Parsing the RTP buffer would require a mini-depayloader, which doesn&apos;t seem worth the effort
for the time being.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::create):

Canonical link: <a href="https://commits.webkit.org/259625@main">https://commits.webkit.org/259625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/891bc878e150f016ce43f37bce4e0491c654d138

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114692 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5444 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97743 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111195 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95115 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26750 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28106 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7938 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6637 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9730 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->