### PR TITLE
storage/indexeddb/modern/leak-1.html is a flaky failure

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/leak-1-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/leak-1-expected.txt
@@ -3,17 +3,12 @@ This tests that certain IDB object relationships don't cause leaks.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
-
-indexedDB.deleteDatabase(dbname)
-indexedDB.open(dbname)
+dbname = "leak-1"
 Initial upgrade needed: Old version - 0 New version - 1
-Issuing a simple request to the object store
-Observing GC on the transaction and request.
-PASS txObserver.wasCollected is true
-PASS reqObserver.wasCollected is true
-PASS versionChangeObserver.wasCollected is true
-PASS dbObserver.wasCollected is true
+PASS transactionObserver.wasCollected is true
+PASS requestObserver.wasCollected is true
+PASS versionChangeTransactionObserver.wasCollected is true
+PASS databaseObserver.wasCollected is true
 PASS openRequestObserver.wasCollected is true
 PASS objectStoreObserver.wasCollected is true
 PASS successfullyParsed is true


### PR DESCRIPTION
#### 663a5020f5eb48eb77f8c7c7315038233cd0d13e
<pre>
storage/indexeddb/modern/leak-1.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=251487">https://bugs.webkit.org/show_bug.cgi?id=251487</a>
rdar://104651623

Reviewed by Youenn Fablet.

This test is used to verify IndexedDB objects can be garbage collected at expected cases, so as long as it can pass once,
it mean our implementation is expected. Therefore, the flakiness is a test issue. To make this test more robust, this
patch makes following changes:
1. Invoke gc() multiple times, with 100ms wait between each call to increase the chance that objects are collected.
2. Avoid using IndexedDB functions via helper script, to avoid unexpcted reference.
3. Use `let` to declare variables if possible, so we don&apos;t need to unset them.

* LayoutTests/storage/indexeddb/modern/leak-1-expected.txt:
* LayoutTests/storage/indexeddb/modern/resources/leak-1.js:
(prepareDatabase):
(testSucceeded):
(sleep):
(async test):
(log): Deleted.
(next): Deleted.
(asyncNext): Deleted.
(prepareDatabase.event.target.onsuccess): Deleted.
(testSteps): Deleted.

Canonical link: <a href="https://commits.webkit.org/259804@main">https://commits.webkit.org/259804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a8e71ced9f4ad6ff027b96bc8cfefb24bcf188f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115084 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175206 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6154 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114844 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40010 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27079 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/81668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8223 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28433 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5021 "Found 60 new test failures: animations/additive-transform-animations.html, animations/duplicate-keys.html, animations/stop-animation-on-suspend.html, compositing/background-color/background-color-alpha-with-opacity.html, compositing/backing/non-composited-visibility-change.html, compositing/backing/solid-color-with-paints-into-ancestor.html, compositing/clipping/nested-overflow-with-border-radius.html, compositing/contents-scale/hidpi-tests/rasterization-scale.html, compositing/iframes/border-radius-composited-frame.html, compositing/overflow/overflow-change-reposition-descendants.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6783 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10259 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->