### PR TITLE
Fix DFG node flag propagation for try catch blocks

### DIFF
--- a/JSTests/stress/try-catch-dfg-node-flag-propagation.js
+++ b/JSTests/stress/try-catch-dfg-node-flag-propagation.js
@@ -1,0 +1,158 @@
+function throwFunction() {
+    throw 2;
+}
+
+let a = [0.1];
+
+// --------- try catch with throw function ---------
+function foo1(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo2(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo3(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throwFunction();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch with throw ---------
+function foo4(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo5(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo6(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throw new Error();
+    } catch { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch finally with throw function ---------
+function foo7(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo8(i) {
+    let x = a[1];
+    try {
+        throw new Error();
+    } catch {
+    } finally {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo9(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throw new Error();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+// --------- try catch finally with throw function ---------
+function foo10(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+function foo11(i) {
+    let x = a[1];
+    try {
+        throwFunction();
+    } catch {
+    } finally {
+        if (x !== undefined) {
+            throw new Error(`x is ${x} at iteration ${i}`);
+        }
+    }
+}
+
+function foo12(i) {
+    let x = a[1];
+    try {
+        if (i % 2)
+            throwFunction();
+    } catch {
+    } finally { }
+    if (x !== undefined) {
+        throw new Error(`x is ${x} at iteration ${i}`);
+    }
+}
+
+for (let i = 0; i < 100000; i++) {
+    foo1(i);
+    foo2(i);
+    foo3(i);
+    foo4(i);
+    foo5(i);
+    foo6(i);
+    foo7(i);
+    foo8(i);
+    foo9(i);
+    foo10(i);
+    foo11(i);
+    foo12(i);
+}

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1973,6 +1973,13 @@ bool CodeBlock::hasOptimizedReplacement()
 }
 #endif
 
+HandlerInfo* CodeBlock::handlerFor(BytecodeIndex bytecodeIndex)
+{
+    if (bytecodeIndex.offset() >= instructions().size())
+        return nullptr;
+    return handlerForBytecodeIndex(bytecodeIndex, RequiredHandler::AnyHandler);
+}
+
 HandlerInfo* CodeBlock::handlerForBytecodeIndex(BytecodeIndex bytecodeIndex, RequiredHandler requiredHandler)
 {
     RELEASE_ASSERT(bytecodeIndex.offset() < instructions().size());

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -236,6 +236,7 @@ public:
         return reg.offset() >= static_cast<int>(m_numVars);
     }
 
+    HandlerInfo* handlerFor(BytecodeIndex);
     HandlerInfo* handlerForBytecodeIndex(BytecodeIndex, RequiredHandler = RequiredHandler::AnyHandler);
     HandlerInfo* handlerForIndex(unsigned, RequiredHandler = RequiredHandler::AnyHandler);
     void removeExceptionHandlerForCallSite(DisposableCallSiteIndex);


### PR DESCRIPTION
#### 75e71100f660c8f0eb854ea3e8493542792e57d4
<pre>
Fix DFG node flag propagation for try catch blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=251411">https://bugs.webkit.org/show_bug.cgi?id=251411</a>

Reviewed by NOBODY (OOPS!).

The DFG catch block, unlikely in bytecode, cannot propagate the node
flags to the try block. To fix this issue, we should enable backward
propagation for try catch blocks.

* JSTests/stress/try-catch-dfg-node-flag-propagation.js: Added.
(foo):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::handlerFor):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::run):
(JSC::DFG::BackwardsPropagationPhase::propagate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e71100f660c8f0eb854ea3e8493542792e57d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114948 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175085 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6014 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114747 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39810 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81533 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95446 "Found 3 new JSC stress test failures: stress/try-catch-dfg-node-flag-propagation.js.ftl-eager-no-cjit-b3o1, stress/try-catch-dfg-node-flag-propagation.js.ftl-no-cjit-no-inline-validate, stress/try-catch-dfg-node-flag-propagation.js.ftl-no-cjit-validate-sampling-profiler (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8082 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28314 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93627 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5869 "Found 3 new JSC stress test failures: stress/try-catch-dfg-node-flag-propagation.js.ftl-eager-no-cjit-b3o1, stress/try-catch-dfg-node-flag-propagation.js.ftl-no-cjit-no-inline-validate, stress/try-catch-dfg-node-flag-propagation.js.ftl-no-cjit-validate-sampling-profiler (failure)") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8576 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4903 "Found 60 new test failures: accessibility/mac/text-marker-paragraph-nav.html, accessibility/mac/text-marker-word-nav.html, accessibility/text-marker/text-marker-previous-next.html, contentfiltering/allow-never.html, editing/execCommand/change-list-type.html, fast/canvas/webgl/tex-image-and-uniform-binding-bugs.html, fast/events/media-element-focus-tab.html, fast/events/wheel/redispatched-wheel-event.html, fast/loader/stateobjects/popstate-does-not-fire-with-page-cache.html, fast/mediastream/audio-unit-reconfigure.html ... (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30430 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47861 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102341 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10129 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25518 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->