### PR TITLE
Non-unified build fixes, early February 2023 edition

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeBasicBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeBasicBlock.cpp
@@ -28,6 +28,7 @@
 
 #include "CodeBlock.h"
 #include "PreciseJumpTargets.h"
+#include "StrongInlines.h"
 #include "UnlinkedCodeBlockGenerator.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -35,9 +35,11 @@
 
 namespace JSC {
 
+#if ENABLE(JIT)
 namespace CallLinkStatusInternal {
 static constexpr bool verbose = false;
 }
+#endif
 
 CallLinkStatus::CallLinkStatus(JSValue value)
     : m_couldTakeSlowPath(false)

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -36,10 +36,6 @@
 
 namespace JSC {
 
-namespace TemporalPlainDateInternal {
-static constexpr bool verbose = false;
-}
-
 const ClassInfo TemporalPlainDate::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalPlainDate) };
 
 TemporalPlainDate* TemporalPlainDate::create(VM& vm, Structure* structure, ISO8601::PlainDate&& plainDate)

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GPUAdapter.h"
 
+#include "JSDOMPromiseDeferred.h"
 #include "JSGPUDevice.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -35,6 +35,7 @@
 #include "HTTPParsers.h"
 #include "JSBlob.h"
 #include "JSDOMFormData.h"
+#include "JSDOMPromiseDeferred.h"
 #include "ResourceError.h"
 #include "ResourceResponse.h"
 #include "WindowEventLoop.h"

--- a/Source/WebCore/Modules/push-api/PushPermissionState.h
+++ b/Source/WebCore/Modules/push-api/PushPermissionState.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include <wtf/EnumTraits.h>
+
 namespace WebCore {
 
 enum class PushPermissionState : uint8_t {

--- a/Source/WebCore/Modules/push-api/PushSubscription.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscription.cpp
@@ -30,6 +30,7 @@
 
 #include "EventLoop.h"
 #include "Exception.h"
+#include "JSDOMPromiseDeferred.h"
 #include "PushSubscriptionOptions.h"
 #include "ScriptExecutionContext.h"
 #include "ServiceWorkerContainer.h"

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -28,6 +28,7 @@
 
 #include "Document.h"
 #include "SleepDisabler.h"
+#include "VisibilityState.h"
 #include "WakeLockSentinel.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WritableStream.h"
 
+#include "JSDOMPromiseDeferred.h"
 #include "JSWritableStream.h"
 #include "JSWritableStreamSink.h"
 

--- a/Source/WebCore/Modules/streams/WritableStreamSink.h
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.h
@@ -26,7 +26,9 @@
 
 #pragma once
 
-#include "JSDOMPromiseDeferredForward.h"
+#include "ExceptionOr.h"
+#include "JSDOMPromiseDeferred.h"
+#include "ScriptExecutionContext.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/Modules/web-locks/WebLockIdentifier.h
+++ b/Source/WebCore/Modules/web-locks/WebLockIdentifier.h
@@ -24,11 +24,10 @@
 
 #pragma once
 
-#include <wtf/Forward.h>
+#include "ProcessQualified.h"
+#include <wtf/ObjectIdentifier.h>
 
 namespace WebCore {
-
-template<typename> class ProcessQualified;
 
 enum WebLockIdentifierType { };
 using WebLockIdentifier = ProcessQualified<ObjectIdentifier<WebLockIdentifierType>>;

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -29,6 +29,7 @@
 #include "ExceptionCode.h"
 #include "ExceptionOr.h"
 #include "JSDOMPromise.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSWebLockManagerSnapshot.h"
 #include "NavigatorBase.h"
 #include "Page.h"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -340,12 +340,6 @@ static inline RefPtr<ShapeValue> blendFunc(ShapeValue* from, ShapeValue* to, con
     return from->blend(*to, context);
 }
 
-static inline RefPtr<FilterOperation> blendFunc(FilterOperation* from, FilterOperation* to, const CSSPropertyBlendingContext& context, bool blendToPassthrough = false)
-{
-    ASSERT(to);
-    return to->blend(from, context, blendToPassthrough);
-}
-
 static inline FilterOperations blendFunc(const FilterOperations& from, const FilterOperations& to, const CSSPropertyBlendingContext& context)
 {
     return from.blend(to, context);

--- a/Source/WebCore/bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(SERVICE_WORKER)
 #include "JSServiceWorkerGlobalScope.h"
 
+#include "JSDOMPromiseDeferred.h"
 #include "ServiceWorkerClients.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "WebCoreOpaqueRoot.h"

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -33,6 +33,8 @@
 #include "CSSValuePair.h"
 #include "MutableStyleProperties.h"
 #include "Pair.h"
+#include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -28,8 +28,10 @@
 
 #include "CSSKeyframesRule.h"
 #include "CSSParser.h"
+#include "MutableStyleProperties.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -32,6 +32,7 @@
 #include "CSSSupportsRule.h"
 
 #include "CSSStyleSheet.h"
+#include "StyleProperties.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -977,11 +977,6 @@ static Ref<CSSValue> computedRotate(RenderObject* renderer, const RenderStyle& s
     return list;
 }
 
-static inline Ref<CSSPrimitiveValue> adjustLengthForZoom(double length, const RenderStyle& style, ComputedStyleExtractor::AdjustPixelValuesForComputedStyle adjust)
-{
-    return adjust == ComputedStyleExtractor::AdjustPixelValuesForComputedStyle::Yes ? zoomAdjustedPixelValue(length, style) : CSSPrimitiveValue::create(length, CSSUnitType::CSS_PX);
-}
-
 static inline Ref<CSSPrimitiveValue> adjustLengthForZoom(const Length& length, const RenderStyle& style, ComputedStyleExtractor::AdjustPixelValuesForComputedStyle adjust)
 {
     return adjust == ComputedStyleExtractor::AdjustPixelValuesForComputedStyle::Yes ? zoomAdjustedPixelValue(length.value(), style) : CSSPrimitiveValue::create(length);

--- a/Source/WebCore/css/DOMCSSNamespace.cpp
+++ b/Source/WebCore/css/DOMCSSNamespace.cpp
@@ -37,6 +37,7 @@
 #include "CSSPropertyParser.h"
 #include "Document.h"
 #include "HighlightRegister.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -30,6 +30,7 @@
 #include "CSSToLengthConversionData.h"
 #include "DOMMatrix.h"
 #include "DOMPoint.h"
+#include "MutableStyleProperties.h"
 #include "ScriptExecutionContext.h"
 #include "StyleProperties.h"
 #include "TransformFunctions.h"

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -31,6 +31,7 @@
 #include "InspectorInstrumentation.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWindowBase.h"
+#include "MutableStyleProperties.h"
 #include "MutationObserverInterestGroup.h"
 #include "MutationRecord.h"
 #include "Quirks.h"

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -41,7 +41,9 @@
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
 #include "MediaList.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include "StyleRuleImport.h"
 
 namespace WebCore {

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -31,7 +31,9 @@
 #include "CSSStyleSheet.h"
 #include "CSSUnparsedValue.h"
 #include "Document.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include "StyleRule.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -31,6 +31,7 @@
 #include "DocumentType.h"
 #include "Element.h"
 #include "FTPDirectoryDocument.h"
+#include "FragmentScriptingPermission.h"
 #include "Frame.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -29,7 +29,10 @@
 #include "Attr.h"
 #include "Element.h"
 #include "HTMLNames.h"
+#include "ImmutableStyleProperties.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include "XMLNames.h"
 
 namespace WebCore {

--- a/Source/WebCore/editing/FontAttributeChanges.cpp
+++ b/Source/WebCore/editing/FontAttributeChanges.cpp
@@ -33,6 +33,7 @@
 #include "CSSValuePool.h"
 #include "EditAction.h"
 #include "EditingStyle.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 
 namespace WebCore {

--- a/Source/WebCore/editing/FontAttributeChanges.h
+++ b/Source/WebCore/editing/FontAttributeChanges.h
@@ -27,6 +27,7 @@
 
 #include "Color.h"
 #include "FontShadow.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
 
 namespace IPC {

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -58,6 +58,7 @@
 #include "InlineRunAndOffset.h"
 #include "LegacyInlineTextBox.h"
 #include "Logging.h"
+#include "MutableStyleProperties.h"
 #include "Page.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "Range.h"
@@ -94,11 +95,6 @@
 namespace WebCore {
 
 using namespace HTMLNames;
-
-static inline LayoutUnit NoXPosForVerticalArrowNavigation()
-{
-    return LayoutUnit::min();
-}
 
 CaretBase::CaretBase(CaretVisibility visibility)
     : m_caretRectNeedsUpdate(true)

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -68,7 +68,7 @@ static const Document* blobOwner(const SecurityOrigin& blobOrigin)
 
 URL BlobURL::getOriginURL(const URL& url)
 {
-    ASSERT(url.protocolIs(kBlobProtocol));
+    ASSERT_UNUSED(kBlobProtocol, url.protocolIs(kBlobProtocol));
 
     if (auto blobOrigin = ThreadableBlobRegistry::getCachedOrigin(url)) {
         if (auto* document = blobOwner(*blobOrigin))
@@ -79,7 +79,7 @@ URL BlobURL::getOriginURL(const URL& url)
 
 bool BlobURL::isSecureBlobURL(const URL& url)
 {
-    ASSERT(url.protocolIs(kBlobProtocol));
+    ASSERT_UNUSED(kBlobProtocol, url.protocolIs(kBlobProtocol));
 
     // As per https://github.com/w3c/webappsec-mixed-content/issues/41, Blob URL is secure if the document that created it is secure.
     if (auto origin = ThreadableBlobRegistry::getCachedOrigin(url)) {

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -69,6 +69,7 @@
 #include "JSHTMLElement.h"
 #include "LabelsNodeList.h"
 #include "MediaControlsHost.h"
+#include "MutableStyleProperties.h"
 #include "NodeTraversal.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "RenderElement.h"

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -30,6 +30,7 @@
 #include "CSSValuePool.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -33,6 +33,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLTableElement.h"
+#include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CanvasBase.h"
+#include "CanvasObserver.h"
 #include "InspectorCanvas.h"
 #include "InspectorCanvasCallTracer.h"
 #include "InspectorWebAgentBase.h"

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -586,15 +586,6 @@ void DocumentLoader::matchRegistration(const URL& url, SWClientConnection::Regis
     auto& connection = ServiceWorkerProvider::singleton().serviceWorkerConnection();
     connection.matchRegistration(WTFMove(origin), url, WTFMove(callback));
 }
-
-static inline bool areRegistrationsEqual(const std::optional<ServiceWorkerRegistrationData>& a, const std::optional<ServiceWorkerRegistrationData>& b)
-{
-    if (!a)
-        return !b;
-    if (!b)
-        return false;
-    return a->identifier == b->identifier;
-}
 #endif
 
 void DocumentLoader::redirectReceived(CachedResource& resource, ResourceRequest&& request, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -197,10 +197,6 @@ const Seconds fakeMouseMoveShortInterval = { 100_ms };
 const Seconds fakeMouseMoveLongInterval = { 250_ms };
 #endif
 
-// The amount of time to wait for a cursor update on style and layout changes
-// Set to 50Hz, no need to be faster than common screen refresh rate
-static const Seconds cursorUpdateInterval { 20_ms };
-
 const int maximumCursorSize = 128;
 
 #if ENABLE(MOUSE_CURSOR_SCALE)

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -132,9 +132,6 @@ static const Seconds scrollFrequency { 1000_s / 60. };
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, frameCounter, ("Frame"));
 
-// We prewarm local storage for at most 5 origins in a given page.
-static const unsigned maxlocalStoragePrewarmingCount { 5 };
-
 static inline float parentPageZoomFactor(Frame* frame)
 {
     Frame* parent = dynamicDowncast<LocalFrame>(frame->tree().parent());

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -36,8 +36,6 @@
 
 namespace WebCore {
 
-static constexpr Seconds clientDataBufferingTimerThrottleDelay { 100_ms };
-
 String convertEnumerationToString(PlatformMediaSession::State state)
 {
     static const NeverDestroyed<String> values[] = {

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
@@ -44,8 +44,6 @@
 
 namespace WebCore {
 
-constexpr unsigned maxUnscheduledFireCount { 1 };
-
 RefPtr<DisplayRefreshMonitor> DisplayRefreshMonitor::createDefaultDisplayRefreshMonitor(PlatformDisplayID displayID)
 {
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -42,9 +42,6 @@
 namespace WebCore {
 namespace DisplayList {
 
-// Should match RenderTheme::platformFocusRingWidth()
-static const float platformFocusRingWidth = 3;
-
 void Save::apply(GraphicsContext& context) const
 {
     context.save();

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -433,15 +433,5 @@ bool RecorderImpl::recordResourceUse(DecomposedGlyphs& decomposedGlyphs)
     return true;
 }
 
-// FIXME: share with ShadowData
-static inline float shadowPaintingExtent(float blurRadius)
-{
-    // Blurring uses a Gaussian function whose std. deviation is m_radius/2, and which in theory
-    // extends to infinity. In 8-bit contexts, however, rounding causes the effect to become
-    // undetectable at around 1.4x the radius.
-    const float radiusExtentMultiplier = 1.4;
-    return ceilf(blurRadius * radiusExtentMultiplier);
-}
-
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -220,6 +220,7 @@ void EventRegion::translate(const IntSize& offset)
 #endif
 }
 
+#if ENABLE(TOUCH_ACTION_REGIONS)
 static inline unsigned toIndex(TouchAction touchAction)
 {
     switch (touchAction) {
@@ -260,7 +261,6 @@ static inline TouchAction toTouchAction(unsigned index)
     return TouchAction::Auto;
 }
 
-#if ENABLE(TOUCH_ACTION_REGIONS)
 void EventRegion::uniteTouchActions(const Region& touchRegion, OptionSet<TouchAction> touchActions)
 {
     for (auto touchAction : touchActions) {

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -66,11 +66,6 @@ LayoutUnit computeMarginLogicalSizeForChild(const RenderGrid& grid, GridTrackSiz
     return marginStartIsAuto(child, flowAwareDirection) ? marginEnd : marginEndIsAuto(child, flowAwareDirection) ? marginStart : marginStart + marginEnd;
 }
 
-static inline GridTrackSizingDirection directionFromSide(GridPositionSide side)
-{
-    return side == ColumnStartSide || side == ColumnEndSide ? ForColumns : ForRows;
-}
-
 static bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
 {
     if (direction == ForColumns)

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -62,6 +62,7 @@
 #include "RenderLineBreak.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
+#include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderRuby.h"
 #include "RenderSVGBlock.h"
 #include "RenderSVGInline.h"

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -34,6 +34,7 @@
 #include "FetchRequest.h"
 #include "FetchResponse.h"
 #include "JSDOMPromise.h"
+#include "JSDOMPromiseDeferred.h"
 #include "MIMETypeRegistry.h"
 #include "ResourceRequest.h"
 #include "ScriptExecutionContextIdentifier.h"

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
@@ -64,8 +64,6 @@ constexpr auto observedDomainCountQuery = "SELECT COUNT(*) FROM ObservedDomains"
 constexpr auto countSubframeUnderTopFrameQuery = "SELECT COUNT(*) FROM SubframeUnderTopFrameDomains WHERE subFrameDomainID = ? AND topFrameDomainID = ?;"_s;
 constexpr auto countSubresourceUnderTopFrameQuery = "SELECT COUNT(*) FROM SubresourceUnderTopFrameDomains WHERE subresourceDomainID = ? AND topFrameDomainID = ?;"_s;
 constexpr auto countSubresourceUniqueRedirectsToQuery = "SELECT COUNT(*) FROM SubresourceUniqueRedirectsTo WHERE subresourceDomainID = ? AND toDomainID = ?;"_s;
-constexpr auto countPrevalentResourcesQuery = "SELECT COUNT(DISTINCT registrableDomain) FROM ObservedDomains WHERE isPrevalent = 1;"_s;
-constexpr auto countPrevalentResourcesWithUserInteractionQuery = "SELECT COUNT(DISTINCT registrableDomain) FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 1;"_s;
 
 constexpr auto countPrevalentResourcesWithoutUserInteractionQuery = "SELECT COUNT(DISTINCT registrableDomain) FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 0;"_s;
 
@@ -73,7 +71,6 @@ constexpr auto countPrevalentResourcesWithoutUserInteractionQuery = "SELECT COUN
 constexpr auto insertObservedDomainQuery = "INSERT INTO ObservedDomains (registrableDomain, lastSeen, hadUserInteraction,"
     "mostRecentUserInteractionTime, grandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, timesAccessedAsFirstPartyDueToUserInteraction,"
     "timesAccessedAsFirstPartyDueToStorageAccessAPI, isScheduledForAllButCookieDataRemoval, mostRecentWebPushInteractionTime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
-constexpr auto insertTopLevelDomainQuery = "INSERT INTO TopLevelDomains VALUES (?)"_s;
 constexpr auto storageAccessUnderTopFrameDomainsQuery = "INSERT OR IGNORE INTO StorageAccessUnderTopFrameDomains (domainID, topLevelDomainID) SELECT ?, domainID FROM ObservedDomains WHERE registrableDomain in ( "_s;
 constexpr auto topFrameUniqueRedirectsToQuery = "INSERT OR IGNORE into TopFrameUniqueRedirectsTo (sourceDomainID, toDomainID) SELECT ?, domainID FROM ObservedDomains where registrableDomain in ( "_s;
 constexpr auto topFrameUniqueRedirectsToSinceSameSiteStrictEnforcementQuery = "INSERT OR IGNORE into TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement (sourceDomainID, toDomainID) SELECT ?, domainID FROM ObservedDomains where registrableDomain in ( "_s;
@@ -94,10 +91,6 @@ constexpr auto subresourceUnderTopFrameDomainExistsQuery = "SELECT EXISTS (SELEC
     "WHERE subresourceDomainID = ? AND topFrameDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
 constexpr auto subresourceUniqueRedirectsToExistsQuery = "SELECT EXISTS (SELECT 1 FROM SubresourceUniqueRedirectsTo WHERE subresourceDomainID = ? "
     "AND toDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
-constexpr auto topFrameLinkDecorationsFromExistsQuery = "SELECT EXISTS (SELECT 1 FROM TopFrameLinkDecorationsFrom WHERE toDomainID = ? "
-    "AND fromDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
-constexpr auto topFrameLoadedThirdPartyScriptsExistsQuery = "SELECT EXISTS (SELECT 1 FROM TopFrameLoadedThirdPartyScripts WHERE topFrameDomainID = ? "
-    "AND subresourceDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
 constexpr auto storageAccessExistsQuery = "SELECT EXISTS (SELECT 1 FROM StorageAccessUnderTopFrameDomains WHERE domainID = ? AND topLevelDomainID = (SELECT domainID FROM ObservedDomains WHERE registrableDomain = ?))"_s;
 
 // UPDATE Queries

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -790,6 +790,9 @@ void NetworkResourceLoader::processClearSiteDataHeader(const WebCore::ResourceRe
     };
 
     auto callbackAggregator = CallbackAggregator::create([this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+#if RELEASE_LOG_DISABLED
+        UNUSED_PARAM(this);
+#endif
         if (!weakThis)
             return completionHandler();
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebSharedWorkerServerToContextConnection.h"
 
+#include "LoadedWebArchive.h"
 #include "Logging.h"
 #include "NetworkConnectionToWebProcess.h"
 #include "NetworkProcess.h"

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -342,13 +342,12 @@
 #define WEBPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i] WebPageProxy::" fmt, this, m_identifier.toUInt64(), m_webPageID.toUInt64(), m_process->processIdentifier(), ##__VA_ARGS__)
 #define WEBPAGEPROXY_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", PID=%i] WebPageProxy::" fmt, this, m_identifier.toUInt64(), m_webPageID.toUInt64(), m_process->processIdentifier(), ##__VA_ARGS__)
 
-// Represents the number of wheel events we can hold in the queue before we start pushing them preemptively.
-static const unsigned wheelEventQueueSizeThreshold = 10;
-
 static const Seconds resetRecentCrashCountDelay = 30_s;
 static unsigned maximumWebProcessRelaunchAttempts = 1;
-static const Seconds audibleActivityClearDelay = 10_s;
 static const Seconds tryCloseTimeoutDelay = 50_ms;
+#if USE(RUNNINGBOARD)
+static const Seconds audibleActivityClearDelay = 10_s;
+#endif
 
 using namespace WebCore;
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -150,8 +150,6 @@ using namespace WebCore;
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, processPoolCounter, ("WebProcessPool"));
 
-constexpr Seconds serviceWorkerTerminationDelay { 5_s };
-
 #if ENABLE(GPU_PROCESS)
 constexpr Seconds resetGPUProcessCrashCountDelay { 30_s };
 constexpr unsigned maximumGPUProcessRelaunchAttemptsBeforeKillingWebProcesses { 2 };

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -249,9 +249,6 @@
 #define WEBPROCESS_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
 #endif
 
-// This should be less than plugInAutoStartExpirationTimeThreshold in PlugInAutoStartProvider.
-static const Seconds plugInAutoStartExpirationTimeUpdateThreshold { 29 * 24 * 60 * 60 };
-
 // This should be greater than tileRevalidationTimeout in TileController.
 static const Seconds nonVisibleProcessGraphicsCleanupDelay { 10_s };
 


### PR DESCRIPTION
#### 5e48fabd1efd472a2733d7e493d11db5e9da67a8
<pre>
Non-unified build fixes, early February 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=251469">https://bugs.webkit.org/show_bug.cgi?id=251469</a>

Reviewed by Yusuke Suzuki.

Fix compile issues. A non-unified build flags additional unused
functions and variables.

* Source/JavaScriptCore/bytecode/BytecodeBasicBlock.cpp:
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
* Source/WebCore/Modules/push-api/PushPermissionState.h:
* Source/WebCore/Modules/push-api/PushSubscription.cpp:
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp:
* Source/WebCore/Modules/streams/WritableStream.cpp:
* Source/WebCore/Modules/streams/WritableStreamSink.h:
* Source/WebCore/Modules/web-locks/WebLockIdentifier.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/bindings/js/JSServiceWorkerGlobalScopeCustom.cpp:
* Source/WebCore/css/CSSCounterStyleRule.cpp:
* Source/WebCore/css/CSSKeyframeRule.cpp:
* Source/WebCore/css/CSSSupportsRule.cpp:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/DOMCSSNamespace.cpp:
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
* Source/WebCore/css/StyleRule.cpp:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
* Source/WebCore/dom/DOMImplementation.cpp:
* Source/WebCore/dom/ElementData.cpp:
* Source/WebCore/editing/FontAttributeChanges.cpp:
* Source/WebCore/editing/FontAttributeChanges.h:
* Source/WebCore/editing/FrameSelection.cpp:
* Source/WebCore/fileapi/BlobURL.cpp:
* Source/WebCore/html/HTMLElement.cpp:
* Source/WebCore/html/HTMLFontElement.cpp:
* Source/WebCore/html/HTMLTablePartElement.cpp:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/loader/DocumentLoader.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/Frame.cpp:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
* Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
* Source/WebCore/rendering/EventRegion.cpp:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/WebProcess/WebProcess.cpp:

Canonical link: <a href="https://commits.webkit.org/259721@main">https://commits.webkit.org/259721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fd088535b42cc6bf3775b19156f4b7ff99dc4c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114921 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5984 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97960 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111449 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95299 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26939 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/95421 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28292 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93594 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5837 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30425 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47839 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102308 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6716 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10101 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25513 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->