### PR TITLE
Resync web-platform-tests/fs from upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -240,6 +240,7 @@
     "web-platform-tests/file-system-access": "import",
     "web-platform-tests/fonts": "import",
     "web-platform-tests/fonts/noto": "import",
+    "web-platform-tests/fs": "import",
     "web-platform-tests/fullscreen": "import",
     "web-platform-tests/gamepad": "import",
     "web-platform-tests/generic-sensor": "skip",

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt
@@ -10,4 +10,5 @@ PASS removeEntry() with ".." name should fail
 PASS removeEntry() with a path separator should fail.
 FAIL removeEntry() while the file has an open writable fails promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL removeEntry() of a directory while a containing file has an open writable fails promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
+FAIL createWritable after removeEntry succeeds but doesnt recreate the file promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt
@@ -10,4 +10,5 @@ PASS removeEntry() with ".." name should fail
 PASS removeEntry() with a path separator should fail.
 FAIL removeEntry() while the file has an open writable fails promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL removeEntry() of a directory while a containing file has an open writable fails promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
+FAIL createWritable after removeEntry succeeds but doesnt recreate the file promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-move.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-move.https.any-expected.txt
@@ -23,4 +23,5 @@ FAIL move(dir) while the destination file has an open writable fails promise_tes
 FAIL move(dir) can overwrite an existing file promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL move(dir, name) while the destination file has an open writable fails promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL move(dir, name) can overwrite an existing file promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
+FAIL FileSystemFileHandles are references, not paths promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-move.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-move.https.any.worker-expected.txt
@@ -23,4 +23,5 @@ FAIL move(dir) while the destination file has an open writable fails promise_tes
 FAIL move(dir) can overwrite an existing file promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL move(dir, name) while the destination file has an open writable fails promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL move(dir, name) can overwrite an existing file promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
+FAIL FileSystemFileHandles are references, not paths promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-read-write.https.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-read-write.https.tentative.worker-expected.txt
@@ -6,8 +6,10 @@ PASS Test second write that is smaller than the first write
 PASS Test initial write with an offset
 PASS Test overwriting the file at an offset
 PASS Test read at an offset
-FAIL Test read with default options assert_equals: Check that all bytes were read expected 0 but got 24
-FAIL Test write with default options promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL Test reading at a negative offset fails. promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
-FAIL Test writing at a negative offset fails. promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+PASS Test read with default options
+PASS Test write with default options
+PASS Test reading at a negative offset fails.
+PASS Test writing at a negative offset fails.
+PASS Test that writing moves the file position cursor
+PASS Test that reading moves the file position cursor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker-expected.txt
@@ -1,4 +1,5 @@
 
 PASS test SyncAccessHandle.truncate with different sizes
 PASS test SyncAccessHandle.truncate after SyncAccessHandle.write
+PASS test SyncAccessHandle.truncate resets the file position cursor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker.js
@@ -37,4 +37,23 @@ sync_access_handle_test((t, handle) => {
   assert_array_equals(expected, readBuffer);
 }, 'test SyncAccessHandle.truncate after SyncAccessHandle.write');
 
+sync_access_handle_test((t, handle) => {
+  // The cursor will be at the end of the file after this write.
+  const writeBuffer = new Uint8Array(4);
+  writeBuffer.set([0, 1, 2, 3]);
+  handle.write(writeBuffer);
+
+  // Extending the file should not move the cursor.
+  handle.truncate(6);
+  let readBuffer = new Uint8Array(2);
+  let expected = new Uint8Array(2);
+  expected.set([0, 0]);
+  assert_equals(2, handle.read(readBuffer));
+  assert_array_equals(expected, readBuffer);
+
+  // Shortening the file should move the cursor to the new end.
+  handle.truncate(2);
+  assert_equals(0, handle.read(readBuffer));
+}, 'test SyncAccessHandle.truncate resets the file position cursor');
+
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/resources/sandboxed-fs-test-helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/resources/sandboxed-fs-test-helpers.js
@@ -7,6 +7,10 @@
 // file-system-access/local-fs-test-helpers.js, where that version uses the
 // local file system instead.
 
+function getFileSystemType() {
+  return 'sandboxed';
+}
+
 async function cleanupSandboxedFileSystem() {
   const dir = await navigator.storage.getDirectory();
   for await (let entry of dir.values())

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-getUniqueId.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-getUniqueId.js
@@ -72,7 +72,7 @@ directory_test(async (t, root_dir) => {
   const id_before = await handle.getUniqueId();
 
   // Write to the file. The unique ID should not change.
-  const writable = await handle.createWritable();
+  const writable = await cleanup_writable(t, await handle.createWritable());
   await writable.write("blah");
   await writable.close();
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-remove.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-remove.js
@@ -79,7 +79,7 @@ directory_test(async (t, root) => {
       await createFileWithContents(t, 'file-to-remove', '12345', root);
   await createFileWithContents(t, 'file-to-keep', 'abc', root);
 
-  const writable = await handle.createWritable();
+  const writable = await cleanup_writable(t, await handle.createWritable());
   await promise_rejects_dom(t, 'NoModificationAllowedError', handle.remove());
 
   await writable.close();

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js
@@ -121,3 +121,15 @@ directory_test(async (t, root) => {
   await dir.removeEntry('file-to-remove');
   assert_array_equals(await getSortedDirectoryEntries(dir), ['file-to-keep']);
 }, 'removeEntry() of a directory while a containing file has an open writable fails');
+
+directory_test(async (t, root) => {
+  const handle =
+      await createFileWithContents(t, 'file-to-remove', '12345', root);
+  await root.removeEntry('file-to-remove');
+
+  await promise_rejects_dom(t, 'NotFoundError', cleanup_writable(t, handle.createWritable({keepExistingData: true})));
+
+  assert_array_equals(
+      await getSortedDirectoryEntries(root),
+      []);
+}, 'createWritable after removeEntry succeeds but doesnt recreate the file');

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-create-sync-access-handle.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-create-sync-access-handle.js
@@ -5,6 +5,12 @@
 //    /fs/resources/test-helpers.js
 
 directory_test(async (t, root_dir) => {
+  const fileSystemType = getFileSystemType();
+  assert_true(
+      fileSystemType == 'sandboxed' || fileSystemType == 'local',
+      'File system type should be sandboxed or local.');
+  const expect_success = fileSystemType == 'sandboxed';
+
   const dedicated_worker =
       create_dedicated_worker(t, kDedicatedWorkerMessageTarget);
   const file_handle =
@@ -17,5 +23,5 @@ directory_test(async (t, root_dir) => {
   const message_event = await event_watcher.wait_for('message');
   const response = message_event.data;
 
-  assert_true(response.success);
+  assert_equals(response.success, expect_success);
 }, 'Attempt to create a sync access handle.');

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-move.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-move.js
@@ -350,3 +350,20 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(file), 'abc');
   assert_equals(await getFileContents(file_dest), 'abc');
 }, 'move(dir, name) can overwrite an existing file');
+
+directory_test(async (t, root) => {
+  const handle =
+      await createFileWithContents(t, 'file-to-move', '12345', root);
+  const handle2 = handle;
+
+  await handle.move('file-was-moved');
+
+  assert_equals(await getFileContents(handle), '12345');
+  assert_equals(await getFileSize(handle), 5);
+  assert_equals(await getFileContents(handle2), '12345');
+  assert_equals(await getFileSize(handle2), 5);
+
+  assert_array_equals(
+      await getSortedDirectoryEntries(root),
+      ['file-was-moved']);
+}, 'FileSystemFileHandles are references, not paths');


### PR DESCRIPTION
#### 531e07cf4cb54b3be8237c776ce4ac7598296bd1
<pre>
Resync web-platform-tests/fs from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=251478">https://bugs.webkit.org/show_bug.cgi?id=251478</a>

Reviewed by Tim Nguyen.

Based on upstream d80a211a093ebb8289e2c8ef5f9520167fb3b0a4.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-move.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemFileHandle-move.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-read-write.https.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-read-write.https.tentative.worker.js:
(sync_access_handle_test):
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker.js:
(sync_access_handle_test):
* LayoutTests/imported/w3c/web-platform-tests/fs/resources/sandboxed-fs-test-helpers.js:
(getFileSystemType):
* LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-getUniqueId.js:
(directory_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-remove.js:
(directory_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemDirectoryHandle-removeEntry.js:
(directory_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-create-sync-access-handle.js:
(directory_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemFileHandle-move.js:
(directory_test.async t):

Canonical link: <a href="https://commits.webkit.org/259695@main">https://commits.webkit.org/259695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/052543f708b73990dd42e06de9e37af7716d95dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114840 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/174989 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5901 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97883 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39732 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26868 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7969 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8475 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47767 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6699 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10026 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->