### PR TITLE
Use Markable instead of std::optional when storing UUIDs in structs

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -104,6 +104,11 @@ public:
 
     UInt128 data() const { return m_data; }
 
+    struct MarkableTraits {
+        static bool isEmptyValue(const UUID& uuid) { return !uuid; }
+        static UUID emptyValue() { return UUID { UInt128 { 0 } }; }
+    };
+
 private:
     WTF_EXPORT_PRIVATE UUID();
     friend void add(Hasher&, UUID);

--- a/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
@@ -39,7 +39,7 @@ using PushSubscriptionIdentifier = ObjectIdentifier<PushSubscriptionIdentifierTy
 struct PushSubscriptionSetIdentifier {
     String bundleIdentifier;
     String pushPartition;
-    std::optional<UUID> dataStoreIdentifier;
+    Markable<UUID> dataStoreIdentifier;
 
     bool operator==(const PushSubscriptionSetIdentifier&) const;
     void add(Hasher&, const PushSubscriptionSetIdentifier&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -265,7 +265,7 @@ protected:
 #endif
 
     PAL::SessionID m_sessionID;
-    std::optional<UUID> m_dataStoreIdentifier;
+    Markable<UUID> m_dataStoreIdentifier;
     Ref<NetworkProcess> m_networkProcess;
     ThreadSafeWeakHashSet<NetworkDataTask> m_dataTaskSet;
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -117,7 +117,7 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!sessionID)
         return std::nullopt;
     
-    std::optional<std::optional<UUID>> dataStoreIdentifier;
+    std::optional<Markable<UUID>> dataStoreIdentifier;
     decoder >> dataStoreIdentifier;
     if (!dataStoreIdentifier)
         return std::nullopt;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -58,7 +58,7 @@ struct NetworkSessionCreationParameters {
     static std::optional<NetworkSessionCreationParameters> decode(IPC::Decoder&);
     
     PAL::SessionID sessionID { PAL::SessionID::defaultSessionID() };
-    std::optional<UUID> dataStoreIdentifier;
+    Markable<UUID> dataStoreIdentifier;
     String boundInterfaceIdentifier;
     AllowsCellularAccess allowsCellularAccess { AllowsCellularAccess::Yes };
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -106,6 +106,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 
 template<typename T> struct Coder<T, typename std::enable_if_t<std::is_enum_v<T>>> : public IPC::ArgumentCoder<T> { };
 template<typename T> struct Coder<std::optional<T>> : public IPC::ArgumentCoder<std::optional<T>> { };
+template<typename T> struct Coder<Markable<T>> : public IPC::ArgumentCoder<Markable<T>> { };
 template<typename ValueType, typename ErrorType> struct Coder<Expected<ValueType, ErrorType>> : IPC::ArgumentCoder<Expected<ValueType, ErrorType>> { };
 template<typename... Elements> struct Coder<std::tuple<Elements...>> : public IPC::ArgumentCoder<std::tuple<Elements...>> { };
 

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -38,7 +38,7 @@ struct WebPushDaemonConnectionConfiguration {
     bool useMockBundlesForTesting { false };
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String pushPartitionString;
-    std::optional<UUID> dataStoreIdentifier;
+    Markable<UUID> dataStoreIdentifier;
 };
 
 template<class Encoder>

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -25,5 +25,5 @@ header: "WebPushDaemonConnectionConfiguration.h"
     bool useMockBundlesForTesting;
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String pushPartitionString;
-    std::optional<UUID> dataStoreIdentifier;
+    Markable<UUID> dataStoreIdentifier;
 };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -29,6 +29,7 @@
 
 #include "APIObject.h"
 #include <wtf/Forward.h>
+#include <wtf/Markable.h>
 #include <wtf/UUID.h>
 
 OBJC_CLASS _WKWebExtensionControllerConfiguration;
@@ -65,7 +66,7 @@ public:
 private:
     static String createStorageDirectoryPath(std::optional<UUID> = std::nullopt);
 
-    std::optional<UUID> m_identifier;
+    Markable<UUID> m_identifier;
     String m_storageDirectory;
 };
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include <wtf/Markable.h>
 #include <wtf/URL.h>
 #include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
@@ -236,7 +237,7 @@ private:
     IsPersistent m_isPersistent { IsPersistent::No };
 
     UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
-    std::optional<UUID> m_identifier;
+    Markable<UUID> m_identifier;
     String m_baseCacheDirectory;
     String m_baseDataDirectory;
     String m_cacheStorageDirectory;

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -99,7 +99,7 @@ private:
     std::optional<bool> m_hostAppHasPushEntitlement;
 
     String m_pushPartitionString;
-    std::optional<UUID> m_dataStoreIdentifier;
+    Markable<UUID> m_dataStoreIdentifier;
 
     Deque<std::unique_ptr<AppBundleRequest>> m_pendingBundleRequests;
     std::unique_ptr<AppBundleRequest> m_currentBundleRequest;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -529,7 +529,7 @@ public:
         TestWebKitAPI::Util::run(&ready);
     }
 
-    const std::optional<UUID>& dataStoreIdentifier() { return m_dataStoreIdentifier; }
+    std::optional<UUID> dataStoreIdentifier() { return m_dataStoreIdentifier; }
 
     const String& origin() { return m_origin; }
 
@@ -709,7 +709,7 @@ public:
 
 private:
     String m_pushPartition;
-    std::optional<UUID> m_dataStoreIdentifier;
+    Markable<UUID> m_dataStoreIdentifier;
     String m_origin;
     RetainPtr<NSURL> m_url;
     RetainPtr<WKWebsiteDataStore> m_dataStore;


### PR DESCRIPTION
#### 4c52b0658f9cb5c07e054f4ae1ffe7788da7be3e
<pre>
Use Markable instead of std::optional when storing UUIDs in structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=251485">https://bugs.webkit.org/show_bug.cgi?id=251485</a>
rdar://104902597

Reviewed by Yusuke Suzuki.

This removes unnecessary and unused padding bytes, decreasing memory use.

* Source/WTF/wtf/UUID.h:
(WTF::UUID::MarkableTraits::isEmptyValue):
(WTF::UUID::MarkableTraits::emptyValue):
* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/Platform/IPC/DaemonCoders.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::identifier const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::identifier const):
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::ClientConnection::dataStoreIdentifier const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/259665@main">https://commits.webkit.org/259665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2b2f9750d8453dd307eabcd69929b751368f0f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114855 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5916 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111381 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/12262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/95242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/97896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/94126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26879 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/97896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/95362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7986 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/28234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/93526 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/5770 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/4819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/30405 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47780 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/102238 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6675 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/25491 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->