### PR TITLE
[WebGPU] Connect PresentationContext and CompositorIntegration

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -74,4 +74,9 @@ Ref<GPUPresentationContext> GPU::createPresentationContext(const GPUPresentation
     return GPUPresentationContext::create(m_backing->createPresentationContext(presentationContextDescriptor.convertToBacking()));
 }
 
+Ref<GPUCompositorIntegration> GPU::createCompositorIntegration()
+{
+    return GPUCompositorIntegration::create(m_backing->createCompositorIntegration());
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -37,6 +37,7 @@
 
 namespace WebCore {
 
+class GPUCompositorIntegration;
 class GPUPresentationContext;
 struct GPUPresentationContextDescriptor;
 
@@ -54,6 +55,8 @@ public:
     GPUTextureFormat getPreferredCanvasFormat();
 
     Ref<GPUPresentationContext> createPresentationContext(const GPUPresentationContextDescriptor&);
+
+    Ref<GPUCompositorIntegration> createCompositorIntegration();
 
 private:
     GPU(Ref<PAL::WebGPU::GPU>&&);

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContextDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContextDescriptor.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUCompositorIntegration.h"
 #include <pal/graphics/WebGPU/WebGPUPresentationContextDescriptor.h>
 
 namespace WebCore {
@@ -33,10 +34,11 @@ struct GPUPresentationContextDescriptor {
     PAL::WebGPU::PresentationContextDescriptor convertToBacking() const
     {
         return {
+            layout.backing(),
         };
     }
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250955 Add integration with the compositor here.
+    GPUCompositorIntegration& layout;
 };
 
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp
@@ -29,6 +29,7 @@
 #if HAVE(WEBGPU_IMPLEMENTATION)
 
 #include "WebGPUAdapterImpl.h"
+#include "WebGPUCompositorIntegrationImpl.h"
 #include "WebGPUDowncastConvertToBackingContext.h"
 #include "WebGPUPresentationContextDescriptor.h"
 #include "WebGPUPresentationContextImpl.h"
@@ -62,8 +63,11 @@ void GPUImpl::requestAdapter(const RequestAdapterOptions& options, CompletionHan
     }).get());
 }
 
-Ref<PresentationContext> GPUImpl::createPresentationContext(const PresentationContextDescriptor&)
+Ref<PresentationContext> GPUImpl::createPresentationContext(const PresentationContextDescriptor& presentationContextDescriptor)
 {
+    // FIXME: Do something with the presentationContextDescriptor
+    UNUSED_PARAM(presentationContextDescriptor);
+
     WGPUSurfaceDescriptorCocoaCustomSurface cocoaSurface {
         { nullptr, static_cast<WGPUSType>(WGPUSTypeExtended_SurfaceDescriptorCocoaSurfaceBacking) },
     };
@@ -74,6 +78,11 @@ Ref<PresentationContext> GPUImpl::createPresentationContext(const PresentationCo
     };
 
     return PresentationContextImpl::create(wgpuInstanceCreateSurface(m_backing, &surfaceDescriptor), m_convertToBackingContext);
+}
+
+Ref<CompositorIntegration> GPUImpl::createCompositorIntegration()
+{
+    return CompositorIntegrationImpl::create(m_convertToBackingContext);
 }
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h
@@ -63,6 +63,8 @@ private:
 
     Ref<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) final;
 
+    Ref<CompositorIntegration> createCompositorIntegration() final;
+
     WGPUInstance m_backing { nullptr };
     Ref<ConvertToBackingContext> m_convertToBackingContext;
 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h
@@ -34,6 +34,7 @@
 namespace PAL::WebGPU {
 
 class Adapter;
+class CompositorIntegration;
 class PresentationContext;
 struct PresentationContextDescriptor;
 
@@ -44,6 +45,8 @@ public:
     virtual void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) = 0;
 
     virtual Ref<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) = 0;
+
+    virtual Ref<CompositorIntegration> createCompositorIntegration() = 0;
 
 protected:
     GPU() = default;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContextDescriptor.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContextDescriptor.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include "WebGPUCompositorIntegration.h"
+
 namespace PAL::WebGPU {
 
 struct PresentationContextDescriptor {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250955 Add integration with the compositor here.
+    CompositorIntegration& compositorIntegration;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -133,6 +133,7 @@ private:
 
     std::optional<GPUCanvasConfiguration> m_configuration;
     Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
+    Ref<GPUCompositorIntegration> m_compositorIntegration;
     Ref<GPUPresentationContext> m_presentationContext;
     RefPtr<GPUTexture> m_currentTexture;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -30,6 +30,7 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "RemoteAdapter.h"
+#include "RemoteCompositorIntegration.h"
 #include "RemoteGPUMessages.h"
 #include "RemoteGPUProxyMessages.h"
 #include "RemotePresentationContext.h"
@@ -178,6 +179,16 @@ void RemoteGPU::createPresentationContext(const WebGPU::PresentationContextDescr
     auto presentationContext = m_backing->createPresentationContext(*convertedDescriptor);
     auto remotePresentationContext = RemotePresentationContext::create(presentationContext, m_objectHeap, *m_streamConnection, identifier);
     m_objectHeap->addObject(identifier, remotePresentationContext);
+}
+
+void RemoteGPU::createCompositorIntegration(WebGPUIdentifier identifier)
+{
+    assertIsCurrent(workQueue());
+    ASSERT(m_backing);
+
+    auto compositorIntegration = m_backing->createCompositorIntegration();
+    auto remoteCompositorIntegration = RemoteCompositorIntegration::create(compositorIntegration, m_objectHeap, *m_streamConnection, identifier);
+    m_objectHeap->addObject(identifier, remoteCompositorIntegration);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -139,6 +139,8 @@ private:
 
     void createPresentationContext(const WebGPU::PresentationContextDescriptor&, WebGPUIdentifier);
 
+    void createCompositorIntegration(WebGPUIdentifier);
+
     WeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     RefPtr<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -26,6 +26,7 @@
 messages -> RemoteGPU NotRefCounted Stream {
     void RequestAdapter(WebKit::WebGPU::RequestAdapterOptions options, WebKit::WebGPUIdentifier identifier) -> (std::optional<WebKit::RemoteGPU::RequestAdapterResponse> response) Synchronous
     void CreatePresentationContext(WebKit::WebGPU::PresentationContextDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
+    void CreateCompositorIntegration(WebKit::WebGPUIdentifier identifier)
 }
 
 #endif

--- a/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp
@@ -34,14 +34,22 @@
 
 namespace WebKit::WebGPU {
 
-std::optional<PresentationContextDescriptor> ConvertToBackingContext::convertToBacking(const PAL::WebGPU::PresentationContextDescriptor&)
+std::optional<PresentationContextDescriptor> ConvertToBackingContext::convertToBacking(const PAL::WebGPU::PresentationContextDescriptor& presentationContextDescriptor)
 {
-    return { { } };
+    auto identifier = convertToBacking(presentationContextDescriptor.compositorIntegration);
+    if (!identifier)
+        return std::nullopt;
+
+    return { { identifier } };
 }
 
-std::optional<PAL::WebGPU::PresentationContextDescriptor> ConvertFromBackingContext::convertFromBacking(const PresentationContextDescriptor&)
+std::optional<PAL::WebGPU::PresentationContextDescriptor> ConvertFromBackingContext::convertFromBacking(const PresentationContextDescriptor& presentationContextDescriptor)
 {
-    return { { } };
+    auto* compositorIntegration = convertCompositorIntegrationFromBacking(presentationContextDescriptor.compositorIntegration);
+    if (!compositorIntegration)
+        return std::nullopt;
+
+    return { { *compositorIntegration } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.h
@@ -30,7 +30,7 @@
 namespace WebKit::WebGPU {
 
 struct PresentationContextDescriptor {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250955 Add integration with the compositor here.
+    WebGPUIdentifier compositorIntegration;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.serialization.in
@@ -22,5 +22,6 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::PresentationContextDescriptor {
+    WebKit::WebGPUIdentifier compositorIntegration;
 };
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -31,6 +31,7 @@
 #include "GPUConnectionToWebProcessMessages.h"
 #include "GPUProcessConnection.h"
 #include "RemoteAdapterProxy.h"
+#include "RemoteCompositorIntegrationProxy.h"
 #include "RemoteGPU.h"
 #include "RemoteGPUMessages.h"
 #include "RemoteGPUProxyMessages.h"
@@ -165,6 +166,17 @@ Ref<PAL::WebGPU::PresentationContext> RemoteGPUProxy::createPresentationContext(
     UNUSED_VARIABLE(sendResult);
 
     return WebGPU::RemotePresentationContextProxy::create(*this, m_convertToBackingContext, identifier);
+}
+
+Ref<PAL::WebGPU::CompositorIntegration> RemoteGPUProxy::createCompositorIntegration()
+{
+    // FIXME: Should we be consulting m_lost?
+
+    auto identifier = WebGPUIdentifier::generate();
+    auto sendResult = send(Messages::RemoteGPU::CreateCompositorIntegration(identifier));
+    UNUSED_VARIABLE(sendResult);
+
+    return WebGPU::RemoteCompositorIntegrationProxy::create(*this, m_convertToBackingContext, identifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -102,6 +102,8 @@ private:
 
     Ref<PAL::WebGPU::PresentationContext> createPresentationContext(const PAL::WebGPU::PresentationContextDescriptor&) final;
 
+    Ref<PAL::WebGPU::CompositorIntegration> createCompositorIntegration() final;
+
     void abandonGPUProcess();
 
     Deque<CompletionHandler<void(RefPtr<PAL::WebGPU::Adapter>&&)>> m_callbacks;


### PR DESCRIPTION
#### 87e3bf778001ed304bd56f4375eee0e38896632b
<pre>
[WebGPU] Connect PresentationContext and CompositorIntegration
<a href="https://bugs.webkit.org/show_bug.cgi?id=251479">https://bugs.webkit.org/show_bug.cgi?id=251479</a>
rdar://104900104

Reviewed by Tadeu Zagallo.

A PresentationContext is created with a PresentationContextDescriptor, which previously had 0
fields. This patch just adds a CompositorIntegration&amp; as a field, so PresentationContexts are now
created with a CompositorIntegration.

This patch doesn&apos;t actually have the PresentationContext do anything with the CompositorIntegration;
it just adds the field in the descriptor. The next patch will make the two actually use each other.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::createCompositorIntegration):
* Source/WebCore/Modules/WebGPU/GPU.h:
* Source/WebCore/Modules/WebGPU/GPUPresentationContextDescriptor.h:
(WebCore::GPUPresentationContextDescriptor::convertToBacking const):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp:
(PAL::WebGPU::GPUImpl::createPresentationContext):
(PAL::WebGPU::GPUImpl::createCompositorIntegration):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPresentationContextDescriptor.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.cpp:
(WebCore::presentationContextDescriptor):
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createCompositorIntegration):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.h:
* Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::createCompositorIntegration):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:

Canonical link: <a href="https://commits.webkit.org/259669@main">https://commits.webkit.org/259669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96cf08df7bf8630a7ecb0086620c6551fe23b64d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114846 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/174996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5907 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97889 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111371 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95232 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/39737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26869 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28224 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47768 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6676 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10032 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->