### PR TITLE
Expose WebCore::ContentExtensions::parseRuleList as WebKit SPI

### DIFF
--- a/Source/WebKit/UIProcess/API/APIContentRuleList.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.cpp
@@ -30,6 +30,7 @@
 
 #include "WebCompiledContentRuleList.h"
 #include <WebCore/CombinedURLFilters.h>
+#include <WebCore/ContentExtensionParser.h>
 #include <WebCore/URLFilterParser.h>
 
 namespace API {
@@ -75,6 +76,15 @@ bool ContentRuleList::supportsRegularExpression(const WTF::String& regex)
         break;
     }
     return false;
+}
+
+std::error_code ContentRuleList::parseRuleList(const WTF::String& ruleList)
+{
+    auto result = WebCore::ContentExtensions::parseRuleList(ruleList);
+    if (result.has_value())
+        return { };
+
+    return result.error();
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIContentRuleList.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.h
@@ -50,6 +50,7 @@ public:
     const WebKit::WebCompiledContentRuleList& compiledRuleList() const { return m_compiledRuleList.get(); }
     
     static bool supportsRegularExpression(const WTF::String&);
+    static std::error_code parseRuleList(const WTF::String&);
 
 private:
     Ref<WebKit::WebCompiledContentRuleList> m_compiledRuleList;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "WKContentRuleListInternal.h"
 
+#import "WKError.h"
 #import "WebCompiledContentRuleList.h"
 #import <WebCore/WebCoreObjCExtras.h>
 
@@ -67,6 +68,20 @@
     return API::ContentRuleList::supportsRegularExpression(regex);
 #else
     return NO;
+#endif
+}
+
++ (NSError *)_parseRuleList:(NSString *)ruleList
+{
+#if ENABLE(CONTENT_EXTENSIONS)
+    std::error_code error = API::ContentRuleList::parseRuleList(ruleList);
+    if (!error)
+        return nil;
+
+    auto userInfo = @{ NSHelpAnchorErrorKey: [NSString stringWithFormat:@"Rule list parsing failed: %s", error.message().c_str()] };
+    return [NSError errorWithDomain:WKErrorDomain code:WKErrorContentRuleListStoreCompileFailed userInfo:userInfo];
+#else
+    return nil;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListPrivate.h
@@ -28,5 +28,6 @@
 @interface WKContentRuleList (WKPrivate)
 
 + (BOOL)_supportsRegularExpression:(NSString *)regex WK_API_AVAILABLE(macos(12.0), ios(15.0));
++ (NSError *)_parseRuleList:(NSString *)ruleList WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end


### PR DESCRIPTION
#### a423cde6af09afbcb38784951a94ff40a28fac6e
<pre>
Expose WebCore::ContentExtensions::parseRuleList as WebKit SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=251465">https://bugs.webkit.org/show_bug.cgi?id=251465</a>
&lt;rdar://problem/99753935&gt;

Reviewed by Alex Christensen.

This patch also adds tests for passing and failing rule parsing.

* Source/WebKit/UIProcess/API/APIContentRuleList.cpp:
(API::ContentRuleList::parseRuleList): Call into WebCore::ContentExtensions::parseRuleList and return the error code if it exists.
* Source/WebKit/UIProcess/API/APIContentRuleList.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.mm:
(+[WKContentRuleList _parseRuleList:]): Call into API::ContentRuleList::parseRuleList and wrap the error code in an NSError if necessary.
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListPrivate.h:

Canonical link: <a href="https://commits.webkit.org/259706@main">https://commits.webkit.org/259706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51484f9ca5a3583ef865d52f445704a2761b3392

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114923 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5986 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111452 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/26942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8055 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47842 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6708 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10103 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->