### PR TITLE
Don't use CG display lists for bitmap-image-only layers

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -133,6 +133,8 @@ public:
 
     virtual TransformationMatrix transformMatrixForProperty(AnimatedProperty) const { return { }; }
 
+    virtual bool layerContainsBitmapOnly(const GraphicsLayer*) const { return false; }
+
 #ifndef NDEBUG
     // RenderLayerBacking overrides this to verify that it is not
     // currently painting contents. An ASSERT fails, if it is.

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -229,6 +229,7 @@ private:
     WEBCORE_EXPORT bool platformCALayerUseGiantTiles() const override;
     WEBCORE_EXPORT bool platformCALayerUseCSS3DTransformInteroperability() const override;
     WEBCORE_EXPORT void platformCALayerLogFilledVisibleFreshTile(unsigned) override;
+    bool platformCALayerContainsBitmapOnly(PlatformCALayer*) const override { return client().layerContainsBitmapOnly(this); }
 
     bool isCommittingChanges() const override { return m_isCommittingChanges; }
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override { return m_usesDisplayListDrawing; }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -71,6 +71,8 @@ public:
 
     virtual void platformCALayerLogFilledVisibleFreshTile(unsigned /* blankPixelCount */) { }
 
+    virtual bool platformCALayerContainsBitmapOnly(PlatformCALayer*) const { return false; }
+
 protected:
     virtual ~PlatformCALayerClient() = default;
 };

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3019,6 +3019,28 @@ bool RenderLayerBacking::isDirectlyCompositedImage() const
     return false;
 }
 
+bool RenderLayerBacking::isBitmapOnly() const
+{
+    if (m_owningLayer.hasVisibleBoxDecorationsOrBackground())
+        return false;
+
+    if (is<RenderHTMLCanvas>(renderer()))
+        return true;
+
+    if (is<RenderImage>(renderer())) {
+        auto& imageRenderer = downcast<RenderImage>(renderer());
+        if (auto* cachedImage = imageRenderer.cachedImage()) {
+            if (!cachedImage->hasImage())
+                return false;
+            return is<BitmapImage>(cachedImage->imageForRenderer(&imageRenderer));
+        }
+        return false;
+    }
+
+    return false;
+}
+
+
 bool RenderLayerBacking::isUnscaledBitmapOnly() const
 {
     if (!is<RenderImage>(renderer()) && !is<RenderHTMLCanvas>(renderer()))

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -230,6 +230,8 @@ public:
     float deviceScaleFactor() const override;
     float contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const override;
 
+    bool layerContainsBitmapOnly(const GraphicsLayer*) const override { return isBitmapOnly(); }
+
     bool paintsOpaquelyAtNonIntegralScales(const GraphicsLayer*) const override;
 
     float pageScaleFactor() const override;
@@ -373,6 +375,7 @@ private:
     bool isDirectlyCompositedImage() const;
     void updateImageContents(PaintedContentsInfo&);
     bool isUnscaledBitmapOnly() const;
+    bool isBitmapOnly() const;
 
     void updateDirectlyCompositedBoxDecorations(PaintedContentsInfo&, bool& didUpdateContentsRect);
     void updateDirectlyCompositedBackgroundColor(PaintedContentsInfo&, bool& didUpdateContentsRect);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -229,6 +229,17 @@ void PlatformCALayerRemote::ensureBackingStore()
     updateBackingStore();
 }
 
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+RemoteLayerBackingStore::IncludeDisplayList PlatformCALayerRemote::shouldIncludeDisplayListInBackingStore() const
+{
+    if (!m_context->useCGDisplayListsForDOMRendering())
+        return RemoteLayerBackingStore::IncludeDisplayList::No;
+    if (owner() && owner()->platformCALayerContainsBitmapOnly(this))
+        return RemoteLayerBackingStore::IncludeDisplayList::No;
+    return RemoteLayerBackingStore::IncludeDisplayList::Yes;
+}
+#endif
+
 void PlatformCALayerRemote::updateBackingStore()
 {
     if (!m_properties.backingStore)
@@ -252,8 +263,7 @@ void PlatformCALayerRemote::updateBackingStore()
     parameters.isOpaque = m_properties.opaque;
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-    if (m_context->useCGDisplayListsForDOMRendering())
-        parameters.includeDisplayList = RemoteLayerBackingStore::IncludeDisplayList::Yes;
+    parameters.includeDisplayList = shouldIncludeDisplayListInBackingStore();
     if (m_context->useCGDisplayListImageCache())
         parameters.useCGDisplayListImageCache = UseCGDisplayListImageCache::Yes;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -234,6 +234,10 @@ private:
     void updateBackingStore();
     void removeSublayer(PlatformCALayerRemote*);
 
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+    RemoteLayerBackingStore::IncludeDisplayList shouldIncludeDisplayListInBackingStore() const;
+#endif
+
     bool requiresCustomAppearanceUpdateOnBoundsChange() const;
 
     WebCore::LayerPool& layerPool() override;


### PR DESCRIPTION
#### 10cc1463e1dc31c50b8b4c888726277c2a9294a8
<pre>
Don&apos;t use CG display lists for bitmap-image-only layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=251448">https://bugs.webkit.org/show_bug.cgi?id=251448</a>
rdar://103615295

Reviewed by Simon Fraser.

* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::layerContainsBitmapOnly const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerContainsBitmapOnly const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isBitmapOnly const):
* Source/WebCore/rendering/RenderLayerBacking.h:
Plumb &quot;isBitmapOnly&quot;, which is much like the existing &quot;isUnscaledBitmapOnly&quot;,
but returns true even in cases where the bitmap is scaled, or the page has pageScale &lt; 1.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::shouldIncludeDisplayListInBackingStore):
(WebKit::PlatformCALayerRemote::updateBackingStore):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
Use isBitmapOnly to disable CG display lists, which are wasteful in this case.

Canonical link: <a href="https://commits.webkit.org/259788@main">https://commits.webkit.org/259788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/831b21949d679088eedef9f7428909f894c9bd26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114949 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175086 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6015 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114748 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39812 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81532 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8083 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28313 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4902 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47860 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10130 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3634 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->