### PR TITLE
Port remaining WebCore/loader types to the new serialization format

### DIFF
--- a/Source/WebCore/loader/AttributionSecondsUntilSendData.h
+++ b/Source/WebCore/loader/AttributionSecondsUntilSendData.h
@@ -48,28 +48,6 @@ struct AttributionSecondsUntilSendData {
 
         return sourceSeconds ? sourceSeconds : destinationSeconds;
     }
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << sourceSeconds << destinationSeconds;
-    }
-
-    template<class Decoder>
-    static std::optional<AttributionSecondsUntilSendData> decode(Decoder& decoder)
-    {
-        std::optional<std::optional<Seconds>> sourceSeconds;
-        decoder >> sourceSeconds;
-        if (!sourceSeconds)
-            return std::nullopt;
-
-        std::optional<std::optional<Seconds>> destinationSeconds;
-        decoder >> destinationSeconds;
-        if (!destinationSeconds)
-            return std::nullopt;
-
-        return AttributionSecondsUntilSendData { WTFMove(*sourceSeconds), WTFMove(*destinationSeconds) };
-    }
 };
 
 

--- a/Source/WebCore/loader/CanvasActivityRecord.h
+++ b/Source/WebCore/loader/CanvasActivityRecord.h
@@ -35,25 +35,5 @@ struct CanvasActivityRecord {
     
     WEBCORE_EXPORT bool recordWrittenOrMeasuredText(const String&);
     void mergeWith(const CanvasActivityRecord&);
-    
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, CanvasActivityRecord&);
 };
-    
-template <class Encoder>
-void CanvasActivityRecord::encode(Encoder& encoder) const
-{
-    encoder << textWritten;
-    encoder << wasDataRead;
-}
-
-template <class Decoder>
-bool CanvasActivityRecord::decode(Decoder& decoder, CanvasActivityRecord& canvasActivityRecord)
-{
-    if (!decoder.decode(canvasActivityRecord.textWritten))
-        return false;
-    if (!decoder.decode(canvasActivityRecord.wasDataRead))
-        return false;
-    return true;
-}
 } // namespace WebCore

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.h
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.h
@@ -63,8 +63,6 @@ struct CrossOriginOpenerPolicy {
 
     CrossOriginOpenerPolicy isolatedCopy() const &;
     CrossOriginOpenerPolicy isolatedCopy() &&;
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CrossOriginOpenerPolicy> decode(Decoder&);
 
     void addPolicyHeadersTo(ResourceResponse&) const;
 };
@@ -82,43 +80,6 @@ inline bool CrossOriginOpenerPolicy::hasReportingEndpoint(COOPDisposition dispos
 inline bool operator==(const CrossOriginOpenerPolicy& a, const CrossOriginOpenerPolicy& b)
 {
     return a.value == b.value && a.reportingEndpoint == b.reportingEndpoint && a.reportOnlyValue == b.reportOnlyValue && a.reportOnlyReportingEndpoint == b.reportOnlyReportingEndpoint;
-}
-
-template<class Encoder>
-void CrossOriginOpenerPolicy::encode(Encoder& encoder) const
-{
-    encoder << value << reportingEndpoint << reportOnlyValue << reportOnlyReportingEndpoint;
-}
-
-template<class Decoder>
-std::optional<CrossOriginOpenerPolicy> CrossOriginOpenerPolicy::decode(Decoder& decoder)
-{
-    std::optional<CrossOriginOpenerPolicyValue> value;
-    decoder >> value;
-    if (!value)
-        return std::nullopt;
-
-    std::optional<String> reportingEndpoint;
-    decoder >> reportingEndpoint;
-    if (!reportingEndpoint)
-        return std::nullopt;
-
-    std::optional<CrossOriginOpenerPolicyValue> reportOnlyValue;
-    decoder >> reportOnlyValue;
-    if (!reportOnlyValue)
-        return std::nullopt;
-
-    std::optional<String> reportOnlyReportingEndpoint;
-    decoder >> reportOnlyReportingEndpoint;
-    if (!reportOnlyReportingEndpoint)
-        return std::nullopt;
-
-    return {{
-        *value,
-        WTFMove(*reportingEndpoint),
-        *reportOnlyValue,
-        WTFMove(*reportOnlyReportingEndpoint)
-    }};
 }
 
 // https://html.spec.whatwg.org/multipage/origin.html#coop-enforcement-result

--- a/Source/WebCore/loader/CustomHeaderFields.h
+++ b/Source/WebCore/loader/CustomHeaderFields.h
@@ -36,32 +36,6 @@ struct WEBCORE_EXPORT CustomHeaderFields {
     Vector<String> thirdPartyDomains;
 
     bool thirdPartyDomainsMatch(const URL&) const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CustomHeaderFields> decode(Decoder&);
 };
-
-template<class Encoder>
-void CustomHeaderFields::encode(Encoder& encoder) const
-{
-    encoder << fields;
-    encoder << thirdPartyDomains;
-}
-
-template<class Decoder>
-std::optional<CustomHeaderFields> CustomHeaderFields::decode(Decoder& decoder)
-{
-    std::optional<Vector<HTTPHeaderField>> fields;
-    decoder >> fields;
-    if (!fields)
-        return std::nullopt;
-    
-    std::optional<Vector<String>> thirdPartyDomains;
-    decoder >> thirdPartyDomains;
-    if (!thirdPartyDomains)
-        return std::nullopt;
-    
-    return {{ WTFMove(*fields), WTFMove(*thirdPartyDomains) }};
-}
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1873,7 +1873,7 @@ URL DocumentLoader::urlForHistory() const
     // Return the URL to be used for history and B/F list.
     // Returns nil for WebDataProtocol URLs that aren't alternates
     // for unreachable URLs, because these can't be stored in history.
-    if (m_substituteData.isValid() && !m_substituteData.shouldRevealToSessionHistory())
+    if (m_substituteData.isValid() && m_substituteData.shouldRevealToSessionHistory() != SubstituteData::SessionHistoryVisibility::Visible)
         return unreachableURL();
 
     return m_originalRequestCopy.url();

--- a/Source/WebCore/loader/HTTPHeaderField.h
+++ b/Source/WebCore/loader/HTTPHeaderField.h
@@ -36,9 +36,6 @@ public:
     const String& name() const { return m_name; }
     const String& value() const { return m_value; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<HTTPHeaderField> decode(Decoder&);
-
 private:
     HTTPHeaderField(String&& name, String&& value)
         : m_name(WTFMove(name))
@@ -47,28 +44,5 @@ private:
     String m_name;
     String m_value;
 };
-
-template<class Encoder>
-void HTTPHeaderField::encode(Encoder& encoder) const
-{
-    encoder << m_name;
-    encoder << m_value;
-}
-
-template<class Decoder>
-std::optional<HTTPHeaderField> HTTPHeaderField::decode(Decoder& decoder)
-{
-    std::optional<String> name;
-    decoder >> name;
-    if (!name)
-        return std::nullopt;
-
-    std::optional<String> value;
-    decoder >> value;
-    if (!value)
-        return std::nullopt;
-
-    return {{ WTFMove(*name), WTFMove(*value) }};
-}
 
 } // namespace WebCore

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -41,46 +41,6 @@ struct NavigationRequester {
     Ref<SecurityOrigin> topOrigin;
     PolicyContainer policyContainer;
     std::optional<GlobalFrameIdentifier> globalFrameIdentifier;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<NavigationRequester> decode(Decoder&);
 };
-
-template<class Encoder>
-void NavigationRequester::encode(Encoder& encoder) const
-{
-    encoder << url << securityOrigin.get() << topOrigin.get() << policyContainer << globalFrameIdentifier;
-}
-
-template<class Decoder>
-std::optional<NavigationRequester> NavigationRequester::decode(Decoder& decoder)
-{
-    std::optional<URL> url;
-    decoder >> url;
-    if (!url)
-        return std::nullopt;
-
-    std::optional<Ref<SecurityOrigin>> securityOrigin;
-    decoder >> securityOrigin;
-    if (!securityOrigin)
-        return std::nullopt;
-
-    std::optional<Ref<SecurityOrigin>> topOrigin;
-    decoder >> topOrigin;
-    if (!topOrigin)
-        return std::nullopt;
-
-    std::optional<PolicyContainer> policyContainer;
-    decoder >> policyContainer;
-    if (!policyContainer)
-        return std::nullopt;
-
-    std::optional<std::optional<GlobalFrameIdentifier>> globalFrameIdentifier;
-    decoder >> globalFrameIdentifier;
-    if (!globalFrameIdentifier)
-        return std::nullopt;
-
-    return NavigationRequester { WTFMove(*url), WTFMove(*securityOrigin), WTFMove(*topOrigin), WTFMove(*policyContainer), *globalFrameIdentifier };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/loader/PolicyContainer.h
+++ b/Source/WebCore/loader/PolicyContainer.h
@@ -41,8 +41,6 @@ struct PolicyContainer {
 
     PolicyContainer isolatedCopy() const & { return { contentSecurityPolicyResponseHeaders.isolatedCopy(), crossOriginEmbedderPolicy.isolatedCopy(), crossOriginOpenerPolicy.isolatedCopy(), referrerPolicy }; }
     PolicyContainer isolatedCopy() && { return { WTFMove(contentSecurityPolicyResponseHeaders).isolatedCopy(), WTFMove(crossOriginEmbedderPolicy).isolatedCopy(), WTFMove(crossOriginOpenerPolicy).isolatedCopy(), referrerPolicy }; }
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PolicyContainer> decode(Decoder&);
 };
 
 inline bool operator==(const PolicyContainer& a, const PolicyContainer& b)
@@ -51,43 +49,6 @@ inline bool operator==(const PolicyContainer& a, const PolicyContainer& b)
         && a.crossOriginEmbedderPolicy == b.crossOriginEmbedderPolicy
         && a.crossOriginOpenerPolicy == b.crossOriginOpenerPolicy
         && a.referrerPolicy == b.referrerPolicy;
-}
-
-template<class Encoder>
-void PolicyContainer::encode(Encoder& encoder) const
-{
-    encoder << contentSecurityPolicyResponseHeaders << crossOriginEmbedderPolicy << crossOriginOpenerPolicy << referrerPolicy;
-}
-
-template<class Decoder>
-std::optional<PolicyContainer> PolicyContainer::decode(Decoder& decoder)
-{
-    std::optional<ContentSecurityPolicyResponseHeaders> contentSecurityPolicyResponseHeaders;
-    decoder >> contentSecurityPolicyResponseHeaders;
-    if (!contentSecurityPolicyResponseHeaders)
-        return std::nullopt;
-
-    std::optional<CrossOriginEmbedderPolicy> crossOriginEmbedderPolicy;
-    decoder >> crossOriginEmbedderPolicy;
-    if (!crossOriginEmbedderPolicy)
-        return std::nullopt;
-
-    std::optional<CrossOriginOpenerPolicy> crossOriginOpenerPolicy;
-    decoder >> crossOriginOpenerPolicy;
-    if (!crossOriginOpenerPolicy)
-        return std::nullopt;
-
-    std::optional<ReferrerPolicy> referrerPolicy;
-    decoder >> referrerPolicy;
-    if (!referrerPolicy)
-        return std::nullopt;
-
-    return {{
-        WTFMove(*contentSecurityPolicyResponseHeaders),
-        WTFMove(*crossOriginEmbedderPolicy),
-        WTFMove(*crossOriginOpenerPolicy),
-        *referrerPolicy
-    }};
 }
 
 WEBCORE_EXPORT void addPolicyContainerHeaders(ResourceResponse&, const PolicyContainer&);

--- a/Source/WebCore/loader/SubstituteData.h
+++ b/Source/WebCore/loader/SubstituteData.h
@@ -32,74 +32,39 @@
 
 namespace WebCore {
 
-    class SubstituteData {
-    public:
-        enum class SessionHistoryVisibility : bool {
-            Visible,
-            Hidden,
-        };
-
-        SubstituteData()
-        {
-        }
-
-        SubstituteData(RefPtr<FragmentedSharedBuffer>&& content, const URL& failingURL, const ResourceResponse& response, SessionHistoryVisibility shouldRevealToSessionHistory)
-            : m_content(WTFMove(content))
-            , m_failingURL(failingURL)
-            , m_response(response)
-            , m_shouldRevealToSessionHistory(shouldRevealToSessionHistory)
-        {
-        }
-
-        bool isValid() const { return m_content != nullptr; }
-        bool shouldRevealToSessionHistory() const { return m_shouldRevealToSessionHistory == SessionHistoryVisibility::Visible; }
-
-        const FragmentedSharedBuffer* content() const { return m_content.get(); }
-        const String& mimeType() const { return m_response.mimeType(); }
-        const String& textEncoding() const { return m_response.textEncodingName(); }
-        const URL& failingURL() const { return m_failingURL; }
-        const ResourceResponse& response() const { return m_response; }
-
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<SubstituteData> decode(Decoder&);
-
-    private:
-        RefPtr<FragmentedSharedBuffer> m_content;
-        URL m_failingURL;
-        ResourceResponse m_response;
-        SessionHistoryVisibility m_shouldRevealToSessionHistory { SessionHistoryVisibility::Hidden };
+class SubstituteData {
+public:
+    enum class SessionHistoryVisibility : bool {
+        Visible,
+        Hidden,
     };
 
-template<class Encoder>
-void SubstituteData::encode(Encoder& encoder) const
-{
-    encoder << m_content << m_failingURL << m_response << m_shouldRevealToSessionHistory;
-}
+    SubstituteData()
+    {
+    }
 
-template<class Decoder>
-std::optional<SubstituteData> SubstituteData::decode(Decoder& decoder)
-{
-    std::optional<RefPtr<FragmentedSharedBuffer>> content;
-    decoder >> content;
-    if (!content)
-        return std::nullopt;
+    SubstituteData(RefPtr<FragmentedSharedBuffer>&& content, const URL& failingURL, const ResourceResponse& response, SessionHistoryVisibility shouldRevealToSessionHistory)
+        : m_content(WTFMove(content))
+        , m_failingURL(failingURL)
+        , m_response(response)
+        , m_shouldRevealToSessionHistory(shouldRevealToSessionHistory)
+    {
+    }
 
-    std::optional<URL> failingURL;
-    decoder >> failingURL;
-    if (!failingURL)
-        return std::nullopt;
+    bool isValid() const { return m_content != nullptr; }
+    SessionHistoryVisibility shouldRevealToSessionHistory() const { return m_shouldRevealToSessionHistory; }
 
-    std::optional<ResourceResponse> response;
-    decoder >> response;
-    if (!response)
-        return std::nullopt;
+    const RefPtr<FragmentedSharedBuffer> content() const { return m_content; }
+    const String& mimeType() const { return m_response.mimeType(); }
+    const String& textEncoding() const { return m_response.textEncodingName(); }
+    const URL& failingURL() const { return m_failingURL; }
+    const ResourceResponse& response() const { return m_response; }
 
-    std::optional<SessionHistoryVisibility> shouldRevealToSessionHistory;
-    decoder >> shouldRevealToSessionHistory;
-    if (!shouldRevealToSessionHistory)
-        return std::nullopt;
-
-    return { { WTFMove(*content), *failingURL, *response, *shouldRevealToSessionHistory } };
-}
+private:
+    RefPtr<FragmentedSharedBuffer> m_content;
+    URL m_failingURL;
+    ResourceResponse m_response;
+    SessionHistoryVisibility m_shouldRevealToSessionHistory { SessionHistoryVisibility::Hidden };
+};
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3287,3 +3287,62 @@ header: <WebCore/DisplayListItems.h>
      WebCore::ImageOrientation m_orientation;
      WebCore::InterpolationQuality m_interpolationQuality;
 };
+
+struct WebCore::CanvasActivityRecord {
+    HashSet<String> textWritten;
+    bool wasDataRead;
+};
+
+header: <WebCore/AttributionSecondsUntilSendData.h>
+[CustomHeader] struct WebCore::PCM::AttributionSecondsUntilSendData {
+    std::optional<Seconds> sourceSeconds;
+    std::optional<Seconds> destinationSeconds;
+};
+
+enum class WebCore::CrossOriginOpenerPolicyValue : uint8_t {
+    UnsafeNone,
+    SameOrigin,
+    SameOriginPlusCOEP,
+    SameOriginAllowPopups
+};
+
+struct WebCore::CrossOriginOpenerPolicy {
+    WebCore::CrossOriginOpenerPolicyValue value;
+    String reportingEndpoint;
+    WebCore::CrossOriginOpenerPolicyValue reportOnlyValue;
+    String reportOnlyReportingEndpoint;
+};
+
+struct WebCore::CustomHeaderFields {
+    Vector<WebCore::HTTPHeaderField> fields;
+    Vector<String> thirdPartyDomains;
+};
+
+[CreateUsing=create] class WebCore::HTTPHeaderField {
+    String name();
+    String value();
+};
+
+struct WebCore::NavigationRequester {
+    URL url;
+    Ref<WebCore::SecurityOrigin> securityOrigin;
+    Ref<WebCore::SecurityOrigin> topOrigin;
+    WebCore::PolicyContainer policyContainer;
+    std::optional<WebCore::GlobalFrameIdentifier> globalFrameIdentifier;
+};
+
+struct WebCore::PolicyContainer {
+    WebCore::ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
+    WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
+    WebCore::CrossOriginOpenerPolicy crossOriginOpenerPolicy;
+    WebCore::ReferrerPolicy referrerPolicy;
+};
+
+[Nested] enum class WebCore::SubstituteData::SessionHistoryVisibility : bool
+
+class WebCore::SubstituteData {
+    RefPtr<WebCore::FragmentedSharedBuffer> content();
+    URL failingURL();
+    WebCore::ResourceResponse response();
+    WebCore::SubstituteData::SessionHistoryVisibility shouldRevealToSessionHistory();
+};

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h
@@ -56,7 +56,7 @@ public:
     virtual ~PageLoaderClient() = default;
 
     virtual void willLoadURLRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, API::Object*) { }
-    virtual void willLoadDataRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, WebCore::FragmentedSharedBuffer*, const WTF::String&, const WTF::String&, const WTF::URL&, API::Object*) { }
+    virtual void willLoadDataRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, RefPtr<WebCore::FragmentedSharedBuffer>, const WTF::String&, const WTF::String&, const WTF::URL&, API::Object*) { }
 
     virtual void didStartProvisionalLoadForFrame(WebKit::WebPage&, WebKit::WebFrame&, RefPtr<API::Object>&) { }
     virtual void didReceiveServerRedirectForProvisionalLoadForFrame(WebKit::WebPage&, WebKit::WebFrame&, RefPtr<API::Object>&) { }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp
@@ -65,7 +65,7 @@ static void releaseSharedBuffer(unsigned char*, const void* data)
     static_cast<const SharedBuffer*>(data)->deref();
 }
 
-void InjectedBundlePageLoaderClient::willLoadDataRequest(WebPage& page, const ResourceRequest& request, FragmentedSharedBuffer* sharedBuffer, const String& MIMEType, const String& encodingName, const URL& unreachableURL, API::Object* userData)
+void InjectedBundlePageLoaderClient::willLoadDataRequest(WebPage& page, const ResourceRequest& request, RefPtr<FragmentedSharedBuffer> sharedBuffer, const String& MIMEType, const String& encodingName, const URL& unreachableURL, API::Object* userData)
 {
     if (!m_client.willLoadDataRequest)
         return;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.h
@@ -47,7 +47,7 @@ public:
     explicit InjectedBundlePageLoaderClient(const WKBundlePageLoaderClientBase*);
 
     void willLoadURLRequest(WebPage&, const WebCore::ResourceRequest&, API::Object*) override;
-    void willLoadDataRequest(WebPage&, const WebCore::ResourceRequest&, WebCore::FragmentedSharedBuffer*, const WTF::String&, const WTF::String&, const URL&, API::Object*) override;
+    void willLoadDataRequest(WebPage&, const WebCore::ResourceRequest&, RefPtr<WebCore::FragmentedSharedBuffer>, const WTF::String&, const WTF::String&, const URL&, API::Object*) override;
 
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame&, RefPtr<API::Object>&) override;
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebPage&, WebFrame&, RefPtr<API::Object>&) override;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1802,7 +1802,7 @@ void WebPage::loadDataImpl(uint64_t navigationID, ShouldTreatAsContinuingLoad sh
 
     // Let the InjectedBundle know we are about to start the load, passing the user data from the UIProcess
     // to all the client to set up any needed state.
-    m_loaderClient->willLoadDataRequest(*this, request, const_cast<FragmentedSharedBuffer*>(substituteData.content()), substituteData.mimeType(), substituteData.textEncoding(), substituteData.failingURL(), WebProcess::singleton().transformHandlesToObjects(userData.object()).get());
+    m_loaderClient->willLoadDataRequest(*this, request, substituteData.content(), substituteData.mimeType(), substituteData.textEncoding(), substituteData.failingURL(), WebProcess::singleton().transformHandlesToObjects(userData.object()).get());
 
     // Initate the load in WebCore.
     FrameLoadRequest frameLoadRequest(*m_mainFrame->coreFrame(), request, substituteData);


### PR DESCRIPTION
#### 148e18aedb4d65cfb801be5fef3af8267cd4c0cd
<pre>
Port remaining WebCore/loader types to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=251434">https://bugs.webkit.org/show_bug.cgi?id=251434</a>
rdar://104866054

Reviewed by Alex Christensen.

This change includes porting types:
    - CanvasActivityRecord
    - AttributionSecondsUntilSendData
    - CrossOriginOpenerPolicyValue
    - CrossOriginOpenerPolicy
    - CustomHeaderFields
    - HTTPHeaderField
    - NavigationRequester
    - PolicyContainer
    - SessionHistoryVisibility
    - SubstituteData

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/AttributionSecondsUntilSendData.h:
(WebCore::PCM::AttributionSecondsUntilSendData::minSecondsUntilSend):
(WebCore::PCM::AttributionSecondsUntilSendData::encode const): Deleted.
(WebCore::PCM::AttributionSecondsUntilSendData::decode): Deleted.
* Source/WebCore/loader/CanvasActivityRecord.h:
(WebCore::CanvasActivityRecord::encode const): Deleted.
(WebCore::CanvasActivityRecord::decode): Deleted.
* Source/WebCore/loader/CrossOriginOpenerPolicy.h:
(WebCore::CrossOriginOpenerPolicy::encode const): Deleted.
(WebCore::CrossOriginOpenerPolicy::decode): Deleted.
* Source/WebCore/loader/CustomHeaderFields.h:
(WebCore::CustomHeaderFields::encode const): Deleted.
(WebCore::CustomHeaderFields::decode): Deleted.
* Source/WebCore/loader/HTTPHeaderField.cpp:
(WebCore::HTTPHeaderField::HTTPHeaderField):
(WebCore::HTTPHeaderField::isValid):
(WebCore::HTTPHeaderField::create):
* Source/WebCore/loader/HTTPHeaderField.h:
(WebCore::HTTPHeaderField::encode const): Deleted.
(WebCore::HTTPHeaderField::decode): Deleted.
* Source/WebCore/loader/NavigationRequester.h:
(WebCore::NavigationRequester::encode const): Deleted.
(WebCore::NavigationRequester::decode): Deleted.
* Source/WebCore/loader/PolicyContainer.h:
(WebCore::PolicyContainer::isolatedCopy):
(WebCore::PolicyContainer::encode const): Deleted.
(WebCore::PolicyContainer::decode): Deleted.
* Source/WebCore/loader/SubstituteData.h:
(WebCore::SubstituteData::SubstituteData):
(WebCore::SubstituteData::isValid const):
(WebCore::SubstituteData::shouldRevealToSessionHistory const):
(WebCore::SubstituteData::content const):
(WebCore::SubstituteData::mimeType const):
(WebCore::SubstituteData::textEncoding const):
(WebCore::SubstituteData::failingURL const):
(WebCore::SubstituteData::response const):
(WebCore::SubstituteData::encode const): Deleted.
(WebCore::SubstituteData::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259811@main">https://commits.webkit.org/259811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2768bfca13dfafe642d3bc749978eb356800047b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105963 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115150 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175270 "Failed to checkout and rebase branch from PR 9383") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6209 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114897 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40065 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27135 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8285 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28487 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5055 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6790 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10319 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->