### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for ApplePayButton

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2213,6 +2213,7 @@ platform/graphics/VelocityData.cpp
 platform/graphics/WebMResourceClient.cpp
 platform/graphics/WOFFFileFormat.cpp
 platform/graphics/WidthIterator.cpp
+platform/graphics/controls/ApplePayButtonPart.cpp
 platform/graphics/controls/ControlFactory.cpp
 platform/graphics/controls/ControlPart.cpp
 platform/graphics/controls/ControlStyle.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -433,6 +433,8 @@ platform/graphics/cocoa/WebCoreCALayerExtras.mm
 platform/graphics/cocoa/WebCoreDecompressionSession.mm
 platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
 platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
+platform/graphics/cocoa/controls/ControlFactoryCocoa.mm
 platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
 platform/graphics/coretext/FontCascadeCoreText.cpp
 platform/graphics/coretext/FontCoreText.cpp

--- a/Source/WebCore/editing/FontAttributeChanges.h
+++ b/Source/WebCore/editing/FontAttributeChanges.h
@@ -29,6 +29,10 @@
 #include "FontShadow.h"
 #include <wtf/Forward.h>
 
+namespace IPC {
+template<typename T, typename> struct ArgumentCoder;
+}
+
 namespace WebCore {
 
 class EditingStyle;

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(APPLE_PAY)
+
+#import "PlatformControl.h"
+
+namespace WebCore {
+
+class ApplePayButtonPart;
+
+class ApplePayButtonCocoa final : public PlatformControl {
+public:
+    ApplePayButtonCocoa(ApplePayButtonPart& owningMeterPart);
+
+private:
+    const ApplePayButtonPart& owningApplePayButtonPart() const { return downcast<ApplePayButtonPart>(m_owningPart); }
+
+    void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ApplePayButtonCocoa.h"
+
+#if ENABLE(APPLE_PAY)
+
+#import "ApplePayButtonPart.h"
+#import "FloatRoundedRect.h"
+#import "GraphicsContext.h"
+
+namespace WebCore {
+
+ApplePayButtonCocoa::ApplePayButtonCocoa(ApplePayButtonPart& owningPart)
+    : PlatformControl(owningPart)
+{
+}
+
+void ApplePayButtonCocoa::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle&)
+{
+    auto largestCornerRadius = std::max({
+        borderRect.radii().topLeft().maxDimension(),
+        borderRect.radii().topRight().maxDimension(),
+        borderRect.radii().bottomLeft().maxDimension(),
+        borderRect.radii().bottomRight().maxDimension()
+    });
+
+    auto systemImage = ApplePayButtonSystemImage::create(
+        owningApplePayButtonPart().buttonType(),
+        owningApplePayButtonPart().buttonStyle(),
+        owningApplePayButtonPart().locale(),
+        largestCornerRadius
+    );
+
+    context.drawSystemImage(systemImage, borderRect.rect());
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/platform/graphics/cocoa/controls/ControlFactoryCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ControlFactoryCocoa.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#import "ControlFactory.h"
+
+namespace WebCore {
+
+class ControlFactoryCocoa : public ControlFactory {
+protected:
+    using ControlFactory::ControlFactory;
+
+#if ENABLE(APPLE_PAY)
+    std::unique_ptr<PlatformControl> createPlatformApplePayButton(ApplePayButtonPart&) override;
+#endif
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cocoa/controls/ControlFactoryCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ControlFactoryCocoa.mm
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ControlFactoryCocoa.h"
+
+#if PLATFORM(COCOA)
+
+namespace WebCore {
+
+#if ENABLE(APPLE_PAY)
+std::unique_ptr<PlatformControl> ControlFactoryCocoa::createPlatformApplePayButton(ApplePayButtonPart& part)
+{
+    return makeUnique<ApplePayButtonCocoa>(part);
+}
+#endif
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/controls/ApplePayButtonPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ApplePayButtonPart.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ApplePayButtonPart.h"
+
+#if ENABLE(APPLE_PAY)
+
+#include "ControlFactory.h"
+
+namespace WebCore {
+
+Ref<ApplePayButtonPart> ApplePayButtonPart::create(ApplePayButtonType buttonType, ApplePayButtonStyle buttonStyle, const String& locale)
+{
+    return adoptRef(*new ApplePayButtonPart(buttonType, buttonStyle, locale));
+}
+
+ApplePayButtonPart::ApplePayButtonPart(ApplePayButtonType buttonType, ApplePayButtonStyle buttonStyle, const String& locale)
+    : ControlPart(StyleAppearance::ApplePayButton)
+    , m_buttonType(buttonType)
+    , m_buttonStyle(buttonStyle)
+    , m_locale(locale)
+{
+}
+
+std::unique_ptr<PlatformControl> ApplePayButtonPart::createPlatformControl()
+{
+    return controlFactory().createPlatformApplePayButton(*this);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/platform/graphics/controls/ApplePayButtonPart.h
+++ b/Source/WebCore/platform/graphics/controls/ApplePayButtonPart.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(APPLE_PAY)
+
+#include "ApplePayButtonSystemImage.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class ApplePayButtonPart : public ControlPart {
+public:
+    WEBCORE_EXPORT static Ref<ApplePayButtonPart> create(ApplePayButtonType, ApplePayButtonStyle, const String& locale);
+
+    ApplePayButtonType buttonType() const { return m_buttonType; }
+    ApplePayButtonStyle buttonStyle() const { return m_buttonStyle; }
+    String locale() const { return m_locale; }
+
+private:
+    ApplePayButtonPart(ApplePayButtonType, ApplePayButtonStyle, const String& locale);
+
+    std::unique_ptr<PlatformControl> createPlatformControl() override;
+
+    ApplePayButtonType m_buttonType;
+    ApplePayButtonStyle m_buttonStyle;
+    String m_locale;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CONTROL_PART(ApplePayButton)
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -27,6 +27,7 @@
 
 namespace WebCore {
 
+class ApplePayButtonPart;
 class ButtonPart;
 class ColorWellPart;
 class ImageControlsButtonPart;
@@ -52,6 +53,9 @@ public:
     WEBCORE_EXPORT static std::unique_ptr<ControlFactory> createControlFactory();
     static ControlFactory& sharedControlFactory();
 
+#if ENABLE(APPLE_PAY)
+    virtual std::unique_ptr<PlatformControl> createPlatformApplePayButton(ApplePayButtonPart&) = 0;
+#endif
     virtual std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) = 0;
 #if ENABLE(INPUT_TYPE_COLOR)
     virtual std::unique_ptr<PlatformControl> createPlatformColorWell(ColorWellPart&) = 0;

--- a/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h
+++ b/Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h
@@ -27,6 +27,7 @@
 
 #if USE(APPKIT)
 
+#include "Color.h"
 #include "SystemImage.h"
 #include <optional>
 #include <wtf/Forward.h>

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -27,16 +27,16 @@
 
 #if PLATFORM(MAC)
 
-#import "ControlFactory.h"
+#import "ControlFactoryCocoa.h"
 #import "WebControlView.h"
 
 OBJC_CLASS NSServicesRolloverButtonCell;
 
 namespace WebCore {
 
-class ControlFactoryMac final : public ControlFactory {
+class ControlFactoryMac final : public ControlFactoryCocoa {
 public:
-    using ControlFactory::ControlFactory;
+    using ControlFactoryCocoa::ControlFactoryCocoa;
 
     static ControlFactoryMac& sharedControlFactory();
 

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -28,9 +28,13 @@
 
 #if PLATFORM(MAC) && ENABLE(SERVICE_CONTROLS)
 
+#import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "ImageControlsButtonPart.h"
+#import "LocalCurrentGraphicsContext.h"
 #import <pal/spi/mac/NSServicesRolloverButtonCellSPI.h>
+#import <wtf/BlockObjCExceptions.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
 #import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "RenderTheme.h"
 
+#include "ApplePayButtonPart.h"
 #include "ButtonPart.h"
 #include "CSSValueKeywords.h"
 #include "ColorBlending.h"
@@ -71,6 +72,7 @@
 #include "TextFieldPart.h"
 #include "ToggleButtonPart.h"
 #include <wtf/FileSystem.h>
+#include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
@@ -484,6 +486,19 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
     return StyleAppearance::None;
 }
 
+#if ENABLE(APPLE_PAY)
+static RefPtr<ControlPart> createApplePayButtonPartForRenderer(const RenderObject& renderer)
+{
+    auto& style = renderer.style();
+
+    String locale = style.computedLocale();
+    if (locale.isEmpty())
+        locale = defaultLanguage(ShouldMinimizeLanguages::No);
+
+    return ApplePayButtonPart::create(style.applePayButtonType(), style.applePayButtonStyle(), locale);
+}
+#endif
+
 static RefPtr<ControlPart> createMeterPartForRenderer(const RenderObject& renderer)
 {
     ASSERT(is<RenderMeter>(renderer));
@@ -598,7 +613,7 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 
 #if ENABLE(APPLE_PAY)
     case StyleAppearance::ApplePayButton:
-        break;
+        return createApplePayButtonPartForRenderer(renderer);
 #endif
 #if ENABLE(ATTACHMENT_ELEMENT)
     case StyleAppearance::Attachment:

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -189,6 +189,9 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
     auto type = renderer.style().effectiveAppearance();
     return type == StyleAppearance::Button
         || type == StyleAppearance::Checkbox
+#if ENABLE(APPLE_PAY)
+        || type == StyleAppearance::ApplePayButton
+#endif
 #if ENABLE(INPUT_TYPE_COLOR)
         || type == StyleAppearance::ColorWell
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -155,6 +155,10 @@
 #include <WebCore/TextRecognitionResult.h>
 #endif
 
+#if ENABLE(APPLE_PAY)
+#include <WebCore/ApplePayButtonPart.h>
+#endif
+
 #if USE(APPKIT)
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
@@ -1464,9 +1468,14 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
         break;
 
     case WebCore::StyleAppearance::SearchField:
+        break;
+            
 #if ENABLE(APPLE_PAY)
     case WebCore::StyleAppearance::ApplePayButton:
+        encoder << downcast<WebCore::ApplePayButtonPart>(part);
+        break;
 #endif
+
 #if ENABLE(ATTACHMENT_ELEMENT)
     case WebCore::StyleAppearance::Attachment:
     case WebCore::StyleAppearance::BorderlessAttachment:
@@ -1556,8 +1565,15 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
         return WebCore::SearchFieldPart::create();
 
 #if ENABLE(APPLE_PAY)
-    case WebCore::StyleAppearance::ApplePayButton:
+    case WebCore::StyleAppearance::ApplePayButton: {
+        std::optional<Ref<WebCore::ApplePayButtonPart>> applePayButtonPart;
+        decoder >> applePayButtonPart;
+        if (applePayButtonPart)
+            return WTFMove(*applePayButtonPart);
+        break;
+    }
 #endif
+
 #if ENABLE(ATTACHMENT_ELEMENT)
     case WebCore::StyleAppearance::Attachment:
     case WebCore::StyleAppearance::BorderlessAttachment:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2492,6 +2492,14 @@ enum class WebCore::StyleAppearance : uint8_t {
     SliderThumbVertical
 };
 
+#if ENABLE(APPLE_PAY)
+[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayButtonPart {
+    WebCore::ApplePayButtonType buttonType();
+    WebCore::ApplePayButtonStyle buttonStyle();
+    String locale();
+};
+#endif
+
 [Nested] enum class WebCore::MeterPart::GaugeRegion : uint8_t {
     Optimum,
     Suboptimal,


### PR DESCRIPTION
#### a586299ede2ec5ded2e1d4495c5b743e2a696540
<pre>
[GPU Process] [FormControls] Add a ControlPart for ApplePayButton
<a href="https://bugs.webkit.org/show_bug.cgi?id=251416">https://bugs.webkit.org/show_bug.cgi?id=251416</a>
rdar://104850550

Reviewed by Aditya Keerthi.

Treat ApplePayButton as a ControlPart and draw it through GraphicsContext::drawControlPart().
Remove the special case for drawing the ApplePayButton as a SystemImage.

* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/FontAttributeChanges.h:
* Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h: Added.
* Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm: Copied from Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm.
(WebCore::ApplePayButtonCocoa::ApplePayButtonCocoa):
(WebCore::ApplePayButtonCocoa::draw):
* Source/WebCore/platform/graphics/cocoa/controls/ControlFactoryCocoa.h: Added.
* Source/WebCore/platform/graphics/cocoa/controls/ControlFactoryCocoa.mm: Copied from Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm.
(WebCore::ControlFactoryCocoa::createPlatformApplePayButton):
* Source/WebCore/platform/graphics/controls/ApplePayButtonPart.cpp: Added.
(WebCore::ApplePayButtonPart::create):
(WebCore::ApplePayButtonPart::ApplePayButtonPart):
(WebCore::ApplePayButtonPart::createPlatformControl):
* Source/WebCore/platform/graphics/controls/ApplePayButtonPart.h: Added.
(WebCore::ApplePayButtonPart::buttonType const):
(WebCore::ApplePayButtonPart::buttonStyle const):
(WebCore::ApplePayButtonPart::locale const):
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/mac/AppKitControlSystemImage.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm:
* Source/WebCore/platform/graphics/mac/controls/SearchFieldMac.mm:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::createApplePayButtonPartForRenderer):
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259652@main">https://commits.webkit.org/259652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b67292729fe49409976199aa6d02952536bf0cb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114766 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174912 "Failed to checkout and rebase branch from PR 9364") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5833 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97810 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111264 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95175 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26811 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7888 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8238 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6665 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9913 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->