### PR TITLE
Fix iOS release build with assertions enabled

### DIFF
--- a/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
@@ -334,7 +334,7 @@ const ElementBox& FormattingContext::containingBlock(const Box& layoutBox)
     return layoutBox.parent();    
 }
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
 const ElementBox& FormattingContext::formattingContextRoot(const Box& layoutBox)
 {
     // We should never need to ask this question on the ICB.
@@ -354,7 +354,6 @@ const ElementBox& FormattingContext::formattingContextRoot(const Box& layoutBox)
 
 void FormattingContext::validateGeometryConstraintsAfterLayout() const
 {
-#if ASSERT_ENABLED
     auto& root = this->root();
     // FIXME: add a descendantsOfType<> flavor that stops at nested formatting contexts
     for (auto& layoutBox : descendantsOfType<Box>(root)) {
@@ -379,7 +378,6 @@ void FormattingContext::validateGeometryConstraintsAfterLayout() const
                 + boxGeometry.paddingAfter().value_or(0) + boxGeometry.borderAfter() + boxGeometry.marginAfter() == containingBlockHeight);
         }
     }
-#endif
 }
 #endif
 

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.h
@@ -84,7 +84,7 @@ public:
 
     static const InitialContainingBlock& initialContainingBlock(const Box&);
     static const ElementBox& containingBlock(const Box&);
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     static const ElementBox& formattingContextRoot(const Box&);
 #endif
 
@@ -94,7 +94,7 @@ protected:
     FormattingState& formattingState() { return m_formattingState; }
     void computeBorderAndPadding(const Box&, const HorizontalConstraints&);
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     virtual void validateGeometryConstraintsAfterLayout() const;
 #endif
 

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -82,14 +82,14 @@ public:
 
 private:
     RetainPtr<WebEvent> m_savedCurrentEvent;
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     RetainPtr<WebEvent> m_event;
 #endif
 };
 
 inline CurrentEventScope::CurrentEventScope(WebEvent *event)
     : m_savedCurrentEvent(currentEventSlot())
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     , m_event(event)
 #endif
 {


### PR DESCRIPTION
#### 1114831422b8103a63b2d328b34c33535f6d16f2
<pre>
Fix iOS release build with assertions enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=251389">https://bugs.webkit.org/show_bug.cgi?id=251389</a>
rdar://104834690

Reviewed by Chris Dumez.

There were some inconsistent uses of NDEBUG and ASSERT_ENABLED.

* Source/WebCore/layout/formattingContexts/FormattingContext.cpp:
(WebCore::Layout::FormattingContext::validateGeometryConstraintsAfterLayout const):
* Source/WebCore/layout/formattingContexts/FormattingContext.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::CurrentEventScope::CurrentEventScope):

Canonical link: <a href="https://commits.webkit.org/259596@main">https://commits.webkit.org/259596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba0418da5b254504c60e4ea4ef69bc0f019c26f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114601 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5350 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97652 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111103 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95043 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26677 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7742 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47581 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9641 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3537 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->