### PR TITLE
[GStreamer] Fix a failure of fast/speechsynthesis/voices-non-mock.html

### DIFF
--- a/LayoutTests/fast/speechsynthesis/voices-non-mock.html
+++ b/LayoutTests/fast/speechsynthesis/voices-non-mock.html
@@ -23,7 +23,7 @@
             foundDefaultVoice = true;
     }
 
-    shouldBeTrue("voiceCount > 20");
+    shouldBeTrue(`voiceCount >= ${window.internals.minimumExpectedVoiceCount}`);
     shouldBeTrue("foundEnglishVoice");
     shouldBeTrue("foundDefaultVoice");
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2337,7 +2337,6 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html [ WontFix ]
 
 # Missing WebSpeech implementation
 webkit.org/b/136224 fast/speechrecognition [ Skip ]
-webkit.org/b/250656 fast/speechsynthesis/voices-non-mock.html [ Failure ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).
 fast/url/data-url-mediatype.html [ Skip ]

--- a/LayoutTests/platform/glib/fast/speechsynthesis/voices-non-mock-expected.txt
+++ b/LayoutTests/platform/glib/fast/speechsynthesis/voices-non-mock-expected.txt
@@ -3,7 +3,7 @@ This tests that we can get synthesizer voices.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS voiceCount >= 21 is true
+PASS voiceCount >= 4 is true
 PASS foundEnglishVoice is true
 PASS foundDefaultVoice is true
 PASS successfullyParsed is true

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1554,6 +1554,18 @@ ExceptionOr<void> Internals::setSpeechUtteranceDuration(double duration)
     return { };
 }
 
+unsigned Internals::minimumExpectedVoiceCount()
+{
+    // https://webkit.org/b/250656
+#if PLATFORM(MAC)
+    return 21;
+#elif USE(GLIB)
+    return 4;
+#else
+    return 1;
+#endif
+}
+
 #endif
 
 #if ENABLE(WEB_RTC)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -673,6 +673,7 @@ public:
     void enableMockSpeechSynthesizer();
     void enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement&);
     ExceptionOr<void> setSpeechUtteranceDuration(double);
+    unsigned minimumExpectedVoiceCount();
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -798,6 +798,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizer();
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement element);
     [Conditional=SPEECH_SYNTHESIS] undefined setSpeechUtteranceDuration(double duration);
+    [Conditional=SPEECH_SYNTHESIS] readonly attribute unsigned long minimumExpectedVoiceCount;
 
     DOMString getImageSourceURL(Element element);
 


### PR DESCRIPTION
#### 3aad9165b15df302e611f79f33378137101d390f
<pre>
[GStreamer] Fix a failure of fast/speechsynthesis/voices-non-mock.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=250656">https://bugs.webkit.org/show_bug.cgi?id=250656</a>

Reviewed by Philippe Normand.

The voices-non-mock.html used a mac platform-specific value to test the number
of available voices. This change introduces a new method of Internals, which allows
each port to decide its minimum expected voice count. Besides, this change includes
a new expected result for ports using GStreamer since the number of available voices
for those ports differs from that of the mac port.

* LayoutTests/fast/speechsynthesis/voices-non-mock.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/fast/speechsynthesis/voices-non-mock-expected.txt: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::minimumExpectedVoiceCount):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/259820@main">https://commits.webkit.org/259820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91a4bced8a1532d1e7bb5100b3228f300995d6a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114926 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175067 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5989 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114731 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39797 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81514 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28296 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4883 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6795 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10106 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->