### PR TITLE
[GStreamer][WebRTC] Implement GstMappedRtpBuffer

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -21,6 +21,7 @@
 
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
+#include "GStreamerCommon.h"
 #include "GUniquePtrGStreamer.h"
 #include "MediaEndpointConfiguration.h"
 #include "PeerConnectionBackend.h"
@@ -35,6 +36,8 @@
 #include "RTCRtpTransceiverDirection.h"
 #include "RTCSdpType.h"
 #include "RTCSignalingState.h"
+
+#include <gst/rtp/rtp.h>
 
 #define GST_USE_UNSTABLE_API
 #include <gst/webrtc/webrtc.h>
@@ -268,5 +271,19 @@ WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromRtpCapabilities(const RTCRtpCapabili
 GstWebRTCRTPTransceiverDirection getDirectionFromSDPMedia(const GstSDPMedia*);
 WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia*);
 
+inline gboolean mapRtpBuffer(GstBuffer* buffer, GstRTPBuffer* rtpBuffer, GstMapFlags flags)
+{
+    *rtpBuffer = GST_RTP_BUFFER_INIT;
+    return gst_rtp_buffer_map(buffer, flags, rtpBuffer);
 }
-#endif
+
+inline void unmapRtpBuffer(GstBuffer*, GstRTPBuffer* rtpBuffer)
+{
+    gst_rtp_buffer_unmap(rtpBuffer);
+}
+
+using GstMappedRtpBuffer = GstBufferMapper<GstRTPBuffer, mapRtpBuffer, unmapRtpBuffer>;
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -525,6 +525,7 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
     }), pipeline);
 }
 
+template<>
 Vector<uint8_t> GstMappedBuffer::createVector() const
 {
     return { data(), size() };

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -104,11 +104,12 @@ inline MediaTime fromGstClockTime(GstClockTime time)
     return MediaTime(GST_TIME_AS_USECONDS(time), G_USEC_PER_SEC);
 }
 
-class GstMappedBuffer {
-    WTF_MAKE_NONCOPYABLE(GstMappedBuffer);
+template<typename MapType, gboolean(mapFunction)(GstBuffer*, MapType*, GstMapFlags), void(unmapFunction)(GstBuffer*, MapType*)>
+class GstBufferMapper {
+    WTF_MAKE_NONCOPYABLE(GstBufferMapper);
 public:
 
-    GstMappedBuffer(GstMappedBuffer&& other)
+    GstBufferMapper(GstBufferMapper&& other)
         : m_buffer(other.m_buffer)
         , m_info(other.m_info)
         , m_isValid(other.m_isValid)
@@ -119,51 +120,67 @@ public:
     // This GstBuffer is [ transfer none ], meaning that no reference
     // is increased. Hence, this buffer must outlive the mapped
     // buffer.
-    GstMappedBuffer(GstBuffer* buffer, GstMapFlags flags)
+    GstBufferMapper(GstBuffer* buffer, GstMapFlags flags)
         : m_buffer(buffer)
     {
         ASSERT(GST_IS_BUFFER(buffer));
-        m_isValid = gst_buffer_map(m_buffer, &m_info, flags);
+        m_isValid = mapFunction(m_buffer, &m_info, flags);
     }
 
     // Unfortunately, GST_MAP_READWRITE is defined out of line from the MapFlags
     // enum as an int, and C++ is careful to not implicity convert it to an enum.
-    GstMappedBuffer(GstBuffer* buffer, int flags)
-        : GstMappedBuffer(buffer, static_cast<GstMapFlags>(flags)) { }
-    GstMappedBuffer(const GRefPtr<GstBuffer>& buffer, GstMapFlags flags)
-        : GstMappedBuffer(buffer.get(), flags) { }
+    GstBufferMapper(GstBuffer* buffer, int flags)
+        : GstBufferMapper(buffer, static_cast<GstMapFlags>(flags)) { }
+    GstBufferMapper(const GRefPtr<GstBuffer>& buffer, GstMapFlags flags)
+        : GstBufferMapper(buffer.get(), flags) { }
 
-    virtual ~GstMappedBuffer()
+    virtual ~GstBufferMapper()
     {
         unmapEarly();
     }
 
     void unmapEarly()
     {
-        if (m_isValid) {
-            m_isValid = false;
-            gst_buffer_unmap(m_buffer, &m_info);
-        }
+        if (!m_isValid)
+            return;
+
+        m_isValid = false;
+        unmapFunction(m_buffer, &m_info);
     }
 
     bool isValid() const { return m_isValid; }
     uint8_t* data() { RELEASE_ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
     const uint8_t* data() const { RELEASE_ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
     size_t size() const { ASSERT(m_isValid); return m_isValid ? static_cast<size_t>(m_info.size) : 0; }
+    MapType* mappedData() const  { ASSERT(m_isValid); return m_isValid ? const_cast<MapType*>(&m_info) : nullptr; }
     Vector<uint8_t> createVector() const;
 
     explicit operator bool() const { return m_isValid; }
     bool operator!() const { return !m_isValid; }
 
 private:
-    friend bool operator==(const GstMappedBuffer&, const GstMappedBuffer&);
-    friend bool operator==(const GstMappedBuffer&, const GstBuffer*);
-    friend bool operator==(const GstBuffer* a, const GstMappedBuffer& b) { return operator==(b, a); }
+    friend bool operator==(const GstBufferMapper& a, const GstBufferMapper& b)
+    {
+        ASSERT(a.isValid());
+        ASSERT(b.isValid());
+        return a.isValid() && b.isValid() && a.size() == b.size() && !gst_buffer_memcmp(a.m_buffer, 0, b.data(), b.size());
+    }
+    friend bool operator==(const GstBufferMapper& a, const GstBuffer* b)
+    {
+        ASSERT(a.isValid());
+        ASSERT(GST_IS_BUFFER(b));
+        GstBuffer* nonConstB = const_cast<GstBuffer*>(b);
+        return a.isValid() && GST_IS_BUFFER(b) && a.size() == gst_buffer_get_size(nonConstB) && !gst_buffer_memcmp(nonConstB, 0, a.data(), a.size());
+    }
+
+    friend bool operator==(const GstBuffer* a, const GstBufferMapper& b) { return operator==(b, a); }
 
     GstBuffer* m_buffer { nullptr };
-    GstMapInfo m_info;
+    MapType m_info;
     bool m_isValid { false };
 };
+
+using GstMappedBuffer = GstBufferMapper<GstMapInfo, gst_buffer_map, gst_buffer_unmap>;
 
 // This class maps only buffers in GST_MAP_READ mode to be able to
 // bump the reference count and keep it alive during the life of this
@@ -208,21 +225,6 @@ private:
 
     GRefPtr<GstBuffer> m_ownedBuffer;
 };
-
-inline bool operator==(const GstMappedBuffer& a, const GstMappedBuffer& b)
-{
-    ASSERT(a.isValid());
-    ASSERT(b.isValid());
-    return a.isValid() && b.isValid() && a.size() == b.size() && !gst_buffer_memcmp(a.m_buffer, 0, b.data(), b.size());
-}
-
-inline bool operator==(const GstMappedBuffer& a, const GstBuffer* b)
-{
-    ASSERT(a.isValid());
-    ASSERT(GST_IS_BUFFER(b));
-    GstBuffer* nonConstB = const_cast<GstBuffer*>(b);
-    return a.isValid() && GST_IS_BUFFER(b) && a.size() == gst_buffer_get_size(nonConstB) && !gst_buffer_memcmp(nonConstB, 0, a.data(), a.size());
-}
 
 class GstMappedFrame {
     WTF_MAKE_NONCOPYABLE(GstMappedFrame);


### PR DESCRIPTION
#### 7878d72b0fd7c5c84e185733ffc2d6ed65bccc02
<pre>
[GStreamer][WebRTC] Implement GstMappedRtpBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=251428">https://bugs.webkit.org/show_bug.cgi?id=251428</a>

Reviewed by Xabier Rodriguez-Calvar.

With this new RAII object for mapping RTP buffers we don&apos;t need to manually unmap anymore.

Canonical link: <a href="https://commits.webkit.org/261074@main">https://commits.webkit.org/261074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ffe5ca34ed2ec179e12e4b543e5ba7ac0183860

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/1859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10722 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/102725 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/98827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/43878 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/85745 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/31834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/12805 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/8799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7673 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14672 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->