### PR TITLE
[WGSL] Add AST node for WorkgroupSizeAttribute

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -36,6 +36,7 @@ class BuiltinAttribute;
 class GroupAttribute;
 class LocationAttribute;
 class StageAttribute;
+class WorkgroupSizeAttribute;
 
 class Decl;
 class FunctionDecl;

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -43,6 +43,7 @@ public:
         GroupAttribute,
         LocationAttribute,
         StageAttribute,
+        WorkgroupSizeAttribute,
 
         // Decl
         FunctionDecl,

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -128,6 +128,11 @@ void StringDumper::visit(StageAttribute& stage)
     }
 }
 
+void StringDumper::visit(WorkgroupSizeAttribute& workgroupSize)
+{
+    m_out.print("@workgroup_size(", workgroupSize.size(), ")");
+}
+
 // Declaration
 void StringDumper::visit(FunctionDecl& function)
 {

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -49,6 +49,7 @@ public:
     void visit(GroupAttribute&) override;
     void visit(LocationAttribute&) override;
     void visit(StageAttribute&) override;
+    void visit(WorkgroupSizeAttribute&) override;
 
     // Declaration
     void visit(FunctionDecl&) override;

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -78,6 +78,9 @@ void Visitor::visit(Attribute& attribute)
     case Node::Kind::StageAttribute:
         checkErrorAndVisit(downcast<StageAttribute>(attribute));
         break;
+    case Node::Kind::WorkgroupSizeAttribute:
+        checkErrorAndVisit(downcast<WorkgroupSizeAttribute>(attribute));
+        break;
     default:
         ASSERT_NOT_REACHED("Unhandled attribute kind");
     }
@@ -100,6 +103,10 @@ void Visitor::visit(LocationAttribute&)
 }
 
 void Visitor::visit(StageAttribute&)
+{
+}
+
+void Visitor::visit(WorkgroupSizeAttribute&)
 {
 }
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -47,6 +47,7 @@ public:
     virtual void visit(GroupAttribute&);
     virtual void visit(LocationAttribute&);
     virtual void visit(StageAttribute&);
+    virtual void visit(WorkgroupSizeAttribute&);
 
     // Declaration
     virtual void visit(Decl&);

--- a/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,34 +25,31 @@
 
 #pragma once
 
-#include "ASTArrayAccess.h"
-#include "ASTAssignmentStatement.h"
-#include "ASTAttribute.h"
-#include "ASTBinaryExpression.h"
-#include "ASTBindingAttribute.h"
-#include "ASTBuiltinAttribute.h"
-#include "ASTCallableExpression.h"
-#include "ASTCompoundStatement.h"
-#include "ASTDecl.h"
-#include "ASTExpression.h"
-#include "ASTFunctionDecl.h"
-#include "ASTGlobalDirective.h"
-#include "ASTGroupAttribute.h"
-#include "ASTIdentifierExpression.h"
-#include "ASTIdentityExpression.h"
-#include "ASTLiteralExpressions.h"
-#include "ASTLocationAttribute.h"
 #include "ASTNode.h"
-#include "ASTPointerDereference.h"
-#include "ASTReturnStatement.h"
-#include "ASTShaderModule.h"
-#include "ASTStageAttribute.h"
-#include "ASTStatement.h"
-#include "ASTStructureAccess.h"
-#include "ASTStructureDecl.h"
-#include "ASTTypeDecl.h"
-#include "ASTUnaryExpression.h"
-#include "ASTVariableDecl.h"
-#include "ASTVariableQualifier.h"
-#include "ASTVariableStatement.h"
-#include "ASTWorkgroupSizeAttribute.h"
+
+#include <wtf/UniqueRef.h>
+#include <wtf/UniqueRefVector.h>
+#include <wtf/Vector.h>
+
+namespace WGSL::AST {
+
+class WorkgroupSizeAttribute final : public Attribute {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    WorkgroupSizeAttribute(SourceSpan span, unsigned size)
+        : Attribute(span)
+        , m_size(size)
+    {
+    }
+
+    Kind kind() const override;
+    unsigned size() const { return m_size; }
+
+private:
+    unsigned m_size;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(WorkgroupSizeAttribute)

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -232,6 +232,14 @@ Expected<Ref<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         CONSUME_TYPE_NAMED(name, Identifier);
         CONSUME_TYPE(ParenRight);
         RETURN_NODE_REF(BuiltinAttribute, name.m_ident);
+    }
+
+    if (ident.m_ident == "workgroup_size"_s) {
+        CONSUME_TYPE(ParenLeft);
+        // FIXME: should more kinds of literals be accepted here?
+        CONSUME_TYPE_NAMED(id, IntegerLiteralUnsigned);
+        CONSUME_TYPE(ParenRight);
+        RETURN_NODE_REF(WorkgroupSizeAttribute, id.m_literalValue);
     }
 
     // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		9789C32329802690009E9006 /* ASTPointerDereference.h in Headers */ = {isa = PBXBuildFile; fileRef = 9789C32129802690009E9006 /* ASTPointerDereference.h */; };
 		978A911B2984076900B37E5E /* API.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A911A2984076900B37E5E /* API.h */; };
 		978A91192983FE3100B37E5E /* ASTIdentityExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A91182983FE3100B37E5E /* ASTIdentityExpression.h */; };
+		978A911D2988096900B37E5E /* ASTWorkgroupSizeAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A911C2988096900B37E5E /* ASTWorkgroupSizeAttribute.h */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -257,6 +258,7 @@
 		9789C32129802690009E9006 /* ASTPointerDereference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTPointerDereference.h; sourceTree = "<group>"; };
 		978A911A2984076900B37E5E /* API.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = API.h; sourceTree = "<group>"; };
 		978A91182983FE3100B37E5E /* ASTIdentityExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTIdentityExpression.h; sourceTree = "<group>"; };
+		978A911C2988096900B37E5E /* ASTWorkgroupSizeAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTWorkgroupSizeAttribute.h; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 				3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */,
 				3A1337E528FBD56300F29B73 /* ASTVisitor.cpp */,
 				3A1337E628FBD56400F29B73 /* ASTVisitor.h */,
+				978A911C2988096900B37E5E /* ASTWorkgroupSizeAttribute.h */,
 			);
 			path = AST;
 			sourceTree = "<group>";
@@ -544,6 +547,7 @@
 				33EA187227BC1FE100A1DD52 /* ASTVariableQualifier.h in Headers */,
 				3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */,
 				3A1337E828FBD56400F29B73 /* ASTVisitor.h in Headers */,
+				978A911D2988096900B37E5E /* ASTWorkgroupSizeAttribute.h in Headers */,
 				9789C31B297EA105009E9006 /* CallGraph.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,


### PR DESCRIPTION
#### 1b0340486392c92f8f0899604c2e3b726be22c00
<pre>
[WGSL] Add AST node for WorkgroupSizeAttribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=251362">https://bugs.webkit.org/show_bug.cgi?id=251362</a>
&lt;rdar://problem/104820892&gt;

Reviewed by Myles C. Maxfield.

Add support for `@workgroup_size(\d)` annotations

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h: Copied from Source/WebGPU/WGSL/AST/AST.h.
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/259613@main">https://commits.webkit.org/259613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/853705a0df1bdbc5b9d57e1b0cff16901d9265b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114531 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5274 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114458 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39500 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81162 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4575 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47539 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6631 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9569 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->