### PR TITLE
[ews] Add result database support for API tests to avoid reruns and clean-tree-runs

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2018-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -4342,21 +4342,29 @@ class ExtractBuiltProduct(shell.ShellCommand):
         super().__init__(logEnviron=False, **kwargs)
 
 
-class RunAPITests(TestWithFailureCount):
+class RunAPITests(TestWithFailureCount, AddToLogMixin):
     name = 'run-api-tests'
     description = ['api tests running']
     descriptionDone = ['api-tests']
     jsonFileName = 'api_test_results.json'
     logfiles = {'json': jsonFileName}
+    test_failures_log_name = 'test-failures'
+    results_db_log_name = 'results-db'
+    suffix = 'first_run'
     command = ['python3', 'Tools/Scripts/run-api-tests', '--no-build',
                WithProperties('--%(configuration)s'), '--verbose', '--json-output={0}'.format(jsonFileName)]
     failedTestsFormatString = '%d api test%s failed or timed out'
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, **kwargs)
+        self.failing_tests_filtered = []
+        self.preexisting_failures_in_results_db = []
 
     @defer.inlineCallbacks
     def run(self):
+        self.log_observer_json = logobserver.BufferLogObserver()
+        self.addLogObserver('json', self.log_observer_json)
+
         platform = self.getProperty('platform')
         if platform == 'gtk':
             self.command = ['python3', 'Tools/Scripts/run-gtk-tests',
@@ -4367,16 +4375,36 @@ class RunAPITests(TestWithFailureCount):
 
         rc = yield super().run()
 
+        yield self.analyze_failures_using_results_db()
+
         if rc in [SUCCESS, WARNINGS]:
             message = 'Passed API tests'
             self.descriptionDone = message
             if self.name != RunAPITestsWithoutChange.name:
                 self.build.results = SUCCESS
                 self.build.buildFinished([message], SUCCESS)
+        elif (self.name != RunAPITestsWithoutChange.name and self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
+            # This means all the tests which failed in this run were also failing or flaky in results database
+            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
+            self.descriptionDone = message
+            self.build.results = SUCCESS
+            self.build.buildFinished([message], SUCCESS)
         else:
             self.doOnFailure()
 
         defer.returnValue(rc)
+
+    @defer.inlineCallbacks
+    def analyze_failures_using_results_db(self):
+        logTextJson = self.log_observer_json.getStdout()
+
+        failures = self.parse_api_failures_from_string(logTextJson)
+        self.setProperty(f'{self.suffix}_failures', sorted(failures))
+        if failures:
+            yield self._addToLog(self.test_failures_log_name, '\n'.join(failures))
+            yield self.filter_api_test_failures_using_results_db(failures)
+            self.setProperty(f'{self.suffix}_failures_filtered', sorted(self.failing_tests_filtered))
+            self.setProperty(f'results-db_{self.suffix}_pre_existing', sorted(self.preexisting_failures_in_results_db))
 
     def countFailures(self, returncode):
         log_text = self.log_observer.getStdout() + self.log_observer.getStderr()
@@ -4393,9 +4421,60 @@ class RunAPITests(TestWithFailureCount):
             ReRunAPITests(),
         ])
 
+    def parse_api_failures_from_string(self, string):
+        if not string:
+            return []
+        try:
+            # Workaround for https://github.com/buildbot/buildbot/issues/4906
+            string = ''.join(string.splitlines())
+            result = json.loads(string)
+        except Exception as ex:
+            self._addToLog('stderr', 'ERROR: unable to parse data, exception: {}'.format(ex))
+            return []
+
+        failures = ([failure.get('name') for failure in result.get('Timedout', [])] +
+                    [failure.get('name') for failure in result.get('Crashed', [])] +
+                    [failure.get('name') for failure in result.get('Failed', [])])
+        return failures
+
+    @defer.inlineCallbacks
+    def filter_api_test_failures_using_results_db(self, failing_tests):
+        self.failing_tests_filtered = failing_tests.copy()
+        identifier = self.getProperty('identifier', None)
+        platform = self.getProperty('platform', None)
+        configuration = {}
+        if platform:
+            configuration['platform'] = platform
+        style = self.getProperty('configuration', None)
+        if style and style in ['debug', 'release']:
+            configuration['style'] = style
+
+        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}')
+        has_commit = False
+        if failing_tests and identifier:
+            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
+            if not has_commit:
+                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+
+        for test in failing_tests:
+            data = yield ResultsDatabase.is_test_pre_existing_failure(
+                test, configuration=configuration,
+                commit=identifier if has_commit else None,
+                suite='api-tests',
+            )
+            yield self._addToLog(self.results_db_log_name, f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
+            if data['is_existing_failure']:
+                self.preexisting_failures_in_results_db.append(test)
+                self.failing_tests_filtered.remove(test)
+            else:
+                # Optimization to skip consulting results-db for every failure if we encounter any new failure,
+                # since until there is atleast one failure which is not pre-existing, we will anayways have to continue with retry logic.
+                break
+
 
 class ReRunAPITests(RunAPITests):
     name = 're-run-api-tests'
+    suffix = 'second_run'
 
     def doOnFailure(self):
         steps_to_add = [UnApplyPatch(), RevertPullRequestChanges(), ValidateChange(verifyBugClosed=False, addURLs=False)]
@@ -4417,6 +4496,9 @@ class RunAPITestsWithoutChange(RunAPITests):
     name = 'run-api-tests-without-change'
 
     def doOnFailure(self):
+        pass
+
+    def analyze_failures_using_results_db(self):
         pass
 
 


### PR DESCRIPTION
#### 3766682046d76ba8dd2b58fa1c9d96ebc11dadc7
<pre>
[ews] Add result database support for API tests to avoid reruns and clean-tree-runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=251388">https://bugs.webkit.org/show_bug.cgi?id=251388</a>
rdar://104834184

Reviewed by Ryan Haddad.

Adding result database support for API tests to avoid reruns and clean-tree-runs. This is similar to
what we did for layout-tests in <a href="https://bugs.webkit.org/show_bug.cgi?id=204368">https://bugs.webkit.org/show_bug.cgi?id=204368</a>

This would significantly improve the runtime for API tests when they are any flaky or pre-existing test failures.

* Tools/CISupport/ews-build/steps.py:
(RunAPITests):
(RunAPITests.run):
(RunAPITests.analyze_failures_using_results_db):
(RunAPITests.parse_api_failures_from_string):
(RunAPITests.filter_api_test_failures_using_results_db):
(ReRunAPITests):
(RunAPITestsWithoutChange.analyze_failures_using_results_db):

Canonical link: <a href="https://commits.webkit.org/259628@main">https://commits.webkit.org/259628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cada56b12361cb0a80a0eabfec11ae60b88d392

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/105458 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14526 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38330 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114713 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/109358 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/15716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97761 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/111214 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/15716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38330 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97761 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/15716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38330 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97761 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38330 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/7958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/104252 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38330 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9749 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3554 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->