### PR TITLE
[GTK] Remove on-demand hardware acceleration setting

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -131,8 +131,10 @@ static const char* hardwareAccelerationPolicy(WebKitURISchemeRequest* request)
         return "never";
     case WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS:
         return "always";
+#if !USE(GTK4)
     case WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND:
         return "on demand";
+#endif
     }
 #endif
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -46,6 +46,17 @@ G_BEGIN_DECLS
 #define WEBKIT_SETTINGS_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_SETTINGS, WebKitSettingsClass))
 
 #if PLATFORM(GTK)
+#if USE(GTK4)
+/**
+ * WebKitHardwareAccelerationPolicy:
+ * @WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS: Hardware acceleration is always enabled, even for websites not requesting it.
+ * @WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER: Hardware acceleration is always disabled, even for websites requesting it.
+ *
+ * Enum values used for determining the hardware acceleration policy.
+ *
+ * Since: 2.16
+ */
+#else
 /**
  * WebKitHardwareAccelerationPolicy:
  * @WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND: Hardware acceleration is enabled/disabled as request by web contents.
@@ -56,8 +67,11 @@ G_BEGIN_DECLS
  *
  * Since: 2.16
  */
+#endif
 typedef enum {
+#if !USE(GTK4)
     WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND,
+#endif
     WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS,
     WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER
 } WebKitHardwareAccelerationPolicy;

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -60,18 +60,18 @@ enabled. This property was previously disabled by default.
 no longer have a [type@Gdk.Event] parameter. Adjust your signal handlers
 accordingly.
 
-## Changes to WebKitWebView construction
+## Changes to WebKitWebView Construction
 
 `webkit_web_view_new_with_context()`, `webkit_web_view_new_with_settings()`, and
 `webkit_web_view_new_with_user_content_manager()` have all been removed. You
 may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] and
 [ctor@WebKit.WebView.new_with_related_view] both remain.
 
-## Most types are final
+## Most Types Are Final
 
 Only two types are now derivable:
 
-- [type@WebView] has been often subclassed to customize its behaviour for an
+- [type@WebView] has been often subclassed to customize its behavior for an
   specific application. This possibility has been kept, as it has proved
   useful in the past.
 - [type@InputMethodContext] is specifically designed in a way that subclassing
@@ -80,7 +80,7 @@ Only two types are now derivable:
 The rest of the types are no longer derivable; they are defined with the
 `G_TYPE_FLAG_FINAL` flag set. Use composition instead of derivation.
 
-## Network session API
+## Network Session API
 
 WebKit now uses a single global network process for all web contexts, and different
 network sessions can be created and used in the same network process. All the networking
@@ -94,3 +94,10 @@ to be used must be passed to the [type@WebKit.WebView] as a construct parameter.
 same [type@WebKit.NetworkSession] object to several web views to use the same session. The only exception
 is automation mode, which uses its own ephemeral session that is configured by the automation
 session capabilities.
+
+## Hardware Acceleration Policy
+
+`WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND` has been removed from
+[enum@WebKit.HardwareAccelerationPolicy]. You may still use
+[method@WebKit.Settings.set_hardware_acceleration_policy] to enable or disable
+hardware acceleration.

--- a/Tools/MiniBrowser/gtk/BrowserSettingsDialog.c
+++ b/Tools/MiniBrowser/gtk/BrowserSettingsDialog.c
@@ -62,8 +62,11 @@ static const char *hardwareAccelerationPolicyToString(WebKitHardwareAcceleration
         return "always";
     case WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER:
         return "never";
+#if !GTK_CHECK_VERSION(3, 98, 0)
     case WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND:
         return "ondemand";
+#endif
+
     }
 
     g_assert_not_reached();
@@ -76,10 +79,12 @@ static int stringToHardwareAccelerationPolicy(const char *policy)
         return WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS;
     if (!g_ascii_strcasecmp(policy, "never"))
         return WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER;
+#if !GTK_CHECK_VERSION(3, 98, 0)
     if (!g_ascii_strcasecmp(policy, "ondemand"))
         return WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND;
+#endif
 
-    g_warning("Invalid value %s for hardware-acceleration-policy setting valid values are always, never and ondemand", policy);
+    g_warning("Invalid value %s for hardware-acceleration-policy setting", policy);
     return -1;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -329,16 +329,16 @@ static void testWebKitSettings(Test*, gconstpointer)
     g_assert_cmpstr(nullptr, ==, webkit_settings_get_media_content_types_requiring_hardware_support(settings));
 
 #if PLATFORM(GTK)
-#if !USE(GTK4)
     // Always is the default hardware acceleration policy.
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
     webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
+#if !USE(GTK4)
     webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
+#endif
     webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
-#endif
 
     // Back-forward navigation gesture is disabled by default
     g_assert_false(webkit_settings_get_enable_back_forward_navigation_gestures(settings));


### PR DESCRIPTION
#### 7e5444b964e5e8685a2e6809f9600c2b29855654
<pre>
[GTK] Remove on-demand hardware acceleration setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=232516">https://bugs.webkit.org/show_bug.cgi?id=232516</a>

Reviewed by Carlos Garcia Campos.

There are now only two options for hardware acceleration: ALWAYS or
NEVER. The ON_DEMAND option does not work anymore and should be removed
from the API.

This also fixes the precondition check in webkit_settings_get_hardware_acceleration_policy
to correctly return the new default value ALWAYS rather than ON_DEMAND,
which was the original default value.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::hardwareAccelerationPolicy):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_class_init):
(webkit_settings_get_hardware_acceleration_policy):
(webkit_settings_set_hardware_acceleration_policy):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md:
* Tools/MiniBrowser/gtk/BrowserSettingsDialog.c:
(hardwareAccelerationPolicyToString):
(stringToHardwareAccelerationPolicy):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):

Canonical link: <a href="https://commits.webkit.org/259686@main">https://commits.webkit.org/259686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a47779464322c26583ed1641938ee9f7b470759

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114897 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5959 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97936 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111423 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95275 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26914 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28267 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8524 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47815 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6691 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10077 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->