### PR TITLE
fast/forms/ios/input-peripherals-with-validation-message.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/forms/ios/input-peripherals-with-validation-message.html
+++ b/LayoutTests/fast/forms/ios/input-peripherals-with-validation-message.html
@@ -23,9 +23,10 @@ addEventListener("load", async () => {
 
     debug("Tap on submit button with an empty required date input.");
     await UIHelper.activateElementAndWaitForInputSession(submit);
-    shouldBe("document.activeElement", "date");
 
     isShowingValidationMessage = await UIHelper.isShowingPopover();
+
+    shouldBe("document.activeElement", "date");
     shouldBeTrue("isShowingValidationMessage");
 
     hasInputSession = await UIHelper.hasInputSession();
@@ -36,9 +37,8 @@ addEventListener("load", async () => {
     await UIHelper.waitForPopoverToDismiss();
     await UIHelper.activateElementAndWaitForInputSession(date);
 
-    shouldBe("document.activeElement", "date");
-
     isShowingValidationMessage = await UIHelper.isShowingPopover();
+    shouldBe("document.activeElement", "date");
     shouldBeFalse("isShowingValidationMessage");
 
     hasInputSession = await UIHelper.hasInputSession();
@@ -52,9 +52,9 @@ addEventListener("load", async () => {
 
     debug("\nTap on submit button with an empty required text input.");
     await UIHelper.activateElementAndWaitForInputSession(submit);
-    shouldBe("document.activeElement", "text");
 
     isShowingValidationMessage = await UIHelper.isShowingPopover();
+    shouldBe("document.activeElement", "text");
     shouldBeTrue("isShowingValidationMessage");
 
     hasInputSession = await UIHelper.hasInputSession();


### PR DESCRIPTION
#### a33428d63fdb18d6287d48c6ab8c9bbdda84b30d
<pre>
fast/forms/ios/input-peripherals-with-validation-message.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=251445">https://bugs.webkit.org/show_bug.cgi?id=251445</a>
rdar://104760120

Reviewed by Wenson Hsieh.

Form controls with validation constraints display a validation bubble if their
contents do not satisfy the constraints when attempting submission. The
&quot;input-peripherals-with-validation-message.html&quot; test verifies that validation
bubbles and input peripherals (such as date pickers) are not presented at the
same time.

If the position of a form control changes the validation bubble is automatically
dismissed. This logic is run as an asynchronous task following layout, which
then dispatches IPC to the UIProcess to perform dismissal.

Prior to verifying whether the validation bubble is visible, the test verifies
the document&apos;s focused element with a call to `shouldBe`. This verification
adds text to the DOM, moving the form control (date input) down, and initiating
dismissal of the validation bubble. Next, the test checks the visibility of the
validation bubble. Recent changes in UIKit introduced an additional delay when
presenting a popover, resulting in the post-layout tasks completing before
presentation, hiding the bubble. This is expected behavior, as the bubble should
be dismissed due to layout changes.

To fix, move the checks for the document&apos;s focused element after allowing the
bubble to be presented.

* LayoutTests/fast/forms/ios/input-peripherals-with-validation-message.html:

Canonical link: <a href="https://commits.webkit.org/259647@main">https://commits.webkit.org/259647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84465f924c075b911aab4dccfc4c214c1dccf900

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114779 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16030 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/5830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97818 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111257 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26800 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7883 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28156 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/5830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47699 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9910 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3568 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->