### PR TITLE
WPT: A subtest in shadow-dom/focus/focus-method-with-delegatesFocus.html fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-method-with-delegatesFocus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-method-with-delegatesFocus-expected.txt
@@ -2,7 +2,7 @@
 
 PASS xshadow0 is not focusable without tabindex.
 PASS xshadow1 becomes focusable with tabindex.
-FAIL on focus(), focusable xshadow2 with delegatesFocus=true delegates focus into its inner element. assert_equals: expected "xshadow2" but got "xshadow1"
+PASS on focus(), focusable xshadow2 with delegatesFocus=true delegates focus into its inner element.
 PASS if an element within shadow is focused, focusing on shadow host should not slide focus to its inner element.
 PASS xshadow2.focus() shouldn't move focus to #one when its inner element is already focused.
 PASS focus() inside shadow DOM should not focus its shadow host, nor focusable siblings.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3336,7 +3336,7 @@ static RefPtr<Element> findFocusDelegateInternal(ContainerNode& target)
 {
     if (auto element = autoFocusDelegate(target))
         return element;
-    for (auto& element : childrenOfType<Element>(target)) {
+    for (auto& element : descendantsOfType<Element>(target)) {
         if (isProgramaticallyFocusable(element))
             return &element;
         if (auto root = shadowRootWithDelegatesFocus(element)) {


### PR DESCRIPTION
#### e873de3c117e4e0e5a8c9103b64b394d0a3c3f3d
<pre>
WPT: A subtest in shadow-dom/focus/focus-method-with-delegatesFocus.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=251462">https://bugs.webkit.org/show_bug.cgi?id=251462</a>

Reviewed by Tim Nguyen.

The bug was caused by findFocusDelegateInternal only iterating over its direct children instead of all descendants.
Fixed the bug by changing it to traverse all descendant nodes.

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/focus/focus-method-with-delegatesFocus-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::findFocusDelegateInternal):

Canonical link: <a href="https://commits.webkit.org/259707@main">https://commits.webkit.org/259707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cad1d6e0ae2d3bd19530a2596b8e456e19aef685

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114808 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174953 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5869 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97851 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39711 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26841 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81415 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28196 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4779 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47740 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9952 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3585 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->