### PR TITLE
Continue porting WebCore/platform types to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1672,6 +1672,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageBuffer.h
     platform/graphics/ImageBufferAllocator.h
     platform/graphics/ImageBufferBackend.h
+    platform/graphics/ImageBufferBackendParameters.h
     platform/graphics/ImageDecoder.h
     platform/graphics/ImageDecoderIdentifier.h
     platform/graphics/ImageFrame.h

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h
@@ -56,7 +56,7 @@ struct RTCRtpParameters;
 struct RTCRtpSendParameters;
 struct RTCRtpTransceiverInit;
 
-enum class RTCPriorityType;
+enum class RTCPriorityType : uint8_t;
 enum class RTCRtpTransceiverDirection;
 
 RTCRtpParameters toRTCRtpParameters(const webrtc::RtpParameters&);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2894,7 +2894,11 @@ void Editor::markAndReplaceFor(const SpellCheckRequest& request, const Vector<Te
 
     for (unsigned i = 0; i < results.size(); i++) {
         auto spellingRangeEndOffset = paragraph.checkingEnd() + offsetDueToReplacement;
-        TextCheckingType resultType = results[i].type;
+        if (!results[i].type.hasExactlyOneBitSet()) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+        TextCheckingType resultType = *results[i].type.toSingleValue();
         auto resultLocation = results[i].range.location + offsetDueToReplacement;
         auto resultLength = results[i].range.length;
         auto resultEndLocation = resultLocation + resultLength;

--- a/Source/WebCore/platform/DragData.h
+++ b/Source/WebCore/platform/DragData.h
@@ -29,7 +29,6 @@
 #include "DragActions.h"
 #include "IntPoint.h"
 #include "PageIdentifier.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
@@ -147,17 +146,3 @@ private:
 };
     
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::DragApplicationFlags> {
-    using values = EnumValues<
-        WebCore::DragApplicationFlags,
-        WebCore::DragApplicationFlags::IsModal,
-        WebCore::DragApplicationFlags::IsSource,
-        WebCore::DragApplicationFlags::HasAttachedSheet,
-        WebCore::DragApplicationFlags::IsCopyKeyDown
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/ProcessIdentity.h
+++ b/Source/WebCore/platform/ProcessIdentity.h
@@ -28,6 +28,7 @@
 #include <optional>
 
 #if HAVE(TASK_IDENTITY_TOKEN)
+#include <wtf/ArgumentCoder.h>
 #include <wtf/MachSendRight.h>
 #else
 #include <variant>
@@ -55,37 +56,12 @@ public:
     task_id_token_t taskIdToken() const { return m_taskIdToken.sendRight(); }
 #endif
 
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<ProcessIdentity> decode(Decoder&);
-
 private:
 #if HAVE(TASK_IDENTITY_TOKEN)
+    friend struct IPC::ArgumentCoder<ProcessIdentity, void>;
     WEBCORE_EXPORT ProcessIdentity(MachSendRight&& taskIdToken);
     MachSendRight m_taskIdToken;
 #endif
 };
-
-template<typename Encoder> void ProcessIdentity::encode(Encoder& encoder) const
-{
-#if HAVE(TASK_IDENTITY_TOKEN)
-    encoder << m_taskIdToken;
-#else
-    UNUSED_PARAM(encoder);
-#endif
-}
-
-template<typename Decoder> std::optional<ProcessIdentity> ProcessIdentity::decode(Decoder& decoder)
-{
-#if HAVE(TASK_IDENTITY_TOKEN)
-    std::optional<MachSendRight> identitySendRight;
-    decoder >> identitySendRight;
-    if (identitySendRight)
-        return ProcessIdentity { WTFMove(*identitySendRight) };
-    return std::nullopt;
-#else
-    UNUSED_PARAM(decoder);
-    return ProcessIdentity { };
-#endif
-}
 
 }

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -58,6 +58,13 @@ struct ComputedPlaneLayout {
     size_t sourceWidthBytes { 0 };
 };
 
+enum class VideoFrameRotation : uint16_t {
+    None = 0,
+    UpsideDown = 180,
+    Right = 90,
+    Left = 270,
+};
+
 // A class representing a video frame from a decoder, capture source, or similar.
 class VideoFrame : public ThreadSafeRefCounted<VideoFrame> {
 public:
@@ -69,12 +76,7 @@ public:
     static RefPtr<VideoFrame> createBGRA(Span<const uint8_t>, size_t width, size_t height, const ComputedPlaneLayout&, PlatformVideoColorSpace&&);
     static RefPtr<VideoFrame> createI420(Span<const uint8_t>, size_t width, size_t height, const ComputedPlaneLayout&, const ComputedPlaneLayout&, const ComputedPlaneLayout&, PlatformVideoColorSpace&&);
 
-    enum class Rotation {
-        None = 0,
-        UpsideDown = 180,
-        Right = 90,
-        Left = 270,
-    };
+    using Rotation = VideoFrameRotation;
 
     MediaTime presentationTime() const { return m_presentationTime; }
     Rotation rotation() const { return m_rotation; }
@@ -116,20 +118,6 @@ private:
     const bool m_isMirrored;
     const Rotation m_rotation;
     const PlatformVideoColorSpace m_colorSpace;
-};
-
-}
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::VideoFrame::Rotation> {
-    using values = EnumValues<
-        WebCore::VideoFrame::Rotation,
-        WebCore::VideoFrame::Rotation::None,
-        WebCore::VideoFrame::Rotation::UpsideDown,
-        WebCore::VideoFrame::Rotation::Right,
-        WebCore::VideoFrame::Rotation::Left
-    >;
 };
 
 }

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -26,7 +26,6 @@
 
 #include "CSSValue.h"
 #include "ExceptionOr.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -299,40 +298,3 @@ SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::LinearTimingFunction, isLinearTim
 SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::CubicBezierTimingFunction, isCubicBezierTimingFunction())
 SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::StepsTimingFunction, isStepsTimingFunction())
 SPECIALIZE_TYPE_TRAITS_TIMINGFUNCTION(WebCore::SpringTimingFunction, isSpringTimingFunction())
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CubicBezierTimingFunction::TimingFunctionPreset> {
-    using values = EnumValues<
-        WebCore::CubicBezierTimingFunction::TimingFunctionPreset,
-        WebCore::CubicBezierTimingFunction::TimingFunctionPreset::Ease,
-        WebCore::CubicBezierTimingFunction::TimingFunctionPreset::EaseIn,
-        WebCore::CubicBezierTimingFunction::TimingFunctionPreset::EaseOut,
-        WebCore::CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut,
-        WebCore::CubicBezierTimingFunction::TimingFunctionPreset::Custom
-    >;
-};
-
-template<> struct EnumTraits<WebCore::StepsTimingFunction::StepPosition> {
-    using values = EnumValues<
-        WebCore::StepsTimingFunction::StepPosition,
-        WebCore::StepsTimingFunction::StepPosition::JumpStart,
-        WebCore::StepsTimingFunction::StepPosition::JumpEnd,
-        WebCore::StepsTimingFunction::StepPosition::JumpNone,
-        WebCore::StepsTimingFunction::StepPosition::JumpBoth,
-        WebCore::StepsTimingFunction::StepPosition::Start,
-        WebCore::StepsTimingFunction::StepPosition::End
-    >;
-};
-
-template<> struct EnumTraits<WebCore::TimingFunction::Type> {
-    using values = EnumValues<
-        WebCore::TimingFunction::Type,
-        WebCore::TimingFunction::Type::LinearFunction,
-        WebCore::TimingFunction::Type::CubicBezierFunction,
-        WebCore::TimingFunction::Type::StepsFunction,
-        WebCore::TimingFunction::Type::SpringFunction
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/audio/AudioIOCallback.h
+++ b/Source/WebCore/platform/audio/AudioIOCallback.h
@@ -40,28 +40,6 @@ struct AudioIOPosition {
     Seconds position;
     // System's monotonic time in seconds corresponding to the contained |position| value.
     MonotonicTime timestamp;
-
-    template<typename Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << position;
-        encoder << timestamp;
-    }
-
-    template<typename Decoder> static std::optional<AudioIOPosition> decode(Decoder& decoder)
-    {
-        std::optional<Seconds> position;
-        decoder >> position;
-        if (!position)
-            return std::nullopt;
-
-        std::optional<MonotonicTime> timestamp;
-        decoder >> timestamp;
-        if (!timestamp)
-            return std::nullopt;
-
-        return AudioIOPosition { *position, *timestamp };
-    }
 };
 
 // Abstract base-class for isochronous audio I/O client.

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -112,7 +112,7 @@ public:
     virtual void handleMutedStateChange() { }
 
     virtual void beginInterruption();
-    enum class MayResume { No, Yes };
+    enum class MayResume : bool { No, Yes };
     virtual void endInterruption(MayResume);
 
     virtual void beginInterruptionForTesting() { beginInterruption(); }
@@ -158,11 +158,13 @@ protected:
     static bool s_shouldManageAudioSessionCategory;
 };
 
+enum class AudioSessionRoutingArbitrationError : uint8_t { None, Failed, Cancelled };
+
 class WEBCORE_EXPORT AudioSessionRoutingArbitrationClient : public CanMakeWeakPtr<AudioSessionRoutingArbitrationClient> {
 public:
     virtual ~AudioSessionRoutingArbitrationClient() = default;
+    using RoutingArbitrationError = AudioSessionRoutingArbitrationError;
 
-    enum class RoutingArbitrationError : uint8_t { None, Failed, Cancelled };
     enum class DefaultRouteChanged : bool { No, Yes };
 
     using ArbitrationCallback = CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>;
@@ -181,53 +183,6 @@ WEBCORE_EXPORT String convertEnumerationToString(AudioSessionRoutingArbitrationC
 } // namespace WebCore
 
 namespace WTF {
-template<> struct EnumTraits<WebCore::RouteSharingPolicy> {
-    using values = EnumValues<
-    WebCore::RouteSharingPolicy,
-    WebCore::RouteSharingPolicy::Default,
-    WebCore::RouteSharingPolicy::LongFormAudio,
-    WebCore::RouteSharingPolicy::Independent,
-    WebCore::RouteSharingPolicy::LongFormVideo
-    >;
-};
-
-template <> struct EnumTraits<WebCore::AudioSession::CategoryType> {
-    using values = EnumValues <
-    WebCore::AudioSession::CategoryType,
-    WebCore::AudioSession::CategoryType::None,
-    WebCore::AudioSession::CategoryType::AmbientSound,
-    WebCore::AudioSession::CategoryType::SoloAmbientSound,
-    WebCore::AudioSession::CategoryType::MediaPlayback,
-    WebCore::AudioSession::CategoryType::RecordAudio,
-    WebCore::AudioSession::CategoryType::PlayAndRecord,
-    WebCore::AudioSession::CategoryType::AudioProcessing
-    >;
-};
-
-template <> struct EnumTraits<WebCore::AudioSession::MayResume> {
-    using values = EnumValues <
-    WebCore::AudioSession::MayResume,
-    WebCore::AudioSession::MayResume::No,
-    WebCore::AudioSession::MayResume::Yes
-    >;
-};
-
-template <> struct EnumTraits<WebCore::AudioSessionRoutingArbitrationClient::RoutingArbitrationError> {
-    using values = EnumValues <
-    WebCore::AudioSessionRoutingArbitrationClient::RoutingArbitrationError,
-    WebCore::AudioSessionRoutingArbitrationClient::RoutingArbitrationError::None,
-    WebCore::AudioSessionRoutingArbitrationClient::RoutingArbitrationError::Failed,
-    WebCore::AudioSessionRoutingArbitrationClient::RoutingArbitrationError::Cancelled
-    >;
-};
-
-template <> struct EnumTraits<WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged> {
-    using values = EnumValues <
-    WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged,
-    WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged::No,
-    WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged::Yes
-    >;
-};
 
 template<typename Type>
 struct LogArgument;

--- a/Source/WebCore/platform/encryptedmedia/CDMKeyStatus.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMKeyStatus.h
@@ -46,20 +46,4 @@ enum class CDMKeyStatus : uint8_t {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CDMKeyStatus> {
-    using values = EnumValues<
-    WebCore::CDMKeyStatus,
-    WebCore::CDMKeyStatus::Usable,
-    WebCore::CDMKeyStatus::Expired,
-    WebCore::CDMKeyStatus::Released,
-    WebCore::CDMKeyStatus::OutputRestricted,
-    WebCore::CDMKeyStatus::OutputDownscaled,
-    WebCore::CDMKeyStatus::StatusPending,
-    WebCore::CDMKeyStatus::InternalError
-    >;
-};
-
-}
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/encryptedmedia/CDMMessageType.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMMessageType.h
@@ -43,18 +43,4 @@ enum class CDMMessageType : uint8_t {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CDMMessageType> {
-    using values = EnumValues<
-        WebCore::CDMMessageType,
-        WebCore::CDMMessageType::LicenseRequest,
-        WebCore::CDMMessageType::LicenseRenewal,
-        WebCore::CDMMessageType::LicenseRelease,
-        WebCore::CDMMessageType::IndividualizationRequest
-    >;
-};
-
-}
-
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/encryptedmedia/CDMRequirement.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMRequirement.h
@@ -42,17 +42,4 @@ enum class CDMRequirement : uint8_t {
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::CDMRequirement> {
-    using values = EnumValues<
-        WebCore::CDMRequirement,
-        WebCore::CDMRequirement::Required,
-        WebCore::CDMRequirement::Optional,
-        WebCore::CDMRequirement::NotAllowed
-    >;
-};
-
-}
-
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/GradientColorStop.h
+++ b/Source/WebCore/platform/graphics/GradientColorStop.h
@@ -35,31 +35,7 @@ namespace WebCore {
 struct GradientColorStop {
     float offset { 0 };
     Color color;
-
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<GradientColorStop> decode(Decoder&);
 };
-
-template<typename Encoder> void GradientColorStop::encode(Encoder& encoder) const
-{
-    encoder << offset;
-    encoder << color;
-}
-
-template<typename Decoder> std::optional<GradientColorStop> GradientColorStop::decode(Decoder& decoder)
-{
-    std::optional<float> offset;
-    decoder >> offset;
-    if (!offset)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    return {{ *offset, *color }};
-}
 
 inline void add(Hasher& hasher, const GradientColorStop& stop)
 {

--- a/Source/WebCore/platform/graphics/GradientColorStops.h
+++ b/Source/WebCore/platform/graphics/GradientColorStops.h
@@ -101,9 +101,6 @@ public:
 
     const StopVector& stops() const { return m_stops; }
 
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<GradientColorStops> decode(Decoder&);
-
 private:
     GradientColorStops(StopVector stops, bool isSorted)
         : m_stops { WTFMove(stops) }
@@ -123,21 +120,6 @@ private:
     StopVector m_stops;
     bool m_isSorted;
 };
-
-template<typename Encoder> void GradientColorStops::encode(Encoder& encoder) const
-{
-    encoder << m_stops;
-}
-
-template<typename Decoder> std::optional<GradientColorStops> GradientColorStops::decode(Decoder& decoder)
-{
-    std::optional<StopVector> stops;
-    decoder >> stops;
-    if (!stops)
-        return std::nullopt;
-
-    return {{ WTFMove(*stops) }};
-}
 
 TextStream& operator<<(TextStream&, const GradientColorStops&);
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -30,6 +30,7 @@
 #include "FloatRect.h"
 #include "GraphicsTypesGL.h"
 #include "ImageBufferAllocator.h"
+#include "ImageBufferBackendParameters.h"
 #include "ImagePaintingOptions.h"
 #include "IntRect.h"
 #include "PixelBufferFormat.h"
@@ -56,7 +57,7 @@ class NativeImage;
 class PixelBuffer;
 class ProcessIdentity;
 
-enum class PreserveResolution : uint8_t {
+enum class PreserveResolution : bool {
     No,
     Yes,
 };
@@ -88,16 +89,7 @@ public:
 
 class ImageBufferBackend {
 public:
-    struct Parameters {
-        FloatSize logicalSize;
-        float resolutionScale;
-        DestinationColorSpace colorSpace;
-        PixelFormat pixelFormat;
-        RenderingPurpose purpose;
-
-        template<typename Encoder> void encode(Encoder&) const;
-        template<typename Decoder> static std::optional<Parameters> decode(Decoder&);
-    };
+    using Parameters = ImageBufferBackendParameters;
 
     struct Info {
         RenderingMode renderingMode;
@@ -200,55 +192,4 @@ protected:
     Parameters m_parameters;
 };
 
-template<typename Encoder> void ImageBufferBackend::Parameters::encode(Encoder& encoder) const
-{
-    encoder << logicalSize;
-    encoder << resolutionScale;
-    encoder << colorSpace;
-    encoder << pixelFormat;
-    encoder << purpose;
-}
-
-template<typename Decoder> std::optional<ImageBufferBackend::Parameters> ImageBufferBackend::Parameters::decode(Decoder& decoder)
-{
-    std::optional<FloatSize> logicalSize;
-    decoder >> logicalSize;
-    if (!logicalSize)
-        return std::nullopt;
-
-    std::optional<float> resolutionScale;
-    decoder >> resolutionScale;
-    if (!resolutionScale)
-        return std::nullopt;
-
-    std::optional<DestinationColorSpace> colorSpace;
-    decoder >> colorSpace;
-    if (!colorSpace)
-        return std::nullopt;
-
-    std::optional<PixelFormat> pixelFormat;
-    decoder >> pixelFormat;
-    if (!pixelFormat)
-        return std::nullopt;
-
-    std::optional<RenderingPurpose> purpose;
-    decoder >> purpose;
-    if (!purpose)
-        return std::nullopt;
-
-    return { { *logicalSize, *resolutionScale, *colorSpace, *pixelFormat, *purpose } };
-}
-
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PreserveResolution> {
-    using values = EnumValues<
-        WebCore::PreserveResolution,
-        WebCore::PreserveResolution::No,
-        WebCore::PreserveResolution::Yes
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/ImageBufferBackendParameters.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackendParameters.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DestinationColorSpace.h"
+#include "FloatSize.h"
+#include "PixelFormat.h"
+#include "RenderingMode.h"
+
+namespace WebCore {
+
+struct ImageBufferBackendParameters {
+    FloatSize logicalSize;
+    float resolutionScale;
+    DestinationColorSpace colorSpace;
+    PixelFormat pixelFormat;
+    RenderingPurpose purpose;
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/mediastream/MediaStreamRequest.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamRequest.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 #if ENABLE(MEDIA_STREAM)
 
 #include "MediaConstraints.h"

--- a/Source/WebCore/platform/mediastream/RTCDataChannelState.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelState.h
@@ -27,8 +27,6 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class RTCDataChannelState : uint8_t {
@@ -39,20 +37,5 @@ enum class RTCDataChannelState : uint8_t {
 };
 
 }; // namespace WebCore
-
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::RTCDataChannelState> {
-    using values = EnumValues<
-        WebCore::RTCDataChannelState,
-        WebCore::RTCDataChannelState::Connecting,
-        WebCore::RTCDataChannelState::Open,
-        WebCore::RTCDataChannelState::Closing,
-        WebCore::RTCDataChannelState::Closed
-    >;
-};
-
-}
 
 #endif

--- a/Source/WebCore/platform/mediastream/RTCPriorityType.h
+++ b/Source/WebCore/platform/mediastream/RTCPriorityType.h
@@ -27,26 +27,10 @@
 
 #if ENABLE(WEB_RTC)
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
-enum class RTCPriorityType { VeryLow, Low, Medium, High };
+enum class RTCPriorityType : uint8_t { VeryLow, Low, Medium, High };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::RTCPriorityType> {
-    using values = EnumValues<
-        WebCore::RTCPriorityType,
-        WebCore::RTCPriorityType::VeryLow,
-        WebCore::RTCPriorityType::Low,
-        WebCore::RTCPriorityType::Medium,
-        WebCore::RTCPriorityType::High
-    >;
-};
-
-}
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -157,28 +157,4 @@ bool RealtimeMediaSourceSupportedConstraints::decode(Decoder& decoder, RealtimeM
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::MediaConstraintType> {
-    using values = EnumValues<
-        WebCore::MediaConstraintType,
-        WebCore::MediaConstraintType::Unknown,
-        WebCore::MediaConstraintType::Width,
-        WebCore::MediaConstraintType::Height,
-        WebCore::MediaConstraintType::AspectRatio,
-        WebCore::MediaConstraintType::FrameRate,
-        WebCore::MediaConstraintType::FacingMode,
-        WebCore::MediaConstraintType::Volume,
-        WebCore::MediaConstraintType::SampleRate,
-        WebCore::MediaConstraintType::SampleSize,
-        WebCore::MediaConstraintType::EchoCancellation,
-        WebCore::MediaConstraintType::DeviceId,
-        WebCore::MediaConstraintType::GroupId,
-        WebCore::MediaConstraintType::DisplaySurface,
-        WebCore::MediaConstraintType::LogicalSurface
-    >;
-};
-
-} // namespace WTF
-
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/network/HTTPCookieAcceptPolicy.h
+++ b/Source/WebCore/platform/network/HTTPCookieAcceptPolicy.h
@@ -34,18 +34,4 @@ enum class HTTPCookieAcceptPolicy : uint8_t {
     ExclusivelyFromMainDocumentDomain = 3,
 };
 
-} // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::HTTPCookieAcceptPolicy> {
-    using values = EnumValues<
-        WebCore::HTTPCookieAcceptPolicy,
-        WebCore::HTTPCookieAcceptPolicy::AlwaysAccept,
-        WebCore::HTTPCookieAcceptPolicy::Never,
-        WebCore::HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain,
-        WebCore::HTTPCookieAcceptPolicy::ExclusivelyFromMainDocumentDomain
-    >;
-};
-
 }

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -424,28 +424,3 @@ RefPtr<AdditionalNetworkLoadMetricsForWebInspector> AdditionalNetworkLoadMetrics
 }
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PrivacyStance> {
-    using values = EnumValues<
-        WebCore::PrivacyStance,
-        WebCore::PrivacyStance::Unknown,
-        WebCore::PrivacyStance::NotEligible,
-        WebCore::PrivacyStance::Proxied,
-        WebCore::PrivacyStance::Failed,
-        WebCore::PrivacyStance::Direct
-    >;
-};
-
-template<> struct EnumTraits<WebCore::NetworkLoadPriority> {
-    using values = EnumValues<
-        WebCore::NetworkLoadPriority,
-        WebCore::NetworkLoadPriority::Low,
-        WebCore::NetworkLoadPriority::Medium,
-        WebCore::NetworkLoadPriority::High,
-        WebCore::NetworkLoadPriority::Unknown
-    >;
-};
-
-}

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -318,28 +318,3 @@ WEBCORE_EXPORT RetainPtr<CFURLStorageSessionRef> createPrivateStorageSession(CFS
 #endif
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ThirdPartyCookieBlockingMode> {
-    using values = EnumValues<
-        WebCore::ThirdPartyCookieBlockingMode,
-        WebCore::ThirdPartyCookieBlockingMode::All,
-        WebCore::ThirdPartyCookieBlockingMode::AllExceptBetweenAppBoundDomains,
-        WebCore::ThirdPartyCookieBlockingMode::AllExceptManagedDomains,
-        WebCore::ThirdPartyCookieBlockingMode::AllOnSitesWithoutUserInteraction,
-        WebCore::ThirdPartyCookieBlockingMode::OnlyAccordingToPerDomainPolicy
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FirstPartyWebsiteDataRemovalMode> {
-    using values = EnumValues<
-        WebCore::FirstPartyWebsiteDataRemovalMode,
-        WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookies,
-        WebCore::FirstPartyWebsiteDataRemovalMode::None,
-        WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookiesLiveOnTestingTimeout,
-        WebCore::FirstPartyWebsiteDataRemovalMode::AllButCookiesReproTestingTimeout
-    >;
-};
-
-}

--- a/Source/WebCore/platform/network/cf/CertificateInfo.h
+++ b/Source/WebCore/platform/network/cf/CertificateInfo.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/cf/TypeCastsCF.h>

--- a/Source/WebCore/platform/text/FontRenderingMode.h
+++ b/Source/WebCore/platform/text/FontRenderingMode.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
@@ -37,15 +36,3 @@ enum class FontRenderingMode : uint8_t {
 };
 
 }
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::FontRenderingMode> {
-    using values = EnumValues<
-        WebCore::FontRenderingMode,
-        WebCore::FontRenderingMode::Normal,
-        WebCore::FontRenderingMode::Alternate
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -70,7 +70,7 @@ struct GrammarDetail {
 };
 
 struct TextCheckingResult {
-    TextCheckingType type;
+    OptionSet<TextCheckingType> type;
     CharacterRange range;
     Vector<GrammarDetail> details;
     String replacement;
@@ -117,22 +117,3 @@ public:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::TextCheckingType> {
-    using values = EnumValues<
-    WebCore::TextCheckingType,
-    WebCore::TextCheckingType::None,
-    WebCore::TextCheckingType::Spelling,
-    WebCore::TextCheckingType::Grammar,
-    WebCore::TextCheckingType::Link,
-    WebCore::TextCheckingType::Quote,
-    WebCore::TextCheckingType::Dash,
-    WebCore::TextCheckingType::Replacement,
-    WebCore::TextCheckingType::Correction,
-    WebCore::TextCheckingType::ShowCorrectionPanel
-    >;
-};
-
-}

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -29,7 +29,6 @@
 #include <optional>
 #include <variant>
 #include <vector>
-#include <wtf/EnumTraits.h>
 #include <wtf/Hasher.h>
 
 namespace WTF {

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -28,7 +28,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     GetPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier imageBuffer, WebKit::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
     DestroyGetPixelBufferSharedMemory()
     PutPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, Ref<WebCore::PixelBuffer> pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
-    GetShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, enum:uint8_t WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmapHandle handle) Synchronous NotStreamEncodableReply
+    GetShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, enum:bool WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmapHandle handle) Synchronous NotStreamEncodableReply
     GetFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, IPC::FilterReference filter) -> (WebKit::ShareableBitmapHandle handle) Synchronous NotStreamEncodableReply
     CacheNativeImage(WebKit::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheFont(Ref<WebCore::Font> font) NotStreamEncodable

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -317,12 +317,29 @@ struct CGAffineTransform {
 [RefCounted, CustomHeader=True] class WebCore::LinearTimingFunction {
 };
 
+[Nested] enum class WebCore::CubicBezierTimingFunction::TimingFunctionPreset : uint8_t {
+    Ease,
+    EaseIn,
+    EaseOut,
+    EaseInOut,
+    Custom
+};
+
 [RefCounted, CustomHeader=True] class WebCore::CubicBezierTimingFunction {
     WebCore::CubicBezierTimingFunction::TimingFunctionPreset timingFunctionPreset()
     double x1()
     double y1()
     double x2()
     double y2()
+};
+
+[Nested] enum class WebCore::StepsTimingFunction::StepPosition : uint8_t {
+    JumpStart,
+    JumpEnd,
+    JumpNone,
+    JumpBoth,
+    Start,
+    End,
 };
 
 [RefCounted, CustomHeader=True] class WebCore::StepsTimingFunction {
@@ -1394,7 +1411,7 @@ header: <WebCore/TextChecking.h>
 
 header: <WebCore/TextChecking.h>
 [CustomHeader] struct WebCore::TextCheckingResult {
-    WebCore::TextCheckingType type;
+    OptionSet<WebCore::TextCheckingType> type;
     WebCore::CharacterRange range;
     Vector<WebCore::GrammarDetail> details;
     String replacement;
@@ -3151,6 +3168,207 @@ class WebCore::SpeechRecognitionUpdate {
     High
 };
 
+header: <WebCore/AudioIOCallback.h>
+[CustomHeader] struct WebCore::AudioIOPosition {
+    Seconds position;
+    MonotonicTime timestamp;
+};
+
+enum class WebCore::VideoFrameRotation : uint16_t {
+    None,
+    UpsideDown,
+    Right,
+    Left,
+};
+
+#if ENABLE(VIDEO) && USE(AVFOUNDATION)
+[RefCounted] class WebCore::VideoFrameCV {
+    MediaTime presentationTime();
+    bool isMirrored();
+    WebCore::VideoFrameRotation rotation();
+    RetainPtr<CVPixelBufferRef> m_pixelBuffer;
+    WebCore::PlatformVideoColorSpace colorSpace();
+};
+#endif
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GradientColorStop {
+    float offset;
+    WebCore::Color color;
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::GradientColorStops {
+    Vector<WebCore::GradientColorStop, 2> stops();
+};
+
+struct WebCore::ImageBufferBackendParameters {
+    WebCore::FloatSize logicalSize;
+    float resolutionScale;
+    WebCore::DestinationColorSpace colorSpace
+    WebCore::PixelFormat pixelFormat;
+    WebCore::RenderingPurpose purpose;
+};
+
+enum class WebCore::PreserveResolution : bool;
+
+[AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::PathElementType : uint8_t {
+    MoveToPoint,
+    AddLineToPoint,
+    AddQuadCurveToPoint,
+    AddCurveToPoint,
+    CloseSubpath
+};
+
+header: <WebCore/Path.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::EncodedPathElementType {
+    std::optional<WebCore::PathElementType> m_type;
+};
+
+class WebCore::ProcessIdentity {
+#if HAVE(TASK_IDENTITY_TOKEN)
+    MachSendRight m_taskIdToken;
+#endif
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::ColorInterpolationColorSpace : uint8_t {
+    HSL,
+    HWB,
+    LCH,
+    Lab,
+    OKLCH,
+    OKLab,
+    SRGB,
+    SRGBLinear,
+    XYZD50,
+    XYZD65
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::HueInterpolationMethod : uint8_t {
+    Shorter,
+    Longer,
+    Increasing,
+    Decreasing
+};
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::HSL {
+    WebCore::HueInterpolationMethod hueInterpolationMethod;
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::HWB {
+    WebCore::HueInterpolationMethod hueInterpolationMethod;
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::LCH {
+    WebCore::HueInterpolationMethod hueInterpolationMethod;
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::Lab {
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::OKLCH {
+    WebCore::HueInterpolationMethod hueInterpolationMethod;
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::OKLab {
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::SRGB {
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::SRGBLinear {
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::XYZD50 {
+};
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod::XYZD65 {
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ColorInterpolationMethod {
+    std::variant<WebCore::ColorInterpolationMethod::HSL, WebCore::ColorInterpolationMethod::HWB, WebCore::ColorInterpolationMethod::LCH, WebCore::ColorInterpolationMethod::Lab, WebCore::ColorInterpolationMethod::OKLCH, WebCore::ColorInterpolationMethod::OKLab, WebCore::ColorInterpolationMethod::SRGB, WebCore::ColorInterpolationMethod::SRGBLinear, WebCore::ColorInterpolationMethod::XYZD50, WebCore::ColorInterpolationMethod::XYZD65> colorSpace;
+    WebCore::AlphaPremultiplication alphaPremultiplication;
+};
+
+#if USE(AUDIO_SESSION)
+header: <WebCore/AudioSession.h>
+[CustomHeader] enum class WebCore::RouteSharingPolicy : uint8_t {
+    Default,
+    LongFormAudio,
+    Independent,
+    LongFormVideo
+};
+
+enum class WebCore::AudioSessionCategory : uint8_t {
+    None,
+    AmbientSound,
+    SoloAmbientSound,
+    MediaPlayback,
+    RecordAudio,
+    PlayAndRecord,
+    AudioProcessing,
+};
+
+[Nested] enum class WebCore::AudioSession::MayResume : bool;
+
+enum class WebCore::AudioSessionRoutingArbitrationError : uint8_t {
+    None,
+    Failed,
+    Cancelled
+};
+
+[Nested] enum class WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged : bool;
+#endif
+
+#if ENABLE(ENCRYPTED_MEDIA)
+enum class WebCore::CDMKeyStatus : uint8_t {
+    Usable,
+    Expired,
+    Released,
+    OutputRestricted,
+    OutputDownscaled,
+    StatusPending,
+    InternalError
+};
+
+enum class WebCore::CDMMessageType : uint8_t {
+    LicenseRequest,
+    LicenseRenewal,
+    LicenseRelease,
+    IndividualizationRequest
+};
+
+enum class WebCore::CDMRequirement : uint8_t {
+    Required,
+    Optional,
+    NotAllowed
+};
+#endif
+
+#if ENABLE(MEDIA_STREAM)
+enum class WebCore::MediaConstraintType : uint8_t {
+    Unknown,
+    Width,
+    Height,
+    AspectRatio,
+    FrameRate,
+    FacingMode,
+    Volume,
+    SampleRate,
+    SampleSize,
+    EchoCancellation,
+    DeviceId,
+    GroupId,
+    DisplaySurface,
+    LogicalSurface,
+};
+#endif
+
+#if ENABLE(WEB_RTC)
+enum class WebCore::RTCDataChannelState : uint8_t {
+    Connecting,
+    Open,
+    Closing,
+    Closed
+};
+
+enum class WebCore::RTCPriorityType : uint8_t {
+    VeryLow,
+    Low,
+    Medium,
+    High
+};
+#endif
+
 [AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::LineCap : uint8_t {
     Butt,
     Round,
@@ -3345,4 +3563,68 @@ class WebCore::SubstituteData {
     URL failingURL();
     WebCore::ResourceResponse response();
     WebCore::SubstituteData::SessionHistoryVisibility shouldRevealToSessionHistory();
+};
+
+header: <WebCore/HTTPCookieAcceptPolicy.h>
+enum class WebCore::HTTPCookieAcceptPolicy : uint8_t {
+    AlwaysAccept,
+    Never,
+    OnlyFromMainDocumentDomain,
+    ExclusivelyFromMainDocumentDomain,
+};
+
+enum class WebCore::NetworkLoadPriority : uint8_t {
+    Low,
+    Medium,
+    High,
+    Unknown,
+};
+
+enum class WebCore::PrivacyStance : uint8_t {
+    Unknown,
+    NotEligible,
+    Proxied,
+    Failed,
+    Direct,
+    FailedUnreachable,
+};
+
+enum class WebCore::ThirdPartyCookieBlockingMode : uint8_t {
+    All,
+    AllExceptBetweenAppBoundDomains,
+    AllExceptManagedDomains,
+    AllOnSitesWithoutUserInteraction,
+    OnlyAccordingToPerDomainPolicy
+};
+
+enum class WebCore::FirstPartyWebsiteDataRemovalMode : uint8_t {
+    AllButCookies,
+    None,
+    AllButCookiesLiveOnTestingTimeout,
+    AllButCookiesReproTestingTimeout
+};
+
+enum class WebCore::FontRenderingMode : uint8_t {
+    Normal,
+    Alternate
+};
+
+header: <WebCore/DragData.h>
+[OptionSet, CustomHeader] enum class WebCore::DragApplicationFlags : uint8_t {
+    IsModal,
+    IsSource,
+    HasAttachedSheet,
+    IsCopyKeyDown
+};
+
+[OptionSet] enum class WebCore::TextCheckingType : uint8_t {
+    None,
+    Spelling,
+    Grammar,
+    Link,
+    Quote,
+    Dash,
+    Replacement,
+    Correction,
+    ShowCorrectionPanel,
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -243,7 +243,7 @@ messages -> WebPageProxy {
     DidFindString(String string, Vector<WebCore::IntRect> matchRect, uint32_t matchCount, int32_t matchIndex, bool didWrapAround)
     DidFailToFindString(String string)
     DidFindStringMatches(String string, Vector<Vector<WebCore::IntRect>> matches, int32_t firstIndexAfterSelection)
-    DidGetImageForFindMatch(struct WebCore::ImageBufferBackend::Parameters parameters, WebKit::ShareableBitmapHandle contentImageHandle, uint32_t matchIndex)
+    DidGetImageForFindMatch(struct WebCore::ImageBufferBackendParameters parameters, WebKit::ShareableBitmapHandle contentImageHandle, uint32_t matchIndex)
 
     # PopupMenu messages
     ShowPopupMenu(WebCore::IntRect rect, uint64_t textDirection, Vector<WebKit::WebPopupItem> items, int32_t selectedIndex, struct WebKit::PlatformPopupMenuData data)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -30,6 +30,7 @@
 #include "GPUProcessConnection.h"
 #include "RemoteVideoFrameIdentifier.h"
 #include <WebCore/VideoFrame.h>
+#include <wtf/ArgumentCoder.h>
 
 namespace IPC {
 class Connection;


### PR DESCRIPTION
#### 32f6c4d6e879210e00c6383497cdb9c43bb8f36b
<pre>
Continue porting WebCore/platform types to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251386">https://bugs.webkit.org/show_bug.cgi?id=251386</a>
rdar://104833997

Reviewed by Alex Christensen.

This change includes porting for types:
    - WebCore::LinearTimingFunction
    - WebCore::CubicBezierTimingFunction::TimingFunctionPreset
    - WebCore::CubicBezierTimingFunction
    - WebCore::StepsTimingFunction
    - WebCore::TextCheckingResult
    - WebCore::AudioIOPosition
    - WebCore::VideoFrameRotation
    - WebCore::VideoFrameCV
    - WebCore::GradientColorStop
    - WebCore::GradientColorStops
    - WebCore::ImageBufferBackendParameters
    - WebCore::PreserveResolution
    - WebCore::PathElementType
    - WebCore::EncodedPathElementType
    - WebCore::ProcessIdentity
    - WebCore::ColorInterpolationColorSpace
    - WebCore::HueInterpolationMethod
    - WebCore::ColorInterpolationMethod::HSL
    - WebCore::ColorInterpolationMethod::HWB
    - WebCore::ColorInterpolationMethod::LCH
    - WebCore::ColorInterpolationMethod::Lab
    - WebCore::ColorInterpolationMethod::OKLCH
    - WebCore::ColorInterpolationMethod::OKLab
    - WebCore::ColorInterpolationMethod::SRGB
    - WebCore::ColorInterpolationMethod::SRGBLinear
    - WebCore::ColorInterpolationMethod::XYZD50
    - WebCore::ColorInterpolationMethod::XYZD65
    - WebCore::ColorInterpolationMethod
    - WebCore::RouteSharingPolicy
    - WebCore::AudioSessionCategory
    - WebCore::AudioSession::MayResume
    - WebCore::AudioSessionRoutingArbitrationError
    - WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged
    - WebCore::CDMKeyStatus
    - WebCore::CDMMessageType
    - WebCore::CDMRequirement
    - WebCore::MediaConstraintType
    - WebCore::RTCDataChannelState
    - WebCore::RTCPriorityType
    - WebCore::HTTPCookieAcceptPolicy
    - WebCore::NetworkLoadPriority
    - WebCore::PrivacyStance
    - WebCore::ThirdPartyCookieBlockingMode
    - WebCore::FirstPartyWebsiteDataRemovalMode
    - WebCore::FontRenderingMode
    - WebCore::DragApplicationFlags
    - WebCore::TextCheckingType

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::markAndReplaceFor):
* Source/WebCore/platform/DragData.h:
* Source/WebCore/platform/ProcessIdentity.h:
(WebCore::ProcessIdentity::encode const): Deleted.
(WebCore::ProcessIdentity::decode): Deleted.
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/animation/TimingFunction.h:
* Source/WebCore/platform/audio/AudioIOCallback.h:
(WebCore::AudioIOPosition::encode const): Deleted.
(WebCore::AudioIOPosition::decode): Deleted.
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/encryptedmedia/CDMKeyStatus.h:
* Source/WebCore/platform/encryptedmedia/CDMMessageType.h:
* Source/WebCore/platform/encryptedmedia/CDMRequirement.h:
* Source/WebCore/platform/graphics/ColorInterpolationMethod.h:
(WebCore::ColorInterpolationMethod::encode const): Deleted.
(WebCore::ColorInterpolationMethod::decode): Deleted.
* Source/WebCore/platform/graphics/GradientColorStop.h:
(WebCore::GradientColorStop::encode const): Deleted.
(WebCore::GradientColorStop::decode): Deleted.
* Source/WebCore/platform/graphics/GradientColorStops.h:
(WebCore::GradientColorStops::encode const): Deleted.
(WebCore::GradientColorStops::decode): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::Parameters::encode const): Deleted.
(WebCore::ImageBufferBackend::Parameters::decode): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackendParameters.h: Copied from Source/WebCore/platform/network/HTTPCookieAcceptPolicy.h.
* Source/WebCore/platform/graphics/Path.h:
(WebCore::EncodedPathElementType::EncodedPathElementType):
(WebCore::EncodedPathElementType::isEndOfPath const):
(WebCore::EncodedPathElementType::isValidPathElementType const):
(WebCore::EncodedPathElementType::isValid const):
(WebCore::EncodedPathElementType::type const):
(WebCore::Path::EncodedPathElementType::EncodedPathElementType): Deleted.
(WebCore::Path::EncodedPathElementType::isEndOfPath const): Deleted.
(WebCore::Path::EncodedPathElementType::isValidPathElementType const): Deleted.
(WebCore::Path::EncodedPathElementType::isValid const): Deleted.
(WebCore::Path::EncodedPathElementType::type const): Deleted.
(WebCore::Path::EncodedPathElementType::encode): Deleted.
(WebCore::Path::EncodedPathElementType::decode): Deleted.
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
(WebCore::VideoFrameCV::encode const): Deleted.
(WebCore::VideoFrameCV::decode): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamRequest.h:
* Source/WebCore/platform/mediastream/RTCDataChannelState.h:
* Source/WebCore/platform/mediastream/RTCPriorityType.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
* Source/WebCore/platform/network/HTTPCookieAcceptPolicy.h:
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cf/CertificateInfo.h:
* Source/WebCore/platform/text/FontRenderingMode.h:
* Source/WebCore/platform/text/TextChecking.h:
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:

Canonical link: <a href="https://commits.webkit.org/259829@main">https://commits.webkit.org/259829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f300f80fae98de5a24465aeb7c18578c9bbf3eb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115244 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175337 "Build was cancelled. Recent messages:Pull request contains relevant changes; Deleted stale build files; Encountered some issues during cleanup") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6288 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98271 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114964 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111816 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95570 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/40141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27213 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28565 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5114 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48109 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6800 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10405 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->