### PR TITLE
[webkitscmpy] Expose hash of HEAD commit

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.11.4',
+    version='5.11.5',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 11, 4)
+version = Version(5, 11, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
@@ -266,6 +266,7 @@ class BitBucket(mocks.Requests):
             json['participants'] = [json['author']]
             json['id'] = 1 + max([0] + [pr.get('id', 0) for pr in self.pull_requests])
             json['fromRef']['displayId'] = '/'.join(json['fromRef']['id'].split('/')[-2:])
+            json['fromRef']['latestCommit'] = json['fromRef']['latestCommit']
             json['toRef']['displayId'] = '/'.join(json['toRef']['id'].split('/')[-2:])
             json['state'] = 'OPEN'
             json['activities'] = []
@@ -304,6 +305,7 @@ class BitBucket(mocks.Requests):
             if method == 'PUT':
                 self.pull_requests[existing].update(json)
                 self.pull_requests[existing]['fromRef']['displayId'] = '/'.join(json['fromRef']['id'].split('/')[-2:])
+                self.pull_requests[existing]['fromRef']['latestCommit'] = json['fromRef']['latestCommit']
                 self.pull_requests[existing]['toRef']['displayId'] = '/'.join(json['toRef']['id'].split('/')[-2:])
             if len(split_url) < 11:
                 return mocks.Response.fromJson({key: value for key, value in self.pull_requests[existing].items() if key != 'activities'})

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -339,6 +339,7 @@ class GitHub(bmocks.GitHub):
                     author=dict(login=candidate['user']['login']),
                     baseRefName=cbase,
                     headRefName=chead,
+                    headRef=dict(target=dict(oid=(candidate.get('head') or {}).get('sha', None))),
                     headRepository=dict(nameWithOwner='{}/{}'.format(candidate['user']['login'], repo_name.split('/')[-1])),
                 )))
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -139,7 +139,7 @@ class PullRequest(object):
         body=None, author=None,
         head=None, base=None,
         opened=None, generator=None, metadata=None,
-        url=None, draft=None
+        url=None, draft=None, hash=None,
     ):
         self.number = number
         self.title = title
@@ -148,6 +148,7 @@ class PullRequest(object):
         self.head = head
         self.base = base
         self.draft = draft
+        self.hash = hash
         self._opened = opened
         self._reviewers = None
         self._approvers = None

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -61,6 +61,7 @@ class GitHub(Scm):
                 body=data.get('body'),
                 author=self.repository.contributors.create((data.get('user') or data.get('author'))['login']),
                 head=(data.get('head') or {}).get('ref', data.get('headRefName')),
+                hash=(data.get('head') or {}).get('sha') or ((data.get('headRef') or {}).get('target') or {}).get('oid'),
                 base=(data.get('base') or {}).get('ref', data.get('baseRefName')),
                 opened=dict(
                     open=True,
@@ -104,6 +105,11 @@ class GitHub(Scm):
           }}
           baseRefName
           headRefName
+          headRef {{
+            target {{
+              oid
+            }}
+          }}
           headRepository {{
             nameWithOwner
           }}

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1420,7 +1420,7 @@ Reviewed by NOBODY (OOPS!).
 * Source/file.cpp:
 </pre>
 ''',
-            head=dict(ref='eng/pull-request'),
+            head=dict(ref='eng/pull-request', sha='95507e3a1a4a919d1a156abbc279fdf6d24b13f5'),
             base=dict(ref='main'),
             requested_reviews=[dict(login='rreviewer')],
             reviews=[
@@ -1439,6 +1439,7 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(prs[0].number, 1)
             self.assertEqual(prs[0].title, 'Example Change')
             self.assertEqual(prs[0].head, 'eng/pull-request')
+            self.assertEqual(prs[0].hash, '95507e3a1a4a919d1a156abbc279fdf6d24b13f5')
             self.assertEqual(prs[0].base, 'main')
 
     def test_get(self):
@@ -1448,6 +1449,7 @@ Reviewed by NOBODY (OOPS!).
             self.assertTrue(pr.opened)
             self.assertEqual(pr.title, 'Example Change')
             self.assertEqual(pr.head, 'eng/pull-request')
+            self.assertEqual(pr.hash, '95507e3a1a4a919d1a156abbc279fdf6d24b13f5')
             self.assertEqual(pr.base, 'main')
             self.assertEqual(pr.draft, False)
 
@@ -1546,7 +1548,7 @@ Reviewed by NOBODY (OOPS!).
 * Source/file.cpp:
 ```
 ''',
-            fromRef=dict(displayId='eng/pull-request'),
+            fromRef=dict(displayId='eng/pull-request', latestCommit='95507e3a1a4a919d1a156abbc279fdf6d24b13f5'),
             toRef=dict(displayId='main'),
             reviewers=[
                 dict(
@@ -1577,6 +1579,7 @@ Reviewed by NOBODY (OOPS!).
                 self.assertEqual(prs[0].number, 1)
                 self.assertEqual(prs[0].title, 'Example Change')
                 self.assertEqual(prs[0].head, 'eng/pull-request')
+                self.assertEqual(prs[0].hash, '95507e3a1a4a919d1a156abbc279fdf6d24b13f5')
                 self.assertEqual(prs[0].base, 'main')
 
     def test_get(self):
@@ -1586,6 +1589,7 @@ Reviewed by NOBODY (OOPS!).
             self.assertTrue(pr.opened)
             self.assertEqual(pr.title, 'Example Change')
             self.assertEqual(pr.head, 'eng/pull-request')
+            self.assertEqual(pr.hash, '95507e3a1a4a919d1a156abbc279fdf6d24b13f5')
             self.assertEqual(pr.base, 'main')
             self.assertEqual(pr.draft, False)
 


### PR DESCRIPTION
#### 6321064705379313571b63cace53a7fc0fe6abd0
<pre>
[webkitscmpy] Expose hash of HEAD commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=251464">https://bugs.webkit.org/show_bug.cgi?id=251464</a>
rdar://104889825

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request): Return hash of PR head.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.graphql): Pass hash of PR head.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest.__init__): Receive hash of PR head.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.PullRequest): Pass hash of PR head.
(BitBucket.PRGenerator.create): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.PullRequest): Pass hash of PR head.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/259691@main">https://commits.webkit.org/259691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b26a8f9b606808fbbc6ddb3de5dd33e7e4a6436

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105685 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/114912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/109586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/16182 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5975 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/111438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/16182 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/109128 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/16182 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/104483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3578 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->