### PR TITLE
[webkitbugspy] Access keywords from Radars and bugzillas

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.9.3',
+    version='0.9.4',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 9, 3)
+version = Version(0, 9, 4)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -165,7 +165,7 @@ class Tracker(GenericTracker):
         issue._link = '{}/show_bug.cgi?id={}'.format(self.url, issue.id)
         issue._labels = []
 
-        if member in ('title', 'timestamp', 'creator', 'opened', 'assignee', 'watchers', 'project', 'component', 'version'):
+        if member in ('title', 'timestamp', 'creator', 'opened', 'assignee', 'watchers', 'project', 'component', 'version', 'keywords'):
             response = requests.get('{}/rest/bug/{}{}'.format(self.url, issue.id, self._login_arguments(required=False)))
             if response.status_code // 100 == 4 and self._logins_left:
                 self._logins_left -= 1
@@ -198,6 +198,7 @@ class Tracker(GenericTracker):
                 issue._project = response.get('product', '')
                 issue._component = response.get('component', '')
                 issue._version = response.get('version', '')
+                issue._keywords = response.get('keywords', [])
 
             else:
                 sys.stderr.write("Failed to fetch '{}'\n".format(issue.link))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -233,6 +233,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
     def populate(self, issue, member=None):
         issue._link = '{}/issues/{}'.format(self.url, issue.id)
         issue._project = self.name
+        issue._keywords = []  # We don't yet have a defined idiom for "keywords" in GitHub Issues
 
         if member in ('title', 'timestamp', 'creator', 'opened', 'assignee', 'description', 'project', 'component', 'version', 'labels', 'milestone'):
             response = self.request(path='issues/{}'.format(issue.id))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -72,6 +72,7 @@ class Issue(object):
         self._component = None
         self._version = None
         self._milestone = None
+        self._keywords = None
 
         self.tracker.populate(self, None)
 
@@ -187,6 +188,12 @@ class Issue(object):
         if self._milestone is None:
             self.tracker.populate(self, 'milestone')
         return self._milestone or None
+
+    @property
+    def keywords(self):
+        if self._keywords is None:
+            self.tracker.populate(self, 'keywords')
+        return self._keywords
 
     @property
     def redacted(self):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -169,6 +169,7 @@ class Bugzilla(Base, mocks.Requests):
                         project=issue.get('project'),
                         component=issue.get('component'),
                         watchers=[candidate, user],
+                        keywords=issue.get('keywords', []),
                     ))
                 issue['comments'].append(
                     Issue.Comment(user=candidate, timestamp=int(time.time()), content='<rdar://problem/{}>'.format(radar_id)),
@@ -185,6 +186,7 @@ class Bugzilla(Base, mocks.Requests):
                 product=issue.get('project'),
                 component=issue.get('component'),
                 version=issue.get('version'),
+                keywords=issue.get('keywords', []),
                 creator_detail=dict(
                     email=issue['creator'].email,
                     name=self.users[issue['creator'].name].username,
@@ -339,6 +341,7 @@ class Bugzilla(Base, mocks.Requests):
             project=data.get('product'),
             component=data.get('component'),
             version=data.get('version'),
+            keywords=[],
             comments=[], watchers=[user, assignee] if assignee else [user],
         )
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -57,6 +57,7 @@ ISSUES = [
         component='Text',
         version='Other',
         milestone='October',
+        keywords=['Keyword A'],
         comments=[
             Issue.Comment(
                 user=USERS['Felix Filer'],
@@ -79,6 +80,7 @@ ISSUES = [
         component='Scrolling',
         version='Safari 15',
         milestone='October',
+        keywords=['Keyword A'],
         comments=[
             Issue.Comment(
                 user=USERS['Tim Contributor'],
@@ -98,6 +100,7 @@ ISSUES = [
         component='SVG',
         version='WebKit Local Build',
         milestone='October',
+        keywords=['Keyword B'],
         comments=[
             Issue.Comment(
                 user=USERS['Tim Contributor'],

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -117,6 +117,10 @@ class RadarModel(object):
         def __init__(self, name):
             self.name = name
 
+    class Keyword(object):
+        def __init__(self, name):
+            self.name = name
+
     def __init__(self, client, issue):
         from datetime import datetime, timedelta
 
@@ -159,6 +163,9 @@ class RadarModel(object):
             ref = self.client.radar_for_id(reference)
             if ref:
                 yield ref
+
+    def keywords(self):
+        return [self.Keyword(keyword) for keyword in self._issue.get('keywords', [])]
 
     def commit_changes(self):
         self.client.parent.issues[self.id]['comments'] = [

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -202,6 +202,9 @@ class Tracker(GenericTracker):
         )
         issue._milestone = radar.milestone.name if radar.milestone else ''
 
+        if member == 'keywords':
+            issue._keywords = [kw.name for kw in (radar.keywords() or [])]
+
         if member == 'watchers':
             issue._watchers = []
             for member in radar.cc_memberships.items():

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -510,3 +510,8 @@ What component in 'WebKit' should the bug be associated with?:
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = bugzilla.Tracker(self.URL)
             self.assertEqual(tracker.issue(1).milestone, None)
+
+    def test_keywords(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
+            tracker = bugzilla.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).keywords, ['Keyword A'])

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -377,3 +377,8 @@ What version of 'WebKit Text' should the bug be associated with?:
         with mocks.Radar(issues=mocks.ISSUES):
             tracker = radar.Tracker()
             self.assertEqual(tracker.issue(1).milestone, 'October')
+
+    def test_keywords(self):
+        with mocks.Radar(issues=mocks.ISSUES):
+            tracker = radar.Tracker()
+            self.assertEqual(tracker.issue(1).keywords, ['Keyword A'])


### PR DESCRIPTION
#### 28af6286be2f3bc10d0144fd2996673067527092
<pre>
[webkitbugspy] Access keywords from Radars and bugzillas
<a href="https://bugs.webkit.org/show_bug.cgi?id=251398">https://bugs.webkit.org/show_bug.cgi?id=251398</a>
rdar://104838949

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): Populate keywords.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.populate): Note that keywords are unsupported.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.__init__): Add keywords.
(Issue.keywords): Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue): Create an issue without any keywords.
(Bugzilla._create): Return keywords.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.Keyword): Added.
(RadarModel.keywords): Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate): Populate keywords associated with radar.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:

Canonical link: <a href="https://commits.webkit.org/259639@main">https://commits.webkit.org/259639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae461db4c3bcb575de4ec6f7548433fa122ba559

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105501 "Failed to checkout and rebase branch from PR 9350") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114761 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109401 "Failed to checkout and rebase branch from PR 9350") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/16001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/111258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/16001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/108940 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/16001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3560 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->