### PR TITLE
[WGSL] Rename `ArgumentBuffer` roles to `BindGroup`

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTParameterValue.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameterValue.h
@@ -35,7 +35,7 @@ namespace WGSL::AST {
 enum class ParameterRole : uint8_t {
     UserDefined,
     StageIn,
-    ArgumentBuffer,
+    BindGroup,
 };
 
 class ParameterValue final : public Value {

--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -38,7 +38,7 @@ enum class StructureRole : uint8_t {
     FragmentInput,
     ComputeInput,
     VertexOutput,
-    ArgumentBuffer,
+    BindGroup,
 };
 
 class Structure final : public Declaration {

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -227,7 +227,7 @@ void RewriteGlobalVariables::insertStructs()
             WTFMove(structName),
             WTFMove(structMembers),
             AST::Attribute::List { },
-            AST::StructureRole::ArgumentBuffer
+            AST::StructureRole::BindGroup
         ));
     }
 }
@@ -243,7 +243,7 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Ind
             AST::Attribute::List {
                 adoptRef(*new AST::GroupAttribute(span, group))
             },
-            AST::ParameterRole::ArgumentBuffer
+            AST::ParameterRole::BindGroup
         ));
     }
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -132,7 +132,7 @@ void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
             checkErrorAndVisit(parameter);
             m_stringBuilder.append(" [[stage_in]]");
             break;
-        case AST::ParameterRole::ArgumentBuffer:
+        case AST::ParameterRole::BindGroup:
             visitArgumentBufferParameter(parameter);
             break;
         }
@@ -256,7 +256,7 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         case AST::StructureRole::FragmentInput:
             m_stringBuilder.append("[[user(loc", location.location(), ")]]");
             return;
-        case AST::StructureRole::ArgumentBuffer:
+        case AST::StructureRole::BindGroup:
             return;
         case AST::StructureRole::VertexInput:
         case AST::StructureRole::ComputeInput:


### PR DESCRIPTION
#### ec8c0fe9d7ca497f95f5ef3952ff3721ee768f7d
<pre>
[WGSL] Rename `ArgumentBuffer` roles to `BindGroup`
<a href="https://bugs.webkit.org/show_bug.cgi?id=251443">https://bugs.webkit.org/show_bug.cgi?id=251443</a>
rdar://104873689

Reviewed by Myles C. Maxfield.

Let&apos;s try use the WGSL nomenclature instead of Metal in parts of the
codebase that aren&apos;t Metal-specific (whenever possible)

* Source/WebGPU/WGSL/AST/ASTFunctionDecl.h:
* Source/WebGPU/WGSL/AST/ASTStructureDecl.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/259670@main">https://commits.webkit.org/259670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e1328e211ea81cef32697f560bf640cc79b6e94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114857 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5918 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111383 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95240 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26877 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7988 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28232 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6677 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10040 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->