### PR TITLE
[web-animations] use the keyframe's StyleProperties to determine whether a property is set to "inherit" in a keyframe

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -29,6 +29,7 @@
 #include "Animation.h"
 #include "CSSAnimation.h"
 #include "CSSKeyframeRule.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSPropertyAnimation.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
@@ -36,6 +37,8 @@
 #include "CSSStyleDeclaration.h"
 #include "CSSTimingFunctionValue.h"
 #include "CSSTransition.h"
+#include "CSSValue.h"
+#include "CSSValueKeywords.h"
 #include "ComputedStyleExtractor.h"
 #include "Element.h"
 #include "FontCascade.h"
@@ -57,6 +60,7 @@
 #include "Settings.h"
 #include "StyleAdjuster.h"
 #include "StylePendingResources.h"
+#include "StyleProperties.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "StyledElement.h"
@@ -838,8 +842,6 @@ ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobal
     // since they can be computed up-front.
     computeMissingKeyframeOffsets(parsedKeyframes);
 
-    m_inheritedProperties.clear();
-
     // 8. For each frame in processed keyframes, perform the following steps:
     for (auto& keyframe : parsedKeyframes) {
         // Let the timing function of frame be the result of parsing the “easing” property on frame using the CSS syntax
@@ -849,12 +851,6 @@ ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobal
         if (timingFunctionResult.hasException())
             return timingFunctionResult.releaseException();
         keyframe.timingFunction = timingFunctionResult.returnValue();
-
-        // FIXME: handle custom properties here.
-        for (auto& [property, value] : keyframe.styleStrings) {
-            if (equalLettersIgnoringASCIICase(value, "inherit"_s))
-                m_inheritedProperties.add(property);
-        }
     }
 
     // 9. Parse each of the values in unused easings using the CSS syntax defined for easing property of the
@@ -883,6 +879,7 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
     KeyframeList keyframeList(m_keyframesName);
     auto& styleResolver = m_target->styleResolver();
 
+    m_inheritedProperties.clear();
     m_containsCSSVariableReferences = false;
 
     for (auto& keyframe : m_parsedKeyframes) {
@@ -906,6 +903,14 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
         auto keyframeRule = StyleRuleKeyframe::create(keyframe.style->immutableCopyIfNeeded());
         if (!m_containsCSSVariableReferences)
             m_containsCSSVariableReferences = keyframeRule->containsCSSVariableReferences();
+
+        for (auto property : keyframeRule->properties()) {
+            if (auto* cssValue = property.value()) {
+                if (cssValue->isPrimitiveValue() && downcast<CSSPrimitiveValue>(cssValue)->valueID() == CSSValueInherit)
+                    m_inheritedProperties.add(property.id());
+            }
+        }
+
         keyframeValue.setStyle(styleResolver.styleForKeyframe(*m_target, elementStyle, resolutionContext, keyframeRule.get(), keyframeValue));
         keyframeList.insert(WTFMove(keyframeValue));
     }


### PR DESCRIPTION
#### 9de2e80cf70bba0c043026bf9e1119a43dd8e0bf
<pre>
[web-animations] use the keyframe&apos;s StyleProperties to determine whether a property is set to &quot;inherit&quot; in a keyframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=251432">https://bugs.webkit.org/show_bug.cgi?id=251432</a>

Reviewed by Antti Koivisto.

Until now we would determine whether a property is set to &quot;inherit&quot; in a keyframe by doing a string
comparison when the Web Animations API is used to set keyframes. However, the StyleRuleKeyframe
created for the keyframe has StyleProperties where the value is parsed, it seems safer to check
the CSSValue rather than do a string comparison here.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::processKeyframes):
(WebCore::KeyframeEffect::updateBlendingKeyframes):

Canonical link: <a href="https://commits.webkit.org/259630@main">https://commits.webkit.org/259630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b5e82828a0ab12751b93436681c6f235f8fe584

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114703 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174860 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5455 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114574 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39626 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26761 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7827 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28117 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7949 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47665 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9740 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3556 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->