### PR TITLE
[GStreamer] ElementHarness: Remove custom sink query handler

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -58,7 +58,6 @@ public:
         Stream(GRefPtr<GstPad>&&, RefPtr<GStreamerElementHarness>&&);
 
         GstFlowReturn chainBuffer(GstBuffer*);
-        bool sinkQuery(GstPad*, GstObject*, GstQuery*);
         bool sinkEvent(GstEvent*);
 
         GRefPtr<GstPad> m_pad;


### PR DESCRIPTION
#### 6c278916f3e19248631b8d9a3f9807208ea0d65f
<pre>
[GStreamer] ElementHarness: Remove custom sink query handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=251363">https://bugs.webkit.org/show_bug.cgi?id=251363</a>

Reviewed by Xabier Rodriguez-Calvar.

In cases where the harnessed element reconfigures a source pad, the associated sink pad caps
need re-negotiation and it&apos;s better to let the default pad query handler do it.

* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::Stream::Stream):
(WebCore::GStreamerElementHarness::Stream::sinkQuery): Deleted.
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:

Canonical link: <a href="https://commits.webkit.org/259619@main">https://commits.webkit.org/259619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a510b7a30fdb865f5db49afaae09cf2e14e3867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114536 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174732 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5277 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114460 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39504 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7688 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27993 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7783 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4573 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/basic/mediasource.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47536 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6636 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9571 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->