### PR TITLE
Fix use-after-move in CacheStorageCache::putRecordsInStore

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -323,9 +323,9 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
             record.info.insertionTime = existingRecordInfo->insertionTime;
             record.info.url = existingRecordInfo->url;
             record.requestHeadersGuard = existingRecord->requestHeadersGuard;
-            record.request = WTFMove(existingRecord->request);
-            record.options = WTFMove(existingRecord->options);
-            record.referrer = WTFMove(existingRecord->referrer);
+            record.request = existingRecord->request;
+            record.options = existingRecord->options;
+            record.referrer = existingRecord->referrer;
             record.info.updateVaryHeaders(record.request, record.responseData.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary));
             sizeIncreased += record.info.size;
             sizeDecreased += existingRecordInfo->size;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -440,9 +440,9 @@ void CacheStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
 
 void CacheStorageManager::removeUnusedCache(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
-    auto cache = m_removedCaches.take(cacheIdentifier);
-    if (cache) {
+    if (auto cache = m_removedCaches.take(cacheIdentifier)) {
         cache->removeAllRecords();
+        m_registry.unregisterCache(cacheIdentifier);
         return;
     }
 


### PR DESCRIPTION
#### e10384deeabd408e49973e4cbc71ad35d70147d9
<pre>
Fix use-after-move in CacheStorageCache::putRecordsInStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=251467">https://bugs.webkit.org/show_bug.cgi?id=251467</a>
rdar://104531316

Reviewed by Youenn Fablet.

CacheStorageCache::putRecordsInStore should not use WTFMove on members of existingRecord because existingRecord will
be accessed later (existingRecord points to an object in m_records). This patch also ensures CacheStorageCache is
unregistered from CacheStorageRegistry when it is removed, so CacheStorageRegistry could remove the entry from m_caches.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::putRecordsInStore):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::removeUnusedCache):

Canonical link: <a href="https://commits.webkit.org/259766@main">https://commits.webkit.org/259766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff2bf671992adb4485fc7523d9e6af1c5d909a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115064 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6133 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98099 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111615 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95420 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27063 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8205 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8686 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47962 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6756 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10242 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->