### PR TITLE
REGRESSION(259423@main): fix VIDEO=OFF

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2944,6 +2944,7 @@ struct WebCore::FourCC {
     uint32_t value;
 };
 
+#if ENABLE(VIDEO)
 header: <WebCore/MediaPlayer.h>
 [CustomHeader] struct WebCore::MediaEngineSupportParameters {
     WebCore::ContentType type;
@@ -2958,6 +2959,7 @@ header: <WebCore/MediaPlayer.h>
     std::optional<Vector<WebCore::FourCC>> allowedMediaAudioCodecIDs;
     std::optional<Vector<WebCore::FourCC>> allowedMediaCaptionFormatTypes;
 };
+#endif
 
 enum class WebCore::MediaPlayerNetworkState : uint8_t {
     Empty,


### PR DESCRIPTION
#### 96987981eeb4c2b23c25b1307123dc03cae4d8e6
<pre>
REGRESSION(259423@main): fix VIDEO=OFF

<a href="https://bugs.webkit.org/show_bug.cgi?id=251427">https://bugs.webkit.org/show_bug.cgi?id=251427</a>

Reviewed by Michael Catanzaro.

/home/thomas/buildroot/output/build/webkitgtk-2.39.6/DerivedSources/WebKit/GeneratedSerializers.cpp: In static member function ‘static void IPC::ArgumentCoder&lt;WebCore::MediaEngineSupportParameters&gt;::encode(IPC::Encoder&amp;, const WebCore::MediaEngineSupportParameters&amp;)’:
/home/thomas/buildroot/output/build/webkitgtk-2.39.6/DerivedSources/WebKit/GeneratedSerializers.cpp:17376:63: error: invalid use of incomplete type ‘const struct WebCore::MediaEngineSupportParameters’
17376 |     static_assert(std::is_same_v&lt;std::remove_cvref_t&lt;decltype(instance.type)&gt;, WebCore::ContentType&gt;);
      |                                                               ^~~~~~~~

...

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;

Canonical link: <a href="https://commits.webkit.org/259627@main">https://commits.webkit.org/259627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/045a176c263217acc22a96431c5d822eddf49be1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114691 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5443 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114563 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39616 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/93998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26749 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28105 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7937 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47653 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6640 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9729 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->