### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for SearchFieldResultsButton and SearchFieldResultsDecoration

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1782,6 +1782,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ProgressBarPart.h
     platform/graphics/controls/SearchFieldCancelButtonPart.h
     platform/graphics/controls/SearchFieldPart.h
+    platform/graphics/controls/SearchFieldResultsPart.h
     platform/graphics/controls/SliderThumbPart.h
     platform/graphics/controls/SliderTrackPart.h
     platform/graphics/controls/TextAreaPart.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -484,6 +484,7 @@ platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SearchControlMac.mm
 platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
 platform/graphics/mac/controls/SearchFieldMac.mm
+platform/graphics/mac/controls/SearchFieldResultsMac.mm
 platform/graphics/mac/controls/SliderThumbMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -39,6 +39,7 @@ class PlatformControl;
 class ProgressBarPart;
 class SearchFieldCancelButtonPart;
 class SearchFieldPart;
+class SearchFieldResultsPart;
 class SliderThumbPart;
 class SliderTrackPart;
 class TextAreaPart;
@@ -70,6 +71,7 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/SearchFieldResultsPart.h
+++ b/Source/WebCore/platform/graphics/controls/SearchFieldResultsPart.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SearchFieldResultsPart final : public ControlPart {
+public:
+    static Ref<SearchFieldResultsPart> create(StyleAppearance type)
+    {
+        return adoptRef(*new SearchFieldResultsPart(type));
+    }
+
+private:
+    SearchFieldResultsPart(StyleAppearance type)
+        : ControlPart(type)
+    {
+        ASSERT(type == StyleAppearance::SearchFieldResultsButton || type == StyleAppearance::SearchFieldResultsDecoration);
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSearchFieldResults(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -61,6 +61,7 @@ private:
     std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSearchField(SearchFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
@@ -74,6 +75,7 @@ private:
     NSLevelIndicatorCell *levelIndicatorCell() const;
     NSPopUpButtonCell *popUpButtonCell() const;
     NSSearchFieldCell *searchFieldCell() const;
+    NSMenu *searchMenuTemplate() const;
     NSSliderCell *sliderCell() const;
     NSTextFieldCell *textFieldCell() const;
 
@@ -89,6 +91,7 @@ private:
     mutable RetainPtr<NSServicesRolloverButtonCell> m_servicesRolloverButtonCell;
 #endif
     mutable RetainPtr<NSSearchFieldCell> m_searchFieldCell;
+    mutable RetainPtr<NSMenu> m_searchMenuTemplate;
     mutable RetainPtr<NSSliderCell> m_sliderCell;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -38,6 +38,8 @@
 #import "ProgressBarMac.h"
 #import "SearchFieldCancelButtonMac.h"
 #import "SearchFieldMac.h"
+#import "SearchFieldResultsMac.h"
+#import "SearchFieldResultsPart.h"
 #import "SliderThumbMac.h"
 #import "SliderTrackMac.h"
 #import "TextAreaMac.h"
@@ -189,6 +191,13 @@ NSSearchFieldCell *ControlFactoryMac::searchFieldCell() const
     return m_searchFieldCell.get();
 }
 
+NSMenu *ControlFactoryMac::searchMenuTemplate() const
+{
+    if (!m_searchMenuTemplate)
+        m_searchMenuTemplate = adoptNS([[NSMenu alloc] initWithTitle:@""]);
+    return m_searchMenuTemplate.get();
+}
+
 NSSliderCell *ControlFactoryMac::sliderCell() const
 {
     if (!m_sliderCell) {
@@ -269,6 +278,11 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchField(Se
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchFieldCancelButton(SearchFieldCancelButtonPart& part)
 {
     return makeUnique<SearchFieldCancelButtonMac>(part, *this, searchFieldCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSearchFieldResults(SearchFieldResultsPart& part)
+{
+    return makeUnique<SearchFieldResultsMac>(part, *this, searchFieldCell(), part.type() == StyleAppearance::SearchFieldResultsButton ? searchMenuTemplate() : nullptr);
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderThumb(SliderThumbPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "SearchControlMac.h"
+
+namespace WebCore {
+
+class SearchFieldResultsPart;
+
+class SearchFieldResultsMac final : public SearchControlMac {
+public:
+    SearchFieldResultsMac(SearchFieldResultsPart& owningPart, ControlFactoryMac&, NSSearchFieldCell *, NSMenu *searchMenuTemplate);
+
+private:
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
+
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
+
+    RetainPtr<NSMenu> m_searchMenuTemplate;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SearchFieldResultsMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "SearchFieldResultsPart.h"
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+SearchFieldResultsMac::SearchFieldResultsMac(SearchFieldResultsPart& owningPart, ControlFactoryMac& controlFactory, NSSearchFieldCell *searchFieldCell, NSMenu *searchMenuTemplate)
+    : SearchControlMac(owningPart, controlFactory, searchFieldCell)
+    , m_searchMenuTemplate(searchMenuTemplate)
+{
+    ASSERT(owningPart.type() == StyleAppearance::SearchFieldResultsButton || owningPart.type() == StyleAppearance::SearchFieldResultsDecoration);
+    ASSERT(searchFieldCell);
+    ASSERT((owningPart.type() == StyleAppearance::SearchFieldResultsButton) == (searchMenuTemplate != nullptr));
+}
+
+void SearchFieldResultsMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    SearchControlMac::updateCellStates(rect, style);
+
+    if ([m_searchFieldCell searchMenuTemplate] != m_searchMenuTemplate)
+        [m_searchFieldCell setSearchMenuTemplate:m_searchMenuTemplate.get()];
+}
+
+void SearchFieldResultsMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    LocalCurrentGraphicsContext localContext(context);
+    
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto logicalRect = borderRect.rect();
+
+    if (style.zoomFactor != 1) {
+        logicalRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    auto *view = m_controlFactory.drawingView(borderRect.rect(), style);
+
+    drawCell(context, logicalRect, deviceScaleFactor, style, [m_searchFieldCell searchButtonCell], view, true);
+
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -39,7 +39,6 @@ public:
     WEBCORE_EXPORT static void setUseFormSemanticContext(bool);
     static bool useFormSemanticContext();
     static void setFocusRingClipRect(const FloatRect&);
-    static bool drawCellOrFocusRingWithViewIntoContext(NSCell *, GraphicsContext&, const FloatRect&, NSView *, bool drawButtonCell, bool drawFocusRing, float deviceScaleFactor);
 
 private:
     friend NeverDestroyed<ThemeMac>;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -61,6 +61,7 @@
 #include "RenderView.h"
 #include "SearchFieldCancelButtonPart.h"
 #include "SearchFieldPart.h"
+#include "SearchFieldResultsPart.h"
 #include "ShadowPseudoIds.h"
 #include "SliderThumbElement.h"
 #include "SliderThumbPart.h"
@@ -649,9 +650,11 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 #endif
 
     case StyleAppearance::SearchFieldDecoration:
+        break;
+
     case StyleAppearance::SearchFieldResultsDecoration:
     case StyleAppearance::SearchFieldResultsButton:
-        break;
+        return SearchFieldResultsPart::create(appearance);
 
     case StyleAppearance::SearchFieldCancelButton:
         return SearchFieldCancelButtonPart::create();

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -123,13 +123,10 @@ private:
     void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const final;
 
     void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) final;
 
     void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const IntRect&) final;
 
     void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const final;
-    bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) final;
 
 #if ENABLE(DATALIST_ELEMENT)
     void adjustListButtonStyle(RenderStyle&, const Element*) const final;
@@ -166,7 +163,6 @@ private:
 
     // Helpers for adjusting appearance and for painting
 
-    void paintCellAndSetFocusedElementNeedsRepaintIfNecessary(NSCell*, const RenderObject&, const PaintInfo&, const FloatRect&);
     void setPopupButtonCellState(const RenderObject&, const IntSize&);
     const IntSize* popupButtonSizes() const;
     const int* popupButtonMargins() const;
@@ -176,12 +172,9 @@ private:
     const IntSize* searchFieldSizes() const;
     const IntSize* cancelButtonSizes() const;
     const IntSize* resultsButtonSizes() const;
-    void setSearchCellState(const RenderObject&, const IntRect&);
     void setSearchFieldSize(RenderStyle&) const;
 
     NSPopUpButtonCell *popupButton() const;
-    NSSearchFieldCell *search() const;
-    NSMenu *searchMenuTemplate() const;
 
 #if ENABLE(SERVICE_CONTROLS)
     IntSize imageControlsButtonSize() const final;
@@ -189,8 +182,6 @@ private:
 #endif
 
     mutable RetainPtr<NSPopUpButtonCell> m_popupButton;
-    mutable RetainPtr<NSSearchFieldCell> m_search;
-    mutable RetainPtr<NSMenu> m_searchMenuTemplate;
 
     bool m_isSliderThumbHorizontalPressed { false };
     bool m_isSliderThumbVerticalPressed { false };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -104,6 +104,7 @@
 #include <WebCore/ScrollingCoordinator.h>
 #include <WebCore/SearchFieldCancelButtonPart.h>
 #include <WebCore/SearchFieldPart.h>
+#include <WebCore/SearchFieldResultsPart.h>
 #include <WebCore/SearchPopupMenu.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SerializedAttachmentData.h>
@@ -1608,9 +1609,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
 #endif
 
     case WebCore::StyleAppearance::SearchFieldDecoration:
+        break;
+
     case WebCore::StyleAppearance::SearchFieldResultsDecoration:
     case WebCore::StyleAppearance::SearchFieldResultsButton:
-        break;
+        return WebCore::SearchFieldResultsPart::create(*type);
 
     case WebCore::StyleAppearance::SearchFieldCancelButton:
         return WebCore::SearchFieldCancelButtonPart::create();


### PR DESCRIPTION
#### bb20f68f21269357d577a49f976ab8ed8dd7c99c
<pre>
[GPU Process] [FormControls] Add a ControlPart for SearchFieldResultsButton and SearchFieldResultsDecoration
<a href="https://bugs.webkit.org/show_bug.cgi?id=251373">https://bugs.webkit.org/show_bug.cgi?id=251373</a>
rdar://104825004

Reviewed by Aditya Keerthi.

This ControlPart will handle drawing the SearchField results button and the
SearchField results decoration which will be created for the following markup:

&apos;&lt;input type=&quot;search&quot; results=&quot;0&quot;&gt;&apos;
&apos;&lt;input type=&quot;search&quot; results=&quot;num&quot;&gt;&apos; where num &gt; 0 respectivly.

The existing position calculations are not needed and seem to be incorrect.

For macOS, AppKit will be used to draw the platform controls.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/SearchFieldResultsPart.h: Added.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::searchMenuTemplate const):
(WebCore::ControlFactoryMac::createPlatformSearchFieldResults):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.h: Added.
* Source/WebCore/platform/graphics/mac/controls/SearchFieldResultsMac.mm: Added.
(WebCore::SearchFieldResultsMac::SearchFieldResultsMac):
(WebCore::SearchFieldResultsMac::updateCellStates):
(WebCore::SearchFieldResultsMac::draw):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::drawCellFocusRingWithFrameAtTime): Deleted.
(WebCore::drawCellFocusRing): Deleted.
(WebCore::drawCellOrFocusRingIntoRectWithView): Deleted.
(WebCore::ThemeMac::drawCellOrFocusRingWithViewIntoContext): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::convertToPaintingPosition): Deleted.
(WebCore::RenderThemeMac::paintCellAndSetFocusedElementNeedsRepaintIfNecessary): Deleted.
(WebCore::RenderThemeMac::setSearchCellState): Deleted.
(WebCore::RenderThemeMac::paintSearchFieldDecorationPart): Deleted.
(WebCore::RenderThemeMac::paintSearchFieldResultsDecorationPart): Deleted.
(WebCore::RenderThemeMac::paintSearchFieldResultsButton): Deleted.
(WebCore::RenderThemeMac::search const): Deleted.
(WebCore::RenderThemeMac::searchMenuTemplate const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/259779@main">https://commits.webkit.org/259779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa3f11ffe09419d206c1b440849fc76e2931c749

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115099 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16391 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98133 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111655 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95449 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27093 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8237 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8719 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47987 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6767 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10273 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->