### PR TITLE
CSS Nesting: implement CSSOM (insertRule, deleteRule, cssRules)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Simple CSSOM manipulation of subrules ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('& .b { color: green; }')', 'ss.cssRules[0].insertRule' is undefined)
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', 3); }" threw object "TypeError: ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('& .broken {}', 3)', 'ss.cssRules[0].insertRule' is undefined)" that is not a DOMException IndexSizeError: property "code" is equal to undefined, expected 1
-FAIL Simple CSSOM manipulation of subrules 2 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', -1); }" threw object "TypeError: ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('& .broken {}', -1)', 'ss.cssRules[0].insertRule' is undefined)" that is not a DOMException IndexSizeError: property "code" is equal to undefined, expected 1
-FAIL Simple CSSOM manipulation of subrules 3 assert_throws_dom: function "() => { ss.cssRules[0].deleteRule(5); }" threw object "TypeError: ss.cssRules[0].deleteRule is not a function. (In 'ss.cssRules[0].deleteRule(5)', 'ss.cssRules[0].deleteRule' is undefined)" that is not a DOMException IndexSizeError: property "code" is equal to undefined, expected 1
-FAIL Simple CSSOM manipulation of subrules 4 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[2]')
-FAIL Simple CSSOM manipulation of subrules 5 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('% {}'); }" threw object "TypeError: ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('% {}')', 'ss.cssRules[0].insertRule' is undefined)" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL Simple CSSOM manipulation of subrules 6 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[1]')
-FAIL Simple CSSOM manipulation of subrules 7 ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('@supports selector(&) { & div { font-size: 10px; }}', 1)', 'ss.cssRules[0].insertRule' is undefined)
-FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;& .b { color: green; }\n}& .c { color: blue; }\n}"
-FAIL Simple CSSOM manipulation of subrules 9 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')
+PASS Simple CSSOM manipulation of subrules
+PASS Simple CSSOM manipulation of subrules 1
+PASS Simple CSSOM manipulation of subrules 2
+PASS Simple CSSOM manipulation of subrules 3
+PASS Simple CSSOM manipulation of subrules 4
+PASS Simple CSSOM manipulation of subrules 5
+PASS Simple CSSOM manipulation of subrules 6
+FAIL Simple CSSOM manipulation of subrules 7 assert_equals: @supports is added expected ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n  & div { font-size: 10px; }\n}\n  & .c { color: blue; }\n}" but got ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
+FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
+FAIL Simple CSSOM manipulation of subrules 9 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('div & {}'); }" did not throw
 FAIL Simple CSSOM manipulation of subrules 10 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Simple CSSOM manipulation of subrules
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@font-face {}', 0); }" threw object "TypeError: undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')" that is not a DOMException HierarchyRequestError: property "code" is equal to undefined, expected 3
+FAIL Simple CSSOM manipulation of subrules assert_equals: expected "div {\n  @media screen {\n  &.a { color: red; }\n}\n}" but got "div {\n  @media screen {\n  :is(div).a { color: red; }\n}\n}"
+FAIL Simple CSSOM manipulation of subrules 1 assert_equals: expected "div {\n  @media screen {\n  &.a { color: red; }\n}\n}" but got "div {\n  @media screen {\n  :is(div).a { color: red; }\n}\n}"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL .foo { & { color: green; } } assert_equals: expected ".foo { color: green; }" but got ".foo {\n  & { color: green; }\n}"
+PASS .foo { & { color: green; } }
 PASS .foo { //color: red; color: green; }
 PASS .foo {
   &.bar { color: green; }
@@ -43,14 +43,14 @@ PASS .foo, .bar {
 PASS .foo {
   & .bar & .baz & .qux { color: green; }
 }
-FAIL .foo {
+PASS .foo {
   @media (min-width: 50px) {
   & { color: green; }
 }
-} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo {\n  @media (min-width: 50px) {\n  & { color: green; }\n}\n}"
-FAIL .foo {
+}
+PASS .foo {
   @media (min-width: 50px) { color: green; }
-} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo {\n  @media (min-width: 50px) {\n  & { color: green; }\n}\n}"
+}
 PASS main {
   & > section, & > article {
   & > header { color: green; }
@@ -67,9 +67,9 @@ PASS .foo {
 PASS .foo {
  color: red; ident { color: green; }
 }
-FAIL .foo {
+PASS .foo {
  //color: comment; & { color: green; }
-} assert_equals: expected ".foo { color: green; }" but got ".foo {\n  & { color: green; }\n}"
+}
 PASS .foo {
  .bar {
   functionalnotation(div) { color: green; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Serialization of declarations in group rules assert_equals: expected "div {\n  @media screen { color: red; background-color: green; }\n}" but got "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}"
-FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n  &:hover { color: navy; }\n}\n}"
-FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen { color: red; }\n}" but got "div {\n  @media screen {\n  & { color: red; }\n}\n}"
-FAIL Serialization of declarations in group rules 3 assert_equals: expected "div { color: red; }" but got "div {\n  & { color: red; }\n}"
+PASS Serialization of declarations in group rules
+FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\ncolor: red; background-color: green;\n  &:hover { color: navy; }\n}\n}"
+FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen {\n  &.cls { color: red; }\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\ncolor: red;\n  &.cls { color: red; }\n}\n}"
+PASS Serialization of declarations in group rules 3
 PASS Serialization of declarations in group rules 4
 

--- a/Source/WebCore/css/CSSConditionRule.cpp
+++ b/Source/WebCore/css/CSSConditionRule.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-CSSConditionRule::CSSConditionRule(StyleRuleGroup& group, CSSStyleSheet* parent)
+CSSConditionRule::CSSConditionRule(StyleRuleBase& group, CSSStyleSheet* parent)
     : CSSGroupingRule(group, parent)
 {
 }

--- a/Source/WebCore/css/CSSConditionRule.h
+++ b/Source/WebCore/css/CSSConditionRule.h
@@ -38,7 +38,7 @@ public:
     virtual String conditionText() const = 0;
 
 protected:
-    CSSConditionRule(StyleRuleGroup&, CSSStyleSheet* parent);
+    CSSConditionRule(StyleRuleBase&, CSSStyleSheet* parent);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -46,7 +46,7 @@ Ref<CSSContainerRule> CSSContainerRule::create(StyleRuleContainer& rule, CSSStyl
 
 const StyleRuleContainer& CSSContainerRule::styleRuleContainer() const
 {
-    return downcast<StyleRuleContainer>(groupRule());
+    return downcast<StyleRuleContainer>(rule());
 }
 
 String CSSContainerRule::cssText() const

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -42,9 +42,10 @@ public:
     CSSRule* item(unsigned index) const;
 
 protected:
-    CSSGroupingRule(StyleRuleGroup&, CSSStyleSheet* parent);
-    const StyleRuleGroup& groupRule() const { return m_groupRule; }
-    StyleRuleGroup& groupRule() { return m_groupRule; }
+    CSSGroupingRule(StyleRuleBase&, CSSStyleSheet* parent);
+    const StyleRuleGroup& groupRule() const;
+    StyleRuleGroup& groupRule();
+    StyleRuleBase& rule() const { return m_groupRule; }
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
 
@@ -52,7 +53,7 @@ protected:
     void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;
 
 private:
-    Ref<StyleRuleGroup> m_groupRule;
+    Ref<StyleRuleBase> m_groupRule;
     mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;
     mutable std::unique_ptr<CSSRuleList> m_ruleListCSSOMWrapper;
 };

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -61,7 +61,7 @@ String CSSLayerBlockRule::cssText() const
 
 String CSSLayerBlockRule::name() const
 {
-    auto& layer = downcast<StyleRuleLayer>(groupRule());
+    auto& layer = downcast<StyleRuleLayer>(rule());
 
     if (layer.name().isEmpty())
         return emptyString();

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -44,12 +44,12 @@ CSSMediaRule::~CSSMediaRule()
 
 const MQ::MediaQueryList& CSSMediaRule::mediaQueries() const
 {
-    return downcast<StyleRuleMedia>(groupRule()).mediaQueries();
+    return downcast<StyleRuleMedia>(rule()).mediaQueries();
 }
 
 void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
 {
-    downcast<StyleRuleMedia>(groupRule()).setMediaQueries(WTFMove(queries));
+    downcast<StyleRuleMedia>(rule()).setMediaQueries(WTFMove(queries));
 }
 
 String CSSMediaRule::cssText() const

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -58,4 +58,17 @@ const CSSParserContext& CSSRule::parserContext() const
     return styleSheet ? styleSheet->contents().parserContext() : strictCSSParserContext();
 }
 
+
+bool CSSRule::hasStyleRuleAscendant() const
+{
+    auto current = this->parentRule();
+    while (current) {
+        if (current->styleRuleType() == StyleRuleType::Style)
+            return true;
+
+        current = current->parentRule();
+    }
+    return false;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -55,6 +55,7 @@ protected:
 
     bool hasCachedSelectorText() const { return m_hasCachedSelectorText; }
     void setHasCachedSelectorText(bool hasCachedSelectorText) const { m_hasCachedSelectorText = hasCachedSelectorText; }
+    bool hasStyleRuleAscendant() const;
 
     const CSSParserContext& parserContext() const;
 

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -193,4 +193,22 @@ bool CSSSelectorList::hasExplicitNestingParent() const
 
     return forEachSelector(functor, this);
 }
+
+bool CSSSelectorList::isNestingSelector() const
+{
+    if (componentCount() != 1)
+        return false;
+
+    auto singleSelector = first();
+
+    if (!singleSelector)
+        return false;
+    
+    // Selector should be a single selector
+    if (singleSelector->tagHistory())
+        return false;
+
+    return singleSelector->match() == CSSSelector::Match::PseudoClass && singleSelector->pseudoClassType() == CSSSelector::PseudoClassType::PseudoClassNestingParent;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -60,6 +60,7 @@ public:
     bool selectorsNeedNamespaceResolution();
     bool hasInvalidSelector() const;
     bool hasExplicitNestingParent() const;
+    bool isNestingSelector() const;
 
     String selectorsText() const;
     void buildSelectorsText(StringBuilder&) const;

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "CSSRule.h"
+#include "CSSGroupingRule.h"
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -34,9 +34,8 @@ class StyleRuleCSSStyleDeclaration;
 class StyleRule;
 class StyleRuleWithNesting;
 
-class CSSStyleRule final : public CSSRule, public CanMakeWeakPtr<CSSStyleRule> {
+class CSSStyleRule final : public CSSGroupingRule, public CanMakeWeakPtr<CSSStyleRule> {
 public:
-    static Ref<CSSStyleRule> create(StyleRule& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSStyleRule(rule, sheet)); }
     static Ref<CSSStyleRule> create(StyleRuleWithNesting& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSStyleRule(rule, sheet)); };
 
     virtual ~CSSStyleRule();
@@ -47,16 +46,11 @@ public:
     WEBCORE_EXPORT CSSStyleDeclaration& style();
 
     // FIXME: Not CSSOM. Remove.
-    StyleRule& styleRule() const { return m_styleRule.get(); }
-
-    CSSRuleList& cssRules() const;
-    unsigned length() const;
-    CSSRule* item(unsigned index) const;
+    StyleRule& styleRule() const;
 
     StylePropertyMap& styleMap();
 
 private:
-    CSSStyleRule(StyleRule&, CSSStyleSheet*);
     CSSStyleRule(StyleRuleWithNesting&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
@@ -64,14 +58,11 @@ private:
     void reattach(StyleRuleBase&) final;
 
     String generateSelectorText() const;
-    Vector<Ref<StyleRuleBase>> nestedRules() const;
+    Vector<RefPtr<StyleRuleBase>> nestedRules() const;
 
-    Ref<StyleRule> m_styleRule;
+    Ref<StyleRuleWithNesting> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;
     RefPtr<StyleRuleCSSStyleDeclaration> m_propertiesCSSOMWrapper;
-
-    mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;
-    mutable std::unique_ptr<CSSRuleList> m_ruleListCSSOMWrapper;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleRule.idl
+++ b/Source/WebCore/css/CSSStyleRule.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -18,6 +18,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+typedef USVString CSSOMString;
+
 [
     Exposed=Window
 ] interface CSSStyleRule : CSSRule {
@@ -26,4 +28,8 @@
 
     // https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects
     [SameObject, EnabledBySetting=CSSTypedOMEnabled] readonly attribute StylePropertyMap styleMap;
+
+    [EnabledBySetting=CSSNestingEnabled, SameObject] readonly attribute CSSRuleList cssRules;
+    [EnabledBySetting=CSSNestingEnabled] unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
+    [EnabledBySetting=CSSNestingEnabled] undefined deleteRule(unsigned long index);
 };

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -117,6 +117,7 @@ public:
 
     bool hadRulesMutation() const { return m_mutatedRules; }
     void clearHadRulesMutation() { m_mutatedRules = false; }
+    void transformStyleRuleToNesting();
 
     enum RuleMutationType { OtherMutation, RuleInsertion, KeyframesRuleMutation, RuleReplace };
     enum WhetherContentsWereClonedForMutation { ContentsWereNotClonedForMutation = 0, ContentsWereClonedForMutation };

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -58,7 +58,7 @@ String CSSSupportsRule::cssText() const
 
 String CSSSupportsRule::conditionText() const
 {
-    return downcast<StyleRuleSupports>(groupRule()).conditionText();
+    return downcast<StyleRuleSupports>(rule()).conditionText();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -71,13 +71,12 @@ public:
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }
     bool isContainerRule() const { return type() == StyleRuleType::Container; }
     bool isPropertyRule() const { return type() == StyleRuleType::Property; }
-    bool isGroupRule() const { return isMediaRule() || isSupportsRule() || type() == StyleRuleType::LayerBlock || isContainerRule(); }
+    bool isGroupRule() const { return isMediaRule() || isSupportsRule() || type() == StyleRuleType::LayerBlock || isContainerRule() || isStyleRuleWithNesting(); }
 
     Ref<StyleRuleBase> copy() const;
 
     Ref<CSSRule> createCSSOMWrapper(CSSStyleSheet& parentSheet) const;
     Ref<CSSRule> createCSSOMWrapper(CSSGroupingRule& parentRule) const;
-    Ref<CSSRule> createCSSOMWrapper(CSSStyleRule& parentRule) const;
 
     // This is only needed to support getMatchedCSSRules.
     Ref<CSSRule> createCSSOMWrapper() const;
@@ -174,18 +173,22 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 class StyleRuleWithNesting final : public StyleRule {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 public:
-    static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<RefPtr<StyleRuleBase>>&&);
+    static Ref<StyleRuleWithNesting> create(StyleRule&&);
     Ref<StyleRuleWithNesting> copy() const;
 
-    const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
+    StyleRuleGroup& ruleGroup() { return m_ruleGroup; }
+    const Vector<RefPtr<StyleRuleBase>>& childRules() const { return m_ruleGroup.childRules(); }
     const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
+    void wrapperAdoptSelectorList(CSSSelectorList&&);
     StyleRuleWithNesting(const StyleRuleWithNesting&);
     ~StyleRuleWithNesting();
 
 private:
-    StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<RefPtr<StyleRuleBase>>&&);
+    StyleRuleWithNesting(StyleRule&&);
 
-    Vector<Ref<StyleRuleBase>> m_nestedRules;
+    StyleRuleGroup m_ruleGroup;
     CSSSelectorList m_originalSelectorList;
 };
 

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -474,7 +474,7 @@ static bool traverseRulesInVector(const Vector<RefPtr<StyleRuleBase>>& rules, co
             return true;
         if (!rule->isGroupRule())
             continue;
-        if (traverseRulesInVector(downcast<StyleRuleGroup>(*rule).childRules(), handler))
+        if (traverseRulesInVector(StyleRuleGroup::fromStyleRuleBase(*rule)->childRules(), handler))
             return true;
     }
     return false;

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -90,6 +90,7 @@ public:
     bool traverseRules(const Function<bool(const StyleRuleBase&)>& handler) const;
     bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
 
+    void transformStyleRuleToNesting() ;
     void setIsUserStyleSheet(bool b) { m_isUserStyleSheet = b; }
     bool isUserStyleSheet() const { return m_isUserStyleSheet; }
     void setHasSyntacticallyValidCSSHeader(bool b) { m_hasSyntacticallyValidCSSHeader = b; }

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -71,9 +71,9 @@ void CSSParser::parseSheetForInspector(const CSSParserContext& context, StyleShe
     return CSSParserImpl::parseStyleSheetForInspector(string, context, sheet, observer);
 }
 
-RefPtr<StyleRuleBase> CSSParser::parseRule(const CSSParserContext& context, StyleSheetContents* sheet, const String& string)
+RefPtr<StyleRuleBase> CSSParser::parseRule(const CSSParserContext& context, StyleSheetContents* sheet, const String& string, CSSParserEnum::IsNestedContext isNestedContext)
 {
-    return CSSParserImpl::parseRule(string, context, sheet, CSSParserImpl::AllowImportRules);
+    return CSSParserImpl::parseRule(string, context, sheet, CSSParserImpl::AllowImportRules, isNestedContext);
 }
 
 RefPtr<StyleRuleKeyframe> CSSParser::parseKeyframeRule(const String& string)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -55,7 +55,7 @@ public:
 
     void parseSheet(StyleSheetContents&, const String&);
     
-    static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&);
+    static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
     
     RefPtr<StyleRuleKeyframe> parseKeyframeRule(const String&);
     static Vector<double> parseKeyframeKeyList(const String&);

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -94,7 +94,7 @@ public:
     static CSSParser::ParseResult parseCustomPropertyValue(MutableStyleProperties*, const AtomString& propertyName, const String&, bool important, const CSSParserContext&);
     static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element*);
     static bool parseDeclarationList(MutableStyleProperties*, const String&, const CSSParserContext&);
-    static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRulesType);
+    static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRulesType, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
     static void parseStyleSheet(const String&, const CSSParserContext&, StyleSheetContents&);
     static CSSSelectorList parsePageSelector(CSSParserTokenRange, StyleSheetContents*);
 
@@ -181,10 +181,11 @@ private:
     }
     bool isNestedContext()
     {
-        return m_styleRuleNestingDepth && context().cssNestingEnabled;
+        return (m_isNestedContext || m_styleRuleNestingDepth) && context().cssNestingEnabled;
     }
 
     unsigned m_styleRuleNestingDepth { 0 };
+    bool m_isNestedContext { false };
     Vector<NestingContext> m_nestingContextStack { NestingContext { } };
     const CSSParserContext& m_context;
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -45,7 +45,6 @@ class StyleRule;
 
 struct CSSParserContext;
 
-
 class CSSSelectorParser {
 public:
     CSSSelectorParser(const CSSParserContext&, StyleSheetContents*, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -40,7 +40,6 @@
 #include "CSSPropertySourceData.h"
 #include "CSSRule.h"
 #include "CSSRuleList.h"
-#include "CSSSelectorParser.h"
 #include "CSSStyleRule.h"
 #include "CSSStyleSheet.h"
 #include "CSSSupportsRule.h"
@@ -1052,6 +1051,7 @@ void InspectorStyleSheet::reparseStyleSheet(const String& text)
     {
         CSSStyleSheet::RuleMutationScope mutationScope(m_pageStyleSheet.get());
         m_pageStyleSheet->contents().parseString(text);
+        m_pageStyleSheet->contents().transformStyleRuleToNesting();
         m_pageStyleSheet->clearChildRuleCSSOMWrappers();
         fireStyleSheetChanged();
     }

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -247,8 +247,8 @@ void RuleSetBuilder::addStyleRule(StyleRuleWithNesting& rule)
     
     // Process nested rules
     m_styleRuleStack.append(&selectorList);
-    for (auto& nestedRule : rule.nestedRules())
-        addChildRule(nestedRule.ptr());
+    for (auto& nestedRule : rule.childRules())
+        addChildRule(nestedRule);
     m_styleRuleStack.removeLast();
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -124,7 +124,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
     case StyleRuleType::Media: {
         auto& mediaRule = downcast<StyleRuleMedia>(*rule);
         if (m_mediaQueryCollector.pushAndEvaluate(mediaRule.mediaQueries()))
-            addChildRules(mediaRule.childRules());
+            addChildRules(mediaRule.ruleGroup().childRules());
         m_mediaQueryCollector.pop(mediaRule.mediaQueries());
         return;
     }
@@ -136,7 +136,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
             m_ruleSet->m_containerQueries.append({ containerRule, previousContainerQueryIdentifier });
             m_currentContainerQueryIdentifier = m_ruleSet->m_containerQueries.size();
         }
-        addChildRules(containerRule.childRules());
+        addChildRules(containerRule.ruleGroup().childRules());
         if (m_ruleSet)
             m_currentContainerQueryIdentifier = previousContainerQueryIdentifier;
         return;
@@ -154,7 +154,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
         }
         // Block syntax.
         pushCascadeLayer(layerRule.name());
-        addChildRules(layerRule.childRules());
+        addChildRules(layerRule.ruleGroup().childRules());
         popCascadeLayer(layerRule.name());
         return;
     }
@@ -171,7 +171,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
 
     case StyleRuleType::Supports:
         if (downcast<StyleRuleSupports>(*rule).conditionIsSupported())
-            addChildRules(downcast<StyleRuleSupports>(*rule).childRules());
+            addChildRules(downcast<StyleRuleSupports>(*rule).ruleGroup().childRules());
         return;
 
     case StyleRuleType::Import:

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -50,7 +50,7 @@ static bool shouldDirtyAllStyle(const Vector<RefPtr<StyleRuleBase>>& rules)
 {
     for (auto& rule : rules) {
         if (is<StyleRuleMedia>(*rule)) {
-            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(*rule).childRules()))
+            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(*rule).ruleGroup().childRules()))
                 return true;
             continue;
         }


### PR DESCRIPTION
#### 674ff8500b9cc3ad12d52ca88f5e64f9c28ceba0
<pre>
CSS Nesting: implement CSSOM (insertRule, deleteRule, cssRules)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251374">https://bugs.webkit.org/show_bug.cgi?id=251374</a>
rdar://103844456

Reviewed by NOBODY (OOPS!).

StyleRule now inherits from GroupingRule (like @media, @supports...)
It allows us to share all of the CSSOM code between the various CSS rules
which support grouping.

The StyleRule IDL file exposes the insertRule/deleteRule/cssRules methods
directly (and not through inheritance from GroupingRule IDL) to allow for
activation/desactivation by the CSSNesting feature flag.

The serialization via cssText() is still not exactly the one expected by WPT,
as it&apos;s currently still un-speced.

Some of the WPT changes are import, the rest will be exported.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::insertRule):
(WebCore::CSSGroupingRule::deleteRule):
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
* Source/WebCore/css/CSSRule.cpp:
(WebCore::CSSRule::hasStyleRuleAscendant const):
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::isNestingSelector const):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::CSSStyleRule):
(WebCore::CSSStyleRule::setSelectorText):
(WebCore::CSSStyleRule::cssText const):
(WebCore::CSSStyleRule::length const): Deleted.
(WebCore::CSSStyleRule::item const): Deleted.
(WebCore::CSSStyleRule::cssRules const): Deleted.
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleRule.idl:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::averageSizeInBytes):
(WebCore::StyleRule::StyleRule):
(WebCore::StyleRule::create):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::StyleRuleBase):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseRule):
(WebCore::CSSParser::parseSelector):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseRule):
(WebCore::CSSParserImpl::createNestingParentRule):
(WebCore::CSSParserImpl::consumeStyleRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::isNestedContext):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::parseCSSSelector):
(WebCore::CSSSelectorParser::CSSSelectorParser):
(WebCore::CSSSelectorParser::consumeNestedSelectorList):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::isValidRuleHeaderText):
(WebCore::isNestedContext):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3650a9c20560e608f4eddef9173771a36514ec6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/777 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/918 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/804 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/732 "6 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/762 "2 flakes 143 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/707 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/755 "1 flakes 8 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/740 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/721 "3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/740 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/750 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->