### PR TITLE
imported/w3c/web-platform-tests/web-animations/responsive/baselineShift.html is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/baselineShift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/baselineShift-expected.txt
@@ -1,4 +1,4 @@
 
 PASS baselineShift responsive to style changes
-FAIL baselineShift responsive to inherited changes assert_equals: expected "80px" but got "20px"
+PASS baselineShift responsive to inherited changes
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1691,7 +1691,7 @@
                 "super"
             ],
             "codegen-properties": {
-                "custom": "Value",
+                "custom": "Inherit|Value",
                 "svg": true,
                 "parser-grammar": "baseline | sub | super | <length-percentage>"
             },

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -139,9 +139,10 @@ public:
     static void applyValueDisplay(BuilderState&, CSSValue&);
     static void applyInheritVerticalAlign(BuilderState&);
     static void applyValueVerticalAlign(BuilderState&, CSSValue&);
+    static void applyInheritBaselineShift(BuilderState&);
+    static void applyValueBaselineShift(BuilderState&, CSSValue&);
 
     // Custom handling of value setting only.
-    static void applyValueBaselineShift(BuilderState&, CSSValue&);
     static void applyValueDirection(BuilderState&, CSSValue&);
     static void applyValueWebkitLocale(BuilderState&, CSSValue&);
     static void applyValueTextOrientation(BuilderState&, CSSValue&);
@@ -1197,6 +1198,14 @@ inline void BuilderCustom::applyValueDisplay(BuilderState& builderState, CSSValu
     DisplayType display = downcast<CSSPrimitiveValue>(value);
     if (isValidDisplayValue(builderState, display))
         builderState.style().setDisplay(display);
+}
+
+inline void BuilderCustom::applyInheritBaselineShift(BuilderState& builderState)
+{
+    auto& svgStyle = builderState.style().accessSVGStyle();
+    auto& svgParentStyle = builderState.parentStyle().svgStyle();
+    svgStyle.setBaselineShift(forwardInheritedValue(svgParentStyle.baselineShift()));
+    svgStyle.setBaselineShiftValue(forwardInheritedValue(svgParentStyle.baselineShiftValue()));
 }
 
 inline void BuilderCustom::applyValueBaselineShift(BuilderState& builderState, CSSValue& value)


### PR DESCRIPTION
#### a83d5abf9aefebf1f2553b169b2391333caeae73
<pre>
imported/w3c/web-platform-tests/web-animations/responsive/baselineShift.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=251490">https://bugs.webkit.org/show_bug.cgi?id=251490</a>

Reviewed by Antti Koivisto.

The baseline-shift CSS property is represented by two different bits on RenderStyle. In the case of
&quot;inherit&quot; we would only forward one of the bits from the parent style. We now add a custom &quot;inherit&quot;
function to the style builder to correctly forward both bits from the parent style.

This fixes the remaining tests in the web-animations/responsive/baselineShift.html WPT which uses
&quot;baseline-shift: inherit&quot; in a @keyframes rule.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/baselineShift-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInheritBaselineShift):

Canonical link: <a href="https://commits.webkit.org/259738@main">https://commits.webkit.org/259738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c747e778fedb3973eef7f25cc18be0cc7f5e95e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114867 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175010 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5929 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97906 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114682 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39749 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81463 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/7998 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28242 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4829 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47790 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10047 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3606 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->