### PR TITLE
[WGSL] Keep expression enums in sync with printed representation

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBinaryExpression.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBinaryExpression.cpp
@@ -26,41 +26,13 @@
 #include "config.h"
 #include "ASTBinaryExpression.h"
 
-#include <wtf/EnumTraits.h>
 #include <wtf/PrintStream.h>
-#include <wtf/text/ASCIILiteral.h>
 
 namespace WGSL::AST {
 
-ASCIILiteral toString(BinaryOperation op)
-{
-    constexpr ASCIILiteral binaryOperationNames[] = {
-        "+"_s,
-        "-"_s,
-        "*"_s,
-        "/"_s,
-        "%"_s,
-        "&"_s,
-        "|"_s,
-        "^"_s,
-        "<<"_s,
-        ">>"_s,
-        "=="_s,
-        "!="_s,
-        ">"_s,
-        ">="_s,
-        "<"_s,
-        "<="_s,
-        "&&"_s,
-        "||"_s
-    };
-
-    return binaryOperationNames[WTF::enumToUnderlyingType(op)];
-}
-
 void printInternal(PrintStream& out, BinaryOperation op)
 {
-    out.print(toString(op));
+    out.print(toASCIILiteral(op));
 }
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
@@ -26,34 +26,50 @@
 #pragma once
 
 #include "ASTExpression.h"
+#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WGSL::AST {
 
+#define WGSL_AST_BINOP_IMPL \
+    WGSL_AST_BINOP(Add, "+") \
+    WGSL_AST_BINOP(Subtract, "-") \
+    WGSL_AST_BINOP(Multiply, "*") \
+    WGSL_AST_BINOP(Divide, "/") \
+    WGSL_AST_BINOP(Modulo, "%") \
+    WGSL_AST_BINOP(And, "&") \
+    WGSL_AST_BINOP(Or, "|") \
+    WGSL_AST_BINOP(Xor, "^") \
+    WGSL_AST_BINOP(LeftShift, "<<") \
+    WGSL_AST_BINOP(RightShift, ">>") \
+    WGSL_AST_BINOP(Equal, "==") \
+    WGSL_AST_BINOP(NotEqual, "!=") \
+    WGSL_AST_BINOP(GreaterThan, ">") \
+    WGSL_AST_BINOP(GreaterEqual, ">=") \
+    WGSL_AST_BINOP(LessThan, "<") \
+    WGSL_AST_BINOP(LessEqual, "<=") \
+    WGSL_AST_BINOP(ShortCircuitAnd, "&&") \
+    WGSL_AST_BINOP(ShortCircuitOr, "||")
+
 enum class BinaryOperation : uint8_t {
-    Add,
-    Subtract,
-    Multiply,
-    Divide,
-    Modulo,
-
-    And,
-    Or,
-    Xor,
-
-    LeftShift,
-    RightShift,
-
-    Equal,
-    NotEqual,
-    GreaterThan,
-    GreaterEqual,
-    LessThan,
-    LessEqual,
-
-    ShortCircuitAnd,
-    ShortCircuitOr,
+#define WGSL_AST_BINOP(x, y) x,
+    WGSL_AST_BINOP_IMPL
+#undef WGSL_AST_BINOP
 };
+
+constexpr ASCIILiteral toASCIILiteral(BinaryOperation op)
+{
+    constexpr ASCIILiteral binaryOperationNames[] = {
+#define WGSL_AST_BINOP(x, y) y##_s,
+        WGSL_AST_BINOP_IMPL
+#undef WGSL_AST_BINOP
+    };
+
+    return binaryOperationNames[WTF::enumToUnderlyingType(op)];
+}
+
+void printInternal(PrintStream&, BinaryOperation);
 
 class BinaryExpression : public Expression {
     WTF_MAKE_FAST_ALLOCATED;
@@ -78,9 +94,6 @@ private:
     Expression::Ref m_rhs;
     BinaryOperation m_operation;
 };
-
-void printInternal(PrintStream&, BinaryOperation);
-ASCIILiteral toString(BinaryOperation);
 
 } // namespace WGSL::AST
 

--- a/Source/WebGPU/WGSL/AST/ASTUnaryExpression.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTUnaryExpression.cpp
@@ -26,21 +26,13 @@
 #include "config.h"
 #include "ASTUnaryExpression.h"
 
-#include <wtf/EnumTraits.h>
-#include <wtf/text/ASCIILiteral.h>
+#include <wtf/PrintStream.h>
 
 namespace WGSL::AST {
 
 void printInternal(PrintStream& out, UnaryOperation op)
 {
-    constexpr ASCIILiteral unaryOperationNames[] = {
-        "&"_s,
-        "~"_s,
-        "*"_s,
-        "-"_s,
-        "!"_s
-    };
-
-    out.print(unaryOperationNames[WTF::enumToUnderlyingType(op)]);
+    out.print(toASCIILiteral(op));
 }
+
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTUnaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTUnaryExpression.h
@@ -26,18 +26,38 @@
 #pragma once
 
 #include "ASTExpression.h"
-#include <wtf/PrintStream.h>
+#include <wtf/EnumTraits.h>
+#include <wtf/Forward.h>
+#include <wtf/text/ASCIILiteral.h>
+
+#define WGSL_AST_UNARYOP_IMPL \
+    WGSL_AST_UNARYOP(AddressOf, "&") \
+    WGSL_AST_UNARYOP(Complement, "~") \
+    WGSL_AST_UNARYOP(Dereference, "*") \
+    WGSL_AST_UNARYOP(Negate, "-") \
+    WGSL_AST_UNARYOP(Not, "!")
 
 namespace WGSL::AST {
 
 enum class UnaryOperation : uint8_t {
-    AddressOf,
-    Complement,
-    Dereference,
-    Negate,
-    Not,
+#define WGSL_AST_UNARYOP(x, y) x,
+WGSL_AST_UNARYOP_IMPL
+#undef WGSL_AST_UNARYOP
 };
-    
+
+constexpr ASCIILiteral toASCIILiteral(UnaryOperation op)
+{
+    constexpr ASCIILiteral unaryOperationNames[] = {
+#define WGSL_AST_UNARYOP(x, y) y##_s,
+WGSL_AST_UNARYOP_IMPL
+#undef WGSL_AST_UNARYOP
+    };
+
+    return unaryOperationNames[WTF::enumToUnderlyingType(op)];
+}
+
+void printInternal(PrintStream&, UnaryOperation);
+
 class UnaryExpression final : public Expression {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -56,7 +76,6 @@ private:
     UnaryOperation m_operation;
 };
 
-void printInternal(PrintStream&, UnaryOperation);
 
 } // namespace WGSL::AST
 


### PR DESCRIPTION
#### 6bc04af6ac1728e5303e75c8434a7179b606f0a3
<pre>
[WGSL] Keep expression enums in sync with printed representation
<a href="https://bugs.webkit.org/show_bug.cgi?id=251484">https://bugs.webkit.org/show_bug.cgi?id=251484</a>
rdar://problem/104902431

Reviewed by Myles C. Maxfield.

Use preprocess fruit lists to keep the enum definition and string representation
of binary and unary expression operations in sync.

* Source/WebGPU/WGSL/AST/ASTBinaryExpression.cpp:
(WGSL::AST::toString):
(WGSL::AST::printInternal): Deleted.
* Source/WebGPU/WGSL/AST/ASTBinaryExpression.h:
(WGSL::AST::toASCIILiteral):
* Source/WebGPU/WGSL/AST/ASTUnaryExpression.cpp:
(WGSL::AST::printInternal):
* Source/WebGPU/WGSL/AST/ASTUnaryExpression.h:
(WGSL::AST::toASCIILiteral):

Canonical link: <a href="https://commits.webkit.org/260290@main">https://commits.webkit.org/260290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26884b64b5a76665fe0916b0573f8d5ebdde0276

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/107808 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/16863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/40697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/116949 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8179 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/99986 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/13790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/96992 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/41494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28633 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/9815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/29981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/6877 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/15969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7118 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12076 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->