### PR TITLE
Use CheckedPtr in CounterNode

### DIFF
--- a/Source/WebCore/rendering/CounterNode.h
+++ b/Source/WebCore/rendering/CounterNode.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 
@@ -38,7 +39,7 @@ namespace WebCore {
 class RenderCounter;
 class RenderElement;
 
-class CounterNode : public RefCounted<CounterNode> {
+class CounterNode : public RefCounted<CounterNode>, public CanMakeCheckedPtr {
 public:
     static Ref<CounterNode> create(RenderElement&, bool isReset, int value);
     ~CounterNode();
@@ -53,11 +54,11 @@ public:
     // Invalidates the text in the renderers of this counter, if any.
     void resetRenderers();
 
-    CounterNode* parent() const { return m_parent; }
-    CounterNode* previousSibling() const { return m_previousSibling; }
-    CounterNode* nextSibling() const { return m_nextSibling; }
-    CounterNode* firstChild() const { return m_firstChild; }
-    CounterNode* lastChild() const { return m_lastChild; }
+    CounterNode* parent() const { return const_cast<CounterNode*>(m_parent.get()); }
+    CounterNode* previousSibling() const { return const_cast<CounterNode*>(m_previousSibling.get()); }
+    CounterNode* nextSibling() const { return const_cast<CounterNode*>(m_nextSibling.get()); }
+    CounterNode* firstChild() const { return const_cast<CounterNode*>(m_firstChild.get()); }
+    CounterNode* lastChild() const { return const_cast<CounterNode*>(m_lastChild.get()); }
     CounterNode* lastDescendant() const;
     CounterNode* previousInPreOrder() const;
     CounterNode* nextInPreOrder(const CounterNode* stayWithin = nullptr) const;
@@ -77,15 +78,15 @@ private:
 
     bool m_hasResetType;
     int m_value;
-    int m_countInParent;
+    int m_countInParent { 0 };
     RenderElement& m_owner;
     RenderCounter* m_rootRenderer { nullptr };
 
-    CounterNode* m_parent { nullptr };
-    CounterNode* m_previousSibling { nullptr };
-    CounterNode* m_nextSibling { nullptr };
-    CounterNode* m_firstChild { nullptr };
-    CounterNode* m_lastChild { nullptr };
+    CheckedPtr<CounterNode> m_parent;
+    CheckedPtr<CounterNode> m_previousSibling;
+    CheckedPtr<CounterNode> m_nextSibling;
+    CheckedPtr<CounterNode> m_firstChild;
+    CheckedPtr<CounterNode> m_lastChild;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -55,7 +55,7 @@ private:
     void computePreferredLogicalWidths(float leadWidth) override;
 
     CounterContent m_counter;
-    CounterNode* m_counterNode { nullptr };
+    CheckedPtr<CounterNode> m_counterNode;
     RenderCounter* m_nextForSameCounter { nullptr };
     friend class CounterNode;
 };


### PR DESCRIPTION
#### c5914bd7c1ee1fa0c1a2b335e805cd830e9da551
<pre>
Use CheckedPtr in CounterNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=251447">https://bugs.webkit.org/show_bug.cgi?id=251447</a>

Reviewed by Alan Baradlay.

Deployed CheckedPtr in CounterNode in place of raw pointers.

* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::CounterNode::CounterNode):
(WebCore::CounterNode::~CounterNode):
(WebCore::CounterNode::nextInPreOrderAfterChildren const):
(WebCore::CounterNode::nextInPreOrder const):
(WebCore::CounterNode::lastDescendant const):
(WebCore::CounterNode::previousInPreOrder const):
(WebCore::CounterNode::resetThisAndDescendantsRenderers):
(WebCore::CounterNode::recount):
(WebCore::CounterNode::insertAfter):
(WebCore::CounterNode::removeChild):
* Source/WebCore/rendering/CounterNode.h:
(WebCore::CounterNode::parent const):
(WebCore::CounterNode::previousSibling const):
(WebCore::CounterNode::nextSibling const):
(WebCore::CounterNode::firstChild const):
(WebCore::CounterNode::lastChild const):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::makeCounterNode):
(WebCore::RenderCounter::originalText const):
(WebCore::destroyCounterNodeWithoutMapRemoval):
(WebCore::RenderCounter::destroyCounterNodes):
(WebCore::RenderCounter::destroyCounterNode):
(WebCore::updateCounters):
(showCounterRendererTree):
* Source/WebCore/rendering/RenderCounter.h:

Canonical link: <a href="https://commits.webkit.org/259659@main">https://commits.webkit.org/259659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a7ea287128e8c42222fce9e05e1324f8308ad5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114773 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5840 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97817 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39690 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26810 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28166 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47709 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9920 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3571 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->