### PR TITLE
(REGRESSION(257434@main): https://readwise.io/read image squished

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<head>
+<title> abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block </title>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:60px; height:60px; background:green;"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title> abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block </title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="match" href="/css/support/60x60-green.png">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css2/#propdef-max-height">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-position/#absolute-positioning-containing-block">
+<meta name="assert" content="image width should be capped by the transferred max width from the max-height property" />
+<style></style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 60px; position: relative;">
+    <img style="position: absolute; max-height: 100%" src="/css/css-sizing/aspect-ratio/support/100x100-green.png">
+    <div style="width: 100px; height: 60px;"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3249,6 +3249,8 @@ LayoutUnit RenderBox::computeLogicalHeightWithoutLayout() const
 
 std::optional<LayoutUnit> RenderBox::computeLogicalHeightUsing(SizeType heightType, const Length& height, std::optional<LayoutUnit> intrinsicContentHeight) const
 {
+    if (is<RenderReplaced>(this))
+        return computeReplacedLogicalHeightUsing(heightType, height) + borderAndPaddingLogicalHeight();
     if (std::optional<LayoutUnit> logicalHeight = computeContentAndScrollbarLogicalHeightUsing(heightType, height, intrinsicContentHeight))
         return adjustBorderBoxLogicalHeightForBoxSizing(logicalHeight.value());
     return std::nullopt;


### PR DESCRIPTION
#### 93e6542aebf91d6a023247a5068e8756eeae53d3
<pre>
(REGRESSION(257434@main): <a href="https://readwise.io/read">https://readwise.io/read</a> image squished
<a href="https://bugs.webkit.org/show_bug.cgi?id=251419">https://bugs.webkit.org/show_bug.cgi?id=251419</a>
rdar://103481329

Reviewed by Alan Baradlay.

When viewing the website on iOS the image of the phone renders
incorrectly as the width that is computed is too large. The image has
max-height: 100%, so this constraint should also provide the transferred
max-width for the image. We should be able to compute this value since
the image is absolutely positioned.

The previous version (before the regression) of this code computed the
&quot;constrained width&quot; by calling computeReplacedLogicalHeight and then
using the intrinsic ratio to compute the final width. computeReplacedLogicalHeight
eventually called into computeReplacedLogicalHeightUsing to compute the
min/max heights. This ended up computing the correct value for the min/max
heights when the image was absolutely positioned and had a percentage
height in an auto-height containing block.

The new version of the code, which used the logic for the css
aspect-ratio property, did not handle this case correctly and returned
an incorrect value for max-height. To resolve this issue, we can check
to see if the object is a RenderReplaced object by the time we get
to RenderBox::computeLogicalHeightUsing and then call into
computeReplacedLogicalHeightUsing to get the correct value.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/abs-pos-transferred-max-width-from-percentage-max-height-in-auto-height-containing-block.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeLogicalHeightUsing const):

Canonical link: <a href="https://commits.webkit.org/259663@main">https://commits.webkit.org/259663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73b575b8a2355097a1ec67f41d38389f6af9b3b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114772 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174919 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5839 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97816 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39680 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81375 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28163 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4755 "Found 1 new test failure: fast/images/avif-heif-container-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47706 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6674 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9919 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->