### PR TITLE
[JSC] UAF Yarr::YarrPatternConstructor::atomParenthesesEnd; Yarr::Parser::parseTokens; JSC::Yarr::parse

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -216,3 +216,9 @@ testRegExp(/(?<=(^(?:A|\u{10400}|\u{10401}|\u{10406})*))x/u, "\u{10401}A\u{10400
 testRegExp(/(?<=(\d{2})(\d{2}))X/, "34121234X", ["X", "12", "34"]);
 testRegExp(/(?<=\2\1(\d{2})(\d{2}))X/, "34121234X", ["X", "12", "34"]);
 testRegExpSyntaxError(".(?<=.)?", "", "SyntaxError: Invalid regular expression: invalid quantifier");
+testRegExp(/(?<=a*\1aaaaaaaaaaaaaa)/, "aaa", null); // The \1 is not a valid back reference, so it becomes an octal escape.
+testRegExp(/(?<=a*\1aaaaaaaaaaaaaa)x/, "aaaaaaaaaaaaaax", null, null);
+
+// Test 91
+testRegExp(/(?<=a*\1aaaaaaaaaaaaaa)x/, "\x01aaaaaaaaaaaaaax", ["x"], null);
+

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -336,10 +336,15 @@ public:
     {
     }
 
-    PatternTerm& lastTerm()
+    unsigned lastTermIndex()
     {
         ASSERT(m_terms.size());
-        return m_terms[m_terms.size() - 1];
+        return m_terms.size() - 1;
+    }
+
+    PatternTerm& lastTerm()
+    {
+        return m_terms[lastTermIndex()];
     }
     
     void removeLastTerm()


### PR DESCRIPTION
#### 561d0e5534c8c0b0d99688e43a2b5eb7f225cd85
<pre>
[JSC] UAF Yarr::YarrPatternConstructor::atomParenthesesEnd; Yarr::Parser::parseTokens; JSC::Yarr::parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=251435">https://bugs.webkit.org/show_bug.cgi?id=251435</a>
rdar://104652578

Reviewed by Mark Lam and Tadeu Zagallo.

When parsing a backreference for a lookbehind, it will likely appear lexically before the capture it references.
In that case, we create a forward reference term and see if we can convert it to a backreference at the end of the
lookbehind if a corresponding capture was found.  The prior code did this by saving a pointer to all such forward
references.  That pointer is a pointer into the storage for a Vector, which can be reallocated as it grows.
The fix here is to save a pointer to the alternative that contains the term and the index of the term in the alternative.
PatternAlternatives are kept alive during parsing, so it is safe to use them.

* JSTests/stress/regexp-lookbehind.js: Added new test cases.
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::UnresolvedForwardReference::UnresolvedForwardReference):
(JSC::Yarr::YarrPatternConstructor::UnresolvedForwardReference::term):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::atomBackReference):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternAlternative::lastTermIndex):
(JSC::Yarr::PatternAlternative::lastTerm):

Canonical link: <a href="https://commits.webkit.org/259657@main">https://commits.webkit.org/259657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70f475369f715f06d3cdca81a6e3e84d96e79ae8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114743 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174896 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97789 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39673 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81364 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95259 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28148 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93378 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5632 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4740 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30376 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47691 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102085 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6669 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9896 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25459 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->