### PR TITLE
InvisibleAutoplay interruption should be lifted when unmuting a video element that was muted then made invisible

### DIFF
--- a/LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay-expected.txt
+++ b/LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay-expected.txt
@@ -1,0 +1,7 @@
+
+Test that "invisible autoplay not allowed restriction" is reverted when a video element goet from muted to unmuted and has some live audio tracks.
+
+
+PASS Unmuting a video that was hidden-then-muted should restart playing it
+PASS Muting a hidden video should pause and unmuting the hidden video should restart playing it
+

--- a/LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html
+++ b/LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+    <head>
+    </head>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script>
+    if (window.internals)
+        internals.settings.setInvisibleAutoplayNotPermitted(true);
+
+        </script>
+    <body>
+        <video autoplay width=320px height=240px id=myVideo1 controls playsInline></video>
+        <video autoplay width=320px height=240px id=myVideo2 controls playsInline></video>
+        <p>Test that "invisible autoplay not allowed restriction" is reverted when a video element goet from muted to unmuted and has some live audio tracks.</p>
+        <script>
+promise_test(async () => {
+     myVideo1.srcObject = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+     await new Promise(resolve => myVideo1.onplay = resolve);
+     assert_false(myVideo1.paused, "test1");
+ 
+     myVideo1.muted = true;
+     await new Promise(resolve => setTimeout(resolve, 50));
+     assert_false(myVideo1.paused, "test2");
+    
+     myVideo1.style.visibility = "hidden";
+     await new Promise(resolve => myVideo1.onpause = resolve);
+     assert_true(myVideo1.paused, "test3");
+ 
+     await new Promise(resolve => setTimeout(resolve, 50));
+     myVideo1.muted = false;
+     await new Promise(resolve => myVideo1.onplay = resolve);
+     assert_false(myVideo1.paused, "test4");
+}, "Unmuting a video that was hidden-then-muted should restart playing it");
+
+promise_test(async () => {
+    myVideo2.srcObject = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    await new Promise(resolve => myVideo2.onplay = resolve);
+    assert_false(myVideo2.paused, "test1");
+
+    myVideo2.style.visibility = "hidden";
+    await new Promise(resolve => setTimeout(resolve, 50));
+    assert_false(myVideo2.paused, "test3");
+
+    myVideo2.muted = true;
+    await new Promise(resolve => myVideo2.onpause = resolve);
+    assert_true(myVideo2.paused, "test2");
+   
+    await new Promise(resolve => setTimeout(resolve, 50));
+    myVideo2.muted = false;
+    await new Promise(resolve => myVideo2.onplay = resolve);
+    assert_false(myVideo2.paused, "test4");
+}, "Muting a hidden video should pause and unmuting the hidden video should restart playing it");
+
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4255,8 +4255,10 @@ void HTMLMediaElement::setMuted(bool muted)
             }
         }
 
-        if (mutedStateChanged)
+        if (mutedStateChanged) {
             scheduleEvent(eventNames().volumechangeEvent);
+            scheduleUpdateShouldAutoplay();
+        }
 
         updateShouldPlay();
 


### PR DESCRIPTION
#### 44f6600b01812adc0f704e20da01abbfb8c0530b
<pre>
InvisibleAutoplay interruption should be lifted when unmuting a video element that was muted then made invisible
<a href="https://bugs.webkit.org/show_bug.cgi?id=251488">https://bugs.webkit.org/show_bug.cgi?id=251488</a>
rdar://101682623

Reviewed by Eric Carlson.

A muted media element will be suspended for InvisibleAutoplay if it ever made hidden.
While playback will resume if the media element is made visible, it should also resum if the media element stays hidden but is unmuted.
To do this, we call scheduleUpdateShouldAutoplay whenever the media element muted state changes.

This also has the effect that a hidden media element that gets muted will also be paused, until it either gets unmuted or made visible again.
Covered by LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html.

* LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay-expected.txt: Added.
* LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setMuted):

Canonical link: <a href="https://commits.webkit.org/259744@main">https://commits.webkit.org/259744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/856da2e9c812922c8384ed385634a61c26ff889a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114883 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175026 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5945 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114695 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39761 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81480 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28257 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8510 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4842 "Found 1 new test failure: fast/images/avif-as-image.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47805 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6737 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10063 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->