### PR TITLE
[ews-build.webkit.org] Filter out non-reviewer validators (Follow-up fix)

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1858,17 +1858,16 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
             reviewers = [reviewer] if reviewer else []
 
         remote = self.getProperty('remote', DEFAULT_REMOTE)
-        validators = self.VALIDATORS_FOR.get(remote, [])
         lower_case_reviewers = [reviewer.lower() for reviewer in reviewers]
-        lower_case_validators = [validator.lower() for validator in validators]
-        if validators and not any([validator in lower_case_reviewers for validator in lower_case_validators]):
-            defer.returnValue(self.fail_build_due_to_no_validators(validators))
+        validators = [validator.lower() for validator in self.VALIDATORS_FOR.get(remote, [])]
+        if validators and not any([validator in lower_case_reviewers for validator in validators]):
+            defer.returnValue(self.fail_build_due_to_no_validators(self.VALIDATORS_FOR.get(remote, [])))
             return
 
-        # Validators are a special case, not all validators are reviewers. If we have a reviewer that is a validator
-        # but NOT a reviewer, remove them
+        # Validators are a special case, not all validators are WebKit reviewers. If we have a reviewer that
+        # is a validator but NOT a WebKit reviewer, remove them
         def filter_out_non_reviewer_validators(candidate):
-            if candidate.lower() not in lower_case_validators:
+            if candidate.lower() not in validators:
                 return True
             return self.is_reviewer(candidate)
         reviewers = list(filter(filter_out_non_reviewer_validators, reviewers))

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -5562,7 +5562,7 @@ class TestValidateCommitterAndReviewer(BuildStepMixinAdditions, unittest.TestCas
 
     def test_success_pr_validators_not_reviewer(self):
         self.setupStep(ValidateCommitterAndReviewer())
-        ValidateCommitterAndReviewer.get_reviewers = lambda x, pull_request, repository_url=None: ['geoffreygaren']
+        ValidateCommitterAndReviewer.get_reviewers = lambda x, pull_request, repository_url=None: ['webkit-bug-bridge']
         self.setProperty('github.number', '1234')
         self.setProperty('owners', ['webkit-commit-queue'])
         self.setProperty('remote', 'apple')


### PR DESCRIPTION
#### af5a52595279782a8075627a124c1d0d44429dba
<pre>
[ews-build.webkit.org] Filter out non-reviewer validators (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251439">https://bugs.webkit.org/show_bug.cgi?id=251439</a>
rdar://104869860

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(ValidateCommitterAndReviewer.run): Clarify comment, make validators lower case.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestValidateCommitterAndReviewer.test_success_pr_validators_not_reviewer):

Canonical link: <a href="https://commits.webkit.org/259633@main">https://commits.webkit.org/259633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7151974c8765c5721564b44a4a717981f6e7243c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105487 "Build is being retried. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109387 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/15937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114599 "Build is in progress. Recent messages:") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111244 "Failed to checkout and rebase branch from PR 9387") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/15937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/15937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/7872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/104281 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/9899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3559 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->