### PR TITLE
[GTK] Fix for build (linker) failure on WAYLAND target caused by dependency on version WPEBackend_fdo 1.6.0

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -252,6 +252,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
             WPE_MAJOR_VERSION, WPE_MINOR_VERSION, WPE_MICRO_VERSION,
             wpe_get_major_version(), wpe_get_minor_version(), wpe_get_micro_version());
 
+#if WPE_FDO_CHECK_VERSION(1, 6, 1)
         g_string_append_printf(html,
             " <tbody><tr>"
             "  <td><div class=\"titlename\">WPEBackend-fdo version</div></td>"
@@ -259,6 +260,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
             " </tbody></tr>",
             WPE_FDO_MAJOR_VERSION, WPE_FDO_MINOR_VERSION, WPE_FDO_MICRO_VERSION,
             wpe_fdo_get_major_version(), wpe_fdo_get_minor_version(), wpe_fdo_get_micro_version());
+#endif
     }
 #endif
 #endif


### PR DESCRIPTION
#### 7f5f2f78dedbda857d3bfcc6594fa42d023fea5b
<pre>
[GTK] Fix for build (linker) failure on WAYLAND target caused by dependency on version WPEBackend_fdo 1.6.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=251355">https://bugs.webkit.org/show_bug.cgi?id=251355</a>

Reviewed by Michael Catanzaro.

WPEBackend_fdo 1.6.0 did not export symbols to get major/minor version numbers. e.g. wpe_fdo_get_major_version.
These symbols were exported in version 1.6.1 as shown in
<a href="https://github.com/Igalia/WPEBackend-fdo/commit/1dda80de5372e56cdc6f818a3fca493f7cc1f9d6.">https://github.com/Igalia/WPEBackend-fdo/commit/1dda80de5372e56cdc6f818a3fca493f7cc1f9d6.</a> Currently this
results in undefined reference linker error on distributions installing version 1.6.0. (e.g Ubuntu 20.04)
So these calls are guarded with check of version 1.6.1.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):

Canonical link: <a href="https://commits.webkit.org/259676@main">https://commits.webkit.org/259676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7f8d61d42e381b05b5d0cd466f9e7d3507226f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114705 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5457 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114576 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39627 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81322 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28119 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/7951 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4726 "Found 2 new test failures: fast/images/avif-as-image.html, fast/repaint/rtl-content-selection-hairline-gap.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6684 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9742 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->