### PR TITLE
Prefix the SVGAnimationElement range setting methods with "set" instead of "calculate"

### DIFF
--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -101,7 +101,7 @@ void SVGAnimateElementBase::resetAnimation()
     m_hasInvalidCSSAttributeType = { };
 }
 
-bool SVGAnimateElementBase::calculateFromAndToValues(const String& fromString, const String& toString)
+bool SVGAnimateElementBase::setFromAndToValues(const String& fromString, const String& toString)
 {
     if (!targetElement())
         return false;
@@ -113,7 +113,7 @@ bool SVGAnimateElementBase::calculateFromAndToValues(const String& fromString, c
     return false;
 }
 
-bool SVGAnimateElementBase::calculateFromAndByValues(const String& fromString, const String& byString)
+bool SVGAnimateElementBase::setFromAndByValues(const String& fromString, const String& byString)
 {
     if (!targetElement())
         return false;
@@ -131,7 +131,7 @@ bool SVGAnimateElementBase::calculateFromAndByValues(const String& fromString, c
     return false;
 }
 
-bool SVGAnimateElementBase::calculateToAtEndOfDurationValue(const String& toAtEndOfDurationString)
+bool SVGAnimateElementBase::setToAtEndOfDurationValue(const String& toAtEndOfDurationString)
 {
     if (!targetElement() || toAtEndOfDurationString.isEmpty())
         return false;

--- a/Source/WebCore/svg/SVGAnimateElementBase.h
+++ b/Source/WebCore/svg/SVGAnimateElementBase.h
@@ -49,9 +49,9 @@ private:
     void setAttributeName(const QualifiedName&) override;
     void resetAnimation() override;
 
-    bool calculateFromAndToValues(const String& fromString, const String& toString) override;
-    bool calculateFromAndByValues(const String& fromString, const String& byString) override;
-    bool calculateToAtEndOfDurationValue(const String& toAtEndOfDurationString) override;
+    bool setFromAndToValues(const String& fromString, const String& toString) override;
+    bool setFromAndByValues(const String& fromString, const String& byString) override;
+    bool setToAtEndOfDurationValue(const String& toAtEndOfDurationString) override;
 
     void startAnimation() override;
     void calculateAnimatedValue(float progress, unsigned repeatCount) override;

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -160,13 +160,7 @@ void SVGAnimateMotionElement::stopAnimation(SVGElement* targetElement)
     applyResultsToTarget();
 }
 
-bool SVGAnimateMotionElement::calculateToAtEndOfDurationValue(const String& toAtEndOfDurationString)
-{
-    m_toPointAtEndOfDuration = valueOrDefault(parsePoint(toAtEndOfDurationString));
-    return true;
-}
-
-bool SVGAnimateMotionElement::calculateFromAndToValues(const String& fromString, const String& toString)
+bool SVGAnimateMotionElement::setFromAndToValues(const String& fromString, const String& toString)
 {
     m_toPointAtEndOfDuration = std::nullopt;
     m_fromPoint = valueOrDefault(parsePoint(fromString));
@@ -174,7 +168,7 @@ bool SVGAnimateMotionElement::calculateFromAndToValues(const String& fromString,
     return true;
 }
     
-bool SVGAnimateMotionElement::calculateFromAndByValues(const String& fromString, const String& byString)
+bool SVGAnimateMotionElement::setFromAndByValues(const String& fromString, const String& byString)
 {
     m_toPointAtEndOfDuration = std::nullopt;
     if (animationMode() == AnimationMode::By && !isAdditive())
@@ -182,6 +176,12 @@ bool SVGAnimateMotionElement::calculateFromAndByValues(const String& fromString,
     m_fromPoint = valueOrDefault(parsePoint(fromString));
     auto byPoint = valueOrDefault(parsePoint(byString));
     m_toPoint = FloatPoint(m_fromPoint.x() + byPoint.x(), m_fromPoint.y() + byPoint.y());
+    return true;
+}
+
+bool SVGAnimateMotionElement::setToAtEndOfDurationValue(const String& toAtEndOfDurationString)
+{
+    m_toPointAtEndOfDuration = valueOrDefault(parsePoint(toAtEndOfDurationString));
     return true;
 }
 

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -43,9 +43,9 @@ private:
 
     void startAnimation() override;
     void stopAnimation(SVGElement* targetElement) override;
-    bool calculateToAtEndOfDurationValue(const String& toAtEndOfDurationString) override;
-    bool calculateFromAndToValues(const String& fromString, const String& toString) override;
-    bool calculateFromAndByValues(const String& fromString, const String& byString) override;
+    bool setFromAndToValues(const String& fromString, const String& toString) override;
+    bool setFromAndByValues(const String& fromString, const String& byString) override;
+    bool setToAtEndOfDurationValue(const String& toAtEndOfDurationString) override;
     void calculateAnimatedValue(float percentage, unsigned repeatCount) override;
     void applyResultsToTarget() override;
     std::optional<float> calculateDistance(const String& fromString, const String& toString) override;

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -572,15 +572,15 @@ void SVGAnimationElement::startedActiveInterval()
         && (hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) && hasAttributeWithoutSynchronization(SVGNames::keyTimesAttr) && (keyTimes.size() < 2 || keyTimes.size() != m_keyPoints.size())))
         return;
     if (animationMode == AnimationMode::FromTo)
-        m_animationValid = calculateFromAndToValues(from, to);
+        m_animationValid = setFromAndToValues(from, to);
     else if (animationMode == AnimationMode::To) {
         // For to-animations the from value is the current accumulated value from lower priority animations.
         // The value is not static and is determined during the animation.
-        m_animationValid = calculateFromAndToValues(emptyString(), to);
+        m_animationValid = setFromAndToValues(emptyString(), to);
     } else if (animationMode == AnimationMode::FromBy)
-        m_animationValid = calculateFromAndByValues(from, by);
+        m_animationValid = setFromAndByValues(from, by);
     else if (animationMode == AnimationMode::By)
-        m_animationValid = calculateFromAndByValues(emptyString(), by);
+        m_animationValid = setFromAndByValues(emptyString(), by);
     else if (animationMode == AnimationMode::Values) {
         m_animationValid = m_values.size() >= 1
             && (calcMode == CalcMode::Paced || !hasAttributeWithoutSynchronization(SVGNames::keyTimesAttr) || hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) || (m_values.size() == keyTimes.size()))
@@ -588,7 +588,7 @@ void SVGAnimationElement::startedActiveInterval()
             && (calcMode != CalcMode::Spline || ((m_keySplines.size() && (m_keySplines.size() == m_values.size() - 1)) || m_keySplines.size() == m_keyPoints.size() - 1))
             && (!hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) || (keyTimes.size() > 1 && keyTimes.size() == m_keyPoints.size()));
         if (m_animationValid)
-            m_animationValid = calculateToAtEndOfDurationValue(m_values.last());
+            m_animationValid = setToAtEndOfDurationValue(m_values.last());
         if (calcMode == CalcMode::Paced && m_animationValid)
             calculateKeyTimesForCalcModePaced();
     } else if (animationMode == AnimationMode::Path)
@@ -608,7 +608,7 @@ void SVGAnimationElement::updateAnimation(float percent, unsigned repeatCount)
         String to;
         currentValuesForValuesAnimation(percent, effectivePercent, from, to);
         if (from != m_lastValuesAnimationFrom || to != m_lastValuesAnimationTo) {
-            m_animationValid = calculateFromAndToValues(from, to);
+            m_animationValid = setFromAndToValues(from, to);
             if (!m_animationValid)
                 return;
             m_lastValuesAnimationFrom = from;

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -114,9 +114,9 @@ private:
     void animationAttributeChanged() override;
     void setAttributeType(const AtomString&);
 
-    virtual bool calculateToAtEndOfDurationValue(const String& toAtEndOfDurationString) = 0;
-    virtual bool calculateFromAndToValues(const String& fromString, const String& toString) = 0;
-    virtual bool calculateFromAndByValues(const String& fromString, const String& byString) = 0;
+    virtual bool setFromAndToValues(const String& fromString, const String& toString) = 0;
+    virtual bool setFromAndByValues(const String& fromString, const String& byString) = 0;
+    virtual bool setToAtEndOfDurationValue(const String& toAtEndOfDurationString) = 0;
     virtual void calculateAnimatedValue(float percent, unsigned repeatCount) = 0;
     virtual std::optional<float> calculateDistance(const String& /*fromString*/, const String& /*toString*/) = 0;
 


### PR DESCRIPTION
#### dd0930cde59d3dd6f7bdf7db838e4d400cf98dff
<pre>
Prefix the SVGAnimationElement range setting methods with &quot;set&quot; instead of &quot;calculate&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=251450">https://bugs.webkit.org/show_bug.cgi?id=251450</a>
rdar://104881126

Reviewed by Nikolas Zimmermann.

This will make the code more readable and the names of these methods will match
the names of the SVGAttributeAnimator methods which are called by these methods.

* Source/WebCore/svg/SVGAnimateElementBase.cpp:
(WebCore::SVGAnimateElementBase::setFromAndToValues):
(WebCore::SVGAnimateElementBase::setFromAndByValues):
(WebCore::SVGAnimateElementBase::setToAtEndOfDurationValue):
(WebCore::SVGAnimateElementBase::calculateFromAndToValues): Deleted.
(WebCore::SVGAnimateElementBase::calculateFromAndByValues): Deleted.
(WebCore::SVGAnimateElementBase::calculateToAtEndOfDurationValue): Deleted.
* Source/WebCore/svg/SVGAnimateElementBase.h:
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::setFromAndToValues):
(WebCore::SVGAnimateMotionElement::setFromAndByValues):
(WebCore::SVGAnimateMotionElement::setToAtEndOfDurationValue):
(WebCore::SVGAnimateMotionElement::calculateToAtEndOfDurationValue): Deleted.
(WebCore::SVGAnimateMotionElement::calculateFromAndToValues): Deleted.
(WebCore::SVGAnimateMotionElement::calculateFromAndByValues): Deleted.
* Source/WebCore/svg/SVGAnimateMotionElement.h:
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::startedActiveInterval):
(WebCore::SVGAnimationElement::updateAnimation):
* Source/WebCore/svg/SVGAnimationElement.h:

Canonical link: <a href="https://commits.webkit.org/259705@main">https://commits.webkit.org/259705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a93aa64a9d13e8390db036212c77f75dddf639b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114782 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174927 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5846 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97825 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39688 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81383 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28174 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4763 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6707 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9927 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->