### PR TITLE
[Wasm-GC] Implement cast operations

### DIFF
--- a/JSTests/wasm/gc/casts.js
+++ b/JSTests/wasm/gc/casts.js
@@ -1,0 +1,659 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function testBasicCasts() {
+  instantiate(`
+     (module
+       (func (export "f") (result (ref null extern))
+         (ref.cast null extern (ref.null extern))))
+  `).exports.f();
+
+  assert.eq(
+    instantiate(`
+       (module
+         (func (export "f") (result i32)
+           (ref.test null extern (ref.null extern))))
+    `).exports.f(),
+    1
+  );
+
+  instantiate(`
+     (module
+       (func (export "f") (result (ref null func))
+         (ref.cast null func (ref.null func))))
+  `).exports.f();
+
+  assert.eq(
+    instantiate(`
+       (module
+         (func (export "f") (result i32)
+           (ref.test null func (ref.null func))))
+    `).exports.f(),
+    1
+  );
+
+  instantiate(`
+     (module
+       (type (array i32))
+       (start 0)
+       (func (export "f")
+         (ref.cast null 0 (ref.null 0))
+         drop))
+  `).exports.f();
+
+  assert.eq(
+    instantiate(`
+       (module
+         (type (array i32))
+         (func (export "f") (result i32)
+           (ref.test null 0 (ref.null 0))))
+    `).exports.f(),
+    1
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (func (export "f") (result (ref null extern))
+          (ref.cast extern (ref.null extern))))
+    `).exports.f(),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (func (export "f") (result i32)
+          (ref.test extern (ref.null extern))))
+    `).exports.f(),
+    0
+  );
+}
+
+function testI31Casts() {
+  instantiate(`
+    (module
+      (start 1)
+      (func (result i31ref)
+        (ref.cast i31 (i31.new (i32.const 42))))
+      (func (call 0) drop))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (func (export "f") (result i32)
+          (ref.test i31 (i31.new (i32.const 42)))))
+    `).exports.f(),
+    1
+  )
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (array i32))
+        (start 0)
+        (func
+          (ref.cast i31 (array.new_canon 0 (i32.const 42) (i32.const 5)))
+          drop))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (func (export "f") (result i32)
+          (ref.test i31 (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+    `).exports.f(),
+    0
+  );
+}
+
+function testFunctionCasts() {
+  instantiate(`
+    (module
+      (type (func (param) (result i32)))
+      (elem declare funcref (ref.func 0))
+      (start 2)
+      (func (type 0) (i32.const 42))
+      (func (result funcref)
+        (ref.cast func (ref.func 0)))
+      (func (call 1) drop))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (elem declare funcref (ref.func 0))
+        (func (type 0) (i32.const 42))
+        (func (export "f") (result i32)
+          (ref.test func (ref.func 0))))
+    `).exports.f(),
+    1
+  )
+
+  instantiate(`
+    (module
+      (type (func (param) (result i32)))
+      (elem declare funcref (ref.func 0))
+      (start 2)
+      (func (type 0) (i32.const 42))
+      (func (param funcref)
+        (ref.cast 0 (local.get 0))
+        drop)
+      (func (call 1 (ref.func 0))))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (elem declare funcref (ref.func 0))
+        (func (type 0) (i32.const 42))
+        (func (param funcref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 1 (ref.func 0))))
+    `).exports.f(),
+    1
+  )
+
+  // Casts should work after properties are added to exported functions.
+  {
+    let f = instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (elem declare funcref (ref.func 0))
+        (func (export "f") (type 0) (i32.const 42)))
+    `).exports.f;
+
+    f.x = 3;
+    Object.seal(f); // Sealing transition shouldn't disrupt cast.
+
+    instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (func (export "g") (param funcref) (result i32)
+          (call_ref 0 (ref.cast 0 (local.get 0)))))
+    `).exports.g(f);
+
+    assert.eq(
+      instantiate(`
+        (module
+          (type (func (param) (result i32)))
+          (func (export "g") (param funcref) (result i32)
+            (ref.test 0 (local.get 0))))
+      `).exports.g(f),
+      1
+    )
+  }
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (start 0)
+        (func
+          (ref.cast func (i31.new (i32.const 42)))
+          drop))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't validate: ref.cast to type I31ref expected a funcref"
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (func (export "f") (result i32)
+          (ref.test func (i31.new (i32.const 42)))))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't validate: ref.test to type I31ref expected a funcref"
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (type (func (param) (result f32)))
+        (elem declare funcref (ref.func 0))
+        (start 2)
+        (func (type 1) (f32.const 42))
+        (func (param funcref)
+          (ref.cast 0 (local.get 0))
+          drop)
+        (func (call 1 (ref.func 0))))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (type (func (param) (result f32)))
+        (elem declare funcref (ref.func 0))
+        (func (type 1) (f32.const 42))
+        (func (param funcref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 1 (ref.func 0))))
+    `).exports.f(),
+    0
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (type (func (param) (result f32)))
+        (elem declare funcref (ref.func 0))
+        (start 1)
+        (func (type 0) (i32.const 42))
+        (func
+          (ref.cast 1 (ref.func 0))
+          drop))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (func (param) (result i32)))
+        (type (func (param) (result f32)))
+        (elem declare funcref (ref.func 0))
+        (func (type 0) (i32.const 42))
+        (func (export "f") (result i32)
+          (ref.test 1 (ref.func 0))))
+    `).exports.f(),
+    0
+  );
+}
+
+function testArrayCasts() {
+  instantiate(`
+    (module
+      (type (array i32))
+      (start 1)
+      (func (result arrayref)
+        (ref.cast array (array.new_canon 0 (i32.const 42) (i32.const 5))))
+      (func (call 0) drop))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (func (export "f") (result i32)
+          (ref.test array (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+    `).exports.f(),
+    1
+  )
+
+  instantiate(`
+    (module
+      (type (array i32))
+      (start 1)
+      (func (param arrayref)
+        (ref.cast 0 (local.get 0))
+        drop)
+      (func (call 0 (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (func (param arrayref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+    `).exports.f(),
+    1
+  )
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (start 0)
+        (func
+          (ref.cast array (i31.new (i32.const 42)))
+          drop))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (func (export "f") (result i32)
+          (ref.test array (i31.new (i32.const 42)))))
+    `).exports.f(),
+    0
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (array i32))
+        (type (array f32))
+        (start 1)
+        (func (param arrayref)
+          (ref.cast 0 (local.get 0))
+          drop)
+        (func (call 0 (array.new_canon 1 (f32.const 42.2) (i32.const 5)))))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (type (array f32))
+        (func (param arrayref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (array.new_canon 1 (f32.const 42.2) (i32.const 5)))))
+    `).exports.f(),
+    0
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (array i32))
+        (type (array f32))
+        (start 0)
+        (func
+          (ref.cast 1 (array.new_canon 0 (i32.const 42) (i32.const 5)))
+          drop))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (type (array f32))
+        (func (export "f") (result i32)
+          (ref.test 1 (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+    `).exports.f(),
+    0
+  );
+}
+
+function testStructCasts() {
+  instantiate(`
+    (module
+      (type (struct (field i32)))
+      (start 1)
+      (func (result structref)
+        (ref.cast struct (struct.new_canon 0 (i32.const 42))))
+      (func (call 0) drop))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (struct (field i32)))
+        (func (export "f") (result i32)
+          (ref.test struct (struct.new_canon 0 (i32.const 42)))))
+    `).exports.f(),
+    1
+  )
+
+  instantiate(`
+    (module
+      (type (struct (field i32)))
+      (start 1)
+      (func (param structref)
+        (ref.cast 0 (local.get 0))
+        drop)
+      (func (call 0 (struct.new_canon 0 (i32.const 42)))))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (struct (field i32)))
+        (func (param structref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (struct.new_canon 0 (i32.const 42)))))
+    `).exports.f(),
+    1
+  )
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (start 0)
+        (func
+          (ref.cast struct (i31.new (i32.const 42)))
+          drop))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (func (export "f") (result i32)
+          (ref.test struct (i31.new (i32.const 42)))))
+    `).exports.f(),
+    0
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (struct (field i32)))
+        (type (struct (field f32)))
+        (start 1)
+        (func (param structref)
+          (ref.cast 0 (local.get 0))
+          drop)
+        (func (call 0 (struct.new_canon 1 (f32.const 42.2)))))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (struct (field i32)))
+        (type (struct (field f32)))
+        (func (param structref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (struct.new_canon 1 (f32.const 42.2)))))
+    `).exports.f(),
+    0
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (struct (field i32)))
+        (type (struct (field f32)))
+        (start 0)
+        (func
+          (ref.cast 1 (struct.new_canon 0 (i32.const 42)))
+          drop))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (struct (field i32)))
+        (type (struct (field f32)))
+        (func (export "f") (result i32)
+          (ref.test 1 (struct.new_canon 0 (i32.const 42)))))
+    `).exports.f(),
+    0
+  );
+}
+
+function testSubtypeCasts() {
+  instantiate(`
+    (module
+      (type (array i32))
+      (type (sub 0 (array i32)))
+      (start 1)
+      (func (param arrayref)
+        (ref.cast 0 (local.get 0))
+        drop)
+      (func (call 0 (array.new_canon 1 (i32.const 42) (i32.const 5)))))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (type (sub 0 (array i32)))
+        (func (param arrayref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (array.new_canon 1 (i32.const 42) (i32.const 5)))))
+    `).exports.f(),
+    1
+  );
+
+  instantiate(`
+    (module
+      (type (struct (field i32)))
+      (type (sub 0 (struct (field i32) (field i64))))
+      (start 1)
+      (func (param structref)
+        (ref.cast 0 (local.get 0))
+        drop)
+      (func (call 0 (struct.new_canon 1 (i32.const 42) (i64.const 43)))))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (struct (field i32)))
+        (type (sub 0 (struct (field i32) (field i64))))
+        (func (param structref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (struct.new_canon 1 (i32.const 42) (i64.const 43)))))
+    `).exports.f(),
+    1
+  );
+
+  instantiate(`
+    (module
+      (type (func (result i32)))
+      (type (sub 0 (func (result i32))))
+      (elem declare funcref (ref.func 0))
+      (start 2)
+      (func (type 1) (i32.const 42))
+      (func (param funcref)
+        (ref.cast 0 (local.get 0))
+        drop)
+      (func (call 1 (ref.func 0))))
+  `);
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (func (result i32)))
+        (type (sub 0 (func (result i32))))
+        (elem declare funcref (ref.func 0))
+        (func (type 1) (i32.const 42))
+        (func (param funcref) (result i32)
+          (ref.test 0 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 1 (ref.func 0))))
+    `).exports.f(),
+    1
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (array i32))
+        (type (sub 0 (array i32)))
+        (start 1)
+        (func (param arrayref)
+          (ref.cast 1 (local.get 0))
+          drop)
+        (func (call 0 (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (array i32))
+        (type (sub 0 (array i32)))
+        (func (param arrayref) (result i32)
+          (ref.test 1 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 0 (array.new_canon 0 (i32.const 42) (i32.const 5)))))
+    `).exports.f(),
+    0
+  );
+
+  assert.throws(
+    () => instantiate(`
+      (module
+        (type (func (result i32)))
+        (type (sub 0 (func (result i32))))
+        (elem declare funcref (ref.func 0))
+        (start 2)
+        (func (type 0) (i32.const 42))
+        (func (param funcref)
+          (ref.cast 1 (local.get 0))
+          drop)
+        (func (call 1 (ref.func 0))))
+    `),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type"
+  );
+
+  assert.eq(
+    instantiate(`
+      (module
+        (type (func (result i32)))
+        (type (sub 0 (func (result i32))))
+        (elem declare funcref (ref.func 0))
+        (func (type 0) (i32.const 42))
+        (func (param funcref) (result i32)
+          (ref.test 1 (local.get 0)))
+        (func (export "f") (result i32)
+          (call 1 (ref.func 0))))
+    `).exports.f(),
+    0
+  );
+}
+
+testBasicCasts();
+testI31Casts();
+testFunctionCasts();
+testArrayCasts();
+testStructCasts();
+testSubtypeCasts();

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -281,6 +281,10 @@
         "i31.new":                   { "category": "gc",         "value": 251, "return": ["i31ref"],                       "parameter": ["i32"],                        "immediate": [], "extendedOp": 32 },
         "i31.get_s":                 { "category": "gc",         "value": 251, "return": ["i32"],                          "parameter": ["i31ref"],                     "immediate": [], "extendedOp": 33 },
         "i31.get_u":                 { "category": "gc",         "value": 251, "return": ["i32"],                          "parameter": ["i31ref"],                     "immediate": [], "extendedOp": 34 },
+        "ref.test":                  { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 64 },
+        "ref.cast":                  { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 65 },
+        "ref.test_null":             { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 72 },
+        "ref.cast_null":             { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 73 },
 
         "i32.trunc_sat_f32_s": { "category": "conversion", "value": 252, "return": ["i32"], "parameter": ["f32"], "immediate": [], "extendedOp": 0 },
         "i32.trunc_sat_f32_u": { "category": "conversion", "value": 252, "return": ["i32"], "parameter": ["f32"], "immediate": [], "extendedOp": 1 },

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1139,6 +1139,8 @@
 		53F6BF6D1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F6BF6C1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FA2AE11CF37F3F0022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 53FA2AE01CF37F3F0022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FD04D41D7AB291003287D3 /* WasmCallingConvention.h in Headers */ = {isa = PBXBuildFile; fileRef = 53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		554C418729B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 554C418529B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp */; };
+		554C418829B14CA5003C9F71 /* WebAssemblyGCObjectBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 554C418629B14CA5003C9F71 /* WebAssemblyGCObjectBase.h */; };
 		55579D9028DD641000153DAE /* WebAssemblyArrayPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 55579D8D28DD640F00153DAE /* WebAssemblyArrayPrototype.h */; };
 		55579D9128DD641000153DAE /* WebAssemblyArrayConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 55579D8E28DD641000153DAE /* WebAssemblyArrayConstructor.h */; };
 		55F5DFB128DA9A2000595620 /* JSWebAssemblyArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F5DFAE28DA9A2000595620 /* JSWebAssemblyArray.h */; };
@@ -4194,6 +4196,8 @@
 		53FA2AE21CF380390022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp; sourceTree = "<group>"; };
 		53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCallingConvention.cpp; sourceTree = "<group>"; };
 		53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmCallingConvention.h; sourceTree = "<group>"; };
+		554C418529B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyGCObjectBase.cpp; path = js/WebAssemblyGCObjectBase.cpp; sourceTree = "<group>"; };
+		554C418629B14CA5003C9F71 /* WebAssemblyGCObjectBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyGCObjectBase.h; path = js/WebAssemblyGCObjectBase.h; sourceTree = "<group>"; };
 		55579D8D28DD640F00153DAE /* WebAssemblyArrayPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyArrayPrototype.h; path = js/WebAssemblyArrayPrototype.h; sourceTree = "<group>"; };
 		55579D8E28DD641000153DAE /* WebAssemblyArrayConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyArrayConstructor.h; path = js/WebAssemblyArrayConstructor.h; sourceTree = "<group>"; };
 		55579D8F28DD641000153DAE /* WebAssemblyArrayPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyArrayPrototype.cpp; path = js/WebAssemblyArrayPrototype.cpp; sourceTree = "<group>"; };
@@ -9582,6 +9586,8 @@
 				AD4937CA1DDD27340077C807 /* WebAssemblyFunction.h */,
 				521322431ECBCE8200F65615 /* WebAssemblyFunctionBase.cpp */,
 				521322441ECBCE8200F65615 /* WebAssemblyFunctionBase.h */,
+				554C418529B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp */,
+				554C418629B14CA5003C9F71 /* WebAssemblyGCObjectBase.h */,
 				E3BF3C4E2390D1FC008BC752 /* WebAssemblyGlobalConstructor.cpp */,
 				E3BF3C512390D1FC008BC752 /* WebAssemblyGlobalConstructor.h */,
 				E3BF3C4F2390D1FC008BC752 /* WebAssemblyGlobalPrototype.cpp */,
@@ -11498,6 +11504,7 @@
 				14D01BE926DEEF3800CAE0D0 /* WebAssemblyExceptionPrototype.h in Headers */,
 				AD4937D41DDD27DE0077C807 /* WebAssemblyFunction.h in Headers */,
 				521322461ECBCE8200F65615 /* WebAssemblyFunctionBase.h in Headers */,
+				554C418829B14CA5003C9F71 /* WebAssemblyGCObjectBase.h in Headers */,
 				E3BF3C532390D205008BC752 /* WebAssemblyGlobalConstructor.h in Headers */,
 				E3BF3C522390D202008BC752 /* WebAssemblyGlobalPrototype.h in Headers */,
 				AD2FCBF11DB58DAD00B3E736 /* WebAssemblyInstanceConstructor.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1176,6 +1176,7 @@ wasm/js/WebAssemblyExceptionConstructor.cpp
 wasm/js/WebAssemblyExceptionPrototype.cpp
 wasm/js/WebAssemblyFunction.cpp
 wasm/js/WebAssemblyFunctionBase.cpp
+wasm/js/WebAssemblyGCObjectBase.cpp
 wasm/js/WebAssemblyGlobalConstructor.cpp
 wasm/js/WebAssemblyGlobalPrototype.cpp
 wasm/js/WebAssemblyInstanceConstructor.cpp

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3491,6 +3491,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType) BBQ_STUB
     PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType, ExpressionType&) BBQ_STUB
     PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t, ExpressionType&) BBQ_STUB
+    PartialResult WARN_UNUSED_RETURN addRefCast(ExpressionType, bool, int32_t, ExpressionType&) BBQ_STUB
+    PartialResult WARN_UNUSED_RETURN addRefTest(ExpressionType, bool, int32_t, ExpressionType&) BBQ_STUB
 
     // Basic operators
     PartialResult WARN_UNUSED_RETURN addSelect(Value condition, Value lhs, Value rhs, Value& result)

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -56,7 +56,8 @@ namespace Wasm {
     macro(NullStructGet, "struct.get to a null reference"_s) \
     macro(NullStructSet, "struct.set to a null reference"_s) \
     macro(TypeErrorInvalidV128Use, "an exported wasm function cannot contain a v128 parameter or return value"_s) \
-    macro(NullRefAsNonNull, "ref.as_non_null to a null reference"_s)
+    macro(NullRefAsNonNull, "ref.as_non_null to a null reference"_s) \
+    macro(CastFailure, "ref.cast failed to cast reference to target heap type"_s)
 
 enum class ExceptionType : uint32_t {
 #define MAKE_ENUM(enumName, error) enumName,
@@ -104,6 +105,7 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::NullStructGet:
     case ExceptionType::NullStructSet:
     case ExceptionType::NullRefAsNonNull:
+    case ExceptionType::CastFailure:
         return false;
     case ExceptionType::FuncrefNotWasm:
     case ExceptionType::InvalidGCTypeUse:

--- a/Source/JavaScriptCore/wasm/WasmInstance.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInstance.cpp
@@ -242,7 +242,8 @@ void Instance::initElementSegment(uint32_t tableIndex, const Element& segment, u
                 functionImport,
                 functionIndex,
                 jsInstance,
-                typeIndex);
+                typeIndex,
+                TypeInformation::getCanonicalRTT(typeIndex));
             jsTable->set(dstIndex, wrapperFunction);
             continue;
         }
@@ -263,7 +264,8 @@ void Instance::initElementSegment(uint32_t tableIndex, const Element& segment, u
             jsInstance,
             jsEntrypointCallee,
             entrypointLoadLocation,
-            typeIndex);
+            typeIndex,
+            TypeInformation::getCanonicalRTT(typeIndex));
         jsTable->set(dstIndex, function);
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmLLIntBuiltin.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntBuiltin.h
@@ -42,6 +42,8 @@ enum class LLIntBuiltin : uint8_t {
     TableCopy,
     DataDrop,
     ElemDrop,
+    RefTest,
+    RefCast,
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -324,6 +324,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t index, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addStructGet(ExpressionType structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addStructSet(ExpressionType structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
+    PartialResult WARN_UNUSED_RETURN addRefTest(ExpressionType reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    PartialResult WARN_UNUSED_RETURN addRefCast(ExpressionType reference, bool allowNull, int32_t heapType, ExpressionType& result);
 
     // Basic operators
 #define X(name, opcode, short, idx, ...) \
@@ -2048,6 +2050,24 @@ auto LLIntGenerator::addStructSet(ExpressionType structReference, const StructTy
 {
     WasmStructSet::emit(this, structReference, fieldIndex, value);
 
+    return { };
+}
+
+auto LLIntGenerator::addRefTest(ExpressionType reference, bool allowNull, int32_t heapType, ExpressionType& result) -> PartialResult
+{
+    ResultList results;
+    addCallBuiltin(LLIntBuiltin::RefTest, { reference, addConstantWithoutPush(Types::I32, static_cast<uint32_t>(allowNull)), addConstantWithoutPush(Types::I32, heapType) }, results);
+    ASSERT(results.size() == 1);
+    result = results.at(0);
+    return { };
+}
+
+auto LLIntGenerator::addRefCast(ExpressionType reference, bool allowNull, int32_t heapType, ExpressionType& result) -> PartialResult
+{
+    ResultList results;
+    addCallBuiltin(LLIntBuiltin::RefCast, { reference, addConstantWithoutPush(Types::I32, static_cast<uint32_t>(allowNull)), addConstantWithoutPush(Types::I32, heapType) }, results);
+    ASSERT(results.size() == 1);
+    result = results.at(0);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -192,6 +192,7 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
     Ref<NameSection> nameSection;
     BranchHints branchHints;
     std::optional<uint32_t> numberOfDataSegments;
+    Vector<RefPtr<const RTT>> rtts;
 
     BitVector m_declaredFunctions;
     BitVector m_declaredExceptions;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -837,7 +837,8 @@ JSC_DEFINE_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (Instance*
     NativeCallFrameTracer tracer(vm, callFrame);
     JSWebAssemblyInstance* jsInstance = instance->owner();
     JSGlobalObject* globalObject = instance->globalObject();
-    return JSValue::encode(JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex));
+    auto structRTT = instance->module().moduleInformation().rtts[typeIndex];
+    return JSValue::encode(JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex, structRTT));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWasmStructGet, EncodedJSValue, (EncodedJSValue encodedStructReference, uint32_t fieldIndex))
@@ -1015,6 +1016,12 @@ JSC_DEFINE_JIT_OPERATION(operationWasmArraySet, void, (Instance* instance, uint3
     VM& vm = instance->vm();
     NativeCallFrameTracer tracer(vm, callFrame);
     return arraySet(instance, typeIndex, arrayValue, index, value);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationWasmIsSubRTT, bool, (RTT* maybeSubRTT, RTT* targetRTT))
+{
+    ASSERT(maybeSubRTT && targetRTT);
+    return maybeSubRTT->isSubRTT(*targetRTT);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -32,6 +32,7 @@
 #include "JSCJSValue.h"
 #include "WasmExceptionType.h"
 #include "WasmOSREntryData.h"
+#include "WasmTypeDefinition.h"
 
 namespace JSC {
 
@@ -107,6 +108,7 @@ struct ThrownExceptionInfo {
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayGet, EncodedJSValue, (Instance* instance, uint32_t typeIndex, EncodedJSValue encValue, uint32_t index));
 JSC_DECLARE_JIT_OPERATION(operationWasmArraySet, void, (Instance* instance, uint32_t typeIndex, EncodedJSValue encValue, uint32_t index, EncodedJSValue value));
+JSC_DECLARE_JIT_OPERATION(operationWasmIsSubRTT, bool, (Wasm::RTT*, Wasm::RTT*));
 
 #if USE(JSVALUE64)
 JSC_DECLARE_JIT_OPERATION(operationWasmRetrieveAndClearExceptionIfCatchable, ThrownExceptionInfo, (Instance*));

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -766,6 +766,22 @@ WASM_SLOW_PATH_DECL(call_builtin)
         Wasm::elemDrop(instance, elementIndex);
         WASM_END();
     }
+    case Wasm::LLIntBuiltin::RefTest: {
+        auto reference = takeGPR().encodedJSValue();
+        bool allowNull = static_cast<bool>(takeGPR().unboxedInt32());
+        int32_t heapType = takeGPR().unboxedInt32();
+        gprStart[0] = static_cast<uint32_t>(Wasm::refCast(instance, reference, allowNull, heapType));
+        WASM_END();
+    }
+    case Wasm::LLIntBuiltin::RefCast: {
+        auto reference = takeGPR().encodedJSValue();
+        bool allowNull = static_cast<bool>(takeGPR().unboxedInt32());
+        int32_t heapType = takeGPR().unboxedInt32();
+        if (!Wasm::refCast(instance, reference, allowNull, heapType))
+            WASM_THROW(Wasm::ExceptionType::CastFailure);
+        gprStart[0] = reference;
+        WASM_END();
+    }
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -51,12 +51,7 @@ inline const TypeDefinition& TypeInformation::get(TypeIndex index)
 
 inline const FunctionSignature& TypeInformation::getFunctionSignature(TypeIndex index)
 {
-    const TypeDefinition& signature = get(index);
-    if (signature.is<Projection>()) {
-        const TypeDefinition& expanded = signature.expand();
-        ASSERT(expanded.is<FunctionSignature>());
-        return *expanded.as<FunctionSignature>();
-    }
+    const TypeDefinition& signature = get(index).expand();
     ASSERT(signature.is<FunctionSignature>());
     return *signature.as<FunctionSignature>();
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -36,32 +36,32 @@ namespace JSC {
 
 const ClassInfo JSWebAssemblyArray::s_info = { "WebAssembly.Array"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyArray) };
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint8_t>&& payload)
-    : Base(vm, structure)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint8_t>&& payload, RefPtr<const Wasm::RTT> rtt)
+    : Base(vm, structure, rtt)
     , m_elementType(elementType)
     , m_size(size)
     , m_payload8(WTFMove(payload))
 {
 }
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint16_t>&& payload)
-    : Base(vm, structure)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint16_t>&& payload, RefPtr<const Wasm::RTT> rtt)
+    : Base(vm, structure, rtt)
     , m_elementType(elementType)
     , m_size(size)
     , m_payload16(WTFMove(payload))
 {
 }
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint32_t>&& payload)
-    : Base(vm, structure)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint32_t>&& payload, RefPtr<const Wasm::RTT> rtt)
+    : Base(vm, structure, rtt)
     , m_elementType(elementType)
     , m_size(size)
     , m_payload32(WTFMove(payload))
 {
 }
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint64_t>&& payload)
-    : Base(vm, structure)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint64_t>&& payload, RefPtr<const Wasm::RTT> rtt)
+    : Base(vm, structure, rtt)
     , m_elementType(elementType)
     , m_size(size)
     , m_payload64(WTFMove(payload))

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -27,17 +27,17 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "JSObject.h"
 #include "WasmOps.h"
 #include "WasmTypeDefinition.h"
+#include "WebAssemblyGCObjectBase.h"
 
 namespace JSC {
 
-class JSWebAssemblyArray final : public JSNonFinalObject {
+class JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
     friend class LLIntOffsetsExtractor;
 
 public:
-    using Base = JSNonFinalObject;
+    using Base = WebAssemblyGCObjectBase;
     static constexpr bool needsDestruction = true;
 
     static void destroy(JSCell*);
@@ -56,9 +56,9 @@ public:
     }
 
     template <typename ElementType>
-    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<ElementType>&& payload)
+    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<ElementType>&& payload, RefPtr<const Wasm::RTT> rtt)
     {
-        JSWebAssemblyArray* array = new (NotNull, allocateCell<JSWebAssemblyArray>(vm)) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(payload));
+        JSWebAssemblyArray* array = new (NotNull, allocateCell<JSWebAssemblyArray>(vm)) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(payload), rtt);
         array->finishCreation(vm);
         return array;
 
@@ -141,10 +141,10 @@ public:
     }
 
 protected:
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint8_t>&&);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint16_t>&&);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint32_t>&&);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint64_t>&&);
+    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint8_t>&&, RefPtr<const Wasm::RTT>);
+    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint16_t>&&, RefPtr<const Wasm::RTT>);
+    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint32_t>&&, RefPtr<const Wasm::RTT>);
+    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint64_t>&&, RefPtr<const Wasm::RTT>);
     ~JSWebAssemblyArray();
 
     void finishCreation(VM&);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -38,14 +38,14 @@ namespace JSC {
 
 const ClassInfo JSWebAssemblyStruct::s_info = { "WebAssembly.Struct"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWebAssemblyStruct) };
 
-JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<const Wasm::TypeDefinition>&& type)
-    : Base(vm, structure)
+JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, Structure* structure, Ref<const Wasm::TypeDefinition>&& type, RefPtr<const Wasm::RTT> rtt)
+    : Base(vm, structure, rtt)
     , m_type(WTFMove(type))
     , m_payload(structType()->instancePayloadSize(), 0)
 {
 }
 
-JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, uint32_t typeIndex)
+JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, uint32_t typeIndex, RefPtr<const Wasm::RTT> rtt)
 {
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -62,7 +62,7 @@ JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(JSGlobalObject* globalObject
         return nullptr;
     }
 
-    auto* structValue = new (NotNull, allocateCell<JSWebAssemblyStruct>(vm)) JSWebAssemblyStruct(vm, structure, WTFMove(type));
+    auto* structValue = new (NotNull, allocateCell<JSWebAssemblyStruct>(vm)) JSWebAssemblyStruct(vm, structure, Ref { type }, rtt);
     structValue->finishCreation(vm);
     return structValue;
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -29,15 +29,16 @@
 
 #include "JSObject.h"
 #include "WasmTypeDefinitionInlines.h"
+#include "WebAssemblyGCObjectBase.h"
 #include <wtf/Ref.h>
 
 namespace JSC {
 
 class JSWebAssemblyInstance;
 
-class JSWebAssemblyStruct final : public JSNonFinalObject {
+class JSWebAssemblyStruct final : public WebAssemblyGCObjectBase {
 public:
-    using Base = JSNonFinalObject;
+    using Base = WebAssemblyGCObjectBase;
     static constexpr bool needsDestruction = true;
 
     static void destroy(JSCell*);
@@ -55,7 +56,7 @@ public:
         return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
     }
 
-    static JSWebAssemblyStruct* tryCreate(JSGlobalObject*, Structure*, JSWebAssemblyInstance*, uint32_t);
+    static JSWebAssemblyStruct* tryCreate(JSGlobalObject*, Structure*, JSWebAssemblyInstance*, uint32_t, RefPtr<const Wasm::RTT>);
 
     DECLARE_VISIT_CHILDREN;
 
@@ -70,7 +71,7 @@ public:
     uint8_t* fieldPointer(uint32_t fieldIndex);
 
 protected:
-    JSWebAssemblyStruct(VM&, Structure*, Ref<const Wasm::TypeDefinition>&&);
+    JSWebAssemblyStruct(VM&, Structure*, Ref<const Wasm::TypeDefinition>&&, RefPtr<const Wasm::RTT>);
     void finishCreation(VM&);
 
     // FIXME: It is possible to encode the type information in the structure field of Wasm.Struct and remove this field.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -436,10 +436,10 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
     return m_jsToWasmICCallee->entrypoint().retagged<JSEntryPtrTag>();
 }
 
-WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::Callee& jsEntrypoint, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex)
+WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::Callee& jsEntrypoint, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
 {
     NativeExecutable* executable = vm.getHostFunction(callWebAssemblyFunction, ImplementationVisibility::Public, WasmFunctionIntrinsic, callHostFunctionAsConstructor, nullptr, name);
-    WebAssemblyFunction* function = new (NotNull, allocateCell<WebAssemblyFunction>(vm)) WebAssemblyFunction(vm, executable, globalObject, structure, jsEntrypoint, wasmToWasmEntrypointLoadLocation, typeIndex);
+    WebAssemblyFunction* function = new (NotNull, allocateCell<WebAssemblyFunction>(vm)) WebAssemblyFunction(vm, executable, globalObject, structure, jsEntrypoint, wasmToWasmEntrypointLoadLocation, typeIndex, rtt);
     function->finishCreation(vm, executable, length, name, instance);
     return function;
 }
@@ -450,8 +450,8 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
 }
 
-WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, Wasm::Callee& jsEntrypoint, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex)
-    : Base { vm, executable, globalObject, structure, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation } }
+WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, Wasm::Callee& jsEntrypoint, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
+    : Base { vm, executable, globalObject, structure, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation }, rtt }
     , m_jsEntrypoint { jsEntrypoint.entrypoint() }
 { }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -56,7 +56,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::Callee& jsEntrypoint, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex);
+    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::Callee& jsEntrypoint, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     CodePtr<WasmEntryPtrTag> jsEntrypoint(ArityCheckMode arity)
@@ -74,7 +74,7 @@ public:
 
 private:
     DECLARE_VISIT_CHILDREN;
-    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, Wasm::Callee& jsEntrypoint, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex);
+    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, Wasm::Callee& jsEntrypoint, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
 
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();
     bool usesTagRegisters() const;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
@@ -38,9 +38,10 @@ namespace JSC {
 
 const ClassInfo WebAssemblyFunctionBase::s_info = { "WebAssemblyFunctionBase"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyFunctionBase) };
 
-WebAssemblyFunctionBase::WebAssemblyFunctionBase(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, WasmToWasmImportableFunction importableFunction)
+WebAssemblyFunctionBase::WebAssemblyFunctionBase(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, WasmToWasmImportableFunction importableFunction, RefPtr<const Wasm::RTT> rtt)
     : Base(vm, executable, globalObject, structure)
     , m_importableFunction(importableFunction)
+    , m_rtt(rtt)
 { }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -49,6 +49,7 @@ public:
     Wasm::TypeIndex typeIndex() const { return m_importableFunction.typeIndex; }
     WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation() const { return m_importableFunction.entrypointLoadLocation; }
     WasmToWasmImportableFunction importableFunction() const { return m_importableFunction; }
+    CompactRefPtr<const Wasm::RTT> rtt() const { ASSERT(m_rtt); return m_rtt; }
 
     static ptrdiff_t offsetOfInstance() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_instance); }
 
@@ -56,10 +57,12 @@ public:
 
     static ptrdiff_t offsetOfEntrypointLoadLocation() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_importableFunction) + WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation(); }
 
+    static ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_rtt); }
+
 protected:
     DECLARE_VISIT_CHILDREN;
     void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name, JSWebAssemblyInstance*);
-    WebAssemblyFunctionBase(VM&, NativeExecutable*, JSGlobalObject*, Structure*, WasmToWasmImportableFunction);
+    WebAssemblyFunctionBase(VM&, NativeExecutable*, JSGlobalObject*, Structure*, WasmToWasmImportableFunction, RefPtr<const Wasm::RTT>);
 
     WriteBarrier<JSWebAssemblyInstance> m_instance;
 
@@ -67,6 +70,9 @@ protected:
     // to our Instance, which points to the CodeBlock, which points to the Module
     // that exported us, which ensures that the actual Signature/code doesn't get deallocated.
     WasmToWasmImportableFunction m_importableFunction;
+
+    // This can be a null pointer if GC support is turned off, in which case the RTT should not be accessed anyway.
+    CompactRefPtr<const Wasm::RTT> m_rtt;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,35 +27,29 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "WebAssemblyFunctionBase.h"
+#include "JSObject.h"
+#include "WasmTypeDefinition.h"
 
 namespace JSC {
 
-class WebAssemblyWrapperFunction final : public WebAssemblyFunctionBase {
+class WebAssemblyGCObjectBase : public JSNonFinalObject {
 public:
-    using Base = WebAssemblyFunctionBase;
+    using Base = JSNonFinalObject;
 
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
+    DECLARE_EXPORT_INFO;
 
-    template<typename CellType, SubspaceAccess mode>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
-    {
-        return vm.webAssemblyWrapperFunctionSpace<mode>();
-    }
+    RefPtr<const Wasm::RTT> rtt() { return m_rtt; }
 
-    DECLARE_INFO;
+    static ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCObjectBase, m_rtt); };
 
-    static WebAssemblyWrapperFunction* create(VM&, JSGlobalObject*, Structure*, JSObject*, unsigned importIndex, JSWebAssemblyInstance*, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
-    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
-
-    JSObject* function() { return m_function.get(); }
-
-private:
-    WebAssemblyWrapperFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, WasmToWasmImportableFunction, RefPtr<const Wasm::RTT>);
-    void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name, JSObject*, JSWebAssemblyInstance*);
+protected:
     DECLARE_VISIT_CHILDREN;
 
-    WriteBarrier<JSObject> m_function;
+    WebAssemblyGCObjectBase(VM&, Structure*, RefPtr<const Wasm::RTT>);
+
+    void finishCreation(VM&);
+
+    RefPtr<const Wasm::RTT> m_rtt;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -509,7 +509,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                 wrapper = functionImport;
             else {
                 Wasm::TypeIndex typeIndex = module->typeIndexFromFunctionIndexSpace(functionIndexSpace);
-                wrapper = WebAssemblyWrapperFunction::create(vm, globalObject, globalObject->webAssemblyWrapperFunctionStructure(), functionImport, functionIndexSpace, m_instance.get(), typeIndex);
+                wrapper = WebAssemblyWrapperFunction::create(vm, globalObject, globalObject->webAssemblyWrapperFunctionStructure(), functionImport, functionIndexSpace, m_instance.get(), typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
             }
         } else {
             //   iii. Otherwise:
@@ -520,7 +520,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndexSpace);
             Wasm::TypeIndex typeIndex = module->typeIndexFromFunctionIndexSpace(functionIndexSpace);
             const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
-            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), makeString(functionIndexSpace), m_instance.get(), jsEntrypointCallee, entrypointLoadLocation, typeIndex);
+            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), makeString(functionIndexSpace), m_instance.get(), jsEntrypointCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
             wrapper = function;
         }
 
@@ -703,7 +703,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         } else {
             Wasm::Callee& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(startFunctionIndexSpace);
-            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), "start"_s, m_instance.get(), jsEntrypointCallee, entrypointLoadLocation, typeIndex);
+            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), "start"_s, m_instance.get(), jsEntrypointCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));
             m_startFunction.set(vm, this, function);
         }
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -39,11 +39,11 @@ const ClassInfo WebAssemblyWrapperFunction::s_info = { "WebAssemblyWrapperFuncti
 static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyWrapperFunction);
 static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyWrapperFunctionIncludingV128);
 
-WebAssemblyWrapperFunction::WebAssemblyWrapperFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, Wasm::WasmToWasmImportableFunction importableFunction)
-    : Base(vm, executable, globalObject, structure, importableFunction)
+WebAssemblyWrapperFunction::WebAssemblyWrapperFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, Wasm::WasmToWasmImportableFunction importableFunction, RefPtr<const Wasm::RTT> rtt)
+    : Base(vm, executable, globalObject, structure, importableFunction, rtt)
 { }
 
-WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, JSObject* function, unsigned importIndex, JSWebAssemblyInstance* instance, Wasm::TypeIndex typeIndex)
+WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, JSObject* function, unsigned importIndex, JSWebAssemblyInstance* instance, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
 {
     ASSERT_WITH_MESSAGE(!function->inherits<WebAssemblyWrapperFunction>(), "We should never double wrap a wrapper function.");
 
@@ -55,7 +55,7 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
     else
         executable = vm.getHostFunction(callWebAssemblyWrapperFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
 
-    WebAssemblyWrapperFunction* result = new (NotNull, allocateCell<WebAssemblyWrapperFunction>(vm)) WebAssemblyWrapperFunction(vm, executable, globalObject, structure, Wasm::WasmToWasmImportableFunction { typeIndex, &instance->instance().importFunctionInfo(importIndex)->importFunctionStub });
+    WebAssemblyWrapperFunction* result = new (NotNull, allocateCell<WebAssemblyWrapperFunction>(vm)) WebAssemblyWrapperFunction(vm, executable, globalObject, structure, Wasm::WasmToWasmImportableFunction { typeIndex, &instance->instance().importFunctionInfo(importIndex)->importFunctionStub }, rtt);
     result->finishCreation(vm, executable, signature.argumentCount(), name, function, instance);
     return result;
 }

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -281,6 +281,10 @@
         "i31.new":                   { "category": "gc",         "value": 251, "return": ["i31ref"],                       "parameter": ["i32"],                        "immediate": [], "extendedOp": 32 },
         "i31.get_s":                 { "category": "gc",         "value": 251, "return": ["i32"],                          "parameter": ["i31ref"],                     "immediate": [], "extendedOp": 33 },
         "i31.get_u":                 { "category": "gc",         "value": 251, "return": ["i32"],                          "parameter": ["i31ref"],                     "immediate": [], "extendedOp": 34 },
+        "ref.test":                  { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 64 },
+        "ref.cast":                  { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 65 },
+        "ref.test_null":             { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 72 },
+        "ref.cast_null":             { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["any"],                        "immediate": [{"name": "heap_type", "type": "varuint32"}], "extendedOp": 73 },
 
         "i32.trunc_sat_f32_s": { "category": "conversion", "value": 252, "return": ["i32"], "parameter": ["f32"], "immediate": [], "extendedOp": 0 },
         "i32.trunc_sat_f32_u": { "category": "conversion", "value": 252, "return": ["i32"], "parameter": ["f32"], "immediate": [], "extendedOp": 1 },


### PR DESCRIPTION
#### 0e2cbf8c3d8ee53e2840c3b87aa7b0adaf410865
<pre>
[Wasm-GC] Implement cast operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=247399">https://bugs.webkit.org/show_bug.cgi?id=247399</a>

Reviewed by Yusuke Suzuki.

Implements the `ref.cast` and `ref.test` instructions. Casts are
supported by associating an RTT with Wasm objects.

For functions, this is done by adding a field in the base function
object.  For arrays and structs, a new WebAsseblyGCObjectBase class is
used as the base class for both arrays and structs. The base class
contains an RTT with a consistent offset for the JIT.

This patch does not yet support `br_on_cast/on_cast_fail`.

* JSTests/wasm/gc/casts.js: Added.
(testBasicCasts):
(testI31Casts):
(testFunctionCasts):
(testArrayCasts):
(testStructCasts):
(testSubtypeCasts):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp:
(JSC::Wasm::AirIRGenerator32::emitBranchForNullReference):
(JSC::Wasm::AirIRGenerator32::makeBranchNotInt32):
(JSC::Wasm::AirIRGenerator32::makeBranchNotCell):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitBranchForNullReference):
(JSC::Wasm::AirIRGenerator64::makeBranchNotInt32):
(JSC::Wasm::AirIRGenerator64::makeBranchNotCell):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addRefCast):
(JSC::Wasm::ExpressionType&gt;::addRefTest):
(JSC::Wasm::ExpressionType&gt;::emitRefTestOrCast):
(JSC::Wasm::ExpressionType&gt;::emitCheckOrBranchForCast):
(JSC::Wasm::ExpressionType&gt;::emitLoadRTTFromFuncref):
(JSC::Wasm::ExpressionType&gt;::emitLoadRTTFromObject):
(JSC::Wasm::ExpressionType&gt;::makeBranchNotRTTKind):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addRefTest):
(JSC::Wasm::B3IRGenerator::addRefCast):
(JSC::Wasm::B3IRGenerator::emitRefTestOrCast):
(JSC::Wasm::B3IRGenerator::emitCheckOrBranchForCast):
(JSC::Wasm::B3IRGenerator::emitLoadRTTFromFuncref):
(JSC::Wasm::B3IRGenerator::emitLoadRTTFromObject):
(JSC::Wasm::B3IRGenerator::emitNotRTTKind):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmInstance.cpp:
(JSC::Wasm::Instance::initElementSegment):
* Source/JavaScriptCore/wasm/WasmLLIntBuiltin.h:
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addRefTest):
(JSC::Wasm::LLIntGenerator::addRefCast):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::structNew):
(JSC::Wasm::refCast):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::RTT::tryCreateRTT):
(JSC::Wasm::TypeInformation::signatureForLLIntBuiltin):
(JSC::Wasm::TypeInformation::TypeInformation):
(JSC::Wasm::TypeInformation::canonicalRTTForType):
(JSC::Wasm::TypeInformation::tryGetCanonicalRTT):
(JSC::Wasm::TypeInformation::getCanonicalRTT):
(): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::RTT::RTT): Deleted.
(JSC::Wasm::RTT::displaySize const): Deleted.
(JSC::Wasm::RTT::displayEntry const): Deleted.
(JSC::Wasm::RTT::setDisplayEntry): Deleted.
(JSC::Wasm::RTT::allocatedRTTSize): Deleted.
(JSC::Wasm::RTT::payload): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
(JSC::Wasm::TypeInformation::getFunctionSignature):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
(JSC::JSWebAssemblyStruct::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::create):
(JSC::WebAssemblyFunction::WebAssemblyFunction):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp:
(JSC::WebAssemblyFunctionBase::WebAssemblyFunctionBase):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h:
(JSC::WebAssemblyFunctionBase::rtt const):
(JSC::WebAssemblyFunctionBase::offsetOfRTT):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp: Copied from Source/JavaScriptCore/wasm/WasmLLIntBuiltin.h.
(JSC::WebAssemblyGCObjectBase::WebAssemblyGCObjectBase):
(JSC::WebAssemblyGCObjectBase::visitChildrenImpl):
(JSC::WebAssemblyGCObjectBase::finishCreation):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h: Copied from Source/JavaScriptCore/wasm/WasmLLIntBuiltin.h.
(JSC::WebAssemblyGCObjectBase::rtt):
(JSC::WebAssemblyGCObjectBase::offsetOfRTT):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::WebAssemblyWrapperFunction::WebAssemblyWrapperFunction):
(JSC::WebAssemblyWrapperFunction::create):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h:
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/261445@main">https://commits.webkit.org/261445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0c6c69f0f7ffa883be1f20c524f27f106d7d3f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111597 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120349 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117362 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104491 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45271 "") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100101 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/130 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11339 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9570 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101316 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52118 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31524 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7964 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15694 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109355 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26927 "Passed tests") | 
<!--EWS-Status-Bubble-End-->