### PR TITLE
Share TouchGestureController among USE(LIBWPE) ports

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -335,6 +335,7 @@ list(APPEND WebKit_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/UIProcess/API/C/glib"
     "${WEBKIT_DIR}/UIProcess/API/C/wpe"
     "${WEBKIT_DIR}/UIProcess/API/glib"
+    "${WEBKIT_DIR}/UIProcess/API/libwpe"
     "${WEBKIT_DIR}/UIProcess/API/wpe"
     "${WEBKIT_DIR}/UIProcess/CoordinatedGraphics"
     "${WEBKIT_DIR}/UIProcess/Inspector/glib"

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -186,11 +186,12 @@ UIProcess/API/glib/WebKitWebsiteDataManager.cpp @no-unify
 UIProcess/API/glib/WebKitWindowProperties.cpp @no-unify
 UIProcess/API/glib/WebKitWebsitePolicies.cpp @no-unify
 
+UIProcess/API/libwpe/TouchGestureController.cpp @no-unify
+
 UIProcess/API/soup/HTTPCookieStoreSoup.cpp
 
 UIProcess/API/wpe/InputMethodFilterWPE.cpp @no-unify
 UIProcess/API/wpe/PageClientImpl.cpp @no-unify
-UIProcess/API/wpe/TouchGestureController.cpp @no-unify
 UIProcess/API/wpe/WebKitColor.cpp @no-unify
 UIProcess/API/wpe/WebKitInputMethodContextWPE.cpp @no-unify
 UIProcess/API/wpe/WebKitPopupMenu.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp
@@ -26,7 +26,8 @@
 #include "config.h"
 #include "TouchGestureController.h"
 
-#include "WebKitSettings.h"
+#if USE(LIBWPE) && ENABLE(TOUCH_EVENTS)
+
 #include <WebCore/Scrollbar.h>
 
 namespace WebKit {
@@ -164,3 +165,5 @@ TouchGestureController::EventVariant TouchGestureController::handleEvent(const s
 }
 
 } // namespace WebKit
+
+#endif // USE(LIBWPE) && ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(LIBWPE) && ENABLE(TOUCH_EVENTS)
+
 #include "WebWheelEvent.h"
 #include <variant>
 #include <wpe/wpe.h>
@@ -82,3 +84,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(LIBWPE) && ENABLE(TOUCH_EVENTS)

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -57,7 +57,9 @@ static Vector<View*>& viewsVector()
 
 View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseConfiguration)
     : m_client(makeUnique<API::ViewClient>())
+#if ENABLE(TOUCH_EVENTS)
     , m_touchGestureController(makeUnique<TouchGestureController>())
+#endif
     , m_pageClient(makeUnique<PageClientImpl>(*this))
     , m_size { 800, 600 }
     , m_viewStateFlags { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow }
@@ -230,6 +232,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
         // handle_touch_event
         [](void* data, struct wpe_input_touch_event* event)
         {
+#if ENABLE(TOUCH_EVENTS)
             auto& view = *reinterpret_cast<View*>(data);
             auto& page = view.page();
 
@@ -267,6 +270,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
             }
 
             page.handleTouchEvent(touchEvent);
+#endif
         },
         // padding
         nullptr,

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.h
@@ -107,7 +107,9 @@ public:
     WebKitWebViewAccessible* accessible() const;
 #endif
 
+#if ENABLE(TOUCH_EVENTS)
     WebKit::TouchGestureController& touchGestureController() const { return *m_touchGestureController; }
+#endif
 #if ENABLE(GAMEPAD)
     static WebKit::WebPageProxy* platformWebPageProxyForGamepadInput();
 #endif
@@ -121,7 +123,9 @@ private:
 
     std::unique_ptr<API::ViewClient> m_client;
 
+#if ENABLE(TOUCH_EVENTS)
     std::unique_ptr<WebKit::TouchGestureController> m_touchGestureController;
+#endif
     std::unique_ptr<WebKit::PageClientImpl> m_pageClient;
     RefPtr<WebKit::WebPageProxy> m_pageProxy;
     WebCore::IntSize m_size;


### PR DESCRIPTION
#### 653d52c1893db8bdd526e840c5e67d1bdd79b351
<pre>
Share TouchGestureController among USE(LIBWPE) ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=251455">https://bugs.webkit.org/show_bug.cgi?id=251455</a>

Reviewed by Michael Catanzaro.

Move TouchGestureController files into a libwpe directory. Add some
missing `ENABLE(TOUCH_EVENTS)` guards in the WPE files.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp: Renamed from Source\WebKit\UIProcess\API\wpe\TouchGestureController.cpp.
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h: Renamed from Source\WebKit\UIProcess\API\wpe\TouchGestureController.h.
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
* Source/WebKit/UIProcess/API/wpe/WPEView.h:

Canonical link: <a href="https://commits.webkit.org/259653@main">https://commits.webkit.org/259653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/326cad442d893bdc586da45ae6bf69e320bd997f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114785 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5848 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97828 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111286 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95184 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26820 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28176 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6663 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9929 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->