### PR TITLE
Optimize padding in CachedRawResource

### DIFF
--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -75,8 +75,8 @@ CrossOriginEmbedderPolicy CrossOriginEmbedderPolicy::isolatedCopy() const &
 {
     return {
         value,
-        reportingEndpoint.isolatedCopy(),
         reportOnlyValue,
+        reportingEndpoint.isolatedCopy(),
         reportOnlyReportingEndpoint.isolatedCopy()
     };
 }
@@ -85,8 +85,8 @@ CrossOriginEmbedderPolicy CrossOriginEmbedderPolicy::isolatedCopy() &&
 {
     return {
         value,
-        WTFMove(reportingEndpoint).isolatedCopy(),
         reportOnlyValue,
+        WTFMove(reportingEndpoint).isolatedCopy(),
         WTFMove(reportOnlyReportingEndpoint).isolatedCopy()
     };
 }
@@ -175,8 +175,8 @@ std::optional<CrossOriginEmbedderPolicy> CrossOriginEmbedderPolicy::decode(WTF::
 
     return { {
         *value,
-        WTFMove(*reportingEndpoint),
         *reportOnlyValue,
+        WTFMove(*reportingEndpoint),
         WTFMove(*reportOnlyReportingEndpoint)
     } };
 }

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
@@ -53,8 +53,8 @@ enum class CrossOriginEmbedderPolicyValue : bool {
 // https://html.spec.whatwg.org/multipage/origin.html#embedder-policy
 struct CrossOriginEmbedderPolicy {
     CrossOriginEmbedderPolicyValue value { CrossOriginEmbedderPolicyValue::UnsafeNone };
-    String reportingEndpoint;
     CrossOriginEmbedderPolicyValue reportOnlyValue { CrossOriginEmbedderPolicyValue::UnsafeNone };
+    String reportingEndpoint;
     String reportOnlyReportingEndpoint;
 
     CrossOriginEmbedderPolicy isolatedCopy() const &;

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -49,9 +49,9 @@ struct FetchOptions {
     using Redirect = FetchOptionsRedirect;
 
     FetchOptions() = default;
-    FetchOptions(Destination, Mode, Credentials, Cache, Redirect, ReferrerPolicy, String&&, bool, std::optional<ScriptExecutionContextIdentifier>, std::optional<ScriptExecutionContextIdentifier>);
-    FetchOptions isolatedCopy() const & { return { destination, mode, credentials, cache, redirect, referrerPolicy, integrity.isolatedCopy(), keepAlive, clientIdentifier, resultingClientIdentifier }; }
-    FetchOptions isolatedCopy() && { return { destination, mode, credentials, cache, redirect, referrerPolicy, WTFMove(integrity).isolatedCopy(), keepAlive, clientIdentifier, resultingClientIdentifier }; }
+    FetchOptions(Destination, Mode, Credentials, Cache, Redirect, ReferrerPolicy, bool, String&&, std::optional<ScriptExecutionContextIdentifier>, std::optional<ScriptExecutionContextIdentifier>);
+    FetchOptions isolatedCopy() const & { return { destination, mode, credentials, cache, redirect, referrerPolicy, keepAlive, integrity.isolatedCopy(), clientIdentifier, resultingClientIdentifier }; }
+    FetchOptions isolatedCopy() && { return { destination, mode, credentials, cache, redirect, referrerPolicy, keepAlive, WTFMove(integrity).isolatedCopy(), clientIdentifier, resultingClientIdentifier }; }
 
     template<class Encoder> void encodePersistent(Encoder&) const;
     template<class Decoder> static WARN_UNUSED_RETURN bool decodePersistent(Decoder&, FetchOptions&);
@@ -62,23 +62,24 @@ struct FetchOptions {
     Cache cache { Cache::Default };
     Redirect redirect { Redirect::Follow };
     ReferrerPolicy referrerPolicy { ReferrerPolicy::EmptyString };
-    String integrity;
     bool keepAlive { false };
+    String integrity;
+    // FIXME: These std::optional<ScriptExecutionContextIdentifier> waste 15 bytes each.
     // Identifier of https://fetch.spec.whatwg.org/#concept-request-client
     std::optional<ScriptExecutionContextIdentifier> clientIdentifier;
     // Identifier of https://fetch.spec.whatwg.org/#concept-request-reserved-client
     std::optional<ScriptExecutionContextIdentifier> resultingClientIdentifier;
 };
 
-inline FetchOptions::FetchOptions(Destination destination, Mode mode, Credentials credentials, Cache cache, Redirect redirect, ReferrerPolicy referrerPolicy, String&& integrity, bool keepAlive, std::optional<ScriptExecutionContextIdentifier> clientIdentifier, std::optional<ScriptExecutionContextIdentifier> resultingClientIdentifier)
+inline FetchOptions::FetchOptions(Destination destination, Mode mode, Credentials credentials, Cache cache, Redirect redirect, ReferrerPolicy referrerPolicy, bool keepAlive, String&& integrity, std::optional<ScriptExecutionContextIdentifier> clientIdentifier, std::optional<ScriptExecutionContextIdentifier> resultingClientIdentifier)
     : destination(destination)
     , mode(mode)
     , credentials(credentials)
     , cache(cache)
     , redirect(redirect)
     , referrerPolicy(referrerPolicy)
-    , integrity(WTFMove(integrity))
     , keepAlive(keepAlive)
+    , integrity(WTFMove(integrity))
     , clientIdentifier(clientIdentifier)
     , resultingClientIdentifier(resultingClientIdentifier)
 {

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -223,10 +223,9 @@ struct ResourceLoaderOptions : public FetchOptions {
 #endif
     Markable<ContentSecurityPolicyResponseHeaders, ContentSecurityPolicyResponseHeaders::MarkableTraits> cspResponseHeaders;
     std::optional<CrossOriginEmbedderPolicy> crossOriginEmbedderPolicy;
-    OptionSet<HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
+
     uint8_t maxRedirectCount { 20 };
-    FetchIdentifier navigationPreloadIdentifier;
-    String nonce;
+    OptionSet<HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
 
     SendCallbackPolicy sendLoadCallbacks : bitWidthOfSendCallbackPolicy;
     ContentSniffingPolicy sniffContent : bitWidthOfContentSniffingPolicy;
@@ -247,6 +246,9 @@ struct ResourceLoaderOptions : public FetchOptions {
     PreflightPolicy preflightPolicy : bitWidthOfPreflightPolicy;
     LoadedFromOpaqueSource loadedFromOpaqueSource : bitWidthOfLoadedFromOpaqueSource;
     LoadedFromPluginElement loadedFromPluginElement : bitWidthOfLoadedFromPluginElement;
+
+    FetchIdentifier navigationPreloadIdentifier;
+    String nonce;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -43,7 +43,6 @@ namespace WebCore {
 
 CachedRawResource::CachedRawResource(CachedResourceRequest&& request, Type type, PAL::SessionID sessionID, const CookieJar* cookieJar)
     : CachedResource(WTFMove(request), type, sessionID, cookieJar)
-    , m_allowEncodedDataReplacement(true)
 {
     ASSERT(isMainOrMediaOrIconOrRawResource());
 }

--- a/Source/WebCore/loader/cache/CachedRawResource.h
+++ b/Source/WebCore/loader/cache/CachedRawResource.h
@@ -75,8 +75,6 @@ private:
 #endif
 
     ResourceLoaderIdentifier m_identifier;
-    bool m_allowEncodedDataReplacement;
-    bool m_inIncrementalDataNotify { false };
 
     struct RedirectPair {
     public:
@@ -96,6 +94,9 @@ private:
         RefPtr<const FragmentedSharedBuffer> buffer;
     };
     std::optional<DelayedFinishLoading> m_delayedFinishLoading;
+
+    bool m_allowEncodedDataReplacement { true };
+    bool m_inIncrementalDataNotify { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -373,13 +373,13 @@ private:
     RefPtr<SecurityOrigin> m_origin;
     AtomString m_initiatorType;
 
+    RedirectChainCacheStatus m_redirectChainCacheStatus;
+
     unsigned m_encodedSize { 0 };
     unsigned m_decodedSize { 0 };
     unsigned m_accessCount { 0 };
     unsigned m_handleCount { 0 };
     unsigned m_preloadCount { 0 };
-
-    RedirectChainCacheStatus m_redirectChainCacheStatus;
 
     Type m_type : bitWidthOfType;
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -66,19 +66,19 @@ public:
     struct RequestData {
         RequestData() { }
         
-        RequestData(const URL& url, double timeoutInterval, const URL& firstPartyForCookies, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true)
+        RequestData(const URL& url, const URL& firstPartyForCookies, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true)
             : m_url(url)
-            , m_timeoutInterval(timeoutInterval)
             , m_firstPartyForCookies(firstPartyForCookies)
+            , m_timeoutInterval(timeoutInterval)
             , m_httpMethod(httpMethod)
             , m_httpHeaderFields(httpHeaderFields)
             , m_responseContentDispositionEncodingFallbackArray(responseContentDispositionEncodingFallbackArray)
             , m_cachePolicy(cachePolicy)
-            , m_allowCookies(allowCookies)
             , m_sameSiteDisposition(sameSiteDisposition)
-            , m_isTopSite(isTopSite)
             , m_priority(priority)
             , m_requester(requester)
+            , m_isTopSite(isTopSite)
+            , m_allowCookies(allowCookies)
             , m_isAppInitiated(isAppInitiated)
         {
         }
@@ -90,17 +90,17 @@ public:
         }
         
         URL m_url;
-        double m_timeoutInterval { s_defaultTimeoutInterval }; // 0 is a magic value for platform default on platforms that have one.
         URL m_firstPartyForCookies;
+        double m_timeoutInterval { s_defaultTimeoutInterval }; // 0 is a magic value for platform default on platforms that have one.
         String m_httpMethod { "GET"_s };
         HTTPHeaderMap m_httpHeaderFields;
         Vector<String> m_responseContentDispositionEncodingFallbackArray;
         ResourceRequestCachePolicy m_cachePolicy { ResourceRequestCachePolicy::UseProtocolCachePolicy };
-        bool m_allowCookies : 1 { false };
         SameSiteDisposition m_sameSiteDisposition { SameSiteDisposition::Unspecified };
-        bool m_isTopSite : 1 { false };
         ResourceLoadPriority m_priority { ResourceLoadPriority::Low };
         ResourceRequestRequester m_requester { ResourceRequestRequester::Unspecified };
+        bool m_isTopSite : 1 { false };
+        bool m_allowCookies : 1 { false };
         bool m_isAppInitiated : 1 { true };
     };
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -72,15 +72,15 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseBase::R
     , m_httpHeaderFields(data ? data->m_httpHeaderFields : HTTPHeaderMap { })
     , m_networkLoadMetrics(data ? data->m_networkLoadMetrics : Box<WebCore::NetworkLoadMetrics> { })
     , m_certificateInfo(data ? data->m_certificateInfo : std::nullopt)
-    , m_isRedirected(data ? data->m_isRedirected : false)
-    , m_isRangeRequested(data ? data->m_isRangeRequested : false)
+    , m_httpStatusCode(data ? data->m_httpStatusCode : 0)
     , m_isNull(data ? false : true)
     , m_usedLegacyTLS(data ? data->m_usedLegacyTLS : UsedLegacyTLS::No)
     , m_wasPrivateRelayed(data ? data->m_wasPrivateRelayed : WasPrivateRelayed::No)
+    , m_isRedirected(data ? data->m_isRedirected : false)
+    , m_isRangeRequested(data ? data->m_isRangeRequested : false)
     , m_tainting(data ? data->m_tainting : Tainting::Basic)
     , m_source(data ? data->m_source : Source::Unknown)
     , m_type(data ? data->m_type : Type::Default)
-    , m_httpStatusCode(data ? data->m_httpStatusCode : 0)
 {
 }
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -299,6 +299,13 @@ protected:
 
     mutable std::optional<CertificateInfo> m_certificateInfo;
 
+    short m_httpStatusCode { 0 };
+
+    bool m_isNull : 1 { true };
+    unsigned m_initLevel : 3; // Controlled by ResourceResponse.
+    mutable UsedLegacyTLS m_usedLegacyTLS : bitWidthOfUsedLegacyTLS { UsedLegacyTLS::No };
+    mutable WasPrivateRelayed m_wasPrivateRelayed : bitWidthOfWasPrivateRelayed { WasPrivateRelayed::No };
+
 private:
     mutable Markable<Seconds, Seconds::MarkableTraits> m_age;
     mutable Markable<WallTime, WallTime::MarkableTraits> m_date;
@@ -315,17 +322,10 @@ private:
     mutable bool m_haveParsedContentRangeHeader : 1 { false };
     bool m_isRedirected : 1 { false };
     bool m_isRangeRequested : 1 { false };
-protected:
-    bool m_isNull : 1 { true };
-    unsigned m_initLevel : 3; // Controlled by ResourceResponse.
-    mutable UsedLegacyTLS m_usedLegacyTLS : bitWidthOfUsedLegacyTLS { UsedLegacyTLS::No };
-    mutable WasPrivateRelayed m_wasPrivateRelayed : bitWidthOfWasPrivateRelayed { WasPrivateRelayed::No };
-private:
+
     Tainting m_tainting : bitWidthOfTainting { Tainting::Basic };
     Source m_source : bitWidthOfSource { Source::Unknown };
     Type m_type : bitWidthOfType { Type::Default };
-protected:
-    short m_httpStatusCode { 0 };
 };
 
 template<class Encoder, typename>

--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -46,13 +46,11 @@ class ResourceError : public ResourceErrorBase {
 public:
     ResourceError(Type type = Type::Null)
         : ResourceErrorBase(type)
-        , m_dataIsUpToDate(true)
     {
     }
 
     ResourceError(const String& domain, int errorCode, const URL& failingURL, const String& localizedDescription, Type type = Type::General, IsSanitized isSanitized = IsSanitized::No)
         : ResourceErrorBase(domain, errorCode, failingURL, localizedDescription, type, isSanitized)
-        , m_dataIsUpToDate(true)
     {
 #if PLATFORM(COCOA)
         ASSERT(domain != getNSURLErrorDomain());
@@ -97,7 +95,9 @@ private:
 
     void doPlatformIsolatedCopy(const ResourceError&);
 
-    bool m_dataIsUpToDate;
+    bool m_dataIsUpToDate { true };
+    bool m_compromisedNetworkConnectionIntegrity { false };
+
 #if USE(CFURLCONNECTION)
     mutable RetainPtr<CFErrorRef> m_platformError;
 #if PLATFORM(WIN)
@@ -106,7 +106,6 @@ private:
 #else
     mutable RetainPtr<NSError> m_platformError;
 #endif
-    bool m_compromisedNetworkConnectionIntegrity { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1262,8 +1262,8 @@ header: <WebCore/FrameLoaderTypes.h>
 header: <WebCore/ResourceRequest.h>
 [CustomHeader, Nested] class WebCore::ResourceRequest::RequestData {
     URL m_url;
-    double m_timeoutInterval;
     URL m_firstPartyForCookies;
+    double m_timeoutInterval;
     String m_httpMethod;
     WebCore::HTTPHeaderMap m_httpHeaderFields;
     Vector<String> m_responseContentDispositionEncodingFallbackArray;
@@ -2401,8 +2401,8 @@ struct WebCore::FetchOptions {
     WebCore::FetchOptionsCache cache;
     WebCore::FetchOptionsRedirect redirect;
     WebCore::ReferrerPolicy referrerPolicy;
-    String integrity;
     bool keepAlive;
+    String integrity;
     std::optional<WebCore::ScriptExecutionContextIdentifier> clientIdentifier;
     std::optional<WebCore::ScriptExecutionContextIdentifier> resultingClientIdentifier;
 }
@@ -2704,8 +2704,8 @@ enum class WebCore::CrossOriginEmbedderPolicyValue : bool
 
 struct WebCore::CrossOriginEmbedderPolicy {
     WebCore::CrossOriginEmbedderPolicyValue value;
-    String reportingEndpoint;
     WebCore::CrossOriginEmbedderPolicyValue reportOnlyValue;
+    String reportingEndpoint;
     String reportOnlyReportingEndpoint;
 };
 


### PR DESCRIPTION
#### a82aafd43736c40bcab96777d5bfc0aa7e7f3775
<pre>
Optimize padding in CachedRawResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=251481">https://bugs.webkit.org/show_bug.cgi?id=251481</a>
rdar://104901267

Reviewed by Alex Christensen.

CachedRawResource was 1104 bytes big, with 171 bytes of padding. Fix by
reordering data members in classes stored by value in CachedRawResource.
End result is a size of 1056 bytes, with 132 bytes of padding, so there
is more that can be done.

* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
(WebCore::CrossOriginEmbedderPolicy::isolatedCopy const):
(WebCore::CrossOriginEmbedderPolicy::isolatedCopy):
(WebCore::CrossOriginEmbedderPolicy::decode):
* Source/WebCore/loader/CrossOriginEmbedderPolicy.h:
* Source/WebCore/loader/FetchOptions.h:
(WebCore::FetchOptions::isolatedCopy const):
(WebCore::FetchOptions::isolatedCopy):
(WebCore::FetchOptions::FetchOptions):
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::CachedRawResource):
* Source/WebCore/loader/cache/CachedRawResource.h:
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::m_type):
(WebCore::m_httpStatusCode): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebCore/platform/network/cf/ResourceError.h:
(WebCore::ResourceError::ResourceError):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/259731@main">https://commits.webkit.org/259731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8eb2e48527f9e6fc40ccaa8a293d4af2640453e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114916 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175056 "Failed to checkout and rebase branch from PR 9430") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5979 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97955 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111444 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39794 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26936 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47836 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6731 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10096 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->