### PR TITLE
Ensure CacheStorageDiskStore make isolated copy of arguments when passing them between WorkQueues

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -421,7 +421,7 @@ void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInforma
         return recordFilePath(recordInfo.key);
     });
 
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = WTFMove(recordFiles), callback = WTFMove(callback)]() mutable {
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), callback = WTFMove(callback)]() mutable {
         bool result = true;
         for (auto recordFile : recordFiles) {
             FileSystem::deleteFile(recordBlobFilePath(recordFile));
@@ -514,7 +514,7 @@ void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, W
         recordBlobDatas.append(WTFMove(bodyData));
     }
 
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = WTFMove(recordFiles), recordDatas = WTFMove(recordDatas), recordBlobDatas = WTFMove(recordBlobDatas), callback = WTFMove(callback)]() mutable {
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), recordDatas = crossThreadCopy(WTFMove(recordDatas)), recordBlobDatas = crossThreadCopy(WTFMove(recordBlobDatas)), callback = WTFMove(callback)]() mutable {
         bool result = true;
         // FIXME: we should probably stop writing and revert changes when result becomes false.
         for (size_t index = 0; index < recordFiles.size(); ++index) {


### PR DESCRIPTION
#### 167dfa751c25fc50f7c2aa6199e2dc968c6fee71
<pre>
Ensure CacheStorageDiskStore make isolated copy of arguments when passing them between WorkQueues
<a href="https://bugs.webkit.org/show_bug.cgi?id=251471">https://bugs.webkit.org/show_bug.cgi?id=251471</a>
rdar://104892197

Reviewed by Per Arne Vollan.

* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::deleteRecords):
(WebKit::CacheStorageDiskStore::writeRecords):

Canonical link: <a href="https://commits.webkit.org/259700@main">https://commits.webkit.org/259700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d2541ac7a728ed5a8735a72c4a36cd289bef649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114824 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5885 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97867 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26851 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81429 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7950 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28206 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8401 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4791 "Found 1 new test failure: fast/repaint/rtl-content-selection-hairline-gap.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6704 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/9981 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->