### PR TITLE
[WebGPU] unsized arrays require bounds checking (251376)

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -108,6 +108,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     return BindGroup::createInvalid(*this);
 
                 [argumentEncoder[stage] setBuffer:buffer offset:entry.offset atIndex:index++];
+                *(uint32_t*)[argumentEncoder[stage] constantDataAtIndex:index++] = static_cast<uint32_t>(entry.size == WGPU_WHOLE_MAP_SIZE ? buffer.length : entry.size);
             } else if (samplerIsPresent) {
                 id<MTLSamplerState> sampler = WebGPU::fromAPI(entry.sampler).samplerState();
                 [argumentEncoder[stage] setSamplerState:sampler atIndex:index++];

--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -70,6 +70,10 @@ public:
 
     bool bindingContainsStage(uint32_t bindingIndex, ShaderStage renderStage) const;
 
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    static WGPUBindGroupLayoutEntry createEntryFromStructMember(MTLStructMember *, uint32_t&, WGPUShaderStage);
+#endif
+
 private:
     BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&&, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>);
     BindGroupLayout();

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -218,6 +218,32 @@ bool BindGroupLayout::bindingContainsStage(uint32_t bindingIndex, ShaderStage sh
     return containsStage(m_shaderStageForBinding.find(bindingIndex + 1)->value, shaderStage);
 }
 
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+WGPUBindGroupLayoutEntry BindGroupLayout::createEntryFromStructMember(MTLStructMember *structMember, uint32_t& currentBindingIndex, WGPUShaderStage shaderStage)
+{
+    WGPUBindGroupLayoutEntry entry = { };
+    entry.binding = currentBindingIndex++;
+    entry.visibility = shaderStage;
+    switch (structMember.dataType) {
+    case MTLDataTypeTexture:
+        entry.texture.sampleType = WGPUTextureSampleType_Float;
+        entry.texture.viewDimension = WGPUTextureViewDimension_2D;
+        break;
+    case MTLDataTypeSampler:
+        entry.sampler.type = WGPUSamplerBindingType_Filtering;
+        break;
+    case MTLDataTypePointer:
+        entry.buffer.type = WGPUBufferBindingType_Uniform;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    return entry;
+}
+#endif // HAVE(METAL_BUFFER_BINDING_REFLECTION)
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -116,8 +116,16 @@ void CommandEncoder::finalizeBlitCommandEncoder()
 
 Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDescriptor& descriptor)
 {
-    UNUSED_PARAM(descriptor);
-    return ComputePassEncoder::createInvalid(m_device);
+    if (descriptor.nextInChain)
+        return ComputePassEncoder::createInvalid(m_device);
+
+    MTLComputePassDescriptor* computePassDescriptor = [MTLComputePassDescriptor computePassDescriptor];
+    computePassDescriptor.dispatchType = MTLDispatchTypeSerial;
+
+    id<MTLComputeCommandEncoder> computeCommandEncoder = [m_commandBuffer computeCommandEncoderWithDescriptor:computePassDescriptor];
+    computeCommandEncoder.label = fromAPI(descriptor.label);
+
+    return ComputePassEncoder::create(computeCommandEncoder, m_device);
 }
 
 bool CommandEncoder::validateRenderPassDescriptor(const WGPURenderPassDescriptor& descriptor) const
@@ -131,7 +139,6 @@ bool CommandEncoder::validateRenderPassDescriptor(const WGPURenderPassDescriptor
 
 Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescriptor& descriptor)
 {
-    UNUSED_PARAM(descriptor);
     if (descriptor.nextInChain)
         return RenderPassEncoder::createInvalid(m_device);
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -85,6 +85,7 @@ private:
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;
+    MTLSize m_threadsPerThreadgroup;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -55,19 +55,17 @@ void ComputePassEncoder::beginPipelineStatisticsQuery(const QuerySet& querySet, 
 
 void ComputePassEncoder::dispatch(uint32_t x, uint32_t y, uint32_t z)
 {
-    UNUSED_PARAM(x);
-    UNUSED_PARAM(y);
-    UNUSED_PARAM(z);
+    [m_computeCommandEncoder dispatchThreadgroups:MTLSizeMake(x, y, z) threadsPerThreadgroup:m_threadsPerThreadgroup];
 }
 
 void ComputePassEncoder::dispatchIndirect(const Buffer& indirectBuffer, uint64_t indirectOffset)
 {
-    UNUSED_PARAM(indirectBuffer);
-    UNUSED_PARAM(indirectOffset);
+    [m_computeCommandEncoder dispatchThreadgroupsWithIndirectBuffer:indirectBuffer.buffer() indirectBufferOffset:indirectOffset threadsPerThreadgroup:m_threadsPerThreadgroup];
 }
 
 void ComputePassEncoder::endPass()
 {
+    [m_computeCommandEncoder endEncoding];
 }
 
 void ComputePassEncoder::endPipelineStatisticsQuery()
@@ -121,15 +119,16 @@ void ComputePassEncoder::pushDebugGroup(String&& groupLabel)
 
 void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group, uint32_t dynamicOffsetCount, const uint32_t* dynamicOffsets)
 {
-    UNUSED_PARAM(groupIndex);
-    UNUSED_PARAM(group);
     UNUSED_PARAM(dynamicOffsetCount);
     UNUSED_PARAM(dynamicOffsets);
+    [m_computeCommandEncoder setBuffer:group.computeArgumentBuffer() offset:0 atIndex:groupIndex];
 }
 
 void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
 {
-    UNUSED_PARAM(pipeline);
+    ASSERT(pipeline.computePipelineState());
+    [m_computeCommandEncoder setComputePipelineState:pipeline.computePipelineState()];
+    m_threadsPerThreadgroup = pipeline.threadsPerThreadgroup();
 }
 
 void ComputePassEncoder::setLabel(String&& label)

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import "BindGroupLayout.h"
+
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
@@ -36,14 +38,19 @@ namespace WebGPU {
 
 class BindGroupLayout;
 class Device;
+class PipelineLayout;
 
 // https://gpuweb.github.io/gpuweb/#gpucomputepipeline
 class ComputePipeline : public WGPUComputePipelineImpl, public RefCounted<ComputePipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, Device& device)
+    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, const PipelineLayout& pipelineLayout, MTLSize threadsPerThreadgroup, Device& device)
     {
-        return adoptRef(*new ComputePipeline(computePipelineState, device));
+        return adoptRef(*new ComputePipeline(computePipelineState, pipelineLayout, threadsPerThreadgroup, device));
+    }
+    static Ref<ComputePipeline> create(id<MTLComputePipelineState> computePipelineState, MTLComputePipelineReflection* reflection, MTLSize threadsPerThreadgroup, Device& device)
+    {
+        return adoptRef(*new ComputePipeline(computePipelineState, reflection, threadsPerThreadgroup, device));
     }
     static Ref<ComputePipeline> createInvalid(Device& device)
     {
@@ -60,14 +67,22 @@ public:
     id<MTLComputePipelineState> computePipelineState() const { return m_computePipelineState; }
 
     Device& device() const { return m_device; }
+    MTLSize threadsPerThreadgroup() const { return m_threadsPerThreadgroup; }
 
 private:
-    ComputePipeline(id<MTLComputePipelineState>, Device&);
+    ComputePipeline(id<MTLComputePipelineState>, const PipelineLayout&, MTLSize, Device&);
+    ComputePipeline(id<MTLComputePipelineState>, MTLComputePipelineReflection*, MTLSize, Device&);
     ComputePipeline(Device&);
 
     const id<MTLComputePipelineState> m_computePipelineState { nil };
 
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    MTLComputePipelineReflection *m_reflection { nil };
+#endif
+    const PipelineLayout *m_pipelineLayout { nullptr };
     const Ref<Device> m_device;
+    HashMap<uint32_t, Ref<BindGroupLayout>> m_cachedBindGroupLayouts;
+    const MTLSize m_threadsPerThreadgroup;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -123,7 +123,7 @@ static id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflec
     return function;
 }
 
-static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> device, id<MTLFunction> function, const PipelineLayout& pipelineLayout, const WGSL::Reflection::Compute& computeInformation, NSString *label)
+static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> device, id<MTLFunction> function, const PipelineLayout& pipelineLayout, const WGSL::Reflection::Compute& computeInformation, NSString *label, MTLComputePipelineReflection **reflection, MTLPipelineOption pipelineOptions)
 {
     auto computePipelineDescriptor = [MTLComputePipelineDescriptor new];
     computePipelineDescriptor.computeFunction = function;
@@ -136,10 +136,16 @@ static id<MTLComputePipelineState> createComputePipelineState(id<MTLDevice> devi
     computePipelineDescriptor.label = label;
     NSError *error = nil;
     // FIXME: Run the asynchronous version of this
-    id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithDescriptor:computePipelineDescriptor options:MTLPipelineOptionNone reflection:nil error:&error];
+    id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithDescriptor:computePipelineDescriptor options:pipelineOptions reflection:reflection error:&error];
+
     if (error)
         WTFLogAlways("Pipeline state creation error: %@", error);
     return computePipelineState;
+}
+
+static MTLSize metalSize(auto workgroupSize)
+{
+    return MTLSizeMake(workgroupSize.width, workgroupSize.height, workgroupSize.depth);
 }
 
 Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDescriptor& descriptor)
@@ -151,22 +157,33 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
     const PipelineLayout& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
     auto label = fromAPI(descriptor.label);
 
-    auto libraryCreationResult = createLibrary(m_device, shaderModule, pipelineLayout, fromAPI(descriptor.compute.entryPoint), label);
-    if (!libraryCreationResult)
-        return ComputePipeline::createInvalid(*this);
+    const auto& computeFunctionName = String::fromLatin1(descriptor.compute.entryPoint);
+    id<MTLFunction> function = shaderModule.getNamedFunction(computeFunctionName, buildKeyValueReplacements(descriptor.compute));
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=251171 - this should come from the WGSL compiler
+    WGSL::Reflection::Compute computeInformation { .workgroupSize = { .width = 1, .height = 1, .depth = 1 } };
+    if (!function) {
+        auto libraryCreationResult = createLibrary(m_device, shaderModule, pipelineLayout, fromAPI(descriptor.compute.entryPoint), label);
+        if (!libraryCreationResult)
+            return ComputePipeline::createInvalid(*this);
 
-    auto library = libraryCreationResult->library;
-    const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
+        auto library = libraryCreationResult->library;
+        const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
 
-    if (!std::holds_alternative<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint))
-        return ComputePipeline::createInvalid(*this);
-    const auto& computeInformation = std::get<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint);
+        if (!std::holds_alternative<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint))
+            return ComputePipeline::createInvalid(*this);
+        computeInformation = std::get<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint);
 
-    auto function = createFunction(library, entryPointInformation, descriptor.compute, label);
+        function = createFunction(library, entryPointInformation, descriptor.compute, label);
+    }
 
-    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, computeInformation, label);
+    MTLComputePipelineReflection *reflection;
+    bool hasBindGroups = pipelineLayout.numberOfBindGroupLayouts() > 0;
+    auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, computeInformation, label, &reflection, hasBindGroups ? MTLPipelineOptionNone : MTLPipelineOptionArgumentInfo);
 
-    return ComputePipeline::create(computePipelineState, *this);
+    if (hasBindGroups)
+        return ComputePipeline::create(computePipelineState, pipelineLayout, metalSize(computeInformation.workgroupSize), *this);
+
+    return ComputePipeline::create(computePipelineState, reflection, metalSize(computeInformation.workgroupSize), *this);
 }
 
 void Device::createComputePipelineAsync(const WGPUComputePipelineDescriptor& descriptor, CompletionHandler<void(WGPUCreatePipelineAsyncStatus, Ref<ComputePipeline>&&, String&& message)>&& callback)
@@ -178,14 +195,30 @@ void Device::createComputePipelineAsync(const WGPUComputePipelineDescriptor& des
     });
 }
 
-ComputePipeline::ComputePipeline(id<MTLComputePipelineState> computePipelineState, Device& device)
+ComputePipeline::ComputePipeline(id<MTLComputePipelineState> computePipelineState, const PipelineLayout& pipelineLayout, MTLSize threadsPerThreadgroup, Device& device)
     : m_computePipelineState(computePipelineState)
+    , m_pipelineLayout(&pipelineLayout)
     , m_device(device)
+    , m_threadsPerThreadgroup(threadsPerThreadgroup)
 {
+}
+
+ComputePipeline::ComputePipeline(id<MTLComputePipelineState> computePipelineState, MTLComputePipelineReflection *reflection, MTLSize threadsPerThreadgroup, Device& device)
+    : m_computePipelineState(computePipelineState)
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    , m_reflection(reflection)
+#endif
+    , m_device(device)
+    , m_threadsPerThreadgroup(threadsPerThreadgroup)
+{
+#if !HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    UNUSED_PARAM(reflection);
+#endif
 }
 
 ComputePipeline::ComputePipeline(Device& device)
     : m_device(device)
+    , m_threadsPerThreadgroup(MTLSizeMake(0, 0, 0))
 {
 }
 
@@ -193,8 +226,37 @@ ComputePipeline::~ComputePipeline() = default;
 
 BindGroupLayout* ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
 {
+    if (m_pipelineLayout)
+        return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
+
+    auto it = m_cachedBindGroupLayouts.find(groupIndex + 1);
+    if (it != m_cachedBindGroupLayouts.end())
+        return it->value.ptr();
+
+#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
+    uint32_t bindingIndex = 0;
+    Vector<WGPUBindGroupLayoutEntry> entries;
+    for (id<MTLBufferBinding> binding in m_reflection.bindings) {
+        if (binding.index != groupIndex)
+            continue;
+
+        ASSERT(binding.type == MTLBindingTypeBuffer);
+        for (MTLStructMember *structMember in binding.bufferStructType.members)
+            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Compute));
+    }
+
+    WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };
+    bindGroupLayoutDescriptor.label = "getBindGroup() generated layout";
+    bindGroupLayoutDescriptor.entryCount = entries.size();
+    bindGroupLayoutDescriptor.entries = entries.size() ? &entries[0] : nullptr;
+    auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
+    m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
+
+    return bindGroupLayout.ptr();
+#else
     UNUSED_PARAM(groupIndex);
     return nullptr;
+#endif
 }
 
 void ComputePipeline::setLabel(String&&)

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -241,8 +241,10 @@ BindGroupLayout* ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
             continue;
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
-        for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Compute));
+        for (MTLStructMember *structMember in binding.bufferStructType.members) {
+            if (structMember.dataType != MTLDataTypeUInt)
+                entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Compute));
+        }
     }
 
     WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -129,6 +129,14 @@ private:
 
     void loseTheDevice(WGPUDeviceLostReason);
     void captureFrameIfNeeded() const;
+    auto buildKeyValueReplacements(const auto& stage) const
+    {
+        HashMap<String, decltype(WGPUConstantEntry::value)> keyValueReplacements;
+        for (auto* kvp = stage.constants, *endKvp = kvp + stage.constantCount; kvp != endKvp; ++kvp)
+            keyValueReplacements.set(String::fromUTF8(kvp->key), kvp->value);
+
+        return keyValueReplacements;
+    }
 
     struct Error {
         WGPUErrorType type;

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -344,17 +344,6 @@ static MTLVertexDescriptor *createVertexDescriptor(WGPUVertexState vertexState)
     return vertexDescriptor;
 }
 
-static auto buildKeyValueReplacements(const auto& stage)
-{
-    HashMap<String, decltype(WGPUConstantEntry::value)> keyValueReplacements;
-    for (size_t i = 0; i < stage.constantCount; ++i) {
-        auto& kvp = stage.constants[i];
-        keyValueReplacements.set(String::fromUTF8(kvp.key), kvp.value);
-    }
-
-    return keyValueReplacements;
-}
-
 static void populateStencilOperation(MTLStencilDescriptor *mtlStencil, const WGPUStencilFaceState& stencil, uint32_t stencilReadMask, uint32_t stencilWriteMask)
 {
     mtlStencil.stencilCompareFunction =  convertToMTLCompare(stencil.compare);
@@ -462,12 +451,13 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
     // FIXME: GPUPrimitiveState.unclippedDepth
 
     MTLRenderPipelineReflection *reflection;
-    id<MTLRenderPipelineState> renderPipelineState = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor options:MTLPipelineOptionArgumentInfo reflection:&reflection error:nil];
+    const auto& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
+    bool hasBindGroups = pipelineLayout.numberOfBindGroupLayouts() > 0;
+    id<MTLRenderPipelineState> renderPipelineState = [m_device newRenderPipelineStateWithDescriptor:mtlRenderPipelineDescriptor options: hasBindGroups ? MTLPipelineOptionNone : MTLPipelineOptionArgumentInfo reflection:&reflection error:nil];
     if (!renderPipelineState)
         return RenderPipeline::createInvalid(*this);
 
-    const auto& pipelineLayout = WebGPU::fromAPI(descriptor.layout);
-    if (pipelineLayout.numberOfBindGroupLayouts())
+    if (hasBindGroups)
         return RenderPipeline::create(renderPipelineState, mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, depthStencilDescriptor, pipelineLayout, *this);
 
     return RenderPipeline::create(renderPipelineState, mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, depthStencilDescriptor, reflection, *this);
@@ -520,32 +510,6 @@ RenderPipeline::RenderPipeline(Device& device)
 
 RenderPipeline::~RenderPipeline() = default;
 
-#if HAVE(METAL_BUFFER_BINDING_REFLECTION)
-static WGPUBindGroupLayoutEntry createEntryFromStructMember(MTLStructMember *structMember, uint32_t& currentBindingIndex, WGPUShaderStage shaderStage)
-{
-    WGPUBindGroupLayoutEntry entry = { };
-    entry.binding = currentBindingIndex++;
-    entry.visibility = shaderStage;
-    switch (structMember.dataType) {
-    case MTLDataTypeTexture:
-        entry.texture.sampleType = WGPUTextureSampleType_Float;
-        entry.texture.viewDimension = WGPUTextureViewDimension_2D;
-        break;
-    case MTLDataTypeSampler:
-        entry.sampler.type = WGPUSamplerBindingType_Filtering;
-        break;
-    case MTLDataTypePointer:
-        entry.buffer.type = WGPUBufferBindingType_Uniform;
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-
-    return entry;
-}
-#endif // HAVE(METAL_BUFFER_BINDING_REFLECTION)
-
 BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 {
     if (m_pipelineLayout)
@@ -565,7 +529,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
         for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Vertex));
+            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Vertex));
     }
 
     for (id<MTLBufferBinding> binding in m_reflection.fragmentBindings) {
@@ -574,7 +538,7 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
         for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Fragment));
+            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Fragment));
     }
 
     WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -528,8 +528,10 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
             continue;
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
-        for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Vertex));
+        for (MTLStructMember *structMember in binding.bufferStructType.members) {
+            if (structMember.dataType != MTLDataTypeUInt)
+                entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Vertex));
+        }
     }
 
     for (id<MTLBufferBinding> binding in m_reflection.fragmentBindings) {
@@ -537,8 +539,10 @@ BindGroupLayout* RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
             continue;
 
         ASSERT(binding.type == MTLBindingTypeBuffer);
-        for (MTLStructMember *structMember in binding.bufferStructType.members)
-            entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Fragment));
+        for (MTLStructMember *structMember in binding.bufferStructType.members) {
+            if (structMember.dataType != MTLDataTypeUInt)
+                entries.append(BindGroupLayout::createEntryFromStructMember(structMember, bindingIndex, WGPUShaderStage_Fragment));
+        }
     }
 
     WGPUBindGroupLayoutDescriptor bindGroupLayoutDescriptor = { };

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
@@ -105,6 +105,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube-indirect.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube-indirect.js
@@ -133,6 +133,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js
@@ -114,14 +114,16 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])
                 {
                     Vertex vout;
-                    float alpha = values.time[0];
-                    float beta = values.time[1];
-                    float gamma = values.time[2];
+                    uint32_t bufferLength = values.bufferLength / sizeof(float);
+                    float alpha = values.time[min(0u, bufferLength - 1)];
+                    float beta = values.time[min(1u, bufferLength - 1)];
+                    float gamma = values.time[min(2u, bufferLength - 1)];
                     float cA = cos(alpha);
                     float sA = sin(alpha);
                     float cB = cos(beta);

--- a/Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js
@@ -164,6 +164,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 struct FragmentShaderArguments {

--- a/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
@@ -146,7 +146,9 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
-                    device float4 *translation [[id(1)]];
+                    uint32_t timeLength [[id(1)]];
+                    device float4 *translation [[id(2)]];
+                    uint32_t translationLength [[id(3)]];
                 };
     
                 struct FragmentShaderArguments {
@@ -158,9 +160,10 @@ async function helloCube() {
                 {
                     VertexOut vout;
                     unsigned offset = InstanceIndex * 3;
-                    float alpha = values.time[offset];
-                    float beta = values.time[offset + 1];
-                    float gamma = values.time[offset + 2];
+                    uint32_t timeLength = values.timeLength / sizeof(values.time[0]);
+                    float alpha = values.time[min(timeLength, offset)];
+                    float beta = values.time[min(timeLength, offset + 1)];
+                    float gamma = values.time[min(timeLength, offset + 2)];
                     float cA = cos(alpha);
                     float sA = sin(alpha);
                     float cB = cos(beta);
@@ -172,7 +175,8 @@ async function helloCube() {
                                           cA*sB*sG - sA*cG,  sA*sB*sG + cA*cG,   cB * sG, 0,
                                           cA*sB*cG + sA*sG, sA*sB*cG - cA*sG, cB * cG, 0,
                                           0,     0,     0, 1);
-                    float4 translation = values.translation[InstanceIndex];
+                    uint32_t translationLength = values.translationLength / sizeof(values.translation[0]);
+                    float4 translation = values.translation[min(translationLength, InstanceIndex)];
 
                     VertexIn vin = *(device VertexIn*)(vertices + VertexIndex * vertexInputPackedFloatSize);
                     vout.position = vin.position * m + translation;

--- a/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
@@ -90,6 +90,7 @@ async function helloTriangle() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
 
                 vertex Vertex vsmain(const device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
@@ -171,6 +171,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 struct FragmentShaderArguments {

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
@@ -164,6 +164,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 struct FragmentShaderArguments {

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
@@ -165,6 +165,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 struct FragmentShaderArguments {

--- a/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
@@ -134,6 +134,7 @@ async function helloCube() {
     
                 struct VertexShaderArguments {
                     device float *time [[id(0)]];
+                    uint32_t bufferLength;
                 };
     
                 vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(8)]], unsigned VertexIndex [[vertex_id]])


### PR DESCRIPTION
#### 119b59ab84b5009acc5db1635ddc6d8281b8ff9d
<pre>
[WebGPU] unsized arrays require bounds checking (251376)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251376">https://bugs.webkit.org/show_bug.cgi?id=251376</a>
&lt;radar://104827098&gt;

Reviewed by NOBODY (OOPS!).

Add the buffer length size to the argument buffer so the
generated metal source can perform bounds checking.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::makeBufferLengthDescriptorForBinding):
(WebGPU::Device::createBindGroupLayout):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::getBindGroupLayout):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):
* Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js:
* Websites/webkit.org/demos/webgpu/scripts/hello-cube-indirect.js:
* Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js:
* Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js:
* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js:
* Websites/webkit.org/demos/webgpu/scripts/query-sets.js:
* Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js:
* Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js:
* Websites/webkit.org/demos/webgpu/scripts/textured-cube.js:
* Websites/webkit.org/demos/webgpu/scripts/two-cubes.js:
</pre>
----------------------------------------------------------------------
#### 67efd6e5cef85e43b8fc5a2738e437cad635809c
<pre>
WebGPU: Compute passes
<a href="https://bugs.webkit.org/show_bug.cgi?id=250863">https://bugs.webkit.org/show_bug.cgi?id=250863</a>
&lt;radar://83213548&gt;

Reviewed by NOBODY (OOPS!).

Implement compute passes which are needed to start
passing a lot of the CTS tests which create a simple
compute shader and read back the result, to ensure
the adapter was created.

<a href="https://bugs.webkit.org/show_bug.cgi?id=251171">https://bugs.webkit.org/show_bug.cgi?id=251171</a> has
been filed for tracking getting the threads per thread
group size from the shader compiler.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):

* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::dispatch):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::ComputePassEncoder::setBindGroup):
(WebGPU::ComputePassEncoder::setPipeline):
(WebGPU::ComputePassEncoder::endPass):

* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::BindGroupLayout::createEntryFromStructMember):
Moved so both compute and render pipeline can access.

* Source/WebGPU/WebGPU/ComputePipeline.h:
(WebGPU::ComputePipeline::create):
(WebGPU::ComputePipeline::threadsPerThreadgroup const):

* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::buildKeyValueReplacements const):
Moved to common path.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::getBindGroupLayout):
(WebGPU::buildKeyValueReplacements): Deleted.
(WebGPU::createEntryFromStructMember): Deleted.
Moved to common path.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/119b59ab84b5009acc5db1635ddc6d8281b8ff9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114637 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5387 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114527 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39602 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7769 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28058 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4653 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47602 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9676 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->