### PR TITLE
[css-scroll-snap] Have ScrollSnapAnimatorState calculate the HashSet of currently snapped boxes immediately

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-snap-remove-snap-area-expected.txt
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-remove-snap-area-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/css3/scroll-snap/scroll-snap-remove-snap-area.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-remove-snap-area.html
@@ -1,0 +1,16 @@
+<style>
+    html {
+      scroll-snap-align: center;
+      scroll-snap-type: x;
+    }
+  </style>
+  <script>
+    onload = () => {
+      document.body.offsetTop;
+      d.style.scrollSnapAlign = '';
+      if (window.testRunner)
+           testRunner.dumpAsText();
+    };
+  </script>
+  <p>This test passes if it does not crash.</p>
+  <div id="d" style="scroll-snap-align: center"></div>  

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -101,7 +101,7 @@ public:
     bool preserveCurrentTargetForAxis(ScrollEventAxis, ElementIdentifier);
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
     ElementIdentifier chooseBoxToResnapTo(const Vector<SnapOffset<LayoutUnit>>&, const Vector<SnapOffset<LayoutUnit>>&) const;
-    HashSet<ElementIdentifier> currentlySnappedBoxes() const;
+    HashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>&, const Vector<SnapOffset<LayoutUnit>>&) const;
 private:
     std::pair<float, std::optional<unsigned>> targetOffsetForStartOffset(ScrollEventAxis, const ScrollExtents&, float startOffset, FloatPoint predictedOffset, float pageScale, float initialDelta) const;
     bool setupAnimationForState(ScrollSnapState, const ScrollExtents&, float pageScale, const FloatPoint& initialOffset, const FloatSize& initialVelocity, const FloatSize& initialDelta);
@@ -115,8 +115,7 @@ private:
     
     std::optional<unsigned> m_activeSnapIndexX;
     std::optional<unsigned> m_activeSnapIndexY;
-    Vector<SnapOffset<LayoutUnit>> m_currentlySnappedBoxesX;
-    Vector<SnapOffset<LayoutUnit>> m_currentlySnappedBoxesY;
+    HashSet<ElementIdentifier> m_currentlySnappedBoxes;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollSnapAnimatorState&);


### PR DESCRIPTION
#### 279d12080527fa36e94941feedf813eac7b87a5a
<pre>
[css-scroll-snap] Have ScrollSnapAnimatorState calculate the HashSet of currently snapped boxes immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=251449">https://bugs.webkit.org/show_bug.cgi?id=251449</a>
rdar://104816359

Reviewed by Simon Fraser.

The added test css3/scroll-snap/scroll-snap-remove-snap-area.html exposes a bug where removing a snap
area while we are currently snapped to multiple boxes will cause the state in the offsets stored in
m_currentlySnappedBoxesX and m_currentlySnappedBoxesY to become out of sync with the state
in m_snapOffsetsInfo. To resolve this, run currentlySnappedBoxes immediately and store its
result, rather than running it when we are no no longer snapped to multiple boxes, where the
state in m_currentlySnappedBoxesX and m_currentlySnappedBoxesY could be stale.

* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::currentlySnappedBoxes const):
(WebCore::ScrollSnapAnimatorState::chooseBoxToResnapTo const):
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout):
(WebCore::isSnappedToMultipleBoxes): Deleted.
* Source/WebCore/platform/ScrollSnapAnimatorState.h:

Canonical link: <a href="https://commits.webkit.org/259696@main">https://commits.webkit.org/259696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92df30fdf4e9d9132be36cc34697b223464ca1c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114806 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174950 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5867 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97849 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39708 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7930 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28189 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4778 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47733 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9950 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3580 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->