### PR TITLE
[build] Refactor JSDOMWrapper.h to not include JSDOMGlobalObject.h

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWrapper.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMWindow.h"
 #include "DOMWrapperWorld.h"
+#include "JSDOMGlobalObject.h"
 #include "JSDOMWindow.h"
 #include "JSRemoteDOMWindow.h"
 #include "SerializedScriptValue.h"
@@ -42,6 +43,16 @@ JSDOMObject::JSDOMObject(JSC::Structure* structure, JSC::JSGlobalObject& globalO
     : Base(globalObject.vm(), structure)
 {
     ASSERT(scriptExecutionContext() || globalObject.classInfo() == JSRemoteDOMWindow::info());
+}
+
+JSDOMGlobalObject* JSDOMObject::globalObject() const
+{
+    return JSC::jsCast<JSDOMGlobalObject*>(JSC::JSNonFinalObject::globalObject());
+}
+
+ScriptExecutionContext* JSDOMObject::scriptExecutionContext() const
+{
+    return globalObject()->scriptExecutionContext();
 }
 
 JSC::JSValue cloneAcrossWorlds(JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSC::JSValue value)

--- a/Source/WebCore/bindings/js/JSDOMWrapper.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.h
@@ -21,13 +21,14 @@
 
 #pragma once
 
-#include "JSDOMGlobalObject.h"
 #include "NodeConstants.h"
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <wtf/SignedPtr.h>
 
 namespace WebCore {
 
+class DOMWrapperWorld;
+class JSDOMGlobalObject;
 class ScriptExecutionContext;
 
 // JSC allows us to extend JSType. If the highest 3 bits are set, we can add any Object types and they are
@@ -62,8 +63,8 @@ public:
     template<typename, JSC::SubspaceAccess>
     static void subspaceFor(JSC::VM&) { RELEASE_ASSERT_NOT_REACHED(); }
 
-    JSDOMGlobalObject* globalObject() const { return JSC::jsCast<JSDOMGlobalObject*>(JSC::JSNonFinalObject::globalObject()); }
-    ScriptExecutionContext* scriptExecutionContext() const { return globalObject()->scriptExecutionContext(); }
+    WEBCORE_EXPORT JSDOMGlobalObject* globalObject() const;
+    WEBCORE_EXPORT ScriptExecutionContext* scriptExecutionContext() const;
 
 protected:
     WEBCORE_EXPORT JSDOMObject(JSC::Structure*, JSC::JSGlobalObject&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp
@@ -193,6 +193,13 @@ JSDOMWindow::JSDOMWindow(VM& vm, Structure* structure, Ref<DOMWindow>&& impl, JS
 {
 }
 
+JSDOMWindow* JSDOMWindow::create(JSC::VM& vm, JSC::Structure* structure, Ref<DOMWindow>&& impl, JSWindowProxy* proxy)
+{
+    JSDOMWindow* ptr = new (NotNull, JSC::allocateCell<JSDOMWindow>(vm)) JSDOMWindow(vm, structure, WTFMove(impl), proxy);
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSDOMWindow::finishCreation(VM& vm, JSWindowProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
@@ -33,13 +33,7 @@ class JSDOMWindow : public JSEventTarget {
 public:
     using Base = JSEventTarget;
     using DOMWrapped = DOMWindow;
-    static JSDOMWindow* create(JSC::VM& vm, JSC::Structure* structure, Ref<DOMWindow>&& impl, JSWindowProxy* proxy)
-    {
-        JSDOMWindow* ptr = new (NotNull, JSC::allocateCell<JSDOMWindow>(vm)) JSDOMWindow(vm, structure, WTFMove(impl), proxy);
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSDOMWindow* create(JSC::VM& vm, JSC::Structure* structure, Ref<DOMWindow>&& impl, JSWindowProxy* proxy);
     static DOMWindow* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;

--- a/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp
@@ -120,6 +120,13 @@ JSDedicatedWorkerGlobalScope::JSDedicatedWorkerGlobalScope(VM& vm, Structure* st
 {
 }
 
+JSDedicatedWorkerGlobalScope* JSDedicatedWorkerGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<DedicatedWorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSDedicatedWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSDedicatedWorkerGlobalScope>(vm)) JSDedicatedWorkerGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSDedicatedWorkerGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h
@@ -31,13 +31,7 @@ class JSDedicatedWorkerGlobalScope : public JSWorkerGlobalScope {
 public:
     using Base = JSWorkerGlobalScope;
     using DOMWrapped = DedicatedWorkerGlobalScope;
-    static JSDedicatedWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<DedicatedWorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSDedicatedWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSDedicatedWorkerGlobalScope>(vm)) JSDedicatedWorkerGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSDedicatedWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<DedicatedWorkerGlobalScope>&& impl, JSC::JSProxy* proxy);
 
     DECLARE_INFO;
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
@@ -152,6 +152,13 @@ JSExposedStar::JSExposedStar(Structure* structure, JSDOMGlobalObject& globalObje
 {
 }
 
+JSExposedStar* JSExposedStar::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<ExposedStar>&& impl)
+{
+    JSExposedStar* ptr = new (NotNull, JSC::allocateCell<JSExposedStar>(globalObject->vm())) JSExposedStar(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSExposedStar::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
@@ -30,13 +30,7 @@ class JSExposedStar : public JSEventTarget {
 public:
     using Base = JSEventTarget;
     using DOMWrapped = ExposedStar;
-    static JSExposedStar* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<ExposedStar>&& impl)
-    {
-        JSExposedStar* ptr = new (NotNull, JSC::allocateCell<JSExposedStar>(globalObject->vm())) JSExposedStar(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSExposedStar* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<ExposedStar>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static ExposedStar* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
@@ -192,6 +192,13 @@ JSExposedToWorkerAndWindow::JSExposedToWorkerAndWindow(Structure* structure, JSD
 {
 }
 
+JSExposedToWorkerAndWindow* JSExposedToWorkerAndWindow::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<ExposedToWorkerAndWindow>&& impl)
+{
+    JSExposedToWorkerAndWindow* ptr = new (NotNull, JSC::allocateCell<JSExposedToWorkerAndWindow>(globalObject->vm())) JSExposedToWorkerAndWindow(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSExposedToWorkerAndWindow::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h
@@ -30,13 +30,7 @@ namespace WebCore {
 class JSExposedToWorkerAndWindow : public JSDOMWrapper<ExposedToWorkerAndWindow> {
 public:
     using Base = JSDOMWrapper<ExposedToWorkerAndWindow>;
-    static JSExposedToWorkerAndWindow* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<ExposedToWorkerAndWindow>&& impl)
-    {
-        JSExposedToWorkerAndWindow* ptr = new (NotNull, JSC::allocateCell<JSExposedToWorkerAndWindow>(globalObject->vm())) JSExposedToWorkerAndWindow(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSExposedToWorkerAndWindow* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<ExposedToWorkerAndWindow>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static ExposedToWorkerAndWindow* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp
@@ -119,6 +119,13 @@ JSPaintWorkletGlobalScope::JSPaintWorkletGlobalScope(VM& vm, Structure* structur
 {
 }
 
+JSPaintWorkletGlobalScope* JSPaintWorkletGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<PaintWorkletGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSPaintWorkletGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSPaintWorkletGlobalScope>(vm)) JSPaintWorkletGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSPaintWorkletGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h
@@ -31,13 +31,7 @@ class JSPaintWorkletGlobalScope : public JSWorkletGlobalScope {
 public:
     using Base = JSWorkletGlobalScope;
     using DOMWrapped = PaintWorkletGlobalScope;
-    static JSPaintWorkletGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<PaintWorkletGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSPaintWorkletGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSPaintWorkletGlobalScope>(vm)) JSPaintWorkletGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSPaintWorkletGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<PaintWorkletGlobalScope>&& impl, JSC::JSProxy* proxy);
 
     DECLARE_INFO;
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp
@@ -119,6 +119,13 @@ JSServiceWorkerGlobalScope::JSServiceWorkerGlobalScope(VM& vm, Structure* struct
 {
 }
 
+JSServiceWorkerGlobalScope* JSServiceWorkerGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<ServiceWorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSServiceWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSServiceWorkerGlobalScope>(vm)) JSServiceWorkerGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSServiceWorkerGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h
@@ -31,13 +31,7 @@ class JSServiceWorkerGlobalScope : public JSWorkerGlobalScope {
 public:
     using Base = JSWorkerGlobalScope;
     using DOMWrapped = ServiceWorkerGlobalScope;
-    static JSServiceWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<ServiceWorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSServiceWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSServiceWorkerGlobalScope>(vm)) JSServiceWorkerGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSServiceWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<ServiceWorkerGlobalScope>&& impl, JSC::JSProxy* proxy);
 
     DECLARE_INFO;
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp
@@ -95,6 +95,13 @@ JSShadowRealmGlobalScope::JSShadowRealmGlobalScope(VM& vm, Structure* structure,
 {
 }
 
+JSShadowRealmGlobalScope* JSShadowRealmGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<ShadowRealmGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSShadowRealmGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSShadowRealmGlobalScope>(vm)) JSShadowRealmGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSShadowRealmGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.h
@@ -30,13 +30,7 @@ class ShadowRealmGlobalScope;
 class JSShadowRealmGlobalScope : public JSDOMWrapper<ShadowRealmGlobalScope> {
 public:
     using Base = JSDOMWrapper<ShadowRealmGlobalScope>;
-    static JSShadowRealmGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<ShadowRealmGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSShadowRealmGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSShadowRealmGlobalScope>(vm)) JSShadowRealmGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSShadowRealmGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<ShadowRealmGlobalScope>&& impl, JSC::JSProxy* proxy);
     static ShadowRealmGlobalScope* toWrapped(JSC::VM&, JSC::JSValue);
     static void destroy(JSC::JSCell*);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp
@@ -120,6 +120,13 @@ JSSharedWorkerGlobalScope::JSSharedWorkerGlobalScope(VM& vm, Structure* structur
 {
 }
 
+JSSharedWorkerGlobalScope* JSSharedWorkerGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<SharedWorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSSharedWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSSharedWorkerGlobalScope>(vm)) JSSharedWorkerGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSSharedWorkerGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h
@@ -31,13 +31,7 @@ class JSSharedWorkerGlobalScope : public JSWorkerGlobalScope {
 public:
     using Base = JSWorkerGlobalScope;
     using DOMWrapped = SharedWorkerGlobalScope;
-    static JSSharedWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<SharedWorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSSharedWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSSharedWorkerGlobalScope>(vm)) JSSharedWorkerGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSSharedWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<SharedWorkerGlobalScope>&& impl, JSC::JSProxy* proxy);
 
     DECLARE_INFO;
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
@@ -138,6 +138,13 @@ JSTestAsyncIterable::JSTestAsyncIterable(Structure* structure, JSDOMGlobalObject
 {
 }
 
+JSTestAsyncIterable* JSTestAsyncIterable::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestAsyncIterable>&& impl)
+{
+    JSTestAsyncIterable* ptr = new (NotNull, JSC::allocateCell<JSTestAsyncIterable>(globalObject->vm())) JSTestAsyncIterable(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestAsyncIterable::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestAsyncIterable : public JSDOMWrapper<TestAsyncIterable> {
 public:
     using Base = JSDOMWrapper<TestAsyncIterable>;
-    static JSTestAsyncIterable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestAsyncIterable>&& impl)
-    {
-        JSTestAsyncIterable* ptr = new (NotNull, JSC::allocateCell<JSTestAsyncIterable>(globalObject->vm())) JSTestAsyncIterable(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestAsyncIterable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestAsyncIterable>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestAsyncIterable* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
@@ -139,6 +139,13 @@ JSTestAsyncKeyValueIterable::JSTestAsyncKeyValueIterable(Structure* structure, J
 {
 }
 
+JSTestAsyncKeyValueIterable* JSTestAsyncKeyValueIterable::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestAsyncKeyValueIterable>&& impl)
+{
+    JSTestAsyncKeyValueIterable* ptr = new (NotNull, JSC::allocateCell<JSTestAsyncKeyValueIterable>(globalObject->vm())) JSTestAsyncKeyValueIterable(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestAsyncKeyValueIterable::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestAsyncKeyValueIterable : public JSDOMWrapper<TestAsyncKeyValueIterable> {
 public:
     using Base = JSDOMWrapper<TestAsyncKeyValueIterable>;
-    static JSTestAsyncKeyValueIterable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestAsyncKeyValueIterable>&& impl)
-    {
-        JSTestAsyncKeyValueIterable* ptr = new (NotNull, JSC::allocateCell<JSTestAsyncKeyValueIterable>(globalObject->vm())) JSTestAsyncKeyValueIterable(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestAsyncKeyValueIterable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestAsyncKeyValueIterable>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestAsyncKeyValueIterable* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
@@ -159,6 +159,13 @@ JSTestCEReactions::JSTestCEReactions(Structure* structure, JSDOMGlobalObject& gl
 {
 }
 
+JSTestCEReactions* JSTestCEReactions::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCEReactions>&& impl)
+{
+    JSTestCEReactions* ptr = new (NotNull, JSC::allocateCell<JSTestCEReactions>(globalObject->vm())) JSTestCEReactions(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestCEReactions::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestCEReactions : public JSDOMWrapper<TestCEReactions> {
 public:
     using Base = JSDOMWrapper<TestCEReactions>;
-    static JSTestCEReactions* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCEReactions>&& impl)
-    {
-        JSTestCEReactions* ptr = new (NotNull, JSC::allocateCell<JSTestCEReactions>(globalObject->vm())) JSTestCEReactions(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestCEReactions* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCEReactions>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestCEReactions* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
@@ -138,6 +138,13 @@ JSTestCEReactionsStringifier::JSTestCEReactionsStringifier(Structure* structure,
 {
 }
 
+JSTestCEReactionsStringifier* JSTestCEReactionsStringifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCEReactionsStringifier>&& impl)
+{
+    JSTestCEReactionsStringifier* ptr = new (NotNull, JSC::allocateCell<JSTestCEReactionsStringifier>(globalObject->vm())) JSTestCEReactionsStringifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestCEReactionsStringifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestCEReactionsStringifier : public JSDOMWrapper<TestCEReactionsStringifier> {
 public:
     using Base = JSDOMWrapper<TestCEReactionsStringifier>;
-    static JSTestCEReactionsStringifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCEReactionsStringifier>&& impl)
-    {
-        JSTestCEReactionsStringifier* ptr = new (NotNull, JSC::allocateCell<JSTestCEReactionsStringifier>(globalObject->vm())) JSTestCEReactionsStringifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestCEReactionsStringifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCEReactionsStringifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestCEReactionsStringifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
@@ -180,6 +180,13 @@ JSTestCallTracer::JSTestCallTracer(Structure* structure, JSDOMGlobalObject& glob
 {
 }
 
+JSTestCallTracer* JSTestCallTracer::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCallTracer>&& impl)
+{
+    JSTestCallTracer* ptr = new (NotNull, JSC::allocateCell<JSTestCallTracer>(globalObject->vm())) JSTestCallTracer(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestCallTracer::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestCallTracer : public JSDOMWrapper<TestCallTracer> {
 public:
     using Base = JSDOMWrapper<TestCallTracer>;
-    static JSTestCallTracer* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCallTracer>&& impl)
-    {
-        JSTestCallTracer* ptr = new (NotNull, JSC::allocateCell<JSTestCallTracer>(globalObject->vm())) JSTestCallTracer(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestCallTracer* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestCallTracer>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestCallTracer* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
@@ -129,6 +129,13 @@ JSTestClassWithJSBuiltinConstructor::JSTestClassWithJSBuiltinConstructor(Structu
 {
 }
 
+JSTestClassWithJSBuiltinConstructor* JSTestClassWithJSBuiltinConstructor::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestClassWithJSBuiltinConstructor>&& impl)
+{
+    JSTestClassWithJSBuiltinConstructor* ptr = new (NotNull, JSC::allocateCell<JSTestClassWithJSBuiltinConstructor>(globalObject->vm())) JSTestClassWithJSBuiltinConstructor(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestClassWithJSBuiltinConstructor::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestClassWithJSBuiltinConstructor : public JSDOMWrapper<TestClassWithJSBuiltinConstructor> {
 public:
     using Base = JSDOMWrapper<TestClassWithJSBuiltinConstructor>;
-    static JSTestClassWithJSBuiltinConstructor* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestClassWithJSBuiltinConstructor>&& impl)
-    {
-        JSTestClassWithJSBuiltinConstructor* ptr = new (NotNull, JSC::allocateCell<JSTestClassWithJSBuiltinConstructor>(globalObject->vm())) JSTestClassWithJSBuiltinConstructor(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestClassWithJSBuiltinConstructor* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestClassWithJSBuiltinConstructor>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestClassWithJSBuiltinConstructor* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
@@ -457,6 +457,13 @@ JSTestConditionalIncludes::JSTestConditionalIncludes(Structure* structure, JSDOM
 {
 }
 
+JSTestConditionalIncludes* JSTestConditionalIncludes::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestConditionalIncludes>&& impl)
+{
+    JSTestConditionalIncludes* ptr = new (NotNull, JSC::allocateCell<JSTestConditionalIncludes>(globalObject->vm())) JSTestConditionalIncludes(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestConditionalIncludes::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestConditionalIncludes : public JSDOMWrapper<TestConditionalIncludes> {
 public:
     using Base = JSDOMWrapper<TestConditionalIncludes>;
-    static JSTestConditionalIncludes* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestConditionalIncludes>&& impl)
-    {
-        JSTestConditionalIncludes* ptr = new (NotNull, JSC::allocateCell<JSTestConditionalIncludes>(globalObject->vm())) JSTestConditionalIncludes(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestConditionalIncludes* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestConditionalIncludes>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestConditionalIncludes* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
@@ -204,6 +204,13 @@ JSTestConditionallyReadWrite::JSTestConditionallyReadWrite(Structure* structure,
 {
 }
 
+JSTestConditionallyReadWrite* JSTestConditionallyReadWrite::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestConditionallyReadWrite>&& impl)
+{
+    JSTestConditionallyReadWrite* ptr = new (NotNull, JSC::allocateCell<JSTestConditionallyReadWrite>(globalObject->vm())) JSTestConditionallyReadWrite(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestConditionallyReadWrite::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestConditionallyReadWrite : public JSDOMWrapper<TestConditionallyReadWrite> {
 public:
     using Base = JSDOMWrapper<TestConditionallyReadWrite>;
-    static JSTestConditionallyReadWrite* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestConditionallyReadWrite>&& impl)
-    {
-        JSTestConditionallyReadWrite* ptr = new (NotNull, JSC::allocateCell<JSTestConditionallyReadWrite>(globalObject->vm())) JSTestConditionallyReadWrite(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestConditionallyReadWrite* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestConditionallyReadWrite>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestConditionallyReadWrite* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
@@ -580,6 +580,13 @@ JSTestDOMJIT::JSTestDOMJIT(Structure* structure, JSDOMGlobalObject& globalObject
 {
 }
 
+JSTestDOMJIT* JSTestDOMJIT::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDOMJIT>&& impl)
+{
+    JSTestDOMJIT* ptr = new (NotNull, JSC::allocateCell<JSTestDOMJIT>(globalObject->vm())) JSTestDOMJIT(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDOMJIT::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h
@@ -31,13 +31,7 @@ class JSTestDOMJIT : public JSNode {
 public:
     using Base = JSNode;
     using DOMWrapped = TestDOMJIT;
-    static JSTestDOMJIT* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDOMJIT>&& impl)
-    {
-        JSTestDOMJIT* ptr = new (NotNull, JSC::allocateCell<JSTestDOMJIT>(globalObject->vm())) JSTestDOMJIT(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDOMJIT* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDOMJIT>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
@@ -223,6 +223,13 @@ JSTestDefaultToJSON::JSTestDefaultToJSON(Structure* structure, JSDOMGlobalObject
 {
 }
 
+JSTestDefaultToJSON* JSTestDefaultToJSON::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSON>&& impl)
+{
+    JSTestDefaultToJSON* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSON>(globalObject->vm())) JSTestDefaultToJSON(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDefaultToJSON::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestDefaultToJSON : public JSDOMWrapper<TestDefaultToJSON> {
 public:
     using Base = JSDOMWrapper<TestDefaultToJSON>;
-    static JSTestDefaultToJSON* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSON>&& impl)
-    {
-        JSTestDefaultToJSON* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSON>(globalObject->vm())) JSTestDefaultToJSON(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDefaultToJSON* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSON>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestDefaultToJSON* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
@@ -158,6 +158,13 @@ JSTestDefaultToJSONFilteredByExposed::JSTestDefaultToJSONFilteredByExposed(Struc
 {
 }
 
+JSTestDefaultToJSONFilteredByExposed* JSTestDefaultToJSONFilteredByExposed::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONFilteredByExposed>&& impl)
+{
+    JSTestDefaultToJSONFilteredByExposed* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONFilteredByExposed>(globalObject->vm())) JSTestDefaultToJSONFilteredByExposed(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDefaultToJSONFilteredByExposed::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestDefaultToJSONFilteredByExposed : public JSDOMWrapper<TestDefaultToJSONFilteredByExposed> {
 public:
     using Base = JSDOMWrapper<TestDefaultToJSONFilteredByExposed>;
-    static JSTestDefaultToJSONFilteredByExposed* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONFilteredByExposed>&& impl)
-    {
-        JSTestDefaultToJSONFilteredByExposed* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONFilteredByExposed>(globalObject->vm())) JSTestDefaultToJSONFilteredByExposed(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDefaultToJSONFilteredByExposed* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONFilteredByExposed>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestDefaultToJSONFilteredByExposed* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp
@@ -121,6 +121,13 @@ JSTestDefaultToJSONIndirectInheritance::JSTestDefaultToJSONIndirectInheritance(S
 {
 }
 
+JSTestDefaultToJSONIndirectInheritance* JSTestDefaultToJSONIndirectInheritance::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONIndirectInheritance>&& impl)
+{
+    JSTestDefaultToJSONIndirectInheritance* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONIndirectInheritance>(globalObject->vm())) JSTestDefaultToJSONIndirectInheritance(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDefaultToJSONIndirectInheritance::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h
@@ -30,13 +30,7 @@ class JSTestDefaultToJSONIndirectInheritance : public JSTestDefaultToJSONInherit
 public:
     using Base = JSTestDefaultToJSONInherit;
     using DOMWrapped = TestDefaultToJSONIndirectInheritance;
-    static JSTestDefaultToJSONIndirectInheritance* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONIndirectInheritance>&& impl)
-    {
-        JSTestDefaultToJSONIndirectInheritance* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONIndirectInheritance>(globalObject->vm())) JSTestDefaultToJSONIndirectInheritance(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDefaultToJSONIndirectInheritance* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONIndirectInheritance>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
@@ -150,6 +150,13 @@ JSTestDefaultToJSONInherit::JSTestDefaultToJSONInherit(Structure* structure, JSD
 {
 }
 
+JSTestDefaultToJSONInherit* JSTestDefaultToJSONInherit::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONInherit>&& impl)
+{
+    JSTestDefaultToJSONInherit* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONInherit>(globalObject->vm())) JSTestDefaultToJSONInherit(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDefaultToJSONInherit::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h
@@ -30,13 +30,7 @@ class JSTestDefaultToJSONInherit : public JSTestDefaultToJSON {
 public:
     using Base = JSTestDefaultToJSON;
     using DOMWrapped = TestDefaultToJSONInherit;
-    static JSTestDefaultToJSONInherit* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONInherit>&& impl)
-    {
-        JSTestDefaultToJSONInherit* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONInherit>(globalObject->vm())) JSTestDefaultToJSONInherit(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDefaultToJSONInherit* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONInherit>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp
@@ -153,6 +153,13 @@ JSTestDefaultToJSONInheritFinal::JSTestDefaultToJSONInheritFinal(Structure* stru
 {
 }
 
+JSTestDefaultToJSONInheritFinal* JSTestDefaultToJSONInheritFinal::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONInheritFinal>&& impl)
+{
+    JSTestDefaultToJSONInheritFinal* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONInheritFinal>(globalObject->vm())) JSTestDefaultToJSONInheritFinal(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDefaultToJSONInheritFinal::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h
@@ -30,13 +30,7 @@ class JSTestDefaultToJSONInheritFinal : public JSTestDefaultToJSONInherit {
 public:
     using Base = JSTestDefaultToJSONInherit;
     using DOMWrapped = TestDefaultToJSONInheritFinal;
-    static JSTestDefaultToJSONInheritFinal* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONInheritFinal>&& impl)
-    {
-        JSTestDefaultToJSONInheritFinal* ptr = new (NotNull, JSC::allocateCell<JSTestDefaultToJSONInheritFinal>(globalObject->vm())) JSTestDefaultToJSONInheritFinal(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDefaultToJSONInheritFinal* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDefaultToJSONInheritFinal>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
@@ -135,6 +135,13 @@ JSTestDelegateToSharedSyntheticAttribute::JSTestDelegateToSharedSyntheticAttribu
 {
 }
 
+JSTestDelegateToSharedSyntheticAttribute* JSTestDelegateToSharedSyntheticAttribute::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDelegateToSharedSyntheticAttribute>&& impl)
+{
+    JSTestDelegateToSharedSyntheticAttribute* ptr = new (NotNull, JSC::allocateCell<JSTestDelegateToSharedSyntheticAttribute>(globalObject->vm())) JSTestDelegateToSharedSyntheticAttribute(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDelegateToSharedSyntheticAttribute::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestDelegateToSharedSyntheticAttribute : public JSDOMWrapper<TestDelegateToSharedSyntheticAttribute> {
 public:
     using Base = JSDOMWrapper<TestDelegateToSharedSyntheticAttribute>;
-    static JSTestDelegateToSharedSyntheticAttribute* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDelegateToSharedSyntheticAttribute>&& impl)
-    {
-        JSTestDelegateToSharedSyntheticAttribute* ptr = new (NotNull, JSC::allocateCell<JSTestDelegateToSharedSyntheticAttribute>(globalObject->vm())) JSTestDelegateToSharedSyntheticAttribute(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDelegateToSharedSyntheticAttribute* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDelegateToSharedSyntheticAttribute>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestDelegateToSharedSyntheticAttribute* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
@@ -157,6 +157,13 @@ JSTestDomainSecurity::JSTestDomainSecurity(Structure* structure, JSDOMGlobalObje
 {
 }
 
+JSTestDomainSecurity* JSTestDomainSecurity::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDomainSecurity>&& impl)
+{
+    JSTestDomainSecurity* ptr = new (NotNull, JSC::allocateCell<JSTestDomainSecurity>(globalObject->vm())) JSTestDomainSecurity(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestDomainSecurity::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestDomainSecurity : public JSDOMWrapper<TestDomainSecurity> {
 public:
     using Base = JSDOMWrapper<TestDomainSecurity>;
-    static JSTestDomainSecurity* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDomainSecurity>&& impl)
-    {
-        JSTestDomainSecurity* ptr = new (NotNull, JSC::allocateCell<JSTestDomainSecurity>(globalObject->vm())) JSTestDomainSecurity(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestDomainSecurity* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestDomainSecurity>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestDomainSecurity* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
@@ -243,6 +243,13 @@ JSTestEnabledBySetting::JSTestEnabledBySetting(Structure* structure, JSDOMGlobal
 {
 }
 
+JSTestEnabledBySetting* JSTestEnabledBySetting::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEnabledBySetting>&& impl)
+{
+    JSTestEnabledBySetting* ptr = new (NotNull, JSC::allocateCell<JSTestEnabledBySetting>(globalObject->vm())) JSTestEnabledBySetting(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestEnabledBySetting::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestEnabledBySetting : public JSDOMWrapper<TestEnabledBySetting> {
 public:
     using Base = JSDOMWrapper<TestEnabledBySetting>;
-    static JSTestEnabledBySetting* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEnabledBySetting>&& impl)
-    {
-        JSTestEnabledBySetting* ptr = new (NotNull, JSC::allocateCell<JSTestEnabledBySetting>(globalObject->vm())) JSTestEnabledBySetting(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestEnabledBySetting* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEnabledBySetting>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestEnabledBySetting* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
@@ -126,6 +126,13 @@ JSTestEnabledForContext::JSTestEnabledForContext(Structure* structure, JSDOMGlob
 {
 }
 
+JSTestEnabledForContext* JSTestEnabledForContext::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEnabledForContext>&& impl)
+{
+    JSTestEnabledForContext* ptr = new (NotNull, JSC::allocateCell<JSTestEnabledForContext>(globalObject->vm())) JSTestEnabledForContext(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestEnabledForContext::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestEnabledForContext : public JSDOMWrapper<TestEnabledForContext> {
 public:
     using Base = JSDOMWrapper<TestEnabledForContext>;
-    static JSTestEnabledForContext* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEnabledForContext>&& impl)
-    {
-        JSTestEnabledForContext* ptr = new (NotNull, JSC::allocateCell<JSTestEnabledForContext>(globalObject->vm())) JSTestEnabledForContext(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestEnabledForContext* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEnabledForContext>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestEnabledForContext* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -240,6 +240,13 @@ JSTestEventConstructor::JSTestEventConstructor(Structure* structure, JSDOMGlobal
 {
 }
 
+JSTestEventConstructor* JSTestEventConstructor::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEventConstructor>&& impl)
+{
+    JSTestEventConstructor* ptr = new (NotNull, JSC::allocateCell<JSTestEventConstructor>(globalObject->vm())) JSTestEventConstructor(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestEventConstructor::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h
@@ -31,13 +31,7 @@ class JSTestEventConstructor : public JSEvent {
 public:
     using Base = JSEvent;
     using DOMWrapped = TestEventConstructor;
-    static JSTestEventConstructor* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEventConstructor>&& impl)
-    {
-        JSTestEventConstructor* ptr = new (NotNull, JSC::allocateCell<JSTestEventConstructor>(globalObject->vm())) JSTestEventConstructor(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestEventConstructor* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEventConstructor>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
@@ -133,6 +133,14 @@ JSTestEventTarget::JSTestEventTarget(Structure* structure, JSDOMGlobalObject& gl
 {
 }
 
+JSTestEventTarget* JSTestEventTarget::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEventTarget>&& impl)
+{
+    globalObject->masqueradesAsUndefinedWatchpointSet().fireAll(globalObject->vm(), "Allocated masquerading object");
+    JSTestEventTarget* ptr = new (NotNull, JSC::allocateCell<JSTestEventTarget>(globalObject->vm())) JSTestEventTarget(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestEventTarget::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
@@ -30,14 +30,7 @@ class JSTestEventTarget : public JSEventTarget {
 public:
     using Base = JSEventTarget;
     using DOMWrapped = TestEventTarget;
-    static JSTestEventTarget* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEventTarget>&& impl)
-    {
-        globalObject->masqueradesAsUndefinedWatchpointSet().fireAll(globalObject->vm(), "Allocated masquerading object");
-        JSTestEventTarget* ptr = new (NotNull, JSC::allocateCell<JSTestEventTarget>(globalObject->vm())) JSTestEventTarget(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestEventTarget* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestEventTarget>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestEventTarget* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
@@ -127,6 +127,13 @@ JSTestException::JSTestException(Structure* structure, JSDOMGlobalObject& global
 {
 }
 
+JSTestException* JSTestException::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestException>&& impl)
+{
+    JSTestException* ptr = new (NotNull, JSC::allocateCell<JSTestException>(globalObject->vm())) JSTestException(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestException::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.h
@@ -30,13 +30,7 @@ namespace WebCore {
 class JSTestException : public JSDOMWrapper<TestException> {
 public:
     using Base = JSDOMWrapper<TestException>;
-    static JSTestException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestException>&& impl)
-    {
-        JSTestException* ptr = new (NotNull, JSC::allocateCell<JSTestException>(globalObject->vm())) JSTestException(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestException>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestException* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
@@ -128,6 +128,13 @@ JSTestGenerateAddOpaqueRoot::JSTestGenerateAddOpaqueRoot(Structure* structure, J
 {
 }
 
+JSTestGenerateAddOpaqueRoot* JSTestGenerateAddOpaqueRoot::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGenerateAddOpaqueRoot>&& impl)
+{
+    JSTestGenerateAddOpaqueRoot* ptr = new (NotNull, JSC::allocateCell<JSTestGenerateAddOpaqueRoot>(globalObject->vm())) JSTestGenerateAddOpaqueRoot(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestGenerateAddOpaqueRoot::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestGenerateAddOpaqueRoot : public JSDOMWrapper<TestGenerateAddOpaqueRoot> {
 public:
     using Base = JSDOMWrapper<TestGenerateAddOpaqueRoot>;
-    static JSTestGenerateAddOpaqueRoot* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGenerateAddOpaqueRoot>&& impl)
-    {
-        JSTestGenerateAddOpaqueRoot* ptr = new (NotNull, JSC::allocateCell<JSTestGenerateAddOpaqueRoot>(globalObject->vm())) JSTestGenerateAddOpaqueRoot(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestGenerateAddOpaqueRoot* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGenerateAddOpaqueRoot>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestGenerateAddOpaqueRoot* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
@@ -138,6 +138,13 @@ JSTestGenerateIsReachable::JSTestGenerateIsReachable(Structure* structure, JSDOM
 {
 }
 
+JSTestGenerateIsReachable* JSTestGenerateIsReachable::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGenerateIsReachable>&& impl)
+{
+    JSTestGenerateIsReachable* ptr = new (NotNull, JSC::allocateCell<JSTestGenerateIsReachable>(globalObject->vm())) JSTestGenerateIsReachable(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestGenerateIsReachable::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestGenerateIsReachable : public JSDOMWrapper<TestGenerateIsReachable> {
 public:
     using Base = JSDOMWrapper<TestGenerateIsReachable>;
-    static JSTestGenerateIsReachable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGenerateIsReachable>&& impl)
-    {
-        JSTestGenerateIsReachable* ptr = new (NotNull, JSC::allocateCell<JSTestGenerateIsReachable>(globalObject->vm())) JSTestGenerateIsReachable(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestGenerateIsReachable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGenerateIsReachable>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestGenerateIsReachable* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
@@ -674,6 +674,13 @@ JSTestGlobalObject::JSTestGlobalObject(Structure* structure, JSDOMGlobalObject& 
 {
 }
 
+JSTestGlobalObject* JSTestGlobalObject::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGlobalObject>&& impl)
+{
+    JSTestGlobalObject* ptr = new (NotNull, JSC::allocateCell<JSTestGlobalObject>(globalObject->vm())) JSTestGlobalObject(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestGlobalObject::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.h
@@ -31,13 +31,7 @@ class TestGlobalObject;
 class JSTestGlobalObject : public JSDOMWrapper<TestGlobalObject> {
 public:
     using Base = JSDOMWrapper<TestGlobalObject>;
-    static JSTestGlobalObject* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGlobalObject>&& impl)
-    {
-        JSTestGlobalObject* ptr = new (NotNull, JSC::allocateCell<JSTestGlobalObject>(globalObject->vm())) JSTestGlobalObject(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestGlobalObject* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestGlobalObject>&& impl);
     static TestGlobalObject* toWrapped(JSC::VM&, JSC::JSValue);
     static void destroy(JSC::JSCell*);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -125,6 +125,13 @@ JSTestIndexedSetterNoIdentifier::JSTestIndexedSetterNoIdentifier(Structure* stru
 {
 }
 
+JSTestIndexedSetterNoIdentifier* JSTestIndexedSetterNoIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterNoIdentifier>&& impl)
+{
+    JSTestIndexedSetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestIndexedSetterNoIdentifier>(globalObject->vm())) JSTestIndexedSetterNoIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestIndexedSetterNoIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestIndexedSetterNoIdentifier : public JSDOMWrapper<TestIndexedSetterNoIdentifier> {
 public:
     using Base = JSDOMWrapper<TestIndexedSetterNoIdentifier>;
-    static JSTestIndexedSetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterNoIdentifier>&& impl)
-    {
-        JSTestIndexedSetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestIndexedSetterNoIdentifier>(globalObject->vm())) JSTestIndexedSetterNoIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestIndexedSetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterNoIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestIndexedSetterNoIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -125,6 +125,13 @@ JSTestIndexedSetterThrowingException::JSTestIndexedSetterThrowingException(Struc
 {
 }
 
+JSTestIndexedSetterThrowingException* JSTestIndexedSetterThrowingException::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterThrowingException>&& impl)
+{
+    JSTestIndexedSetterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestIndexedSetterThrowingException>(globalObject->vm())) JSTestIndexedSetterThrowingException(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestIndexedSetterThrowingException::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestIndexedSetterThrowingException : public JSDOMWrapper<TestIndexedSetterThrowingException> {
 public:
     using Base = JSDOMWrapper<TestIndexedSetterThrowingException>;
-    static JSTestIndexedSetterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterThrowingException>&& impl)
-    {
-        JSTestIndexedSetterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestIndexedSetterThrowingException>(globalObject->vm())) JSTestIndexedSetterThrowingException(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestIndexedSetterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterThrowingException>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestIndexedSetterThrowingException* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -134,6 +134,13 @@ JSTestIndexedSetterWithIdentifier::JSTestIndexedSetterWithIdentifier(Structure* 
 {
 }
 
+JSTestIndexedSetterWithIdentifier* JSTestIndexedSetterWithIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterWithIdentifier>&& impl)
+{
+    JSTestIndexedSetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestIndexedSetterWithIdentifier>(globalObject->vm())) JSTestIndexedSetterWithIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestIndexedSetterWithIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestIndexedSetterWithIdentifier : public JSDOMWrapper<TestIndexedSetterWithIdentifier> {
 public:
     using Base = JSDOMWrapper<TestIndexedSetterWithIdentifier>;
-    static JSTestIndexedSetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterWithIdentifier>&& impl)
-    {
-        JSTestIndexedSetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestIndexedSetterWithIdentifier>(globalObject->vm())) JSTestIndexedSetterWithIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestIndexedSetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIndexedSetterWithIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestIndexedSetterWithIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -486,6 +486,13 @@ JSTestInterface::JSTestInterface(Structure* structure, JSDOMGlobalObject& global
 {
 }
 
+JSTestInterface* JSTestInterface::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestInterface>&& impl)
+{
+    JSTestInterface* ptr = new (NotNull, JSC::allocateCell<JSTestInterface>(globalObject->vm())) JSTestInterface(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestInterface::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h
@@ -31,13 +31,7 @@ namespace WebCore {
 class WEBCORE_EXPORT JSTestInterface : public JSDOMWrapper<TestInterface> {
 public:
     using Base = JSDOMWrapper<TestInterface>;
-    static JSTestInterface* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestInterface>&& impl)
-    {
-        JSTestInterface* ptr = new (NotNull, JSC::allocateCell<JSTestInterface>(globalObject->vm())) JSTestInterface(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestInterface* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestInterface>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestInterface* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
@@ -127,6 +127,13 @@ JSTestInterfaceLeadingUnderscore::JSTestInterfaceLeadingUnderscore(Structure* st
 {
 }
 
+JSTestInterfaceLeadingUnderscore* JSTestInterfaceLeadingUnderscore::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestInterfaceLeadingUnderscore>&& impl)
+{
+    JSTestInterfaceLeadingUnderscore* ptr = new (NotNull, JSC::allocateCell<JSTestInterfaceLeadingUnderscore>(globalObject->vm())) JSTestInterfaceLeadingUnderscore(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestInterfaceLeadingUnderscore::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestInterfaceLeadingUnderscore : public JSDOMWrapper<TestInterfaceLeadingUnderscore> {
 public:
     using Base = JSDOMWrapper<TestInterfaceLeadingUnderscore>;
-    static JSTestInterfaceLeadingUnderscore* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestInterfaceLeadingUnderscore>&& impl)
-    {
-        JSTestInterfaceLeadingUnderscore* ptr = new (NotNull, JSC::allocateCell<JSTestInterfaceLeadingUnderscore>(globalObject->vm())) JSTestInterfaceLeadingUnderscore(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestInterfaceLeadingUnderscore* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestInterfaceLeadingUnderscore>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestInterfaceLeadingUnderscore* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
@@ -140,6 +140,13 @@ JSTestIterable::JSTestIterable(Structure* structure, JSDOMGlobalObject& globalOb
 {
 }
 
+JSTestIterable* JSTestIterable::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIterable>&& impl)
+{
+    JSTestIterable* ptr = new (NotNull, JSC::allocateCell<JSTestIterable>(globalObject->vm())) JSTestIterable(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestIterable::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestIterable : public JSDOMWrapper<TestIterable> {
 public:
     using Base = JSDOMWrapper<TestIterable>;
-    static JSTestIterable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIterable>&& impl)
-    {
-        JSTestIterable* ptr = new (NotNull, JSC::allocateCell<JSTestIterable>(globalObject->vm())) JSTestIterable(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestIterable* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestIterable>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestIterable* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp
@@ -137,6 +137,13 @@ const ClassInfo JSTestJSBuiltinConstructor::s_info = { "TestJSBuiltinConstructor
 JSTestJSBuiltinConstructor::JSTestJSBuiltinConstructor(Structure* structure, JSDOMGlobalObject& globalObject)
     : JSDOMObject(structure, globalObject) { }
 
+JSTestJSBuiltinConstructor* JSTestJSBuiltinConstructor::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject)
+{
+    JSTestJSBuiltinConstructor* ptr = new (NotNull, JSC::allocateCell<JSTestJSBuiltinConstructor>(globalObject->vm())) JSTestJSBuiltinConstructor(structure, *globalObject);
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestJSBuiltinConstructor::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.h
@@ -27,13 +27,7 @@ namespace WebCore {
 class JSTestJSBuiltinConstructor : public JSDOMObject {
 public:
     using Base = JSDOMObject;
-    static JSTestJSBuiltinConstructor* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject)
-    {
-        JSTestJSBuiltinConstructor* ptr = new (NotNull, JSC::allocateCell<JSTestJSBuiltinConstructor>(globalObject->vm())) JSTestJSBuiltinConstructor(structure, *globalObject);
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestJSBuiltinConstructor* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static void destroy(JSC::JSCell*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
@@ -180,6 +180,13 @@ JSTestLegacyFactoryFunction::JSTestLegacyFactoryFunction(Structure* structure, J
 {
 }
 
+JSTestLegacyFactoryFunction* JSTestLegacyFactoryFunction::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyFactoryFunction>&& impl)
+{
+    JSTestLegacyFactoryFunction* ptr = new (NotNull, JSC::allocateCell<JSTestLegacyFactoryFunction>(globalObject->vm())) JSTestLegacyFactoryFunction(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestLegacyFactoryFunction::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestLegacyFactoryFunction : public JSDOMWrapper<TestLegacyFactoryFunction> {
 public:
     using Base = JSDOMWrapper<TestLegacyFactoryFunction>;
-    static JSTestLegacyFactoryFunction* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyFactoryFunction>&& impl)
-    {
-        JSTestLegacyFactoryFunction* ptr = new (NotNull, JSC::allocateCell<JSTestLegacyFactoryFunction>(globalObject->vm())) JSTestLegacyFactoryFunction(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestLegacyFactoryFunction* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyFactoryFunction>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestLegacyFactoryFunction* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
@@ -133,6 +133,13 @@ JSTestLegacyNoInterfaceObject::JSTestLegacyNoInterfaceObject(Structure* structur
 {
 }
 
+JSTestLegacyNoInterfaceObject* JSTestLegacyNoInterfaceObject::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyNoInterfaceObject>&& impl)
+{
+    JSTestLegacyNoInterfaceObject* ptr = new (NotNull, JSC::allocateCell<JSTestLegacyNoInterfaceObject>(globalObject->vm())) JSTestLegacyNoInterfaceObject(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestLegacyNoInterfaceObject::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h
@@ -31,13 +31,7 @@ namespace WebCore {
 class JSTestLegacyNoInterfaceObject : public JSDOMWrapper<TestLegacyNoInterfaceObject> {
 public:
     using Base = JSDOMWrapper<TestLegacyNoInterfaceObject>;
-    static JSTestLegacyNoInterfaceObject* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyNoInterfaceObject>&& impl)
-    {
-        JSTestLegacyNoInterfaceObject* ptr = new (NotNull, JSC::allocateCell<JSTestLegacyNoInterfaceObject>(globalObject->vm())) JSTestLegacyNoInterfaceObject(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestLegacyNoInterfaceObject* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyNoInterfaceObject>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestLegacyNoInterfaceObject* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
@@ -134,6 +134,13 @@ JSTestLegacyOverrideBuiltIns::JSTestLegacyOverrideBuiltIns(Structure* structure,
 {
 }
 
+JSTestLegacyOverrideBuiltIns* JSTestLegacyOverrideBuiltIns::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyOverrideBuiltIns>&& impl)
+{
+    JSTestLegacyOverrideBuiltIns* ptr = new (NotNull, JSC::allocateCell<JSTestLegacyOverrideBuiltIns>(globalObject->vm())) JSTestLegacyOverrideBuiltIns(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestLegacyOverrideBuiltIns::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestLegacyOverrideBuiltIns : public JSDOMWrapper<TestLegacyOverrideBuiltIns> {
 public:
     using Base = JSDOMWrapper<TestLegacyOverrideBuiltIns>;
-    static JSTestLegacyOverrideBuiltIns* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyOverrideBuiltIns>&& impl)
-    {
-        JSTestLegacyOverrideBuiltIns* ptr = new (NotNull, JSC::allocateCell<JSTestLegacyOverrideBuiltIns>(globalObject->vm())) JSTestLegacyOverrideBuiltIns(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestLegacyOverrideBuiltIns* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestLegacyOverrideBuiltIns>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestLegacyOverrideBuiltIns* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
@@ -153,6 +153,13 @@ JSTestMapLike::JSTestMapLike(Structure* structure, JSDOMGlobalObject& globalObje
 {
 }
 
+JSTestMapLike* JSTestMapLike::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestMapLike>&& impl)
+{
+    JSTestMapLike* ptr = new (NotNull, JSC::allocateCell<JSTestMapLike>(globalObject->vm())) JSTestMapLike(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestMapLike::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestMapLike : public JSDOMWrapper<TestMapLike> {
 public:
     using Base = JSDOMWrapper<TestMapLike>;
-    static JSTestMapLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestMapLike>&& impl)
-    {
-        JSTestMapLike* ptr = new (NotNull, JSC::allocateCell<JSTestMapLike>(globalObject->vm())) JSTestMapLike(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestMapLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestMapLike>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestMapLike* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
@@ -157,6 +157,13 @@ JSTestMapLikeWithOverriddenOperations::JSTestMapLikeWithOverriddenOperations(Str
 {
 }
 
+JSTestMapLikeWithOverriddenOperations* JSTestMapLikeWithOverriddenOperations::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestMapLikeWithOverriddenOperations>&& impl)
+{
+    JSTestMapLikeWithOverriddenOperations* ptr = new (NotNull, JSC::allocateCell<JSTestMapLikeWithOverriddenOperations>(globalObject->vm())) JSTestMapLikeWithOverriddenOperations(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestMapLikeWithOverriddenOperations::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestMapLikeWithOverriddenOperations : public JSDOMWrapper<TestMapLikeWithOverriddenOperations> {
 public:
     using Base = JSDOMWrapper<TestMapLikeWithOverriddenOperations>;
-    static JSTestMapLikeWithOverriddenOperations* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestMapLikeWithOverriddenOperations>&& impl)
-    {
-        JSTestMapLikeWithOverriddenOperations* ptr = new (NotNull, JSC::allocateCell<JSTestMapLikeWithOverriddenOperations>(globalObject->vm())) JSTestMapLikeWithOverriddenOperations(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestMapLikeWithOverriddenOperations* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestMapLikeWithOverriddenOperations>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestMapLikeWithOverriddenOperations* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
@@ -126,6 +126,13 @@ JSTestNamedAndIndexedSetterNoIdentifier::JSTestNamedAndIndexedSetterNoIdentifier
 {
 }
 
+JSTestNamedAndIndexedSetterNoIdentifier* JSTestNamedAndIndexedSetterNoIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterNoIdentifier>&& impl)
+{
+    JSTestNamedAndIndexedSetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedAndIndexedSetterNoIdentifier>(globalObject->vm())) JSTestNamedAndIndexedSetterNoIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedAndIndexedSetterNoIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedAndIndexedSetterNoIdentifier : public JSDOMWrapper<TestNamedAndIndexedSetterNoIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedAndIndexedSetterNoIdentifier>;
-    static JSTestNamedAndIndexedSetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterNoIdentifier>&& impl)
-    {
-        JSTestNamedAndIndexedSetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedAndIndexedSetterNoIdentifier>(globalObject->vm())) JSTestNamedAndIndexedSetterNoIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedAndIndexedSetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterNoIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedAndIndexedSetterNoIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
@@ -126,6 +126,13 @@ JSTestNamedAndIndexedSetterThrowingException::JSTestNamedAndIndexedSetterThrowin
 {
 }
 
+JSTestNamedAndIndexedSetterThrowingException* JSTestNamedAndIndexedSetterThrowingException::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterThrowingException>&& impl)
+{
+    JSTestNamedAndIndexedSetterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestNamedAndIndexedSetterThrowingException>(globalObject->vm())) JSTestNamedAndIndexedSetterThrowingException(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedAndIndexedSetterThrowingException::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedAndIndexedSetterThrowingException : public JSDOMWrapper<TestNamedAndIndexedSetterThrowingException> {
 public:
     using Base = JSDOMWrapper<TestNamedAndIndexedSetterThrowingException>;
-    static JSTestNamedAndIndexedSetterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterThrowingException>&& impl)
-    {
-        JSTestNamedAndIndexedSetterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestNamedAndIndexedSetterThrowingException>(globalObject->vm())) JSTestNamedAndIndexedSetterThrowingException(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedAndIndexedSetterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterThrowingException>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedAndIndexedSetterThrowingException* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
@@ -137,6 +137,13 @@ JSTestNamedAndIndexedSetterWithIdentifier::JSTestNamedAndIndexedSetterWithIdenti
 {
 }
 
+JSTestNamedAndIndexedSetterWithIdentifier* JSTestNamedAndIndexedSetterWithIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterWithIdentifier>&& impl)
+{
+    JSTestNamedAndIndexedSetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedAndIndexedSetterWithIdentifier>(globalObject->vm())) JSTestNamedAndIndexedSetterWithIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedAndIndexedSetterWithIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedAndIndexedSetterWithIdentifier : public JSDOMWrapper<TestNamedAndIndexedSetterWithIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedAndIndexedSetterWithIdentifier>;
-    static JSTestNamedAndIndexedSetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterWithIdentifier>&& impl)
-    {
-        JSTestNamedAndIndexedSetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedAndIndexedSetterWithIdentifier>(globalObject->vm())) JSTestNamedAndIndexedSetterWithIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedAndIndexedSetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedAndIndexedSetterWithIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedAndIndexedSetterWithIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
@@ -125,6 +125,13 @@ JSTestNamedDeleterNoIdentifier::JSTestNamedDeleterNoIdentifier(Structure* struct
 {
 }
 
+JSTestNamedDeleterNoIdentifier* JSTestNamedDeleterNoIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterNoIdentifier>&& impl)
+{
+    JSTestNamedDeleterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterNoIdentifier>(globalObject->vm())) JSTestNamedDeleterNoIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedDeleterNoIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedDeleterNoIdentifier : public JSDOMWrapper<TestNamedDeleterNoIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedDeleterNoIdentifier>;
-    static JSTestNamedDeleterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterNoIdentifier>&& impl)
-    {
-        JSTestNamedDeleterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterNoIdentifier>(globalObject->vm())) JSTestNamedDeleterNoIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedDeleterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterNoIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedDeleterNoIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
@@ -125,6 +125,13 @@ JSTestNamedDeleterThrowingException::JSTestNamedDeleterThrowingException(Structu
 {
 }
 
+JSTestNamedDeleterThrowingException* JSTestNamedDeleterThrowingException::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterThrowingException>&& impl)
+{
+    JSTestNamedDeleterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterThrowingException>(globalObject->vm())) JSTestNamedDeleterThrowingException(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedDeleterThrowingException::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedDeleterThrowingException : public JSDOMWrapper<TestNamedDeleterThrowingException> {
 public:
     using Base = JSDOMWrapper<TestNamedDeleterThrowingException>;
-    static JSTestNamedDeleterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterThrowingException>&& impl)
-    {
-        JSTestNamedDeleterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterThrowingException>(globalObject->vm())) JSTestNamedDeleterThrowingException(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedDeleterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterThrowingException>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedDeleterThrowingException* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
@@ -133,6 +133,13 @@ JSTestNamedDeleterWithIdentifier::JSTestNamedDeleterWithIdentifier(Structure* st
 {
 }
 
+JSTestNamedDeleterWithIdentifier* JSTestNamedDeleterWithIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterWithIdentifier>&& impl)
+{
+    JSTestNamedDeleterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterWithIdentifier>(globalObject->vm())) JSTestNamedDeleterWithIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedDeleterWithIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedDeleterWithIdentifier : public JSDOMWrapper<TestNamedDeleterWithIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedDeleterWithIdentifier>;
-    static JSTestNamedDeleterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterWithIdentifier>&& impl)
-    {
-        JSTestNamedDeleterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterWithIdentifier>(globalObject->vm())) JSTestNamedDeleterWithIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedDeleterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterWithIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedDeleterWithIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
@@ -126,6 +126,13 @@ JSTestNamedDeleterWithIndexedGetter::JSTestNamedDeleterWithIndexedGetter(Structu
 {
 }
 
+JSTestNamedDeleterWithIndexedGetter* JSTestNamedDeleterWithIndexedGetter::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterWithIndexedGetter>&& impl)
+{
+    JSTestNamedDeleterWithIndexedGetter* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterWithIndexedGetter>(globalObject->vm())) JSTestNamedDeleterWithIndexedGetter(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedDeleterWithIndexedGetter::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedDeleterWithIndexedGetter : public JSDOMWrapper<TestNamedDeleterWithIndexedGetter> {
 public:
     using Base = JSDOMWrapper<TestNamedDeleterWithIndexedGetter>;
-    static JSTestNamedDeleterWithIndexedGetter* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterWithIndexedGetter>&& impl)
-    {
-        JSTestNamedDeleterWithIndexedGetter* ptr = new (NotNull, JSC::allocateCell<JSTestNamedDeleterWithIndexedGetter>(globalObject->vm())) JSTestNamedDeleterWithIndexedGetter(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedDeleterWithIndexedGetter* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedDeleterWithIndexedGetter>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedDeleterWithIndexedGetter* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
@@ -125,6 +125,13 @@ JSTestNamedGetterCallWith::JSTestNamedGetterCallWith(Structure* structure, JSDOM
 {
 }
 
+JSTestNamedGetterCallWith* JSTestNamedGetterCallWith::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterCallWith>&& impl)
+{
+    JSTestNamedGetterCallWith* ptr = new (NotNull, JSC::allocateCell<JSTestNamedGetterCallWith>(globalObject->vm())) JSTestNamedGetterCallWith(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedGetterCallWith::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedGetterCallWith : public JSDOMWrapper<TestNamedGetterCallWith> {
 public:
     using Base = JSDOMWrapper<TestNamedGetterCallWith>;
-    static JSTestNamedGetterCallWith* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterCallWith>&& impl)
-    {
-        JSTestNamedGetterCallWith* ptr = new (NotNull, JSC::allocateCell<JSTestNamedGetterCallWith>(globalObject->vm())) JSTestNamedGetterCallWith(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedGetterCallWith* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterCallWith>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedGetterCallWith* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
@@ -125,6 +125,13 @@ JSTestNamedGetterNoIdentifier::JSTestNamedGetterNoIdentifier(Structure* structur
 {
 }
 
+JSTestNamedGetterNoIdentifier* JSTestNamedGetterNoIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterNoIdentifier>&& impl)
+{
+    JSTestNamedGetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedGetterNoIdentifier>(globalObject->vm())) JSTestNamedGetterNoIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedGetterNoIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedGetterNoIdentifier : public JSDOMWrapper<TestNamedGetterNoIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedGetterNoIdentifier>;
-    static JSTestNamedGetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterNoIdentifier>&& impl)
-    {
-        JSTestNamedGetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedGetterNoIdentifier>(globalObject->vm())) JSTestNamedGetterNoIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedGetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterNoIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedGetterNoIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
@@ -131,6 +131,13 @@ JSTestNamedGetterWithIdentifier::JSTestNamedGetterWithIdentifier(Structure* stru
 {
 }
 
+JSTestNamedGetterWithIdentifier* JSTestNamedGetterWithIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterWithIdentifier>&& impl)
+{
+    JSTestNamedGetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedGetterWithIdentifier>(globalObject->vm())) JSTestNamedGetterWithIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedGetterWithIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedGetterWithIdentifier : public JSDOMWrapper<TestNamedGetterWithIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedGetterWithIdentifier>;
-    static JSTestNamedGetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterWithIdentifier>&& impl)
-    {
-        JSTestNamedGetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedGetterWithIdentifier>(globalObject->vm())) JSTestNamedGetterWithIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedGetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedGetterWithIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedGetterWithIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
@@ -125,6 +125,13 @@ JSTestNamedSetterNoIdentifier::JSTestNamedSetterNoIdentifier(Structure* structur
 {
 }
 
+JSTestNamedSetterNoIdentifier* JSTestNamedSetterNoIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterNoIdentifier>&& impl)
+{
+    JSTestNamedSetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterNoIdentifier>(globalObject->vm())) JSTestNamedSetterNoIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterNoIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterNoIdentifier : public JSDOMWrapper<TestNamedSetterNoIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterNoIdentifier>;
-    static JSTestNamedSetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterNoIdentifier>&& impl)
-    {
-        JSTestNamedSetterNoIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterNoIdentifier>(globalObject->vm())) JSTestNamedSetterNoIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterNoIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterNoIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterNoIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
@@ -125,6 +125,13 @@ JSTestNamedSetterThrowingException::JSTestNamedSetterThrowingException(Structure
 {
 }
 
+JSTestNamedSetterThrowingException* JSTestNamedSetterThrowingException::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterThrowingException>&& impl)
+{
+    JSTestNamedSetterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterThrowingException>(globalObject->vm())) JSTestNamedSetterThrowingException(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterThrowingException::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterThrowingException : public JSDOMWrapper<TestNamedSetterThrowingException> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterThrowingException>;
-    static JSTestNamedSetterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterThrowingException>&& impl)
-    {
-        JSTestNamedSetterThrowingException* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterThrowingException>(globalObject->vm())) JSTestNamedSetterThrowingException(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterThrowingException* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterThrowingException>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterThrowingException* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
@@ -133,6 +133,13 @@ JSTestNamedSetterWithIdentifier::JSTestNamedSetterWithIdentifier(Structure* stru
 {
 }
 
+JSTestNamedSetterWithIdentifier* JSTestNamedSetterWithIdentifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIdentifier>&& impl)
+{
+    JSTestNamedSetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithIdentifier>(globalObject->vm())) JSTestNamedSetterWithIdentifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterWithIdentifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterWithIdentifier : public JSDOMWrapper<TestNamedSetterWithIdentifier> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterWithIdentifier>;
-    static JSTestNamedSetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIdentifier>&& impl)
-    {
-        JSTestNamedSetterWithIdentifier* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithIdentifier>(globalObject->vm())) JSTestNamedSetterWithIdentifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterWithIdentifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIdentifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterWithIdentifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
@@ -137,6 +137,13 @@ JSTestNamedSetterWithIndexedGetter::JSTestNamedSetterWithIndexedGetter(Structure
 {
 }
 
+JSTestNamedSetterWithIndexedGetter* JSTestNamedSetterWithIndexedGetter::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIndexedGetter>&& impl)
+{
+    JSTestNamedSetterWithIndexedGetter* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithIndexedGetter>(globalObject->vm())) JSTestNamedSetterWithIndexedGetter(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterWithIndexedGetter::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterWithIndexedGetter : public JSDOMWrapper<TestNamedSetterWithIndexedGetter> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterWithIndexedGetter>;
-    static JSTestNamedSetterWithIndexedGetter* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIndexedGetter>&& impl)
-    {
-        JSTestNamedSetterWithIndexedGetter* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithIndexedGetter>(globalObject->vm())) JSTestNamedSetterWithIndexedGetter(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterWithIndexedGetter* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIndexedGetter>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterWithIndexedGetter* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
@@ -137,6 +137,13 @@ JSTestNamedSetterWithIndexedGetterAndSetter::JSTestNamedSetterWithIndexedGetterA
 {
 }
 
+JSTestNamedSetterWithIndexedGetterAndSetter* JSTestNamedSetterWithIndexedGetterAndSetter::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIndexedGetterAndSetter>&& impl)
+{
+    JSTestNamedSetterWithIndexedGetterAndSetter* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithIndexedGetterAndSetter>(globalObject->vm())) JSTestNamedSetterWithIndexedGetterAndSetter(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterWithIndexedGetterAndSetter::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterWithIndexedGetterAndSetter : public JSDOMWrapper<TestNamedSetterWithIndexedGetterAndSetter> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterWithIndexedGetterAndSetter>;
-    static JSTestNamedSetterWithIndexedGetterAndSetter* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIndexedGetterAndSetter>&& impl)
-    {
-        JSTestNamedSetterWithIndexedGetterAndSetter* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithIndexedGetterAndSetter>(globalObject->vm())) JSTestNamedSetterWithIndexedGetterAndSetter(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterWithIndexedGetterAndSetter* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithIndexedGetterAndSetter>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterWithIndexedGetterAndSetter* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
@@ -125,6 +125,13 @@ JSTestNamedSetterWithLegacyOverrideBuiltIns::JSTestNamedSetterWithLegacyOverride
 {
 }
 
+JSTestNamedSetterWithLegacyOverrideBuiltIns* JSTestNamedSetterWithLegacyOverrideBuiltIns::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyOverrideBuiltIns>&& impl)
+{
+    JSTestNamedSetterWithLegacyOverrideBuiltIns* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithLegacyOverrideBuiltIns>(globalObject->vm())) JSTestNamedSetterWithLegacyOverrideBuiltIns(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterWithLegacyOverrideBuiltIns::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterWithLegacyOverrideBuiltIns : public JSDOMWrapper<TestNamedSetterWithLegacyOverrideBuiltIns> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterWithLegacyOverrideBuiltIns>;
-    static JSTestNamedSetterWithLegacyOverrideBuiltIns* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyOverrideBuiltIns>&& impl)
-    {
-        JSTestNamedSetterWithLegacyOverrideBuiltIns* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithLegacyOverrideBuiltIns>(globalObject->vm())) JSTestNamedSetterWithLegacyOverrideBuiltIns(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterWithLegacyOverrideBuiltIns* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyOverrideBuiltIns>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterWithLegacyOverrideBuiltIns* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
@@ -151,6 +151,13 @@ JSTestNamedSetterWithLegacyUnforgeableProperties::JSTestNamedSetterWithLegacyUnf
 {
 }
 
+JSTestNamedSetterWithLegacyUnforgeableProperties* JSTestNamedSetterWithLegacyUnforgeableProperties::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyUnforgeableProperties>&& impl)
+{
+    JSTestNamedSetterWithLegacyUnforgeableProperties* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithLegacyUnforgeableProperties>(globalObject->vm())) JSTestNamedSetterWithLegacyUnforgeableProperties(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterWithLegacyUnforgeableProperties::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterWithLegacyUnforgeableProperties : public JSDOMWrapper<TestNamedSetterWithLegacyUnforgeableProperties> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterWithLegacyUnforgeableProperties>;
-    static JSTestNamedSetterWithLegacyUnforgeableProperties* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyUnforgeableProperties>&& impl)
-    {
-        JSTestNamedSetterWithLegacyUnforgeableProperties* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithLegacyUnforgeableProperties>(globalObject->vm())) JSTestNamedSetterWithLegacyUnforgeableProperties(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterWithLegacyUnforgeableProperties* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyUnforgeableProperties>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterWithLegacyUnforgeableProperties* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
@@ -151,6 +151,13 @@ JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::JSTes
 {
 }
 
+JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>&& impl)
+{
+    JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>(globalObject->vm())) JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns : public JSDOMWrapper<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns> {
 public:
     using Base = JSDOMWrapper<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>;
-    static JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>&& impl)
-    {
-        JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* ptr = new (NotNull, JSC::allocateCell<JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>(globalObject->vm())) JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp
@@ -76,6 +76,13 @@ const ClassInfo JSTestNamespaceConst::s_info = { "TestNamespaceConst"_s, &Base::
 JSTestNamespaceConst::JSTestNamespaceConst(Structure* structure, JSDOMGlobalObject& globalObject)
     : JSDOMObject(structure, globalObject) { }
 
+JSTestNamespaceConst* JSTestNamespaceConst::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject)
+{
+    JSTestNamespaceConst* ptr = new (NotNull, JSC::allocateCell<JSTestNamespaceConst>(globalObject->vm())) JSTestNamespaceConst(structure, *globalObject);
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamespaceConst::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.h
@@ -27,13 +27,7 @@ namespace WebCore {
 class JSTestNamespaceConst : public JSDOMObject {
 public:
     using Base = JSDOMObject;
-    static JSTestNamespaceConst* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject)
-    {
-        JSTestNamespaceConst* ptr = new (NotNull, JSC::allocateCell<JSTestNamespaceConst>(globalObject->vm())) JSTestNamespaceConst(structure, *globalObject);
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamespaceConst* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject);
     static void destroy(JSC::JSCell*);
 
     DECLARE_INFO;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp
@@ -136,6 +136,13 @@ const ClassInfo JSTestNamespaceObject::s_info = { "TestInterfaceName"_s, &Base::
 JSTestNamespaceObject::JSTestNamespaceObject(Structure* structure, JSDOMGlobalObject& globalObject)
     : JSDOMObject(structure, globalObject) { }
 
+JSTestNamespaceObject* JSTestNamespaceObject::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject)
+{
+    JSTestNamespaceObject* ptr = new (NotNull, JSC::allocateCell<JSTestNamespaceObject>(globalObject->vm())) JSTestNamespaceObject(structure, *globalObject);
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNamespaceObject::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.h
@@ -27,13 +27,7 @@ namespace WebCore {
 class JSTestNamespaceObject : public JSDOMObject {
 public:
     using Base = JSDOMObject;
-    static JSTestNamespaceObject* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject)
-    {
-        JSTestNamespaceObject* ptr = new (NotNull, JSC::allocateCell<JSTestNamespaceObject>(globalObject->vm())) JSTestNamespaceObject(structure, *globalObject);
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNamespaceObject* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject);
     static void destroy(JSC::JSCell*);
 
     DECLARE_INFO;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -242,6 +242,13 @@ JSTestNode::JSTestNode(Structure* structure, JSDOMGlobalObject& globalObject, Re
 {
 }
 
+JSTestNode* JSTestNode::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNode>&& impl)
+{
+    JSTestNode* ptr = new (NotNull, JSC::allocateCell<JSTestNode>(globalObject->vm())) JSTestNode(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestNode::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.h
@@ -30,13 +30,7 @@ class WEBCORE_EXPORT JSTestNode : public JSNode {
 public:
     using Base = JSNode;
     using DOMWrapped = TestNode;
-    static JSTestNode* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNode>&& impl)
-    {
-        JSTestNode* ptr = new (NotNull, JSC::allocateCell<JSTestNode>(globalObject->vm())) JSTestNode(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestNode* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestNode>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2649,6 +2649,13 @@ JSTestObj::JSTestObj(Structure* structure, JSDOMGlobalObject& globalObject, Ref<
 {
 }
 
+JSTestObj* JSTestObj::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestObj>&& impl)
+{
+    JSTestObj* ptr = new (NotNull, JSC::allocateCell<JSTestObj>(globalObject->vm())) JSTestObj(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestObj::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -31,13 +31,7 @@ namespace WebCore {
 class JSTestObj : public JSDOMWrapper<TestObj> {
 public:
     using Base = JSDOMWrapper<TestObj>;
-    static JSTestObj* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestObj>&& impl)
-    {
-        JSTestObj* ptr = new (NotNull, JSC::allocateCell<JSTestObj>(globalObject->vm())) JSTestObj(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestObj* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestObj>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestObj* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
@@ -151,6 +151,13 @@ JSTestOperationConditional::JSTestOperationConditional(Structure* structure, JSD
 {
 }
 
+JSTestOperationConditional* JSTestOperationConditional::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOperationConditional>&& impl)
+{
+    JSTestOperationConditional* ptr = new (NotNull, JSC::allocateCell<JSTestOperationConditional>(globalObject->vm())) JSTestOperationConditional(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestOperationConditional::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h
@@ -31,13 +31,7 @@ namespace WebCore {
 class JSTestOperationConditional : public JSDOMWrapper<TestOperationConditional> {
 public:
     using Base = JSDOMWrapper<TestOperationConditional>;
-    static JSTestOperationConditional* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOperationConditional>&& impl)
-    {
-        JSTestOperationConditional* ptr = new (NotNull, JSC::allocateCell<JSTestOperationConditional>(globalObject->vm())) JSTestOperationConditional(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestOperationConditional* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOperationConditional>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestOperationConditional* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
@@ -259,6 +259,13 @@ JSTestOverloadedConstructors::JSTestOverloadedConstructors(Structure* structure,
 {
 }
 
+JSTestOverloadedConstructors* JSTestOverloadedConstructors::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOverloadedConstructors>&& impl)
+{
+    JSTestOverloadedConstructors* ptr = new (NotNull, JSC::allocateCell<JSTestOverloadedConstructors>(globalObject->vm())) JSTestOverloadedConstructors(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestOverloadedConstructors::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestOverloadedConstructors : public JSDOMWrapper<TestOverloadedConstructors> {
 public:
     using Base = JSDOMWrapper<TestOverloadedConstructors>;
-    static JSTestOverloadedConstructors* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOverloadedConstructors>&& impl)
-    {
-        JSTestOverloadedConstructors* ptr = new (NotNull, JSC::allocateCell<JSTestOverloadedConstructors>(globalObject->vm())) JSTestOverloadedConstructors(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestOverloadedConstructors* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOverloadedConstructors>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestOverloadedConstructors* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
@@ -195,6 +195,13 @@ JSTestOverloadedConstructorsWithSequence::JSTestOverloadedConstructorsWithSequen
 {
 }
 
+JSTestOverloadedConstructorsWithSequence* JSTestOverloadedConstructorsWithSequence::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOverloadedConstructorsWithSequence>&& impl)
+{
+    JSTestOverloadedConstructorsWithSequence* ptr = new (NotNull, JSC::allocateCell<JSTestOverloadedConstructorsWithSequence>(globalObject->vm())) JSTestOverloadedConstructorsWithSequence(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestOverloadedConstructorsWithSequence::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestOverloadedConstructorsWithSequence : public JSDOMWrapper<TestOverloadedConstructorsWithSequence> {
 public:
     using Base = JSDOMWrapper<TestOverloadedConstructorsWithSequence>;
-    static JSTestOverloadedConstructorsWithSequence* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOverloadedConstructorsWithSequence>&& impl)
-    {
-        JSTestOverloadedConstructorsWithSequence* ptr = new (NotNull, JSC::allocateCell<JSTestOverloadedConstructorsWithSequence>(globalObject->vm())) JSTestOverloadedConstructorsWithSequence(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestOverloadedConstructorsWithSequence* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestOverloadedConstructorsWithSequence>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestOverloadedConstructorsWithSequence* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
@@ -124,6 +124,13 @@ JSTestPluginInterface::JSTestPluginInterface(Structure* structure, JSDOMGlobalOb
 {
 }
 
+JSTestPluginInterface* JSTestPluginInterface::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestPluginInterface>&& impl)
+{
+    JSTestPluginInterface* ptr = new (NotNull, JSC::allocateCell<JSTestPluginInterface>(globalObject->vm())) JSTestPluginInterface(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestPluginInterface::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h
@@ -30,13 +30,7 @@ namespace WebCore {
 class JSTestPluginInterface : public JSDOMWrapper<TestPluginInterface> {
 public:
     using Base = JSDOMWrapper<TestPluginInterface>;
-    static JSTestPluginInterface* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestPluginInterface>&& impl)
-    {
-        JSTestPluginInterface* ptr = new (NotNull, JSC::allocateCell<JSTestPluginInterface>(globalObject->vm())) JSTestPluginInterface(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestPluginInterface* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestPluginInterface>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestPluginInterface* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -236,6 +236,13 @@ JSTestPromiseRejectionEvent::JSTestPromiseRejectionEvent(Structure* structure, J
 {
 }
 
+JSTestPromiseRejectionEvent* JSTestPromiseRejectionEvent::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestPromiseRejectionEvent>&& impl)
+{
+    JSTestPromiseRejectionEvent* ptr = new (NotNull, JSC::allocateCell<JSTestPromiseRejectionEvent>(globalObject->vm())) JSTestPromiseRejectionEvent(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestPromiseRejectionEvent::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h
@@ -31,13 +31,7 @@ class JSTestPromiseRejectionEvent : public JSEvent {
 public:
     using Base = JSEvent;
     using DOMWrapped = TestPromiseRejectionEvent;
-    static JSTestPromiseRejectionEvent* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestPromiseRejectionEvent>&& impl)
-    {
-        JSTestPromiseRejectionEvent* ptr = new (NotNull, JSC::allocateCell<JSTestPromiseRejectionEvent>(globalObject->vm())) JSTestPromiseRejectionEvent(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestPromiseRejectionEvent* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestPromiseRejectionEvent>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
@@ -147,6 +147,13 @@ JSTestReadOnlyMapLike::JSTestReadOnlyMapLike(Structure* structure, JSDOMGlobalOb
 {
 }
 
+JSTestReadOnlyMapLike* JSTestReadOnlyMapLike::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReadOnlyMapLike>&& impl)
+{
+    JSTestReadOnlyMapLike* ptr = new (NotNull, JSC::allocateCell<JSTestReadOnlyMapLike>(globalObject->vm())) JSTestReadOnlyMapLike(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestReadOnlyMapLike::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestReadOnlyMapLike : public JSDOMWrapper<TestReadOnlyMapLike> {
 public:
     using Base = JSDOMWrapper<TestReadOnlyMapLike>;
-    static JSTestReadOnlyMapLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReadOnlyMapLike>&& impl)
-    {
-        JSTestReadOnlyMapLike* ptr = new (NotNull, JSC::allocateCell<JSTestReadOnlyMapLike>(globalObject->vm())) JSTestReadOnlyMapLike(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestReadOnlyMapLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReadOnlyMapLike>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestReadOnlyMapLike* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
@@ -145,6 +145,13 @@ JSTestReadOnlySetLike::JSTestReadOnlySetLike(Structure* structure, JSDOMGlobalOb
 {
 }
 
+JSTestReadOnlySetLike* JSTestReadOnlySetLike::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReadOnlySetLike>&& impl)
+{
+    JSTestReadOnlySetLike* ptr = new (NotNull, JSC::allocateCell<JSTestReadOnlySetLike>(globalObject->vm())) JSTestReadOnlySetLike(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestReadOnlySetLike::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestReadOnlySetLike : public JSDOMWrapper<TestReadOnlySetLike> {
 public:
     using Base = JSDOMWrapper<TestReadOnlySetLike>;
-    static JSTestReadOnlySetLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReadOnlySetLike>&& impl)
-    {
-        JSTestReadOnlySetLike* ptr = new (NotNull, JSC::allocateCell<JSTestReadOnlySetLike>(globalObject->vm())) JSTestReadOnlySetLike(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestReadOnlySetLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReadOnlySetLike>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestReadOnlySetLike* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
@@ -123,6 +123,13 @@ JSTestReportExtraMemoryCost::JSTestReportExtraMemoryCost(Structure* structure, J
 {
 }
 
+JSTestReportExtraMemoryCost* JSTestReportExtraMemoryCost::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReportExtraMemoryCost>&& impl)
+{
+    JSTestReportExtraMemoryCost* ptr = new (NotNull, JSC::allocateCell<JSTestReportExtraMemoryCost>(globalObject->vm())) JSTestReportExtraMemoryCost(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestReportExtraMemoryCost::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestReportExtraMemoryCost : public JSDOMWrapper<TestReportExtraMemoryCost> {
 public:
     using Base = JSDOMWrapper<TestReportExtraMemoryCost>;
-    static JSTestReportExtraMemoryCost* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReportExtraMemoryCost>&& impl)
-    {
-        JSTestReportExtraMemoryCost* ptr = new (NotNull, JSC::allocateCell<JSTestReportExtraMemoryCost>(globalObject->vm())) JSTestReportExtraMemoryCost(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestReportExtraMemoryCost* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestReportExtraMemoryCost>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestReportExtraMemoryCost* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
@@ -156,6 +156,13 @@ JSTestSerializedScriptValueInterface::JSTestSerializedScriptValueInterface(Struc
 {
 }
 
+JSTestSerializedScriptValueInterface* JSTestSerializedScriptValueInterface::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSerializedScriptValueInterface>&& impl)
+{
+    JSTestSerializedScriptValueInterface* ptr = new (NotNull, JSC::allocateCell<JSTestSerializedScriptValueInterface>(globalObject->vm())) JSTestSerializedScriptValueInterface(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestSerializedScriptValueInterface::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h
@@ -31,13 +31,7 @@ namespace WebCore {
 class JSTestSerializedScriptValueInterface : public JSDOMWrapper<TestSerializedScriptValueInterface> {
 public:
     using Base = JSDOMWrapper<TestSerializedScriptValueInterface>;
-    static JSTestSerializedScriptValueInterface* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSerializedScriptValueInterface>&& impl)
-    {
-        JSTestSerializedScriptValueInterface* ptr = new (NotNull, JSC::allocateCell<JSTestSerializedScriptValueInterface>(globalObject->vm())) JSTestSerializedScriptValueInterface(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestSerializedScriptValueInterface* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSerializedScriptValueInterface>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestSerializedScriptValueInterface* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
@@ -151,6 +151,13 @@ JSTestSetLike::JSTestSetLike(Structure* structure, JSDOMGlobalObject& globalObje
 {
 }
 
+JSTestSetLike* JSTestSetLike::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSetLike>&& impl)
+{
+    JSTestSetLike* ptr = new (NotNull, JSC::allocateCell<JSTestSetLike>(globalObject->vm())) JSTestSetLike(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestSetLike::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestSetLike : public JSDOMWrapper<TestSetLike> {
 public:
     using Base = JSDOMWrapper<TestSetLike>;
-    static JSTestSetLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSetLike>&& impl)
-    {
-        JSTestSetLike* ptr = new (NotNull, JSC::allocateCell<JSTestSetLike>(globalObject->vm())) JSTestSetLike(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestSetLike* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSetLike>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestSetLike* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
@@ -155,6 +155,13 @@ JSTestSetLikeWithOverriddenOperations::JSTestSetLikeWithOverriddenOperations(Str
 {
 }
 
+JSTestSetLikeWithOverriddenOperations* JSTestSetLikeWithOverriddenOperations::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSetLikeWithOverriddenOperations>&& impl)
+{
+    JSTestSetLikeWithOverriddenOperations* ptr = new (NotNull, JSC::allocateCell<JSTestSetLikeWithOverriddenOperations>(globalObject->vm())) JSTestSetLikeWithOverriddenOperations(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestSetLikeWithOverriddenOperations::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestSetLikeWithOverriddenOperations : public JSDOMWrapper<TestSetLikeWithOverriddenOperations> {
 public:
     using Base = JSDOMWrapper<TestSetLikeWithOverriddenOperations>;
-    static JSTestSetLikeWithOverriddenOperations* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSetLikeWithOverriddenOperations>&& impl)
-    {
-        JSTestSetLikeWithOverriddenOperations* ptr = new (NotNull, JSC::allocateCell<JSTestSetLikeWithOverriddenOperations>(globalObject->vm())) JSTestSetLikeWithOverriddenOperations(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestSetLikeWithOverriddenOperations* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestSetLikeWithOverriddenOperations>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestSetLikeWithOverriddenOperations* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
@@ -130,6 +130,13 @@ JSTestStringifier::JSTestStringifier(Structure* structure, JSDOMGlobalObject& gl
 {
 }
 
+JSTestStringifier* JSTestStringifier::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifier>&& impl)
+{
+    JSTestStringifier* ptr = new (NotNull, JSC::allocateCell<JSTestStringifier>(globalObject->vm())) JSTestStringifier(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifier::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifier : public JSDOMWrapper<TestStringifier> {
 public:
     using Base = JSDOMWrapper<TestStringifier>;
-    static JSTestStringifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifier>&& impl)
-    {
-        JSTestStringifier* ptr = new (NotNull, JSC::allocateCell<JSTestStringifier>(globalObject->vm())) JSTestStringifier(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifier* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifier>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifier* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
@@ -130,6 +130,13 @@ JSTestStringifierAnonymousOperation::JSTestStringifierAnonymousOperation(Structu
 {
 }
 
+JSTestStringifierAnonymousOperation* JSTestStringifierAnonymousOperation::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierAnonymousOperation>&& impl)
+{
+    JSTestStringifierAnonymousOperation* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierAnonymousOperation>(globalObject->vm())) JSTestStringifierAnonymousOperation(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifierAnonymousOperation::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifierAnonymousOperation : public JSDOMWrapper<TestStringifierAnonymousOperation> {
 public:
     using Base = JSDOMWrapper<TestStringifierAnonymousOperation>;
-    static JSTestStringifierAnonymousOperation* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierAnonymousOperation>&& impl)
-    {
-        JSTestStringifierAnonymousOperation* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierAnonymousOperation>(globalObject->vm())) JSTestStringifierAnonymousOperation(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifierAnonymousOperation* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierAnonymousOperation>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifierAnonymousOperation* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
@@ -132,6 +132,13 @@ JSTestStringifierNamedOperation::JSTestStringifierNamedOperation(Structure* stru
 {
 }
 
+JSTestStringifierNamedOperation* JSTestStringifierNamedOperation::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierNamedOperation>&& impl)
+{
+    JSTestStringifierNamedOperation* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierNamedOperation>(globalObject->vm())) JSTestStringifierNamedOperation(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifierNamedOperation::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifierNamedOperation : public JSDOMWrapper<TestStringifierNamedOperation> {
 public:
     using Base = JSDOMWrapper<TestStringifierNamedOperation>;
-    static JSTestStringifierNamedOperation* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierNamedOperation>&& impl)
-    {
-        JSTestStringifierNamedOperation* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierNamedOperation>(globalObject->vm())) JSTestStringifierNamedOperation(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifierNamedOperation* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierNamedOperation>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifierNamedOperation* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
@@ -132,6 +132,13 @@ JSTestStringifierOperationImplementedAs::JSTestStringifierOperationImplementedAs
 {
 }
 
+JSTestStringifierOperationImplementedAs* JSTestStringifierOperationImplementedAs::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierOperationImplementedAs>&& impl)
+{
+    JSTestStringifierOperationImplementedAs* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierOperationImplementedAs>(globalObject->vm())) JSTestStringifierOperationImplementedAs(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifierOperationImplementedAs::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifierOperationImplementedAs : public JSDOMWrapper<TestStringifierOperationImplementedAs> {
 public:
     using Base = JSDOMWrapper<TestStringifierOperationImplementedAs>;
-    static JSTestStringifierOperationImplementedAs* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierOperationImplementedAs>&& impl)
-    {
-        JSTestStringifierOperationImplementedAs* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierOperationImplementedAs>(globalObject->vm())) JSTestStringifierOperationImplementedAs(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifierOperationImplementedAs* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierOperationImplementedAs>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifierOperationImplementedAs* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
@@ -130,6 +130,13 @@ JSTestStringifierOperationNamedToString::JSTestStringifierOperationNamedToString
 {
 }
 
+JSTestStringifierOperationNamedToString* JSTestStringifierOperationNamedToString::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierOperationNamedToString>&& impl)
+{
+    JSTestStringifierOperationNamedToString* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierOperationNamedToString>(globalObject->vm())) JSTestStringifierOperationNamedToString(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifierOperationNamedToString::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifierOperationNamedToString : public JSDOMWrapper<TestStringifierOperationNamedToString> {
 public:
     using Base = JSDOMWrapper<TestStringifierOperationNamedToString>;
-    static JSTestStringifierOperationNamedToString* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierOperationNamedToString>&& impl)
-    {
-        JSTestStringifierOperationNamedToString* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierOperationNamedToString>(globalObject->vm())) JSTestStringifierOperationNamedToString(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifierOperationNamedToString* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierOperationNamedToString>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifierOperationNamedToString* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
@@ -133,6 +133,13 @@ JSTestStringifierReadOnlyAttribute::JSTestStringifierReadOnlyAttribute(Structure
 {
 }
 
+JSTestStringifierReadOnlyAttribute* JSTestStringifierReadOnlyAttribute::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierReadOnlyAttribute>&& impl)
+{
+    JSTestStringifierReadOnlyAttribute* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierReadOnlyAttribute>(globalObject->vm())) JSTestStringifierReadOnlyAttribute(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifierReadOnlyAttribute::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifierReadOnlyAttribute : public JSDOMWrapper<TestStringifierReadOnlyAttribute> {
 public:
     using Base = JSDOMWrapper<TestStringifierReadOnlyAttribute>;
-    static JSTestStringifierReadOnlyAttribute* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierReadOnlyAttribute>&& impl)
-    {
-        JSTestStringifierReadOnlyAttribute* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierReadOnlyAttribute>(globalObject->vm())) JSTestStringifierReadOnlyAttribute(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifierReadOnlyAttribute* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierReadOnlyAttribute>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifierReadOnlyAttribute* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
@@ -134,6 +134,13 @@ JSTestStringifierReadWriteAttribute::JSTestStringifierReadWriteAttribute(Structu
 {
 }
 
+JSTestStringifierReadWriteAttribute* JSTestStringifierReadWriteAttribute::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierReadWriteAttribute>&& impl)
+{
+    JSTestStringifierReadWriteAttribute* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierReadWriteAttribute>(globalObject->vm())) JSTestStringifierReadWriteAttribute(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestStringifierReadWriteAttribute::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestStringifierReadWriteAttribute : public JSDOMWrapper<TestStringifierReadWriteAttribute> {
 public:
     using Base = JSDOMWrapper<TestStringifierReadWriteAttribute>;
-    static JSTestStringifierReadWriteAttribute* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierReadWriteAttribute>&& impl)
-    {
-        JSTestStringifierReadWriteAttribute* ptr = new (NotNull, JSC::allocateCell<JSTestStringifierReadWriteAttribute>(globalObject->vm())) JSTestStringifierReadWriteAttribute(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestStringifierReadWriteAttribute* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestStringifierReadWriteAttribute>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestStringifierReadWriteAttribute* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
@@ -123,6 +123,13 @@ JSTestTaggedWrapper::JSTestTaggedWrapper(Structure* structure, JSDOMGlobalObject
 {
 }
 
+JSTestTaggedWrapper* JSTestTaggedWrapper::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestTaggedWrapper>&& impl)
+{
+    JSTestTaggedWrapper* ptr = new (NotNull, JSC::allocateCell<JSTestTaggedWrapper>(globalObject->vm())) JSTestTaggedWrapper(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestTaggedWrapper::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h
@@ -30,13 +30,7 @@ WTF_DECLARE_PTRTAG(TestTaggedWrapperPtrTag)
 class JSTestTaggedWrapper : public JSDOMWrapper<TestTaggedWrapper, SignedPtrTraits<TestTaggedWrapper, TestTaggedWrapperPtrTag>> {
 public:
     using Base = JSDOMWrapper<TestTaggedWrapper, SignedPtrTraits<TestTaggedWrapper, TestTaggedWrapperPtrTag>>;
-    static JSTestTaggedWrapper* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestTaggedWrapper>&& impl)
-    {
-        JSTestTaggedWrapper* ptr = new (NotNull, JSC::allocateCell<JSTestTaggedWrapper>(globalObject->vm())) JSTestTaggedWrapper(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestTaggedWrapper* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestTaggedWrapper>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestTaggedWrapper* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
@@ -248,6 +248,13 @@ JSTestTypedefs::JSTestTypedefs(Structure* structure, JSDOMGlobalObject& globalOb
 {
 }
 
+JSTestTypedefs* JSTestTypedefs::create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestTypedefs>&& impl)
+{
+    JSTestTypedefs* ptr = new (NotNull, JSC::allocateCell<JSTestTypedefs>(globalObject->vm())) JSTestTypedefs(structure, *globalObject, WTFMove(impl));
+    ptr->finishCreation(globalObject->vm());
+    return ptr;
+}
+
 void JSTestTypedefs::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h
@@ -29,13 +29,7 @@ namespace WebCore {
 class JSTestTypedefs : public JSDOMWrapper<TestTypedefs> {
 public:
     using Base = JSDOMWrapper<TestTypedefs>;
-    static JSTestTypedefs* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestTypedefs>&& impl)
-    {
-        JSTestTypedefs* ptr = new (NotNull, JSC::allocateCell<JSTestTypedefs>(globalObject->vm())) JSTestTypedefs(structure, *globalObject, WTFMove(impl));
-        ptr->finishCreation(globalObject->vm());
-        return ptr;
-    }
-
+    static JSTestTypedefs* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<TestTypedefs>&& impl);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static TestTypedefs* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp
@@ -145,6 +145,13 @@ JSWorkerGlobalScope::JSWorkerGlobalScope(VM& vm, Structure* structure, Ref<Worke
 {
 }
 
+JSWorkerGlobalScope* JSWorkerGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<WorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSWorkerGlobalScope>(vm)) JSWorkerGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSWorkerGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
@@ -31,13 +31,7 @@ class JSWorkerGlobalScope : public JSEventTarget {
 public:
     using Base = JSEventTarget;
     using DOMWrapped = WorkerGlobalScope;
-    static JSWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<WorkerGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSWorkerGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSWorkerGlobalScope>(vm)) JSWorkerGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSWorkerGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<WorkerGlobalScope>&& impl, JSC::JSProxy* proxy);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static WorkerGlobalScope* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp
@@ -114,6 +114,13 @@ JSWorkletGlobalScope::JSWorkletGlobalScope(VM& vm, Structure* structure, Ref<Wor
 {
 }
 
+JSWorkletGlobalScope* JSWorkletGlobalScope::create(JSC::VM& vm, JSC::Structure* structure, Ref<WorkletGlobalScope>&& impl, JSC::JSProxy* proxy)
+{
+    JSWorkletGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSWorkletGlobalScope>(vm)) JSWorkletGlobalScope(vm, structure, WTFMove(impl));
+    ptr->finishCreation(vm, proxy);
+    return ptr;
+}
+
 void JSWorkletGlobalScope::finishCreation(VM& vm, JSProxy* proxy)
 {
     Base::finishCreation(vm, proxy);

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
@@ -31,13 +31,7 @@ class JSWorkletGlobalScope : public JSEventTarget {
 public:
     using Base = JSEventTarget;
     using DOMWrapped = WorkletGlobalScope;
-    static JSWorkletGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<WorkletGlobalScope>&& impl, JSC::JSProxy* proxy)
-    {
-        JSWorkletGlobalScope* ptr = new (NotNull, JSC::allocateCell<JSWorkletGlobalScope>(vm)) JSWorkletGlobalScope(vm, structure, WTFMove(impl));
-        ptr->finishCreation(vm, proxy);
-        return ptr;
-    }
-
+    static JSWorkletGlobalScope* create(JSC::VM& vm, JSC::Structure* structure, Ref<WorkletGlobalScope>&& impl, JSC::JSProxy* proxy);
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
     static WorkletGlobalScope* toWrapped(JSC::VM&, JSC::JSValue);

--- a/Source/WebCore/domjit/DOMJITHelpers.h
+++ b/Source/WebCore/domjit/DOMJITHelpers.h
@@ -33,6 +33,8 @@
 
 #if ENABLE(JIT)
 
+#include "JSDOMGlobalObject.h"
+
 IGNORE_WARNINGS_BEGIN("frame-address")
 
 namespace WebCore { namespace DOMJIT {


### PR DESCRIPTION
#### d3cff5f4c1b4dd52877b1941dd26aa7af528667f
<pre>
[build] Refactor JSDOMWrapper.h to not include JSDOMGlobalObject.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=251474">https://bugs.webkit.org/show_bug.cgi?id=251474</a>
rdar://problem/104894173

Reviewed by NOBODY (OOPS!).

Profiling of compilation show that JSDOMGlobalObject.h is the most expensive
header when building WebCore, contributing over 6 minutes across all compilation
units. By moving implementations in header files to source files, this small
refactoring removed include JSDOMGlobalObject.h in JSDOMWrapper.h, reducing the
cost of JSDOMGlobalObject.h by 30 seconds.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3cff5f4c1b4dd52877b1941dd26aa7af528667f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38482 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114837 "Hash d3cff5f4 for PR 9423 does not build (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174985 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5898 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97880 "Hash d3cff5f4 for PR 9423 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114663 "Hash d3cff5f4 for PR 9423 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95224 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/97880 "Hash d3cff5f4 for PR 9423 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26861 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/97880 "Hash d3cff5f4 for PR 9423 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28216 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4804 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47760 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10024 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->