### PR TITLE
Inline FloatSize::FloatSize(WebCore::IntSize& const) constructor

### DIFF
--- a/Source/WebCore/platform/graphics/FloatSize.cpp
+++ b/Source/WebCore/platform/graphics/FloatSize.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2003, 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc.  All rights reserved.§
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
  * Copyright (C) 2005 Nokia.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,12 +36,6 @@
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
-
-FloatSize::FloatSize(const IntSize& size)
-    : m_width(size.width())
-    , m_height(size.height())
-{
-}
 
 FloatSize FloatSize::constrainedBetween(const FloatSize& min, const FloatSize& max) const
 {

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2003-2016 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
  * Copyright (C) 2005 Nokia.  All rights reserved.
  *               2008 Eric Seidel <eric@webkit.org>
  *
@@ -59,8 +60,12 @@ class IntSize;
 class FloatSize {
 public:
     FloatSize() { }
-    FloatSize(float width, float height) : m_width(width), m_height(height) { }
-    WEBCORE_EXPORT FloatSize(const IntSize&);
+    FloatSize(float width, float height) 
+        : m_width(width)
+        , m_height(height) { }
+    FloatSize(const IntSize& size) 
+        : m_width(size.width())
+        , m_height(size.height()) { }
 
     static FloatSize narrowPrecision(double width, double height);
 


### PR DESCRIPTION
#### d2a7afb940a10cd9a2fc90d77fbd50ae12cb01ac
<pre>
Inline FloatSize::FloatSize(WebCore::IntSize&amp; const) constructor

Inline FloatSize::FloatSize(WebCore::IntSize&amp; const) constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=250655">https://bugs.webkit.org/show_bug.cgi?id=250655</a>
rdar://problem/104536651

Reviewed by Alan Baradlay.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/8ef1d2d2935beef0baf377ee37b76f584b4db631">https://chromium.googlesource.com/chromium/blink/+/8ef1d2d2935beef0baf377ee37b76f584b4db631</a>

This patch is potential optimization for scrollview code calling IntSize by inlining constructor.

* Source/WebCore/platform/graphics/FloatSize.cpp:
(FloatSize:FloatSize): Remove &apos;IntSize&apos; constructor function
* Source/WebCore/platform/graphics/FloatSize.h: Inline &apos;FloatSize&apos; constructor

Canonical link: <a href="https://commits.webkit.org/259693@main">https://commits.webkit.org/259693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0477fb25d46004e39bf7db791ba2cb048a0f2d58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114903 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5965 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97942 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111429 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26924 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8034 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8530 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47824 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6697 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10083 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->