### PR TITLE
Make findPropertyIndex & findCustomPropertyIndex faster

### DIFF
--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -292,9 +293,10 @@ int MutableStyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
 {
     // Convert here propertyID into an uint16_t to compare it with the metadata's m_propertyID to avoid
     // the compiler converting it to an int multiple times in the loop.
+    auto* properties = m_propertyVector.data();
     uint16_t id = static_cast<uint16_t>(propertyID);
     for (int n = m_propertyVector.size() - 1 ; n >= 0; --n) {
-        if (m_propertyVector.at(n).metadata().m_propertyID == id)
+        if (properties[n].metadata().m_propertyID == id)
             return n;
     }
     return -1;
@@ -302,12 +304,13 @@ int MutableStyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
 
 int MutableStyleProperties::findCustomPropertyIndex(StringView propertyName) const
 {
+    auto* properties = m_propertyVector.data();
     for (int n = m_propertyVector.size() - 1 ; n >= 0; --n) {
-        if (m_propertyVector.at(n).metadata().m_propertyID == CSSPropertyCustom) {
+        if (properties[n].metadata().m_propertyID == CSSPropertyCustom) {
             // We found a custom property. See if the name matches.
-            if (!m_propertyVector.at(n).value())
+            if (!properties[n].value())
                 continue;
-            if (downcast<CSSCustomPropertyValue>(*m_propertyVector.at(n).value()).name() == propertyName)
+            if (downcast<CSSCustomPropertyValue>(*properties[n].value()).name() == propertyName)
                 return n;
         }
     }


### PR DESCRIPTION
#### b98bb73bfb6f9ae4587896ec0eefd76fde9f4aec
<pre>
Make findPropertyIndex &amp; findCustomPropertyIndex faster

Make findPropertyIndex &amp; findCustomPropertyIndex faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=250581">https://bugs.webkit.org/show_bug.cgi?id=250581</a>
rdar://problem/104479595

Reviewed by Darin Adler.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/501ce3bc186b2bf535ecf3af9f3ce973fe13fd4c">https://chromium.googlesource.com/chromium/blink/+/501ce3bc186b2bf535ecf3af9f3ce973fe13fd4c</a>

This patch is potential optimization, which is by modifying to remove calls to
&quot;WTF::Vector::at()&quot; from &apos;findPropertyIndex&apos; and &apos;findCustomPropertyIndex&apos; functions.

* Source/WebCore/css/MutableStyleProperties.cpp:
(MutableStyleProperties::findPropertyIndex): Add variable for &apos;m_propertyVector.data()&apos;
and use it instead of &apos;m_propertyVector.at(n)&apos;
(MutableStyleProperties::findCustomPropertyIndex): Ditto

Canonical link: <a href="https://commits.webkit.org/259726@main">https://commits.webkit.org/259726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/337f2f0617ebbf17a1375a43de348972228969fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114871 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175016 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5933 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97910 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39752 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26893 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28246 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4833 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6725 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10051 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->