### PR TITLE
Use named constructors to construct String, StringView from Span objects

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -139,7 +139,7 @@ static String canonicalizeTimeZoneName(const String& timeZoneName)
         Vector<UChar, 32> buffer;
         auto status = callBufferProducingFunction(ucal_getCanonicalTimeZoneID, ianaTimeZone, ianaTimeZoneLength, buffer, nullptr);
         ASSERT_UNUSED(status, U_SUCCESS(status));
-        canonical = String(buffer);
+        canonical = String::fromSpan(buffer);
     } while (canonical.isNull());
     uenum_close(timeZones);
 
@@ -1290,7 +1290,7 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) c
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
 
-    return jsString(vm, String(WTFMove(result)));
+    return jsString(vm, String::fromSpan(result));
 }
 
 static ASCIILiteral partTypeString(UDateFormatField field)
@@ -1449,7 +1449,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
         }
     }
 
-    dataLogLnIf(IntlDateTimeFormatInternal::verbose, "interval format pattern:(", String(pattern), "),skeleton:(", String(skeleton), ")");
+    dataLogLnIf(IntlDateTimeFormatInternal::verbose, "interval format pattern:(", StringView::fromSpan(pattern), "),skeleton:(", StringView::fromSpan(skeleton), ")");
 
     // While the pattern is including right HourCycle patterns, UDateIntervalFormat does not follow.
     // We need to enforce HourCycle by setting "hc" extension if it is specified.
@@ -1613,7 +1613,7 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
         return { };
     }
 
-    return jsString(vm, String(WTFMove(buffer)));
+    return jsString(vm, String::fromSpan(buffer));
 #endif
 }
 

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -339,7 +339,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
         buffer = vm.intlCache().getFieldDisplayName(m_localeCString.data(), field.value(), style, status);
         if (U_FAILURE(status))
             return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, WTFMove(code));
-        return jsString(vm, String(WTFMove(buffer)));
+        return jsString(vm, String::fromSpan(buffer));
     }
     }
     if (U_FAILURE(status)) {
@@ -349,7 +349,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
             return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, String(canonicalCode.data(), canonicalCode.length()));
         return throwTypeError(globalObject, scope, "Failed to query a display name."_s);
     }
-    return jsString(vm, String(WTFMove(buffer)));
+    return jsString(vm, String::fromSpan(buffer));
 }
 
 // https://tc39.es/proposal-intl-displaynames/#sec-Intl.DisplayNames.prototype.resolvedOptions

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -397,7 +397,7 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                     return { };
                 }
 
-                return String(WTFMove(buffer));
+                return String::fromSpan(buffer);
             };
 
             auto formatDouble = [&](const String& skeleton) -> std::unique_ptr<UFormattedNumber, ICUDeleter<unumf_closeResult>> {
@@ -535,7 +535,7 @@ JSValue IntlDurationFormat::format(JSGlobalObject* globalObject, ISO8601::Durati
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
 
-    return jsString(vm, String(WTFMove(result)));
+    return jsString(vm, String::fromSpan(result));
 #else
     UNUSED_PARAM(duration);
     return throwTypeError(globalObject, scope, "failed to format list of strings"_s);

--- a/Source/JavaScriptCore/runtime/IntlListFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.cpp
@@ -194,7 +194,7 @@ JSValue IntlListFormat::format(JSGlobalObject* globalObject, JSValue list) const
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
 
-    return jsString(vm, String(WTFMove(result)));
+    return jsString(vm, String::fromSpan(result));
 #else
     UNUSED_PARAM(list);
     return throwTypeError(globalObject, scope, "failed to format list of strings"_s);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -787,7 +787,7 @@ JSValue IntlNumberFormat::format(JSGlobalObject* globalObject, double value) con
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "Failed to format a number."_s);
 #endif
-    return jsString(vm, String(WTFMove(buffer)));
+    return jsString(vm, String::fromSpan(buffer));
 }
 
 // https://tc39.es/ecma402/#sec-formatnumber
@@ -818,7 +818,7 @@ JSValue IntlNumberFormat::format(JSGlobalObject* globalObject, IntlMathematicalV
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "Failed to format a BigInt."_s);
 #endif
-    return jsString(vm, String(WTFMove(buffer)));
+    return jsString(vm, String::fromSpan(buffer));
 }
 
 #if HAVE(ICU_U_NUMBER_RANGE_FORMATTER)
@@ -1553,7 +1553,7 @@ JSValue IntlNumberFormat::formatToParts(JSGlobalObject* globalObject, double val
     IntlFieldIterator iterator(*fieldItr.get());
 #endif
 
-    auto resultString = String(WTFMove(result));
+    auto resultString = String::fromSpan(result);
 
     JSArray* parts = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0);
     if (!parts)
@@ -1599,7 +1599,7 @@ JSValue IntlNumberFormat::formatToParts(JSGlobalObject* globalObject, IntlMathem
 
     IntlFieldIterator iterator(*fieldItr.get());
 
-    auto resultString = String(WTFMove(result));
+    auto resultString = String::fromSpan(result);
 
     JSArray* parts = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0);
     if (!parts)

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -260,7 +260,7 @@ JSValue IntlPluralRules::select(JSGlobalObject* globalObject, double value) cons
     status = callBufferProducingFunction(uplrules_selectFormatted, m_pluralRules.get(), formattedNumber.get(), buffer);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to select plural value"_s);
-    return jsString(vm, String(WTFMove(buffer)));
+    return jsString(vm, String::fromSpan(buffer));
 #else
     Vector<UChar, 8> result(8);
     auto length = uplrules_selectWithFormat(m_pluralRules.get(), value, m_numberFormat.get(), result.data(), result.size(), &status);
@@ -295,7 +295,7 @@ JSValue IntlPluralRules::selectRange(JSGlobalObject* globalObject, double start,
     status = callBufferProducingFunction(uplrules_selectForRange, m_pluralRules.get(), range.get(), buffer);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to select plural value"_s);
-    return jsString(vm, String(WTFMove(buffer)));
+    return jsString(vm, String::fromSpan(buffer));
 }
 #endif
 

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -258,7 +258,7 @@ String IntlRelativeTimeFormat::formatInternal(JSGlobalObject* globalObject, doub
         return String();
     }
 
-    return String(result);
+    return String::fromSpan(result);
 }
 
 // https://tc39.es/ecma402/#sec-FormatRelativeTime
@@ -293,7 +293,7 @@ JSValue IntlRelativeTimeFormat::formatToParts(JSGlobalObject* globalObject, doub
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format relative time"_s);
 
-    auto formattedNumber = String(buffer);
+    auto formattedNumber = String::fromSpan(buffer);
 
     JSArray* parts = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0);
     if (!parts)

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -463,7 +463,7 @@ void DateCache::timeZoneCacheSlow()
         Vector<UChar, 32> canonicalBuffer;
         auto status = callBufferProducingFunction(ucal_getCanonicalTimeZoneID, timeZoneID.data(), timeZoneID.size(), canonicalBuffer, nullptr);
         if (U_SUCCESS(status))
-            canonical = String(canonicalBuffer);
+            canonical = String::fromSpan(canonicalBuffer);
     }
     if (canonical.isNull() || isUTCEquivalent(canonical))
         canonical = "UTC"_s;

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1430,7 +1430,7 @@ static EncodedJSValue toLocaleCase(JSGlobalObject* globalObject, CallFrame* call
         return throwVMTypeError(globalObject, scope, String::fromLatin1(u_errorName(status)));
 
     // 18. Return L.
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, String { WTFMove(buffer) })));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, String::fromSpan(buffer))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToLocaleLowerCase, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -60,18 +60,24 @@ public:
     StringView& operator=(const StringView&);
 #endif
 
+    // Construct a string view with UTF-16 data.
+    StringView(const UChar*, unsigned length);
+    ALWAYS_INLINE static StringView fromSpan(Span<const UChar> span) { return StringView { span.data(), static_cast<unsigned>(span.size()) }; }
+
+    // Construct a string view with Latin-1 data.
+    StringView(const LChar*, unsigned length);
+    StringView(const char*, unsigned length);
+    ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
+    ALWAYS_INLINE static StringView fromLatin1Span(Span<const LChar> span) { return StringView { span.data(), static_cast<unsigned>(span.size()) }; }
+
+    // Construct a string view referencing an existing StringImpl.
     StringView(const AtomString&);
     StringView(const String&);
     StringView(const StringImpl&);
     StringView(const StringImpl*);
-    StringView(const LChar*, unsigned length);
-    StringView(const UChar*, unsigned length);
-    StringView(const char*, unsigned length);
-    StringView(ASCIILiteral);
-    ALWAYS_INLINE StringView(Span<const LChar> characters) : StringView(characters.data(), characters.size()) { }
-    ALWAYS_INLINE StringView(Span<const UChar> characters) : StringView(characters.data(), characters.size()) { }
 
-    ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
+    // Construct a string view from a constant string literal.
+    StringView(ASCIILiteral);
 
     static StringView empty();
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -58,13 +58,13 @@ public:
 
     // Construct a string with UTF-16 data.
     WTF_EXPORT_PRIVATE String(const UChar* characters, unsigned length);
-    ALWAYS_INLINE String(Span<const UChar> characters) : String(characters.data(), characters.size()) { }
+    ALWAYS_INLINE static String fromSpan(Span<const UChar> span) { return String { span.data(), static_cast<unsigned>(span.size()) }; }
 
     // Construct a string with Latin-1 data.
     WTF_EXPORT_PRIVATE String(const LChar* characters, unsigned length);
     WTF_EXPORT_PRIVATE String(const char* characters, unsigned length);
-    ALWAYS_INLINE String(Span<const LChar> characters) : String(characters.data(), characters.size()) { }
     ALWAYS_INLINE static String fromLatin1(const char* characters) { return String { characters }; }
+    ALWAYS_INLINE static String fromLatin1Span(Span<const LChar> span) { return String { span.data(), static_cast<unsigned>(span.size()) }; }
 
     // Construct a string referencing an existing StringImpl.
     String(StringImpl&);

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp
@@ -100,7 +100,7 @@ String ThreadableWebSocketChannelClientWrapper::subprotocol() const
 {
     if (m_subprotocol.isEmpty())
         return emptyString();
-    return String(m_subprotocol);
+    return String::fromSpan(m_subprotocol);
 }
 
 void ThreadableWebSocketChannelClientWrapper::setSubprotocol(const String& subprotocol)
@@ -114,7 +114,7 @@ String ThreadableWebSocketChannelClientWrapper::extensions() const
 {
     if (m_extensions.isEmpty())
         return emptyString();
-    return String(m_extensions);
+    return String::fromSpan(m_extensions);
 }
 
 void ThreadableWebSocketChannelClientWrapper::setExtensions(const String& extensions)

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -141,7 +141,7 @@ bool HTMLConstructionSite::isFormattingTag(TagName tagName)
 class HTMLTreeBuilder::ExternalCharacterTokenBuffer {
 public:
     explicit ExternalCharacterTokenBuffer(AtomHTMLToken& token)
-        : m_text(token.characters())
+        : m_text(StringView::fromSpan(token.characters()))
         , m_isAll8BitData(token.charactersIsAll8BitData())
     {
         ASSERT(!isEmpty());
@@ -3003,7 +3003,7 @@ void HTMLTreeBuilder::processTokenInForeignContent(AtomHTMLToken&& token)
         m_tree.insertComment(WTFMove(token));
         return;
     case HTMLToken::Type::Character: {
-        String characters = token.characters();
+        auto characters = String::fromSpan(token.characters());
         m_tree.insertTextNode(characters);
         if (m_framesetOk && !isAllWhitespaceOrReplacementCharacters(characters))
             m_framesetOk = false;


### PR DESCRIPTION
#### 1a8542ef43120d556721c573faff4085ea0446f3
<pre>
Use named constructors to construct String, StringView from Span objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=251385">https://bugs.webkit.org/show_bug.cgi?id=251385</a>

Reviewed by NOBODY (OOPS!).

Turn conversion constructors on String and StringView classes accepting Span
objects into named constructor equivalents. This avoids unintentional use of
constructors through implicit construction of Span objects from e.g. containers
like Vectors, C arrays or string literals.

For latin-1 data spans, fromLatin1Span() is provided. For UTF-16 data spans, the
generic fromSpan() is provided. StringView constructors are regrouped and
reordered to mirror grouping and ordering of String constructors.

* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::canonicalizeTimeZoneName):
(JSC::IntlDateTimeFormat::format const):
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
(JSC::IntlDateTimeFormat::formatRange):
* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):
(JSC::IntlDurationFormat::format const):
* Source/JavaScriptCore/runtime/IntlListFormat.cpp:
(JSC::IntlListFormat::format const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::format const):
(JSC::IntlNumberFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::select const):
(JSC::IntlPluralRules::selectRange const):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::formatInternal const):
(JSC::IntlRelativeTimeFormat::formatToParts const):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::timeZoneCacheSlow):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::toLocaleCase):
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp:
(WebCore::ThreadableWebSocketChannelClientWrapper::subprotocol const):
(WebCore::ThreadableWebSocketChannelClientWrapper::extensions const):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::ExternalCharacterTokenBuffer):
(WebCore::HTMLTreeBuilder::processTokenInForeignContent):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;String&gt;::decode):
(IPC::decodeStringText): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a8542ef43120d556721c573faff4085ea0446f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114880 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175024 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5942 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114693 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39762 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81478 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28254 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93551 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5794 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4840 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30411 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47802 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102264 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10060 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25499 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->