### PR TITLE
Remove unnecessary add when loading a JSCConfig field.

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2019-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -189,8 +189,8 @@ end
             restoreCalleeSavesUsedByWasm()
             restoreCallerPCAndCFR()
             if ARM64E
-                leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::wasmOSREntry) * PtrSize, ws1
-                jmp [ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
+                leap _g_config, ws1
+                jmp JSCConfigGateMapOffset + (constexpr Gate::wasmOSREntry) * PtrSize[ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
             else
                 jmp ws0, WasmEntryPtrTag
             end
@@ -217,8 +217,8 @@ macro checkSwitchToJITForLoop()
             move r0, a0
             if ARM64E
                 move r1, ws0
-                leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::wasmOSREntry) * PtrSize, ws1
-                jmp [ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
+                leap _g_config, ws1
+                jmp JSCConfigGateMapOffset + (constexpr Gate::wasmOSREntry) * PtrSize[ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
             else
                 jmp r1, WasmEntryPtrTag
             end
@@ -539,8 +539,8 @@ end
     restoreCalleeSavesUsedByWasm()
     restoreCallerPCAndCFR()
     if ARM64E
-        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::wasmOSREntry) * PtrSize, ws1
-        jmp [ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
+        leap _g_config, ws1
+        jmp JSCConfigGateMapOffset + (constexpr Gate::wasmOSREntry) * PtrSize[ws1], NativeToJITGatePtrTag # WasmEntryPtrTag
     else
         jmp ws0, WasmEntryPtrTag
     end
@@ -739,8 +739,8 @@ macro doReturn()
     restoreCalleeSavesUsedByWasm()
     restoreCallerPCAndCFR()
     if ARM64E
-        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::returnFromLLInt) * PtrSize, ws0
-        jmp [ws0], NativeToJITGatePtrTag
+        leap _g_config, ws0
+        jmp JSCConfigGateMapOffset + (constexpr Gate::returnFromLLInt) * PtrSize[ws0], NativeToJITGatePtrTag
     else
         ret
     end
@@ -769,8 +769,8 @@ end)
 macro jumpToException()
     if ARM64E
         move r0, a0
-        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::exceptionHandler) * PtrSize, a1
-        jmp [a1], NativeToJITGatePtrTag # ExceptionHandlerPtrTag
+        leap _g_config, a1
+        jmp JSCConfigGateMapOffset + (constexpr Gate::exceptionHandler) * PtrSize[a1], NativeToJITGatePtrTag # ExceptionHandlerPtrTag
     else
         jmp r0, ExceptionHandlerPtrTag
     end
@@ -1030,8 +1030,8 @@ end
             ctx(macro(opcodeName, opcodeStruct, size)
                 macro callNarrow()
                     if ARM64E
-                        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::%opcodeName%) * PtrSize, ws1
-                        jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
+                        leap _g_config, ws1
+                        jmp JSCConfigGateMapOffset + (constexpr Gate::%opcodeName%) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
                     end
                     _wasm_trampoline_%opcodeName%:
                     call ws0, JSEntrySlowPathPtrTag
@@ -1039,8 +1039,8 @@ end
 
                 macro callWide16()
                     if ARM64E
-                        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::%opcodeName%_wide16) * PtrSize, ws1
-                        jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
+                        leap _g_config, ws1
+                        jmp JSCConfigGateMapOffset + (constexpr Gate::%opcodeName%_wide16) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
                     end
                     _wasm_trampoline_%opcodeName%_wide16:
                     call ws0, JSEntrySlowPathPtrTag
@@ -1048,8 +1048,8 @@ end
 
                 macro callWide32()
                     if ARM64E
-                        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::%opcodeName%_wide32) * PtrSize, ws1
-                        jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
+                        leap _g_config, ws1
+                        jmp JSCConfigGateMapOffset + (constexpr Gate::%opcodeName%_wide32) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
                     end
                     _wasm_trampoline_%opcodeName%_wide32:
                     call ws0, JSEntrySlowPathPtrTag
@@ -1254,8 +1254,8 @@ end
             ctx(macro(opcodeName, opcodeStruct, size)
                 macro jumpNarrow()
                     if ARM64E
-                        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::wasmTailCallJSEntrySlowPathPtrTag) * PtrSize, ws1
-                        jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
+                        leap _g_config, ws1
+                        jmp JSCConfigGateMapOffset + (constexpr Gate::wasmTailCallJSEntrySlowPathPtrTag) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
                     end
                     _wasm_trampoline_%opcodeName%:
                     jmp ws0, JSEntrySlowPathPtrTag
@@ -1263,8 +1263,8 @@ end
 
                 macro jumpWide16()
                     if ARM64E
-                        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::wasmTailCallJSEntrySlowPathPtrTag) * PtrSize, ws1
-                        jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
+                        leap _g_config, ws1
+                        jmp JSCConfigGateMapOffset + (constexpr Gate::wasmTailCallJSEntrySlowPathPtrTag) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
                     end
                     _wasm_trampoline_%opcodeName%_wide16:
                     jmp ws0, JSEntrySlowPathPtrTag
@@ -1272,8 +1272,8 @@ end
 
                 macro jumpWide32()
                     if ARM64E
-                        leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::wasmTailCallJSEntrySlowPathPtrTag) * PtrSize, ws1
-                        jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
+                        leap _g_config, ws1
+                        jmp JSCConfigGateMapOffset + (constexpr Gate::wasmTailCallJSEntrySlowPathPtrTag) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
                     end
                     _wasm_trampoline_%opcodeName%_wide32:
                     jmp ws0, JSEntrySlowPathPtrTag


### PR DESCRIPTION
#### 95dcffb800f801ab71e757f034cc5ccbde53f61e
<pre>
Remove unnecessary add when loading a JSCConfig field.
<a href="https://bugs.webkit.org/show_bug.cgi?id=251421">https://bugs.webkit.org/show_bug.cgi?id=251421</a>
rdar://104854843

Reviewed by Tadeu Zagallo.

Currently, to load a JSCConfig field, our LLInt asm does something like this:
```
    leap JSCConfig + constexpr JSC::offsetOfJSCConfigGateMap + (constexpr Gate::%opcodeName%) * PtrSize, ws1
    jmp [ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
```
... and generates this:
```
                  #if OS(DARWIN)
&quot;.loc 1 1\n&quot;          &quot;Ljsc_llint_loh_adrp_1508: \n&quot;       // LowLevelInterpreter.asm:1
                      &quot;adrp x10, &quot; LOCAL_REFERENCE(g_config) &quot;@GOTPAGE \n&quot;
                      &quot;Ljsc_llint_loh_ldr_1508: \n&quot;
                      &quot;ldr x10, [x10, &quot; LOCAL_REFERENCE(g_config) &quot;@GOTPAGEOFF] \n&quot;
                  #elif OS(LINUX)
                      ...
                  #endif
&quot;.loc 1 1\n&quot;          &quot;add x10, x10, #3592 \n&quot;   // &lt;---- this add can be applied as an offset to the ldr below.
&quot;.loc 6 1034\n&quot;       &quot;movz x13, #57366 \n&quot;                // WebAssembly.asm:1034
                      &quot;ldr x17, [x10] \n&quot;
                      &quot;brab x17, x13 \n&quot;
```

This patch re-arranges the LLInt assembly to look like this instead:
```
    leap _g_config, ws1
    jmp JSCConfigGateMapOffset + (constexpr Gate::%opcodeName%) * PtrSize[ws1], NativeToJITGatePtrTag # JSEntrySlowPathPtrTag
```
... resulting in the removal of the unnecessary add instruction:
```
                  #if OS(DARWIN)
&quot;.loc 1 1\n&quot;          &quot;Ljsc_llint_loh_adrp_1508: \n&quot;       // LowLevelInterpreter.asm:1
                      &quot;adrp x10, &quot; LOCAL_REFERENCE(g_config) &quot;@GOTPAGE \n&quot;
                      &quot;Ljsc_llint_loh_ldr_1508: \n&quot;
                      &quot;ldr x10, [x10, &quot; LOCAL_REFERENCE(g_config) &quot;@GOTPAGEOFF] \n&quot;
                  #elif OS(LINUX)
                      ...
                  #endif
&quot;.loc 6 1034\n&quot;       &quot;movz x13, #57366 \n&quot;                // WebAssembly.asm:1034
                      &quot;ldr x17, [x10, #3592] \n&quot;
                      &quot;brab x17, x13 \n&quot;
```

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:

Canonical link: <a href="https://commits.webkit.org/259629@main">https://commits.webkit.org/259629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ce57e67ef0dcb1520d3316e0be7d66af8cc147

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114679 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174841 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5431 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114554 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39603 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81291 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95207 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7803 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28094 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93321 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5573 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4688 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30364 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47642 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102026 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9717 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25447 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3555 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->