### PR TITLE
Move SVG conditional processing attributes to SVGElementRareData

### DIFF
--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1089,4 +1089,16 @@ void SVGElement::invalidateInstances()
     }
 }
 
+SVGConditionalProcessingAttributes& SVGElement::conditionalProcessingAttributes()
+{
+    return ensureSVGRareData().conditionalProcessingAttributes(*this);
+}
+
+SVGConditionalProcessingAttributes* SVGElement::conditionalProcessingAttributesIfExists() const
+{
+    if (!m_svgRareData)
+        return nullptr;
+    return m_svgRareData->conditionalProcessingAttributesIfExists();
+}
+
 }

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -164,6 +164,9 @@ public:
     AtomString className() const { return AtomString { m_className->currentValue() }; }
     SVGAnimatedString& classNameAnimated() { return m_className; }
 
+    SVGConditionalProcessingAttributes& conditionalProcessingAttributes();
+    SVGConditionalProcessingAttributes* conditionalProcessingAttributesIfExists() const;
+
 protected:
     SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, ConstructionType = CreateSVGElement);
     virtual ~SVGElement();

--- a/Source/WebCore/svg/SVGElementRareData.h
+++ b/Source/WebCore/svg/SVGElementRareData.h
@@ -21,6 +21,7 @@
 
 #include "MutableStyleProperties.h"
 #include "SVGResourceElementClient.h"
+#include "SVGTests.h"
 #include "StyleResolver.h"
 #include <wtf/HashSet.h>
 #include <wtf/Noncopyable.h>
@@ -88,6 +89,14 @@ public:
     void setUseOverrideComputedStyle(bool value) { m_useOverrideComputedStyle = value; }
     void setNeedsOverrideComputedStyleUpdate() { m_needsOverrideComputedStyleUpdate = true; }
 
+    SVGConditionalProcessingAttributes* conditionalProcessingAttributesIfExists() const { return m_conditionalProcessingAttributes.get(); }
+    SVGConditionalProcessingAttributes& conditionalProcessingAttributes(SVGElement& contextElement)
+    {
+        if (!m_conditionalProcessingAttributes)
+            m_conditionalProcessingAttributes = makeUnique<SVGConditionalProcessingAttributes>(contextElement);
+        return *m_conditionalProcessingAttributes;
+    }
+
 private:
     WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> m_referencingElements;
     WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_referenceTarget;
@@ -101,6 +110,7 @@ private:
     bool m_needsOverrideComputedStyleUpdate : 1;
     RefPtr<MutableStyleProperties> m_animatedSMILStyleProperties;
     std::unique_ptr<RenderStyle> m_overrideComputedStyle;
+    std::unique_ptr<SVGConditionalProcessingAttributes> m_conditionalProcessingAttributes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -33,6 +33,23 @@ class SVGStringList;
 template<typename OwnerType, typename... BaseTypes>
 class SVGPropertyOwnerRegistry;
 
+class SVGTests;
+
+class SVGConditionalProcessingAttributes {
+    WTF_MAKE_NONCOPYABLE(SVGConditionalProcessingAttributes); WTF_MAKE_FAST_ALLOCATED;
+public:
+    SVGConditionalProcessingAttributes(SVGElement& contextElement);
+
+    SVGStringList& requiredFeatures() { return m_requiredFeatures; }
+    SVGStringList& requiredExtensions() { return m_requiredExtensions; }
+    SVGStringList& systemLanguage() { return m_systemLanguage; }
+
+private:
+    Ref<SVGStringList> m_requiredFeatures;
+    Ref<SVGStringList> m_requiredExtensions;
+    Ref<SVGStringList> m_systemLanguage;
+};
+
 class SVGTests {
     WTF_MAKE_NONCOPYABLE(SVGTests);
 public:
@@ -48,19 +65,19 @@ public:
 
     WEBCORE_EXPORT static bool hasFeatureForLegacyBindings(const String& feature, const String& version);
 
+    SVGConditionalProcessingAttributes& conditionalProcessingAttributes();
+    SVGConditionalProcessingAttributes* conditionalProcessingAttributesIfExists() const;
+
     // These methods are called from DOM through the super classes.
-    SVGStringList& requiredFeatures() { return m_requiredFeatures; }
-    SVGStringList& requiredExtensions() { return m_requiredExtensions; }
-    SVGStringList& systemLanguage() { return m_systemLanguage; }
+    SVGStringList& requiredFeatures() { return conditionalProcessingAttributes().requiredFeatures(); }
+    SVGStringList& requiredExtensions() { return conditionalProcessingAttributes().requiredExtensions(); }
+    SVGStringList& systemLanguage() { return conditionalProcessingAttributes().systemLanguage(); }
 
 protected:
     SVGTests(SVGElement* contextElement);
 
 private:
     SVGElement& m_contextElement;
-    Ref<SVGStringList> m_requiredFeatures;
-    Ref<SVGStringList> m_requiredExtensions;
-    Ref<SVGStringList> m_systemLanguage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/properties/SVGPropertyAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAccessorImpl.h
@@ -27,18 +27,52 @@
 
 #include "SVGPropertyAccessor.h"
 #include "SVGStringList.h"
+#include "SVGTests.h"
 
 namespace WebCore {
 
 template<typename OwnerType>
-class SVGStringListAccessor final : public SVGPropertyAccessor<OwnerType, SVGStringList> {
-    using Base = SVGPropertyAccessor<OwnerType, SVGStringList>;
+class SVGConditionalProcessingAttributeAccessor final : public SVGMemberAccessor<OwnerType> {
+    using Base = SVGMemberAccessor<OwnerType>;
 
 public:
-    using Base::Base;
-    template<Ref<SVGStringList> OwnerType::*property>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGStringListAccessor, property>(); }
+    SVGConditionalProcessingAttributeAccessor(Ref<SVGStringList> SVGConditionalProcessingAttributes::*property)
+        : m_property(property)
+    {
+    }
+
+    Ref<SVGStringList>& property(OwnerType& owner) const { return owner.conditionalProcessingAttributes().*m_property; }
+    const Ref<SVGStringList>& property(const OwnerType& owner) const { return const_cast<OwnerType&>(owner).conditionalProcessingAttributes().*m_property; }
+
+    void detach(const OwnerType& owner) const override
+    {
+        property(owner)->detach();
+    }
+
+    std::optional<String> synchronize(const OwnerType& owner) const override
+    {
+        return property(owner)->synchronize();
+    }
+
+    bool matches(const OwnerType& owner, const SVGProperty& property) const override
+    {
+        return this->property(owner).ptr() == &property;
+    }
+
+    template<Ref<SVGStringList> SVGConditionalProcessingAttributes::*>
+    static const SVGMemberAccessor<OwnerType>& singleton();
+
+private:
+    Ref<SVGStringList> SVGConditionalProcessingAttributes::*m_property;
 };
+
+template<typename OwnerType>
+template<Ref<SVGStringList> SVGConditionalProcessingAttributes::*member>
+const SVGMemberAccessor<OwnerType>& SVGConditionalProcessingAttributeAccessor<OwnerType>::singleton()
+{
+    static NeverDestroyed<SVGConditionalProcessingAttributeAccessor<OwnerType>> propertyAccessor { member };
+    return propertyAccessor;
+}
 
 template<typename OwnerType>
 class SVGTransformListAccessor final : public SVGPropertyAccessor<OwnerType, SVGTransformList> {

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class SVGAttributeAnimator;
+class SVGConditionalProcessingAttributes;
 
 struct SVGAttributeHashTranslator {
     static unsigned hash(const QualifiedName& key)
@@ -59,10 +60,10 @@ public:
     {
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, Ref<SVGStringList> OwnerType::*property>
-    static void registerProperty()
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, Ref<SVGStringList> SVGConditionalProcessingAttributes::*property>
+    static void registerConditionalProcessingAttributeProperty()
     {
-        registerProperty(attributeName, SVGStringListAccessor<OwnerType>::template singleton<property>());
+        registerProperty(attributeName, SVGConditionalProcessingAttributeAccessor<OwnerType>::template singleton<property>());
     }
 
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, Ref<SVGTransformList> OwnerType::*property>


### PR DESCRIPTION
#### a0e6d8e81896cbb5cb78fdc8eccd67c598b8c459
<pre>
Move SVG conditional processing attributes to SVGElementRareData
<a href="https://bugs.webkit.org/show_bug.cgi?id=251413">https://bugs.webkit.org/show_bug.cgi?id=251413</a>
rdar://problem/104849618

Reviewed by Sam Weinig and Said Abou-Hallawa.

The SVG conditional processing attributes (requiredFeatures, requiredExtensions,
and systemLanguage) are rarely used. Currently nearly every SVG element creates
SVGStringList objects for these three attributes in WebCore::SVGTests, at a cost
of 48 bytes each SVGStringList plus the three pointers. We can move these to
SVGElementRareData to save 72 bytes per SVG element in this common case, which
for SVG documents with a large number of graphical elements can add up.

The existing SVG property registration mechanism expects members
corresponding to the attribute to exist on the owner element object. We adds a
new SVGConditionalProcessingAttributeAccessor for these three
attributes, which looks them up on the element&apos;s SVGElementRareData.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::SVGAnimationElement):
* Source/WebCore/svg/SVGCursorElement.cpp:
(WebCore::SVGCursorElement::SVGCursorElement):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::conditionalProcessingAttributes):
(WebCore::SVGElement::conditionalProcessingAttributesIfExists const):
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGElementRareData.h:
(WebCore::SVGElementRareData::conditionalProcessingAttributesIfExists const):
(WebCore::SVGElementRareData::conditionalProcessingAttributes):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::SVGGraphicsElement):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::SVGMaskElement):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::SVGPatternElement):
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGConditionalProcessingAttributes::SVGConditionalProcessingAttributes):
(WebCore::SVGTests::SVGTests):
(WebCore::SVGTests::isValid const):
(WebCore::SVGTests::parseAttribute):
(WebCore::SVGTests::conditionalProcessingAttributes):
(WebCore::SVGTests::conditionalProcessingAttributesIfExists const):
* Source/WebCore/svg/SVGTests.h:
(WebCore::SVGConditionalProcessingAttributes::requiredFeatures):
(WebCore::SVGConditionalProcessingAttributes::requiredExtensions):
(WebCore::SVGConditionalProcessingAttributes::systemLanguage):
(WebCore::SVGTests::requiredFeatures):
(WebCore::SVGTests::requiredExtensions):
(WebCore::SVGTests::systemLanguage):
* Source/WebCore/svg/properties/SVGPropertyAccessorImpl.h:
(WebCore::SVGConditionalProcessingAttributeAccessor&lt;OwnerType&gt;::singleton):
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::SVGPropertyOwnerRegistry::registerConditionalProcessingAttributeProperty):

Canonical link: <a href="https://commits.webkit.org/259772@main">https://commits.webkit.org/259772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b4f189a6a3de663439255c36a4a8cbf670ae1e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105580 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114822 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174968 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5883 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114653 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39719 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7948 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8394 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4792 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47745 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6762 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9974 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->