### PR TITLE
Shrink Layout::ElementBox slightly

### DIFF
--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -41,10 +41,10 @@ namespace Layout {
 WTF_MAKE_ISO_ALLOCATED_IMPL(Box);
 
 Box::Box(ElementAttributes&& elementAttributes, RenderStyle&& style, std::unique_ptr<RenderStyle>&& firstLineStyle, OptionSet<BaseTypeFlag> baseTypeFlags)
-    : m_style(WTFMove(style))
-    , m_nodeType(elementAttributes.nodeType)
+    : m_nodeType(elementAttributes.nodeType)
     , m_isAnonymous(static_cast<bool>(elementAttributes.isAnonymous))
     , m_baseTypeFlags(baseTypeFlags.toRaw())
+    , m_style(WTFMove(style))
 {
     if (firstLineStyle)
         ensureRareData().firstLineStyle = WTFMove(firstLineStyle);

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -213,8 +213,6 @@ private:
 
     static RareDataMap& rareDataMap();
 
-    RenderStyle m_style;
-
     NodeType m_nodeType : 4;
     bool m_isAnonymous : 1;
 
@@ -222,6 +220,8 @@ private:
     bool m_hasRareData : 1 { false };
     bool m_isInlineIntegrationRoot : 1 { false };
     bool m_isFirstChildForIntegration : 1 { false };
+
+    RenderStyle m_style;
 
     CheckedPtr<ElementBox> m_parent;
     

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -101,8 +101,8 @@ private:
     std::unique_ptr<Box> m_firstChild;
     CheckedPtr<Box> m_lastChild;
 
-    std::optional<LayoutUnit> m_baselineForIntegration;
     std::unique_ptr<ReplacedData> m_replacedData;
+    std::optional<LayoutUnit> m_baselineForIntegration;
 };
 
 }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -90,6 +90,10 @@ struct SameSizeAsRenderStyle {
 
 static_assert(sizeof(RenderStyle) == sizeof(SameSizeAsRenderStyle), "RenderStyle should stay small");
 
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+#error
+#endif
+
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyle);
 
 RenderStyle& RenderStyle::defaultStyle()


### PR DESCRIPTION
#### 1b555d02b07f3338afe4aac3ed96bca02f43992d
<pre>
Shrink Layout::ElementBox slightly
<a href="https://bugs.webkit.org/show_bug.cgi?id=251475">https://bugs.webkit.org/show_bug.cgi?id=251475</a>
rdar://104894626

Reviewed by Alan Baradlay.

Shrink Layout::ElementBox from 184 bytes (13 bytes of padding) to 176 bytes
(5 bytes of padding) by shifting the bitfields in Box up into the spare
4 bytes between CanMakeCheckedPtr&apos;s m_count and m_style.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::Box):
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:

Canonical link: <a href="https://commits.webkit.org/259688@main">https://commits.webkit.org/259688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bbd39c64ea18a97907a39fcb804ef99c86d14d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114834 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174991 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5895 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97877 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39728 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26858 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28213 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47757 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6695 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10011 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->