### PR TITLE
Use sysctlbyname to get model from Apple products

### DIFF
--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo.cpp
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo.cpp
@@ -243,46 +243,6 @@ bool ParseAMDCatalystDriverVersion(const std::string &content, std::string *vers
     return false;
 }
 
-bool ParseMacMachineModel(const std::string &identifier,
-                          std::string *type,
-                          int32_t *major,
-                          int32_t *minor)
-{
-    size_t numberLoc = identifier.find_first_of("0123456789");
-    if (numberLoc == std::string::npos)
-    {
-        return false;
-    }
-
-    size_t commaLoc = identifier.find(',', numberLoc);
-    if (commaLoc == std::string::npos || commaLoc >= identifier.size())
-    {
-        return false;
-    }
-
-    const char *numberPtr = &identifier[numberLoc];
-    const char *commaPtr  = &identifier[commaLoc + 1];
-    char *endPtr          = nullptr;
-
-    int32_t majorTmp = static_cast<int32_t>(std::strtol(numberPtr, &endPtr, 10));
-    if (endPtr == numberPtr)
-    {
-        return false;
-    }
-
-    int32_t minorTmp = static_cast<int32_t>(std::strtol(commaPtr, &endPtr, 10));
-    if (endPtr == commaPtr)
-    {
-        return false;
-    }
-
-    *major = majorTmp;
-    *minor = minorTmp;
-    *type  = identifier.substr(0, numberLoc);
-
-    return true;
-}
-
 bool CMDeviceIDToDeviceAndVendorID(const std::string &id, uint32_t *vendorId, uint32_t *deviceId)
 {
     unsigned int vendor = 0;

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo.h
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo.h
@@ -88,7 +88,7 @@ struct SystemInfo
     // Only available on macOS and Android
     std::string machineModelName;
 
-    // Only available on macOS
+    // Only available on macOS and iOS
     std::string machineModelVersion;
 };
 

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_internal.h
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_internal.h
@@ -23,10 +23,6 @@ bool GetNvidiaDriverVersionWithXNVCtrl(std::string *version);
 // Live in SystemInfo.cpp
 bool ParseAMDBrahmaDriverVersion(const std::string &content, std::string *version);
 bool ParseAMDCatalystDriverVersion(const std::string &content, std::string *version);
-bool ParseMacMachineModel(const std::string &identifier,
-                          std::string *type,
-                          int32_t *major,
-                          int32_t *minor);
 bool CMDeviceIDToDeviceAndVendorID(const std::string &id, uint32_t *vendorId, uint32_t *deviceId);
 
 #if defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_MACCATALYST)

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_ios.cpp
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_ios.cpp
@@ -10,6 +10,8 @@
 
 #if defined(ANGLE_PLATFORM_IOS) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
 
+#    include <sys/sysctl.h>
+#    include <sys/types.h>
 #    include "gpu_info_util/SystemInfo_internal.h"
 
 namespace angle
@@ -17,13 +19,18 @@ namespace angle
 
 bool GetSystemInfo_ios(SystemInfo *info)
 {
-    {
-        // TODO(anglebug.com/4275): Get the actual system version and GPU info.
-        info->machineModelVersion = "0.0";
-        GPUDeviceInfo deviceInfo;
-        deviceInfo.vendorId = kVendorID_Apple;
-        info->gpus.push_back(deviceInfo);
-    }
+    size_t len;
+    sysctlbyname("hw.model", NULL, &len, NULL, 0);
+
+    char *model = static_cast<char *>(malloc(len));
+    sysctlbyname("hw.model", model, &len, NULL, 0);
+
+    info->machineModelVersion = std::string(model);
+    free(model);
+
+    GPUDeviceInfo deviceInfo;
+    deviceInfo.vendorId = kVendorID_Apple;
+    info->gpus.push_back(deviceInfo);
 
     return true;
 }

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_unittest.cpp
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_unittest.cpp
@@ -72,34 +72,6 @@ TEST(SystemInfoTest, AMDCatalystVersionParsing)
     ASSERT_EQ("42.0.56", version);
 }
 
-// Test Mac machine model parsing
-TEST(SystemInfoTest, MacMachineModelParsing)
-{
-    std::string model;
-    int32_t major = 1, minor = 2;
-
-    // Test on the empty string, that is returned by GetMachineModel on an error
-    EXPECT_FALSE(ParseMacMachineModel("", &model, &major, &minor));
-    EXPECT_EQ(0U, model.length());
-    EXPECT_EQ(1, major);
-    EXPECT_EQ(2, minor);
-
-    // Test on an invalid string
-    EXPECT_FALSE(ParseMacMachineModel("FooBar", &model, &major, &minor));
-
-    // Test on a MacPro model
-    EXPECT_TRUE(ParseMacMachineModel("MacPro4,1", &model, &major, &minor));
-    EXPECT_EQ("MacPro", model);
-    EXPECT_EQ(4, major);
-    EXPECT_EQ(1, minor);
-
-    // Test on a MacBookPro model
-    EXPECT_TRUE(ParseMacMachineModel("MacBookPro6,2", &model, &major, &minor));
-    EXPECT_EQ("MacBookPro", model);
-    EXPECT_EQ(6, major);
-    EXPECT_EQ(2, minor);
-}
-
 // Test Windows CM Device ID parsing
 TEST(SystemInfoTest, CMDeviceIDToDeviceAndVendorID)
 {


### PR DESCRIPTION
#### 3633409e7d1d5e4f8e59f575bbc978556d5b7c12
<pre>
Use sysctlbyname to get model from Apple products
https://bugs.webkit.org/show_bug.cgi?id=251437

Reviewed by NOBODY (OOPS!).

Instead of not supporting iOS model versions on iOS,
we can use sysctlbyname. This also works on macOS, so let&apos;s
do that there as well instead of whatever arduous
workaround we use now.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/679c77f06b8b46c0207bd47357983912e1044fdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115090 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175212 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6158 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114847 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40015 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81683 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28441 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5025 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47981 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10265 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->