### PR TITLE
Web Inspector: Add experimental feature to enable aggressive limits on the length of lines we let CodeMirror process/format

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -235,6 +235,7 @@ WI.settings = {
     experimentalAllowInspectingInspector: new WI.Setting("experimental-allow-inspecting-inspector", false),
     experimentalCSSSortPropertyNameAutocompletionByUsage: new WI.Setting("experimental-css-sort-property-name-autocompletion-by-usage", true),
     experimentalEnableNetworkEmulatedCondition: new WI.Setting("experimental-enable-network-emulated-condition", false),
+    experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
 
     // Protocol
     protocolLogAsText: new WI.Setting("protocol-log-as-text", false),

--- a/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorTokenTrackingController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorTokenTrackingController.js
@@ -337,6 +337,9 @@ WI.CodeMirrorTokenTrackingController = class CodeMirrorTokenTrackingController e
     {
         // Get the position in the text and the token at that position.
         var position = this._codeMirror.coordsChar(mouseCoords);
+        if (WI.settings.experimentalLimitSourceCodeHighlighting.value && position.ch > 120)
+            return;
+
         var token = this._codeMirror.getTokenAt(position);
 
         if (!token || !token.type || !token.string) {

--- a/Source/WebInspectorUI/UserInterface/Views/CodeMirrorEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CodeMirrorEditor.js
@@ -40,6 +40,9 @@ WI.CodeMirrorEditor = class CodeMirrorEditor
             tabSize: WI.settings.tabSize.value,
             lineWrapping: WI.settings.enableLineWrapping.value,
             showWhitespaceCharacters: WI.settings.showWhitespaceCharacters.value,
+            maxHighlightLength: WI.settings.experimentalLimitSourceCodeHighlighting.value ? 120 : 10000,
+            maxScanLineLength: WI.settings.experimentalLimitSourceCodeHighlighting.value ? 120 : 10000,
+            maxHighlightLineLength: WI.settings.experimentalLimitSourceCodeHighlighting.value ? 120 : 1000,
             ...options,
         });
 

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -414,6 +414,11 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
             experimentalSettingsView.addSeparator();
         }
 
+        let sourcesGroup = experimentalSettingsView.addGroup(WI.UIString("Sources:"));
+        sourcesGroup.addSetting(WI.settings.experimentalLimitSourceCodeHighlighting, WI.UIString("Limit syntax highlighting on long lines of code"));
+
+        experimentalSettingsView.addSeparator();
+
         let diagnosticsGroup = experimentalSettingsView.addGroup(WI.UIString("Diagnostics:", "Diagnostics: @ Experimental Settings", "Category label for experimental settings related to Web Inspector diagnostics."));
         diagnosticsGroup.addSetting(WI.settings.experimentalAllowInspectingInspector, WI.UIString("Allow Inspecting Web Inspector", "Allow Inspecting Web Inspector @ Experimental Settings", "Label for setting that allows the user to inspect the Web Inspector user interface."));
         experimentalSettingsView.addSeparator();
@@ -441,6 +446,8 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
 
         if (hasNetworkEmulatedCondition)
             listenForChange(WI.settings.experimentalEnableNetworkEmulatedCondition);
+
+        listenForChange(WI.settings.experimentalLimitSourceCodeHighlighting);
 
         this._createReferenceLink(experimentalSettingsView);
 


### PR DESCRIPTION
#### b79f1636634fa4631caf970168c2bbe763edb3b7
<pre>
Web Inspector: Add experimental feature to enable aggressive limits on the length of lines we let CodeMirror process/format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251401">https://bugs.webkit.org/show_bug.cgi?id=251401</a>
rdar://104840214

Reviewed by Devin Rousso and Justin Michaud.

In select cases, we are finding that Web Inspector is effectively unusable on some sites with many source files with
very longs lines of source code. The highlighting of very longs lines of code accounts for upwards of 30 seconds of
delay for very long lines of code. While we investigate further improvements we can make to solve this problem, we
are adding an experimental setting that enforces very low line limits for highlight, as well as for determining the
hovered token. These two changes will unblock developers encountering this issue when they enable the added experimental
setting.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorTokenTrackingController.js:
(WI.CodeMirrorTokenTrackingController.prototype._updateHoveredTokenInfo):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createExperimentalSettingsView):
* Source/WebInspectorUI/UserInterface/Views/TextEditor.js:
(WI.TextEditor):

Canonical link: <a href="https://commits.webkit.org/259603@main">https://commits.webkit.org/259603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285e0712eb3c5853ea98917a73ce6beae31c98b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114659 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5410 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97708 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95085 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/93970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26720 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/13929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47624 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6622 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9697 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->