### PR TITLE
[ iOS BigSur+ ] fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html is a flaky failure.

### DIFF
--- a/LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html
+++ b/LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html
@@ -35,13 +35,13 @@ function onTestWindowLoad(event)
         break;            
     case 2:
         debug('going back to page 1 with new state object');
-        setTimeout(function() {
+        timeoutHandle = setTimeout(function() {
             testWindow.history.back();
             setTimeout(() => {
                 shouldBe("testWindowPopstateFireCount", "1");
                 testWindow.close();
                 finishJSTest();
-            }, 100);
+            }, 20000);
         }, 0);
         break;
     default:
@@ -66,6 +66,7 @@ function onTestWindowPopState(event)
     debug('popstate fired with state ' + event.state);
     testWindowPopstateFireCount++;
     shouldBe("testWindowPopstateFireCount", "1");
+    clearTimeout(timeoutHandle);
     setTimeout(function() {
         testWindow.close();
         finishJSTest();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3895,8 +3895,6 @@ webkit.org/b/251302 accessibility/ios-simulator/table-cell-ranges.html [ Failure
 
 webkit.org/b/251306 http/tests/in-app-browser-privacy/sub-frame-redirect-to-non-app-bound-domain-blocked.html [ Pass Crash ]
 
-webkit.org/b/251312 fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html [ Pass Failure ]
-
 http/tests/webgpu/webgpu/idl/constants/flags.html [ Skip ]
 http/tests/webgpu/webgpu/idl/exposed.https.html [ Skip ]
 http/tests/webgpu/webgpu/idl/exposed.http.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2786,4 +2786,3 @@ webkit.org/b/242804 media/track/track-forced-subtitles-in-band.html [ Pass Failu
 
 webkit.org/b/251051 [ BigSur+ Debug ] storage/indexeddb/modern/deleteindex-4-private.html [ Crash ]
 
-webkit.org/b/251312 [ BigSur+ ] fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html [ Pass Failure ]


### PR DESCRIPTION
#### 67c6a041f39ce0314fd554bb4ec86f61150b890b
<pre>
[ iOS BigSur+ ] fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251312">https://bugs.webkit.org/show_bug.cgi?id=251312</a>
rdar://104775065

Reviewed by Alex Christensen.

We expect an event and call finishJSTest() when we get that event. However, we
also had a timeout handler to complete the test with an error in case we never
got the event. The timeout handler was too short (100ms) and would sometimes
trigger before receiving the event on some of the slower bots. Increase the
timeout delay to avoid the issue.

* LayoutTests/fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/259649@main">https://commits.webkit.org/259649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5703d0cbc597f2fcc51400d565d546f1a1cd44b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114784 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16041 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97827 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111284 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26815 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7906 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28171 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47714 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6660 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9928 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->