### PR TITLE
[GTK] Remove webkit_web_context_[g,s]et_use_system_appearance_for_scrollbars()

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -317,7 +317,7 @@ WEBKIT_API void
 webkit_web_context_send_message_to_all_extensions   (WebKitWebContext              *context,
                                                      WebKitUserMessage             *message);
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && !USE(GTK4)
 WEBKIT_API void
 webkit_web_context_set_use_system_appearance_for_scrollbars (WebKitWebContext      *context,
                                                              gboolean               enabled);

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -37,6 +37,19 @@ warnings, then it is time to attempt to upgrade to GTK 4 and webkitgtk-6.0.
 This is easier said than done, but [the GTK 4 migration guide](https://docs.gtk.org/gtk4/migrating-3to4.html)
 will help. Good luck.
 
+## Most Types Are Final
+
+Only two types are now derivable:
+
+- [type@WebView] has been often subclassed to customize its behavior for an
+  specific application. This possibility has been kept, as it has proved
+  useful in the past.
+- [type@InputMethodContext] is specifically designed in a way that subclassing
+  is required to make use of it.
+
+The rest of the types are no longer derivable; they are defined with the
+`G_TYPE_FLAG_FINAL` flag set. Use composition instead of derivation.
+
 ## Mandatory Web Process Sandbox
 
 The `webkit_web_context_set_sandbox_enabled()` and `webkit_web_context_get_sandbox_enabled()`
@@ -67,19 +80,6 @@ accordingly.
 may directly use `g_object_new()` instead. [ctor@WebKit.WebView.new] and
 [ctor@WebKit.WebView.new_with_related_view] both remain.
 
-## Most Types Are Final
-
-Only two types are now derivable:
-
-- [type@WebView] has been often subclassed to customize its behavior for an
-  specific application. This possibility has been kept, as it has proved
-  useful in the past.
-- [type@InputMethodContext] is specifically designed in a way that subclassing
-  is required to make use of it.
-
-The rest of the types are no longer derivable; they are defined with the
-`G_TYPE_FLAG_FINAL` flag set. Use composition instead of derivation.
-
 ## Network Session API
 
 WebKit now uses a single global network process for all web contexts, and different
@@ -101,3 +101,11 @@ session capabilities.
 [enum@WebKit.HardwareAccelerationPolicy]. You may still use
 [method@WebKit.Settings.set_hardware_acceleration_policy] to enable or disable
 hardware acceleration.
+
+## Scrollbar Appearance
+
+Because GTK 4 does not contain a foreign drawing API, it is no longer possible
+to draw scrollbars that match arbitrary GTK themes. Accordingly, the
+`webkit_web_context_get_use_system_appearance_for_scrollbars` and
+`webkit_web_context_set_use_system_appearance_for_scrollbars` APIs have been
+removed. WebKit will draw scrollbars that match the Adwaita GTK theme.


### PR DESCRIPTION
#### c2e9b5aaac76080146c351d0b6b74a9bb1ac6e56
<pre>
[GTK] Remove webkit_web_context_[g,s]et_use_system_appearance_for_scrollbars()
<a href="https://bugs.webkit.org/show_bug.cgi?id=227841">https://bugs.webkit.org/show_bug.cgi?id=227841</a>

Reviewed by Adrian Perez de Castro.

This API is already not defined and applications that attempt to use it
won&apos;t link successfully. We just need to remove it from the header.

* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md:

Canonical link: <a href="https://commits.webkit.org/259716@main">https://commits.webkit.org/259716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8376e83446fd8c7745392baa5aac014de4e0d64d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114934 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5998 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97971 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111465 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95308 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26949 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8067 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6714 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10114 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->