### PR TITLE
Use CheckedPtr for m_preloads in CachedResourceLoader

### DIFF
--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -34,6 +34,7 @@
 #include "Timer.h"
 #include <pal/SessionID.h>
 #include <time.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashSet.h>
 #include <wtf/TypeCasts.h>
@@ -62,7 +63,7 @@ enum class CachePolicy : uint8_t;
 // from CachedResourceClient, to get the function calls in case the requested data has arrived.
 // This class also does the actual communication with the loader to obtain the resource from the network.
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CachedResource);
-class CachedResource {
+class CachedResource : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(CachedResource);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CachedResource);
     friend class MemoryCache;
@@ -258,7 +259,7 @@ public:
     bool isPreloaded() const { return m_preloadCount; }
     void increasePreloadCount() { ++m_preloadCount; }
     void decreasePreloadCount() { ASSERT(m_preloadCount); --m_preloadCount; }
-    bool isLinkPreload() { return m_isLinkPreload; }
+    bool isLinkPreload() const { return m_isLinkPreload; }
     void setLinkPreload() { m_isLinkPreload = true; }
     bool hasUnknownEncoding() { return m_hasUnknownEncoding; }
     void setHasUnknownEncoding(bool hasUnknownEncoding) { m_hasUnknownEncoding = hasUnknownEncoding; }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1663,7 +1663,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::prel
         resourceValue->increasePreloadCount();
 
         if (!m_preloads)
-            m_preloads = makeUnique<ListHashSet<CachedResource*>>();
+            m_preloads = makeUnique<ListHashSet<CheckedPtr<CachedResource>>>();
         m_preloads->add(resourceValue.get());
     }
     return resource;
@@ -1700,12 +1700,12 @@ void CachedResourceLoader::clearPreloads(ClearPreloadsMode mode)
     if (!m_preloads)
         return;
 
-    std::unique_ptr<ListHashSet<CachedResource*>> remainingLinkPreloads;
-    for (auto* resource : *m_preloads) {
+    std::unique_ptr<ListHashSet<CheckedPtr<CachedResource>>> remainingLinkPreloads;
+    for (auto& resource : *m_preloads) {
         ASSERT(resource);
         if (mode == ClearPreloadsMode::ClearSpeculativePreloads && resource->isLinkPreload()) {
             if (!remainingLinkPreloads)
-                remainingLinkPreloads = makeUnique<ListHashSet<CachedResource*>>();
+                remainingLinkPreloads = makeUnique<ListHashSet<CheckedPtr<CachedResource>>>();
             remainingLinkPreloads->add(resource);
             continue;
         }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -211,7 +211,7 @@ private:
 
     int m_requestCount { 0 };
 
-    std::unique_ptr<ListHashSet<CachedResource*>> m_preloads;
+    std::unique_ptr<ListHashSet<CheckedPtr<CachedResource>>> m_preloads;
     Timer m_unusedPreloadsTimer;
 
     Timer m_garbageCollectDocumentResourcesTimer;


### PR DESCRIPTION
#### b572acb5aaff48a236c2cbb19eeaf7ec79b72b21
<pre>
Use CheckedPtr for m_preloads in CachedResourceLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=251440">https://bugs.webkit.org/show_bug.cgi?id=251440</a>

Reviewed by NOBODY (OOPS!).

Made it possible to make CheckedPtr for CachedResource and deployed it in CachedResourceLoader::m_preloads.

* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::isLinkPreload const):
(WebCore::CachedResource::isLinkPreload): Made this accessor function const.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::preload):
(WebCore::CachedResourceLoader::clearPreloads):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b572acb5aaff48a236c2cbb19eeaf7ec79b72b21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114744 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174895 "Found 30 new test failures: dom/html/level2/html/HTMLScriptElement01.html, dom/html/level2/html/HTMLScriptElement02.html, dom/html/level2/html/HTMLScriptElement03.html, dom/html/level2/html/HTMLScriptElement04.html, dom/html/level2/html/HTMLScriptElement05.html, dom/html/level2/html/HTMLScriptElement06.html, dom/html/level2/html/HTMLScriptElement07.html, fast/encoding/preload-encoding.html, fast/images/slower-animation-than-decoding-image.html, fast/images/stopped-animation-deleted-image.html ... (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/15943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5818 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114597 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111239 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12171 "Found 60 new test failures: dom/html/level2/html/HTMLScriptElement01.html, dom/html/level2/html/HTMLScriptElement02.html, dom/html/level2/html/HTMLScriptElement03.html, dom/html/level2/html/HTMLScriptElement04.html, dom/html/level2/html/HTMLScriptElement05.html, dom/html/level2/html/HTMLScriptElement06.html, dom/html/level2/html/HTMLScriptElement07.html, fast/box-shadow/box-shadow-huge-area-crash.html, fast/canvas/image-pattern-rotate.html, fast/encoding/pseudo-tags-in-attributes.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95155 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39659 "Found 63 new test failures: dom/html/level2/html/HTMLScriptElement01.html, dom/html/level2/html/HTMLScriptElement02.html, dom/html/level2/html/HTMLScriptElement03.html, dom/html/level2/html/HTMLScriptElement04.html, dom/html/level2/html/HTMLScriptElement05.html, dom/html/level2/html/HTMLScriptElement06.html, dom/html/level2/html/HTMLScriptElement07.html, fast/images/reset-image-animation.html, fast/images/slower-animation-than-decoding-image.html, fast/images/stopped-animation-deleted-image.html ... (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94035 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26791 "Found 60 new test failures: dom/html/level2/html/HTMLScriptElement01.html, dom/html/level2/html/HTMLScriptElement02.html, dom/html/level2/html/HTMLScriptElement03.html, dom/html/level2/html/HTMLScriptElement04.html, dom/html/level2/html/HTMLScriptElement05.html, dom/html/level2/html/HTMLScriptElement06.html, fast/encoding/preload-encoding.html, fast/images/stopped-animation-deleted-image.html, fast/text/fontface-rebuild-during-loading-2.html, fast/text/fontface-rebuild-during-loading.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81350 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7869 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28147 "Found 60 new test failures: accessibility/mac/text-marker-paragraph-nav.html, compositing/clipping/border-radius-async-overflow-non-stacking.html, dom/html/level2/html/HTMLScriptElement01.html, dom/html/level2/html/HTMLScriptElement02.html, dom/html/level2/html/HTMLScriptElement03.html, dom/html/level2/html/HTMLScriptElement04.html, dom/html/level2/html/HTMLScriptElement05.html, dom/html/level2/html/HTMLScriptElement06.html, dom/html/level2/html/HTMLScriptElement07.html, fast/encoding/pseudo-tags-in-attributes.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8223 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4741 "Found 60 new test failures: accessibility/mac/text-marker-paragraph-nav.html, animations/stop-animation-on-suspend.html, dom/html/level2/html/HTMLScriptElement01.html, dom/html/level2/html/HTMLScriptElement02.html, dom/html/level2/html/HTMLScriptElement03.html, dom/html/level2/html/HTMLScriptElement04.html, dom/html/level2/html/HTMLScriptElement05.html, dom/html/level2/html/HTMLScriptElement06.html, dom/html/level2/html/HTMLScriptElement07.html, fast/encoding/pseudo-tags-in-attributes.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/13997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47690 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9897 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->