### PR TITLE
Use transient activation for media playback

### DIFF
--- a/LayoutTests/http/tests/media/autoplay-if-audio-is-playing-expected.txt
+++ b/LayoutTests/http/tests/media/autoplay-if-audio-is-playing-expected.txt
@@ -2,5 +2,5 @@ Click on play button: video1 should start to play, then video2 should also start
 Play video 1
 
 PASS Ensuring video is not playing if no user gesture
-PASS Should not autoplay even when a video is already playing audio
+PASS Video 2 should be allowed to play after video 1 started with a user gesture
 

--- a/LayoutTests/http/tests/media/autoplay-if-audio-is-playing.html
+++ b/LayoutTests/http/tests/media/autoplay-if-audio-is-playing.html
@@ -19,11 +19,15 @@ if (window.internals) {
     internals.setMediaElementRestrictions(video1, "RequireUserGestureForVideoRateChange");
     internals.setMediaElementRestrictions(video2, "RequireUserGestureForVideoRateChange");
     internals.setMediaElementRestrictions(video3, "RequireUserGestureForVideoRateChange");
+    internals.setTransientActivationDuration(1);
 }
+
+let resolve;
+const firstTestCompleted = new Promise(r => resolve = r);
 
 promise_test((test) => {
     video3.src = findMediaFile("video", "resources/test-25fps");
-    return video3.play().then(assert_unreached, () => { });
+    return video3.play().then(assert_unreached, resolve);
 }, "Ensuring video is not playing if no user gesture");
 
 var resolveTest, rejectTest;
@@ -32,25 +36,31 @@ promise_test((test) => {
         resolveTest = resolve;
         rejectTest = reject;
     });
-}, "Should not autoplay even when a video is already playing audio");
+}, "Video 2 should be allowed to play after video 1 started with a user gesture");
 
 function doTest()
 {
     video1.src = findMediaFile("video", "resources/test-25fps");
     return video1.play().then(() => {
         video2.src = findMediaFile("video", "resources/test-25fps");
-        video2.play().then(() => rejectTest("video2 did start"), resolveTest);
+        video2.play().then(() => resolveTest("video2 started"), resolveTest);
     });
 }
 
-var x = video1Button.offsetLeft + 5;
-var y = video1Button.offsetTop + 5;
+(async function() {
 
-if (window.eventSender) {
-    eventSender.mouseMoveTo(x, y);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
-}
+    await firstTestCompleted;
+
+    var x = video1Button.offsetLeft + 5;
+    var y = video1Button.offsetTop + 5;
+
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(x, y);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+}());
+
          </script>
     </body>
 </html>

--- a/LayoutTests/media/media-fullscreen-inline-expected.txt
+++ b/LayoutTests/media/media-fullscreen-inline-expected.txt
@@ -24,7 +24,6 @@ EVENT(canplaythrough)
 EXPECTED (mediaElement.webkitSupportsFullscreen == 'true') OK
 EXPECTED (mediaElement.webkitSupportsPresentationMode('fullscreen') == 'true') OK
 EXPECTED (mediaElement.webkitDisplayingFullscreen == 'false') OK
-TEST(mediaElement.webkitEnterFullScreen()) THROWS(DOMException.INVALID_STATE_ERR) OK
 * clicking on button
 EVENT(mouseup)
 * event handler triggered by user gesture

--- a/LayoutTests/media/media-fullscreen.js
+++ b/LayoutTests/media/media-fullscreen.js
@@ -83,11 +83,6 @@ function canplaythrough()
         testExpected("mediaElement.webkitSupportsPresentationMode", undefined);
         testExpected("mediaElement.webkitDisplayingFullscreen", undefined);
     }
-    
-    // Verify that we get an exception when trying to enter fullscreen since this isn't
-    // called in response to a user gesture.
-    if (movie.type == 'video')
-        testDOMException("mediaElement.webkitEnterFullScreen()", "DOMException.INVALID_STATE_ERR");
 
     // Click on the button
     runWithKeyDown(clickEnterFullscreenButton);

--- a/LayoutTests/media/playlist-inherits-user-gesture.html
+++ b/LayoutTests/media/playlist-inherits-user-gesture.html
@@ -7,8 +7,10 @@
     <script>
     async function runTest() {
         consoleWrite("** Start first video with user gesture.")
-        if (window.internals)
+        if (window.internals) {
             run('window.internals.settings.setRequiresUserGestureForVideoPlayback(true);');
+            internals.setTransientActivationDuration(1);
+        }
         run('video1 = document.createElement("video")');
         run('video1.src = findMediaFile("video", "content/test")');
         video1.controls = 1;
@@ -37,13 +39,17 @@
         await waitFor(video2, 'ended');
 
         consoleWrite("<br>** Start third video without user gesture but after inheritance window, should fail.")
+        if (window.internals)
+            internals.setTransientActivationDuration(.4);
         await sleepFor(1200);
         run('video3 = document.createElement("video")');
         run('video3.src = findMediaFile("video", "content/test")');
         video3.controls = 1;
         run('document.body.appendChild(video3)');
 
-        await shouldReject(video3.play());
+        try {
+            await shouldReject(video3.play());
+        } catch (ex) { }
 
         endTest();
     }

--- a/LayoutTests/media/restricted-audio-playback-with-multiple-settimeouts.html
+++ b/LayoutTests/media/restricted-audio-playback-with-multiple-settimeouts.html
@@ -18,8 +18,10 @@
         }
 
         mediaElement = document.createElement('audio');
-        if (window.internals)
+        if (window.internals) {
             internals.setMediaElementRestrictions(mediaElement, "RequireUserGestureForAudioRateChange");
+            internals.setTransientActivationDuration(1);
+        }
 
         var nextTest = tests.shift();
         consoleWrite('');

--- a/LayoutTests/platform/glib/media/media-fullscreen-inline-expected.txt
+++ b/LayoutTests/platform/glib/media/media-fullscreen-inline-expected.txt
@@ -23,7 +23,6 @@ EVENT(canplaythrough)
 * event handler NOT triggered by a user gesture
 EXPECTED (mediaElement.webkitSupportsFullscreen == 'true') OK
 EXPECTED (mediaElement.webkitDisplayingFullscreen == 'false') OK
-TEST(mediaElement.webkitEnterFullScreen()) THROWS(DOMException.INVALID_STATE_ERR) OK
 * clicking on button
 EVENT(mouseup)
 * event handler triggered by user gesture

--- a/LayoutTests/platform/glib/media/media-fullscreen-not-in-document-expected.txt
+++ b/LayoutTests/platform/glib/media/media-fullscreen-not-in-document-expected.txt
@@ -10,7 +10,6 @@ EVENT(canplaythrough)
 * event handler NOT triggered by a user gesture
 EXPECTED (mediaElement.webkitSupportsFullscreen == 'true') OK
 EXPECTED (mediaElement.webkitDisplayingFullscreen == 'false') OK
-TEST(mediaElement.webkitEnterFullScreen()) THROWS(DOMException.INVALID_STATE_ERR) OK
 * clicking on button
 EVENT(mouseup)
 * event handler triggered by user gesture

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7428,6 +7428,9 @@ bool Document::processingUserGestureForMedia() const
     if (UserGestureIndicator::processingUserGestureForMedia())
         return true;
 
+    if (m_domWindow && m_domWindow->hasTransientActivation())
+        return true;
+
     if (m_userActivatedMediaFinishedPlayingTimestamp + maxIntervalForUserGestureForwardingAfterMediaFinishesPlaying >= MonotonicTime::now())
         return true;
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6657,6 +6657,10 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
     ALWAYS_LOG(LOGIDENTIFIER, ", m_videoFullscreenMode = ", m_videoFullscreenMode, ", mode = ", mode);
     ASSERT(mode != VideoFullscreenModeNone);
 
+    auto* window = document().domWindow();
+    if (!window)
+        return;
+
     if (m_videoFullscreenMode == mode)
         return;
 
@@ -6673,6 +6677,12 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
         return;
     }
 #endif
+
+    ALWAYS_LOG(LOGIDENTIFIER, ", transient activation = ", window->hasTransientActivation());
+    if (mediaSession().hasBehaviorRestriction(MediaElementSession::RequireUserGestureForFullscreen) && !window->consumeTransientActivation()) {
+        ERROR_LOG(LOGIDENTIFIER, "User activation required to enter fullscreen");
+        return;
+    }
 
     queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, mode, logIdentifier = LOGIDENTIFIER] {
         if (isContextStopped())

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/autoplaying-multiple-media-elements.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/autoplaying-multiple-media-elements.html
@@ -30,5 +30,6 @@
     <br />
     <video id="video1" onplaying="didPlayVideo('video1')" src="video-with-audio.mp4"></video>
     <video id="video2" onplaying="didPlayVideo('video2')" src="video-with-audio.mp4"></video>
+    <video id="video3" onplaying="didPlayVideo('video3')" src="video-with-audio.mp4"></video>
 </body>
 </html>


### PR DESCRIPTION
#### 98a09842676c3af9db9a11e6617993db076c133c
<pre>
Use transient activation for media playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=251372">https://bugs.webkit.org/show_bug.cgi?id=251372</a>
rdar://103800206

Reviewed by Jer Noble.

Allow media to play when there is an active transient activation. Require and consume
a transient activation when video fullscreen requires a user gesture.

* LayoutTests/http/tests/media/autoplay-if-audio-is-playing-expected.txt:
* LayoutTests/http/tests/media/autoplay-if-audio-is-playing.html: Update test and
results as the second video is now able to play because the first was started with
a user gesture.
* LayoutTests/media/media-fullscreen-inline-expected.txt:
* LayoutTests/media/media-fullscreen.js:
(canplaythrough): Remove now invalid portion of the test.
* LayoutTests/platform/glib/media/media-fullscreen-inline-expected.txt:
* LayoutTests/platform/glib/media/media-fullscreen-not-in-document-expected.txt:

* LayoutTests/media/playlist-inherits-user-gesture.html:
* LayoutTests/media/restricted-audio-playback-with-multiple-settimeouts.html: Decrease
 transient activation time so these old tests work.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm: Update test to account for
and test playing because of transient activation.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/autoplaying-multiple-media-elements.html

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processingUserGestureForMedia const): Return true when there is an
active transient activation.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement): Drive-by logging cleanup. Log
all errors.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::enterFullscreen): Require and consume a transient activation
if a user gesture is required to enter fullscreen.

Canonical link: <a href="https://commits.webkit.org/259626@main">https://commits.webkit.org/259626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ec3eb8b54727a0539e66c6aad6742ad9201291

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114657 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174823 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5408 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97706 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114539 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39583 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81269 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28078 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7904 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4668 "Found 1 new test failure: fast/repaint/rtl-content-selection-hairline-gap.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47625 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6639 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9695 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->