### PR TITLE
Make sure `Clear-Site-Data: "cache"` properly clears the last back/forward cache entry

### DIFF
--- a/LayoutTests/http/wpt/clear-site-data/clear-back-forward-cache-expected.txt
+++ b/LayoutTests/http/wpt/clear-site-data/clear-back-forward-cache-expected.txt
@@ -1,0 +1,3 @@
+
+PASS `Clear-Site-Data: cache` should clear the back/forward cache
+

--- a/LayoutTests/http/wpt/clear-site-data/clear-back-forward-cache.html
+++ b/LayoutTests/http/wpt/clear-site-data/clear-back-forward-cache.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async_test(function(t) {
+    popup = open("resources/clear-back-forward-cache-popup.html");
+    popup.addEventListener("load", t.step_func(() => {
+        popup.generateSecret();
+        assert_equals(popup.getSecret(), "secret", "Secret before logging out");
+        popup.logout();
+
+        addEventListener("logged-out", t.step_func(() => {
+            addEventListener("secret-page-loaded", t.step_func(() => {
+                assert_equals(popup.getSecret(), "", "Secret after logging out");
+                t.done();
+            })); 
+            popup.history.back();
+        }));
+    }));
+}, '`Clear-Site-Data: cache` should clear the back/forward cache');
+</script>
+</html>

--- a/LayoutTests/http/wpt/clear-site-data/resources/clear-back-forward-cache-popup.html
+++ b/LayoutTests/http/wpt/clear-site-data/resources/clear-back-forward-cache-popup.html
@@ -1,0 +1,33 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<a id="logoutLink" href="logout.html">Log out</a>
+<div id="secretDiv"></div>
+<script>
+function generateSecret()
+{
+    document.getElementById("secretDiv").innerText = "secret";
+}
+
+function getSecret()
+{
+    return document.getElementById("secretDiv").innerText;
+}
+
+function logout()
+{
+    document.getElementById("logoutLink").click();
+}
+
+onload = () => {
+    opener.dispatchEvent(new Event("secret-page-loaded"));
+}
+
+onpageshow = (e) => {
+    if (e.persisted)
+        opener.dispatchEvent(new Event("secret-page-loaded"));
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/clear-site-data/resources/logout.html
+++ b/LayoutTests/http/wpt/clear-site-data/resources/logout.html
@@ -1,0 +1,8 @@
+You are now logged out.
+<script>
+onload = () => {
+    setTimeout(() => {
+        opener.dispatchEvent(new Event('logged-out'));
+    }, 0);
+}
+</script>

--- a/LayoutTests/http/wpt/clear-site-data/resources/logout.html.headers
+++ b/LayoutTests/http/wpt/clear-site-data/resources/logout.html.headers
@@ -1,0 +1,1 @@
+Clear-Site-Data: "cache"

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -58,6 +58,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLObjectElement.h"
 #include "HTTPHeaderNames.h"
+#include "HTTPParsers.h"
 #include "HistoryItem.h"
 #include "HistoryController.h"
 #include "IconLoader.h"
@@ -880,6 +881,9 @@ void DocumentLoader::responseReceived(CachedResource& resource, const ResourceRe
         m_contentSecurityPolicy = nullptr;
     if (m_frame && m_frame->document() && m_frame->document()->settings().crossOriginOpenerPolicyEnabled())
         m_responseCOOP = obtainCrossOriginOpenerPolicy(response);
+    // FIXME: Parse Clear-Site-Data header.
+    if (m_frame->settings().clearSiteDataHTTPHeaderEnabled())
+        m_responseClearSiteDataValues = parseClearSiteDataHeader(response);
 
 #if ENABLE(TRACKING_PREVENTION)
     // FIXME(218779): Remove this quirk once microsoft.com completes their login flow redesign.

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -94,6 +94,7 @@ class SubresourceLoader;
 class SubstituteResource;
 class UserContentURLPattern;
 
+enum class ClearSiteDataValue : uint8_t;
 enum class ShouldContinue;
 
 using ResourceLoaderMap = HashMap<ResourceLoaderIdentifier, RefPtr<ResourceLoader>>;
@@ -460,6 +461,7 @@ public:
 
     ContentSecurityPolicy* contentSecurityPolicy() const { return m_contentSecurityPolicy.get(); }
     const std::optional<CrossOriginOpenerPolicy>& crossOriginOpenerPolicy() const { return m_responseCOOP; }
+    OptionSet<ClearSiteDataValue> responseClearSiteDataValues() const { return m_responseClearSiteDataValues; }
 
     bool isContinuingLoadAfterProvisionalLoadStarted() const { return m_isContinuingLoadAfterProvisionalLoadStarted; }
     void setIsContinuingLoadAfterProvisionalLoadStarted(bool isContinuingLoadAfterProvisionalLoadStarted) { m_isContinuingLoadAfterProvisionalLoadStarted = isContinuingLoadAfterProvisionalLoadStarted; }
@@ -633,6 +635,7 @@ private:
     bool m_stopRecordingResponses { false };
 
     std::optional<CrossOriginOpenerPolicy> m_responseCOOP;
+    OptionSet<ClearSiteDataValue> m_responseClearSiteDataValues;
     
     typedef HashMap<RefPtr<ResourceLoader>, RefPtr<SubstituteResource>> SubstituteResourceMap;
     SubstituteResourceMap m_pendingSubstituteResources;

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 typedef HashSet<String, ASCIICaseInsensitiveHash> HTTPHeaderSet;
 
+class ResourceResponse;
 enum class HTTPHeaderName;
 
 enum class XSSProtectionDisposition {
@@ -69,6 +70,12 @@ enum class CrossOriginResourcePolicy : uint8_t {
     Invalid
 };
 
+enum class ClearSiteDataValue : uint8_t {
+    Cache = 1 << 0,
+    Cookies = 1 << 1,
+    Storage = 1 << 2,
+};
+
 bool isValidReasonPhrase(const String&);
 bool isValidHTTPHeaderValue(const String&);
 bool isValidAcceptHeaderValue(const String&);
@@ -85,6 +92,7 @@ WEBCORE_EXPORT StringView extractCharsetFromMediaType(StringView);
 XSSProtectionDisposition parseXSSProtectionHeader(const String& header, String& failureReason, unsigned& failurePosition, String& reportURL);
 AtomString extractReasonPhraseFromHTTPStatusLine(const String&);
 WEBCORE_EXPORT XFrameOptionsDisposition parseXFrameOptionsHeader(StringView);
+WEBCORE_EXPORT OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse&);
 
 // -1 could be set to one of the return parameters to indicate the value is not specified.
 WEBCORE_EXPORT bool parseRange(StringView, long long& rangeOffset, long long& rangeEnd, long long& rangeSuffixLength);


### PR DESCRIPTION
#### 66a67bafdb3335c5c4f2849a0fdaff0a9c69374f
<pre>
Make sure `Clear-Site-Data: &quot;cache&quot;` properly clears the last back/forward cache entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=251470">https://bugs.webkit.org/show_bug.cgi?id=251470</a>

Reviewed by Geoffrey Garen.

Make sure `Clear-Site-Data: &quot;cache&quot;` properly clears the last back/forward
cache entry.

In the case, where page &quot;LoggedIn&quot; is navigating to page &quot;LoggedOut&quot;
(same-origin) and the &quot;LoggedOut&quot; page serves the `Clear-Site-Data: &quot;cache&quot;`
HTTP header, we expect no back/forward cache entry for &quot;LoggedIn&quot; to be
present.

The `Clear-Site-Data` header gets handled in the NetworkProcess when the
network response is received. At this point, we do indeed ask to clear existing
back/forward cache entries for the origin. However, we only create the
back/forward cache entry for the current page when committing the load, which
occurs later on. This means we would clear the back/forward entries for the
origin but then still create one for &quot;LoggedIn&quot;.

To address the issue, the back/forward cache logic in WebCore now also checks
the `Clear-Site-Data` HTTP header on the response and disables back/forward
caching if we&apos;re navigating to a same-origin resource that serves
`Clear-Site-Data: &quot;cache&quot;`.

Note that the navigation gesture snapshot still gets generated for such
navigation. I will address this in a follow-up.

* LayoutTests/http/wpt/clear-site-data/clear-back-forward-cache-expected.txt: Added.
* LayoutTests/http/wpt/clear-site-data/clear-back-forward-cache.html: Added.
* LayoutTests/http/wpt/clear-site-data/resources/clear-back-forward-cache-popup.html: Added.
* LayoutTests/http/wpt/clear-site-data/resources/logout.html: Added.
* LayoutTests/http/wpt/clear-site-data/resources/logout.html.headers: Added.
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCachePage):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::responseClearSiteDataValues const):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseClearSiteDataHeader):
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::processClearSiteDataHeader):

Canonical link: <a href="https://commits.webkit.org/259777@main">https://commits.webkit.org/259777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed8065dfe423c5a42ad7480591f697f22ade1b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115057 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6126 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98092 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111608 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39993 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27058 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8198 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28411 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/5001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6765 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10236 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->