### PR TITLE
Remove checks for A8 devices

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
@@ -54,21 +54,11 @@ bool IsMetalRendererAvailable()
                     ANGLE_APPLE_ALLOW_DEPRECATED_END
                 }
 #elif defined(ANGLE_PLATFORM_IOS) && !TARGET_OS_SIMULATOR
-                // A8 devices (iPad Mini 4, iPad Air 2) cannot use ANGLE's Metal backend.
-                // This check can be removed once they are no longer supported.
-                if (ANGLE_APPLE_AVAILABLE_XCI(10.15, 13.1, 13))
-                {
-                    if ([device supportsFamily:MTLGPUFamilyApple3])
-                        gpuFamilySufficient = true;
-                }
-                else
-                {
-                    // Hardcode constant to sidestep compiler errors. Call will
-                    // return false on older macOS versions.
-                    const NSUInteger iosFamily3v1 = 4;
-                    if ([device supportsFeatureSet:static_cast<MTLFeatureSet>(iosFamily3v1)])
-                        gpuFamilySufficient = true;
-                }
+                // Hardcode constant to sidestep compiler errors. Call will
+                // return false on older macOS versions.
+                const NSUInteger iosFamily3v1 = 4;
+                if ([device supportsFeatureSet:static_cast<MTLFeatureSet>(iosFamily3v1)])
+                    gpuFamilySufficient = true;
 #elif defined(ANGLE_PLATFORM_IOS) && TARGET_OS_SIMULATOR
                 // FIXME: Currently we do not have good simulator query, as it does not support
                 // the whole feature set needed for iOS.

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -105,16 +105,13 @@ static bool platformSupportsMetal()
     auto device = adoptNS(MTLCreateSystemDefaultDevice());
 
     if (device) {
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-        // A8 devices (iPad Mini 4, iPad Air 2) cannot use WebGL via Metal.
-        // This check can be removed once they are no longer supported.
-        return [device supportsFamily:MTLGPUFamilyApple3];
-#elif PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
         // This check can be removed once they are no longer supported.
         return [device supportsFamily:MTLGPUFamilyMac2];
-#endif
+#else
         return true;
+#endif
     }
 
     return false;

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -218,12 +218,7 @@ bool Internals::platformSupportsMetal(bool isWebGL2)
     UNUSED_PARAM(isWebGL2);
 
     if (device) {
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)
-        // A8 devices (iPad Mini 4, iPad Air 2) cannot use WebGL2 via Metal.
-        // This check can be removed once they are no longer supported.
-        if (isWebGL2)
-            return [device supportsFamily:MTLGPUFamilyApple3];
-#elif PLATFORM(MAC) || PLATFORM(MACCATALYST)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
         // This check can be removed once they are no longer supported.
         return [device supportsFamily:MTLGPUFamilyMac2];


### PR DESCRIPTION
#### 6ba0490a7f959e169af8d6419003b783dc2da1ec
<pre>
Remove checks for A8 devices
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

As of iOS 13, A8 devices are no longer supported

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(platformSupportsMetal)
* Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm:
(IsMetalRendererAvailable)
* Source/WebCore/testing/Internals.mm:
((NSAttributedString *)_attributedStringForRange:(NSRange)range):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/321dde179b53a6fb9d92d2938aadb9de2c01916f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/105312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/109217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/15564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/111069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/15564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/15564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->