### PR TITLE
CacheStorageCache should update size file when all records are removed

### DIFF
--- a/LayoutTests/http/wpt/cache-storage/cache-quota-add.any-expected.txt
+++ b/LayoutTests/http/wpt/cache-storage/cache-quota-add.any-expected.txt
@@ -3,4 +3,5 @@ CONSOLE MESSAGE: Cache API operation failed: Quota exceeded
 
 PASS Testing that cache.add checks against quota
 PASS Testing that cache.addAll checks against quota
+PASS Testing that caches.delete will reduce usage
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -356,11 +356,17 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
 
 void CacheStorageCache::removeAllRecords()
 {
+    uint64_t sizeDecreased = 0;
     Vector<CacheStorageRecordInformation> targetRecordInfos;
     for (auto& urlRecords : m_records.values()) {
-        for (auto& record : urlRecords)
+        for (auto& record : urlRecords) {
             targetRecordInfos.append(record);
+            sizeDecreased += record.size;
+        }
     }
+
+    if (m_manager && sizeDecreased)
+        m_manager->sizeDecreased(sizeDecreased);
 
     m_records.clear();
     m_store->deleteRecords(targetRecordInfos, [](auto) { });


### PR DESCRIPTION
#### 2a92809741635a6895fae66b03a812f944e407ad
<pre>
CacheStorageCache should update size file when all records are removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=251418">https://bugs.webkit.org/show_bug.cgi?id=251418</a>
rdar://104852161

Reviewed by Youenn Fablet.

CacheStorageCache currently updates size file when records are added and removed, but not when all records are removed
(cleared).

* LayoutTests/http/wpt/cache-storage/cache-quota-add.any-expected.txt:
* LayoutTests/http/wpt/cache-storage/cache-quota-add.any.js:
(promise_test.async test):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::removeAllRecords):

Canonical link: <a href="https://commits.webkit.org/259660@main">https://commits.webkit.org/259660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/149176853287f098ad39b899187285f193547acc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114752 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174904 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5825 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97798 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39666 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81357 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7877 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28152 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4746 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47695 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6670 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9904 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->