### PR TITLE
Fix a rare crash under data detector highlight painting logic

### DIFF
--- a/Source/WebCore/platform/mac/DataDetectorHighlight.mm
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.mm
@@ -117,6 +117,9 @@ void DataDetectorHighlight::paintContents(const GraphicsLayer*, GraphicsContext&
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return;
 
+    if (!highlight())
+        return;
+
     CGRect highlightBoundingRect = PAL::softLink_DataDetectors_DDHighlightGetBoundingRect(highlight());
     highlightBoundingRect.origin = CGPointZero;
 


### PR DESCRIPTION
#### 312ff43f570cd2057a1508cad8c8b6be6bee8b3a
<pre>
Fix a rare crash under data detector highlight painting logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=251384">https://bugs.webkit.org/show_bug.cgi?id=251384</a>
rdar://104723803

Reviewed by Megan Gardner.

Add a null check for the `DDHighlightRef` before attempting to ask for `DDHighlightGetBoundingRect`.
It&apos;s not clear how to trigger this crash, so this patch only makes this painting codepath robust
against `m_highlight` being `nil`.

* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::paintContents):

Canonical link: <a href="https://commits.webkit.org/259599@main">https://commits.webkit.org/259599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31a6744c2b7eb4ac1bf63ef57aacf6f30dfff7f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114595 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5343 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97647 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95039 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26673 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28033 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6619 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9635 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->