### PR TITLE
Skip tracksAreWiderThanMinTrackBreadth() if the grid is Masonry

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1639,9 +1639,6 @@ void GridTrackSizingAlgorithm::run()
 
     if (m_renderGrid->isMasonry(m_direction))
         return;
-    
-    if (m_renderGrid->isMasonry(m_direction))
-        return;
 
     if (m_renderGrid->isSubgrid(m_direction) && copyUsedTrackSizesForSubgrid())
         return;
@@ -1698,6 +1695,9 @@ bool GridTrackSizingAlgorithm::tracksAreWiderThanMinTrackBreadth() const
     // Subgrids inherit their sizing directly from the parent, so may be unrelated
     // to their initial base size.
     if (m_renderGrid->isSubgrid(m_direction))
+        return true;
+
+    if (m_renderGrid->isMasonry(m_direction))
         return true;
 
     const Vector<GridTrack>& allTracks = tracks(m_direction);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -85,7 +85,11 @@ public:
     void setGrowthLimitCap(std::optional<LayoutUnit>);
     std::optional<LayoutUnit> growthLimitCap() const { return m_growthLimitCap; }
 
-    const GridTrackSize& cachedTrackSize() const { return *m_cachedTrackSize; }
+    const GridTrackSize& cachedTrackSize() const
+    {
+        RELEASE_ASSERT(m_cachedTrackSize);
+        return *m_cachedTrackSize;
+    }
     void setCachedTrackSize(const GridTrackSize&);
 
 private:


### PR DESCRIPTION
#### 92c4a270002ac42a89d6f05a558ae53c7c135352
<pre>
Skip tracksAreWiderThanMinTrackBreadth() if the grid is Masonry
<a href="https://bugs.webkit.org/show_bug.cgi?id=251399">https://bugs.webkit.org/show_bug.cgi?id=251399</a>

Reviewed by Matt Woodrow.

Similar to subgrid let&apos;s skip the tracksAreWiderThanMinTrackBreadth() when the Grid is set to Masonry.
Under Masonry the GridTrackSizing algorithm is skipped, so it is not needed to run this.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::run):
(WebCore::GridTrackSizingAlgorithm::tracksAreWiderThanMinTrackBreadth const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
(WebCore::GridTrack::cachedTrackSize const):

Canonical link: <a href="https://commits.webkit.org/259604@main">https://commits.webkit.org/259604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bb880bf15fab597bbe8e98069ea773ec37e2316

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114622 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5371 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97673 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39563 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26696 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7759 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28056 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7873 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6624 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9662 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->