### PR TITLE
[WebGPU] Implement GPUSampleMask support

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -30,6 +30,14 @@
 #import "BindGroupLayout.h"
 #import "Device.h"
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <Metal/MTLRenderPipeline_Private.h>
+#else
+@interface MTLRenderPipelineDescriptor ()
+- (void)setSampleMask:(NSUInteger)mask;
+@end
+#endif
+
 namespace WebGPU {
 
 static MTLBlendOperation blendOperation(WGPUBlendOperation operation)
@@ -442,6 +450,9 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
 
     mtlRenderPipelineDescriptor.rasterSampleCount = descriptor.multisample.count ?: 1;
     mtlRenderPipelineDescriptor.alphaToCoverageEnabled = descriptor.multisample.alphaToCoverageEnabled;
+    ASSERT([mtlRenderPipelineDescriptor respondsToSelector:@selector(setSampleMask:)]);
+    if (descriptor.multisample.mask != ~static_cast<decltype(descriptor.multisample.mask)>(0))
+        [mtlRenderPipelineDescriptor setSampleMask:descriptor.multisample.mask];
 
     if (descriptor.vertex.bufferCount)
         mtlRenderPipelineDescriptor.vertexDescriptor = createVertexDescriptor(descriptor.vertex);


### PR DESCRIPTION
#### 2b3c2009955c89cf1b1b4ae8415437220fa5e22e
<pre>
[WebGPU] Implement GPUSampleMask support
<a href="https://bugs.webkit.org/show_bug.cgi?id=251444">https://bugs.webkit.org/show_bug.cgi?id=251444</a>
&lt;radar://103304584&gt;

Reviewed by NOBODY (OOPS!).

Sample mask from the pipeline descriptor is anded with
any sample mask in the shader.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b3c2009955c89cf1b1b4ae8415437220fa5e22e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114774 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5841 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114621 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39691 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28164 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8246 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4756 "Found 1 new test failure: fast/images/avif-image-document.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47707 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9921 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->