### PR TITLE
[WGSL] Add a name mangling pass

### DIFF
--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MangleNames.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+#include "CallGraph.h"
+#include "WGSL.h"
+#include <wtf/DataLog.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+
+namespace WGSL {
+
+struct MangledName {
+    enum Kind : uint8_t {
+        Type,
+        Local,
+        Global,
+        Parameter,
+        Function,
+        Field,
+    };
+    static constexpr unsigned numberOfKinds = 6;
+
+    Kind kind;
+    uint32_t index;
+    String originalName;
+
+    String toString() const
+    {
+        static const ASCIILiteral prefixes[] = {
+            "type"_s,
+            "local"_s,
+            "global"_s,
+            "parameter"_s,
+            "function"_s,
+            "field"_s,
+        };
+        return makeString(prefixes[WTF::enumToUnderlyingType(kind)], String::number(index));
+    }
+};
+
+class NameManglerVisitor : public AST::Visitor {
+public:
+    NameManglerVisitor(const CallGraph& callGraph)
+        : m_callGraph(callGraph)
+    {
+    }
+
+    HashMap<String, String> run();
+
+    void visit(AST::Function&) override;
+    void visit(AST::VariableStatement&) override;
+    void visit(AST::Structure&) override;
+    void visit(AST::Variable&) override;
+    void visit(AST::IdentifierExpression&) override;
+    void visit(AST::FieldAccessExpression&) override;
+    void visit(AST::NamedTypeName&) override;
+
+private:
+    using NameMap = HashMap<String, MangledName>;
+
+    class Context {
+    public:
+        Context(const Context *const parent)
+            : m_parent(parent)
+        {
+        }
+
+        // FIXME: this should return a reference, all values should be declared
+        const MangledName* lookup(const AST::Identifier& name) const
+        {
+            auto it = m_map.find(name.id());
+            if (it != m_map.end())
+                return &it->value;
+            if (m_parent)
+                return m_parent->lookup(name);
+            return nullptr;
+        }
+
+        const MangledName& add(const AST::Identifier& name, MangledName&& mangledName)
+        {
+            auto result = m_map.add(name.id(), WTFMove(mangledName));
+            ASSERT(result.isNewEntry);
+            return result.iterator->value;
+        }
+
+    private:
+        const Context* m_parent { nullptr };
+        NameMap m_map;
+    };
+
+    friend class ContextScope;
+    class ContextScope {
+    public:
+        ContextScope(NameManglerVisitor* visitor)
+            : m_visitor(*visitor)
+            , m_previousContext(visitor->m_context)
+        {
+            m_visitor.m_contexts.append(Context { m_previousContext });
+            m_visitor.m_context = &m_visitor.m_contexts.last();
+        }
+
+        ~ContextScope()
+        {
+            m_visitor.m_context = m_previousContext;
+            m_visitor.m_contexts.removeLast();
+        }
+
+    private:
+        NameManglerVisitor& m_visitor;
+        Context* m_previousContext;
+    };
+
+    void introduceVariable(AST::Identifier&, MangledName::Kind);
+    void readVariable(AST::Identifier&) const;
+
+    MangledName makeMangledName(const String&, MangledName::Kind);
+
+    void visitVariableDeclaration(AST::Variable&, MangledName::Kind);
+    void visitFunctionBody(AST::Function&);
+
+    const CallGraph& m_callGraph;
+    Context* m_context { nullptr };
+    Vector<Context> m_contexts;
+    HashMap<AST::Structure*, NameMap> m_structFieldMapping;
+    uint32_t m_indexPerType[MangledName::numberOfKinds] { 0 };
+};
+
+HashMap<String, String> NameManglerVisitor::run()
+{
+    HashMap<String, String> entryPointMap;
+    ContextScope moduleScope(this);
+
+    for (const auto& entrypoint : m_callGraph.entrypoints()) {
+        String originalName = entrypoint.m_function.name();
+        introduceVariable(entrypoint.m_function.name(), MangledName::Function);
+        auto result = entryPointMap.add(originalName, entrypoint.m_function.name());
+        ASSERT_UNUSED(result, result.isNewEntry);
+    }
+
+    auto& module = m_callGraph.ast();
+    for (auto& structure : module.structures())
+        visit(structure);
+
+    for (auto& variable : module.variables())
+        visit(variable);
+
+    for (auto& function : module.functions())
+        visitFunctionBody(function);
+
+    return entryPointMap;
+}
+
+void NameManglerVisitor::visit(AST::Function& function)
+{
+    introduceVariable(function.name(), MangledName::Function);
+}
+
+void NameManglerVisitor::visitFunctionBody(AST::Function& function)
+{
+    ContextScope functionScope(this);
+
+    for (auto& parameter : function.parameters()) {
+        AST::Visitor::visit(parameter.typeName());
+        introduceVariable(parameter.name(), MangledName::Parameter);
+    }
+
+    AST::Visitor::visit(function.body());
+    if (function.maybeReturnType())
+        AST::Visitor::visit(*function.maybeReturnType());
+}
+
+void NameManglerVisitor::visit(AST::Structure& structure)
+{
+    introduceVariable(structure.name(), MangledName::Type);
+
+    NameMap fieldMap;
+    for (auto& member : structure.members()) {
+        AST::Visitor::visit(member.type());
+        auto mangledName = makeMangledName(member.name(), MangledName::Field);
+        fieldMap.add(member.name(), mangledName);
+        // FIXME: need to resolve type of expressions in order to be able to replace struct fields
+    }
+    auto result = m_structFieldMapping.add(&structure, WTFMove(fieldMap));
+    ASSERT_UNUSED(result, result.isNewEntry);
+}
+
+void NameManglerVisitor::visit(AST::Variable& variable)
+{
+    visitVariableDeclaration(variable, MangledName::Global);
+}
+
+void NameManglerVisitor::visit(AST::VariableStatement& variable)
+{
+    visitVariableDeclaration(variable.variable(), MangledName::Local);
+}
+
+void NameManglerVisitor::visitVariableDeclaration(AST::Variable& variable, MangledName::Kind kind)
+{
+    introduceVariable(variable.name(), kind);
+    AST::Visitor::visit(variable);
+}
+
+void NameManglerVisitor::visit(AST::IdentifierExpression& identifier)
+{
+    readVariable(identifier.identifier());
+}
+
+void NameManglerVisitor::visit(AST::FieldAccessExpression& access)
+{
+    // FIXME: need to resolve type of expressions in order to be able to replace struct fields
+    AST::Visitor::visit(access.base());
+}
+
+void NameManglerVisitor::visit(AST::NamedTypeName& type)
+{
+    readVariable(type.name());
+}
+
+void NameManglerVisitor::introduceVariable(AST::Identifier& name, MangledName::Kind kind)
+{
+    const auto& mangledName = m_context->add(name, makeMangledName(name, kind));
+    name = AST::Identifier::makeWithSpan(name.span(), mangledName.toString());
+}
+
+MangledName NameManglerVisitor::makeMangledName(const String& name, MangledName::Kind kind)
+{
+    return MangledName {
+        kind,
+        m_indexPerType[WTF::enumToUnderlyingType(kind)]++,
+        name
+    };
+}
+
+void NameManglerVisitor::readVariable(AST::Identifier& name) const
+{
+    // FIXME: this should be unconditional
+    if (const auto* mangledName = m_context->lookup(name))
+        name = AST::Identifier::makeWithSpan(name.span(), mangledName->toString());
+}
+
+HashMap<String, String> mangleNames(CallGraph& callGraph)
+{
+    return NameManglerVisitor(callGraph).run();
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/MangleNames.h
+++ b/Source/WebGPU/WGSL/MangleNames.h
@@ -25,40 +25,12 @@
 
 #pragma once
 
-// FIXME: move Stage out of StageAttribute so we don't need to include this
-#include "ASTForward.h"
-#include "ASTStageAttribute.h"
-#include <wtf/HashMap.h>
-#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WGSL {
 
-class CallGraph {
-    friend class CallGraphBuilder;
+class CallGraph;
 
-public:
-    struct Callee {
-        AST::Function* m_target;
-        Vector<AST::CallExpression*> m_callSites;
-    };
-
-    struct EntryPoint {
-        AST::Function& m_function;
-        AST::StageAttribute::Stage m_stage;
-    };
-
-    AST::ShaderModule& ast() const { return m_ast; }
-    const Vector<EntryPoint>& entrypoints() const { return m_entrypoints; }
-
-private:
-    CallGraph(AST::ShaderModule&);
-
-    AST::ShaderModule& m_ast;
-    Vector<EntryPoint> m_entrypoints;
-    HashMap<String, AST::Function*> m_functionsByName;
-    HashMap<AST::Function*, Vector<Callee>> m_callees;
-};
-
-CallGraph buildCallGraph(AST::ShaderModule&);
+HashMap<String, String> mangleNames(CallGraph&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -124,6 +124,8 @@
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
 		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
+		978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9123298A4E8400B37E5E /* MangleNames.cpp */; };
+		978A9126298A4E8400B37E5E /* MangleNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9124298A4E8400B37E5E /* MangleNames.h */; };
 		979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B2297018290050EA2C /* MetalCodeGenerator.h */; };
 		979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240B3297018290050EA2C /* MetalFunctionWriter.h */; };
 		979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240B4297018290050EA2C /* MetalCodeGenerator.cpp */; };
@@ -326,6 +328,8 @@
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
 		9789C318297EA105009E9006 /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallGraph.cpp; sourceTree = "<group>"; };
 		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
+		978A9123298A4E8400B37E5E /* MangleNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangleNames.cpp; sourceTree = "<group>"; };
+		978A9124298A4E8400B37E5E /* MangleNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MangleNames.h; sourceTree = "<group>"; };
 		979240B2297018290050EA2C /* MetalCodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalCodeGenerator.h; sourceTree = "<group>"; };
 		979240B3297018290050EA2C /* MetalFunctionWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalFunctionWriter.h; sourceTree = "<group>"; };
 		979240B4297018290050EA2C /* MetalCodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCodeGenerator.cpp; sourceTree = "<group>"; };
@@ -467,6 +471,8 @@
 				97F547B7298055D90011D79A /* GlobalVariableRewriter.h */,
 				338BB2D527B6B68700E066AB /* Lexer.cpp */,
 				338BB2D327B6B66C00E066AB /* Lexer.h */,
+				978A9123298A4E8400B37E5E /* MangleNames.cpp */,
+				978A9124298A4E8400B37E5E /* MangleNames.h */,
 				339B7B1A27D800090072BF9A /* Parser.cpp */,
 				339B7B1727D7FFA40072BF9A /* Parser.h */,
 				66DC575428627E0B0014CABD /* ParserPrivate.h */,
@@ -685,6 +691,7 @@
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
 				97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
+				978A9126298A4E8400B37E5E /* MangleNames.h in Headers */,
 				979240B6297018290050EA2C /* MetalCodeGenerator.h in Headers */,
 				979240B7297018290050EA2C /* MetalFunctionWriter.h in Headers */,
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
@@ -852,6 +859,7 @@
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
 				97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
+				978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */,
 				979240B8297018290050EA2C /* MetalCodeGenerator.cpp in Sources */,
 				979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -236,9 +236,12 @@ void ShaderModule::setLabel(String&& label)
         m_library.label = label;
 }
 
-id<MTLFunction> ShaderModule::getNamedFunction(const String& name, const HashMap<String, double>& keyValueReplacements) const
+id<MTLFunction> ShaderModule::getNamedFunction(const String& originalName, const HashMap<String, double>& keyValueReplacements) const
 {
+    const auto* information = entryPointInformation(originalName);
+    const String& name = information ? information->mangledName : originalName;
     auto originalFunction = [m_library newFunctionWithName:name];
+
     if (!keyValueReplacements.size())
         return originalFunction;
 


### PR DESCRIPTION
#### 4697eaccd00f7f8e11b01e96fe00b5976d8e047f
<pre>
[WGSL] Add a name mangling pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=251441">https://bugs.webkit.org/show_bug.cgi?id=251441</a>
rdar://104872078

Reviewed by Myles C. Maxfield.

Initial name mangling pass implementation. It&apos;s still a bit bare bones, and until
we implement the type checking we can&apos;t rename struct fields, but everything else
(that is currently supported) works. The implementation is a bit rough, just
renaming everything in place, but it&apos;s fairly concise and gets the job done, at
least for the time being.

* Source/WebGPU/WGSL/AST/ASTFunctionDecl.h:
* Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h:
* Source/WebGPU/WGSL/AST/ASTStructureAccess.h:
* Source/WebGPU/WGSL/AST/ASTStructureDecl.h:
* Source/WebGPU/WGSL/AST/ASTTypeDecl.h:
* Source/WebGPU/WGSL/AST/ASTVariableDecl.h:
* Source/WebGPU/WGSL/CallGraph.h:
(WGSL::CallGraph::ast const):
(WGSL::CallGraph::entrypoints const):
(WGSL::CallGraph::ast): Deleted.
(WGSL::CallGraph::entrypoints): Deleted.
* Source/WebGPU/WGSL/MangleNames.cpp: Added.
(WGSL::MangledName::toString const):
(WGSL::NameManglerVisitor::NameManglerVisitor):
(WGSL::NameManglerVisitor::Context::Context):
(WGSL::NameManglerVisitor::Context::lookup const):
(WGSL::NameManglerVisitor::Context::add):
(WGSL::NameManglerVisitor::ContextScope::ContextScope):
(WGSL::NameManglerVisitor::ContextScope::~ContextScope):
(WGSL::NameManglerVisitor::run):
(WGSL::NameManglerVisitor::visit):
(WGSL::NameManglerVisitor::visitFunctionBody):
(WGSL::NameManglerVisitor::visitVariableDeclaration):
(WGSL::NameManglerVisitor::def):
(WGSL::NameManglerVisitor::makeMangledName):
(WGSL::NameManglerVisitor::read const):
(WGSL::mangleNames):
* Source/WebGPU/WGSL/MangleNames.h: Copied from Source/WebGPU/WGSL/CallGraph.h.
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepare):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::getNamedFunction const):

Canonical link: <a href="https://commits.webkit.org/259671@main">https://commits.webkit.org/259671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40430baa892277a982367bedbd41fc7414223147

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114866 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5928 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111392 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7997 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6681 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10046 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->