### PR TITLE
Clear DumpRenderTree and WebKitTestRunner defaults before running tests

### DIFF
--- a/Tools/DumpRenderTree/mac/Configurations/DumpRenderTree.xcconfig
+++ b/Tools/DumpRenderTree/mac/Configurations/DumpRenderTree.xcconfig
@@ -30,6 +30,7 @@ OTHER_LDFLAGS_ = -lWebCoreTestSupport -force_load $(BUILT_PRODUCTS_DIR)/libDumpR
 LD_RUNPATH_SEARCH_PATHS = "@loader_path/.";
 STRIP_STYLE = debugging;
 PRODUCT_NAME = DumpRenderTree;
+PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.DumpRenderTree;
 
 SKIP_INSTALL[sdk=embedded*] = YES;
 

--- a/Tools/DumpRenderTree/mac/Info.plist
+++ b/Tools/DumpRenderTree/mac/Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 </dict>

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -278,7 +278,7 @@ class MacPort(DarwinPort):
     def reset_preferences(self):
         _log.debug("Resetting persistent preferences")
 
-        for domain in ["DumpRenderTree", "WebKitTestRunner"]:
+        for domain in ["com.apple.WebKit.DumpRenderTree", "com.apple.WebKit.WebKitTestRunner"]:
             try:
                 self._executive.run_command(["defaults", "delete", domain])
             except ScriptError as e:


### PR DESCRIPTION
#### 165e0db5c7299e734a4a6c04f157a835d3ee7452
<pre>
Clear DumpRenderTree and WebKitTestRunner defaults before running tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=251397">https://bugs.webkit.org/show_bug.cgi?id=251397</a>
rdar://104838472

Reviewed by Jonathan Bedard.

Historically DumpRenderTree had no bundleID specified, so would save NSUserDefaults using
&quot;DumpRenderTree&quot;. WebKitTestRunner, on the other hand, was correctly set up to use
&quot;com.apple.WebKit.WebKitTestRunner&quot;. This patch gives DumpRenderTree a bundleID with
a &quot;com.apple.WebKit&quot; prefix.

These bundleIDs matter because webkitpy uses them to clear NSUserDefaults before test runs;
this worked fine for DumpRenderTree, but failed for WebKitTestRunner because the bundleID
was incorrect. Fix that in mac.py, and use the new bundleID com.apple.WebKit.DumpRenderTree too.

Generally failing to clear NSUserDefaults before testing isn&apos;t an issue, but defaults like WebCoreLogging
can get saved into NSUserDefaults if you run WebKitTestRunner directly with logging arguments, so clearing
before running tests is useful in that scenario.

* Tools/DumpRenderTree/mac/Configurations/DumpRenderTree.xcconfig:
* Tools/DumpRenderTree/mac/Info.plist:
* Tools/Scripts/webkitpy/port/mac.py:
(MacPort.reset_preferences):

Canonical link: <a href="https://commits.webkit.org/259687@main">https://commits.webkit.org/259687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c884c3943bf6b99872620d100598fe7d662ef40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114831 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174978 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5892 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97874 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39726 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/109034 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26852 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28207 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4796 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47751 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6694 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10005 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->