### PR TITLE
[GTK][WPE] Move frame-name from WebKitNavigationPolicyDecision to WebKitNavigationAction

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp
@@ -185,3 +185,27 @@ gboolean webkit_navigation_action_is_redirect(WebKitNavigationAction* navigation
     g_return_val_if_fail(navigation, FALSE);
     return navigation->action->isRedirect();
 }
+
+/**
+ * webkit_navigation_action_get_frame_name:
+ * @navigation: a #WebKitNavigationAction
+ *
+ * Gets the @navigation target frame name. For example if navigation was triggered by clicking a
+ * link with a target attribute equal to "_blank", this will return the value of that attribute.
+ * In all other cases this function will return %NULL.
+ *
+ * Returns: (nullable): The name of the new frame this navigation action targets or %NULL
+ *
+ * Since: 2.40
+ */
+const char* webkit_navigation_action_get_frame_name(WebKitNavigationAction* navigation)
+{
+    g_return_val_if_fail(navigation, nullptr);
+    if (!navigation->frameName) {
+        if (auto targetFrameName = navigation->action->targetFrameName())
+            navigation->frameName = targetFrameName->utf8();
+        else
+            navigation->frameName = CString();
+    }
+    return navigation->frameName->data();
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in
@@ -80,6 +80,9 @@ webkit_navigation_action_is_user_gesture     (WebKitNavigationAction *navigation
 WEBKIT_API gboolean
 webkit_navigation_action_is_redirect         (WebKitNavigationAction *navigation);
 
+WEBKIT_API const char *
+webkit_navigation_action_get_frame_name      (WebKitNavigationAction *navigation);
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationActionPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationActionPrivate.h
@@ -22,6 +22,7 @@
 #include "APINavigationAction.h"
 #include "WebKitNavigationAction.h"
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/CString.h>
 
 struct _WebKitNavigationAction {
     _WebKitNavigationAction(Ref<API::NavigationAction>&& action)
@@ -36,6 +37,7 @@ struct _WebKitNavigationAction {
 
     RefPtr<API::NavigationAction> action;
     GRefPtr<WebKitURIRequest> request;
+    std::optional<CString> frameName;
 };
 
 WebKitNavigationAction* webkitNavigationActionCreate(Ref<API::NavigationAction>&&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp
@@ -28,7 +28,6 @@
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
-#include <wtf/text/CString.h>
 
 using namespace WebKit;
 using namespace WebCore;
@@ -51,7 +50,6 @@ struct _WebKitNavigationPolicyDecisionPrivate {
     }
 
     WebKitNavigationAction* navigationAction;
-    CString frameName;
 };
 
 WEBKIT_DEFINE_FINAL_TYPE_IN_2022_API(WebKitNavigationPolicyDecision, webkit_navigation_policy_decision, WEBKIT_TYPE_POLICY_DECISION)
@@ -65,7 +63,9 @@ enum {
     PROP_MODIFIERS,
     PROP_REQUEST,
 #endif
+#if !ENABLE(2022_GLIB_API)
     PROP_FRAME_NAME,
+#endif
 };
 
 static void webkitNavigationPolicyDecisionGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
@@ -89,9 +89,11 @@ static void webkitNavigationPolicyDecisionGetProperty(GObject* object, guint pro
         g_value_set_object(value, webkit_navigation_action_get_request(decision->priv->navigationAction));
         break;
 #endif
+#if !ENABLE(2022_GLIB_API)
     case PROP_FRAME_NAME:
-        g_value_set_string(value, webkit_navigation_policy_decision_get_frame_name(decision));
+        g_value_set_string(value, webkit_navigation_action_get_frame_name(decision->priv->navigationAction));
         break;
+#endif
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
@@ -189,6 +191,7 @@ static void webkit_navigation_policy_decision_class_init(WebKitNavigationPolicyD
                                                       WEBKIT_PARAM_READABLE));
 #endif
 
+#if !ENABLE(2022_GLIB_API)
     /**
      * WebKitNavigationPolicyDecision:frame-name:
      *
@@ -196,6 +199,8 @@ static void webkit_navigation_policy_decision_class_init(WebKitNavigationPolicyD
      * the name of that frame. For example if the decision was triggered by clicking a
      * link with a target attribute equal to "_blank", this property will contain the
      * value of that attribute. In all other cases, this value will be %NULL.
+     *
+     * Deprecated: 2.40: Use #WebKitNavigationPolicyDecision:navigation-action instead
      */
     g_object_class_install_property(objectClass,
                                     PROP_FRAME_NAME,
@@ -203,6 +208,7 @@ static void webkit_navigation_policy_decision_class_init(WebKitNavigationPolicyD
                                                       nullptr, nullptr,
                                                       0,
                                                       WEBKIT_PARAM_READABLE));
+#endif
 }
 
 /**
@@ -287,6 +293,7 @@ WebKitURIRequest* webkit_navigation_policy_decision_get_request(WebKitNavigation
 }
 #endif
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_navigation_policy_decision_get_frame_name:
  * @decision: a #WebKitNavigationPolicyDecision
@@ -294,22 +301,20 @@ WebKitURIRequest* webkit_navigation_policy_decision_get_request(WebKitNavigation
  * Gets the value of the #WebKitNavigationPolicyDecision:frame-name property.
  *
  * Returns: The name of the new frame this navigation action targets or %NULL
+ *
+ * Deprecated: 2.40: Use webkit_navigation_policy_decision_get_navigation_action() instead.
  */
 const char* webkit_navigation_policy_decision_get_frame_name(WebKitNavigationPolicyDecision* decision)
 {
     g_return_val_if_fail(WEBKIT_IS_NAVIGATION_POLICY_DECISION(decision), nullptr);
-    // FIXME: frame name should also be moved to WebKitNavigationAction and this method deprecated.
-    return decision->priv->frameName.data();
+    return webkit_navigation_action_get_frame_name(decision->priv->navigationAction);
 }
+#endif
 
 WebKitPolicyDecision* webkitNavigationPolicyDecisionCreate(Ref<API::NavigationAction>&& navigationAction, Ref<WebFramePolicyListenerProxy>&& listener)
 {
     WebKitNavigationPolicyDecision* navigationDecision = WEBKIT_NAVIGATION_POLICY_DECISION(g_object_new(WEBKIT_TYPE_NAVIGATION_POLICY_DECISION, nullptr));
-    // FIXME: frame name should also be moved to WebKitNavigationAction.
-    auto targetFrameName = navigationAction->targetFrameName();
     navigationDecision->priv->navigationAction = webkitNavigationActionCreate(WTFMove(navigationAction));
-    if (targetFrameName)
-        navigationDecision->priv->frameName = targetFrameName->utf8();
     WebKitPolicyDecision* decision = WEBKIT_POLICY_DECISION(navigationDecision);
     webkitPolicyDecisionSetListener(decision, WTFMove(listener));
     return decision;

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.h.in
@@ -78,8 +78,10 @@ WEBKIT_DEPRECATED_FOR(webkit_navigation_policy_decision_get_navigation_action) W
 webkit_navigation_policy_decision_get_request           (WebKitNavigationPolicyDecision *decision);
 #endif
 
-WEBKIT_API const gchar *
+#if !ENABLE(2022_GLIB_API)
+WEBKIT_DEPRECATED_FOR(webkit_navigation_policy_decision_get_navigation_action) const gchar *
 webkit_navigation_policy_decision_get_frame_name        (WebKitNavigationPolicyDecision *decision);
+#endif
 
 G_END_DECLS
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2012 Igalia S.L.
  *
@@ -163,7 +164,7 @@ static void testNavigationPolicy(PolicyClientTest* test, gconstpointer)
     g_assert_cmpint(webkit_navigation_action_get_mouse_button(navigationAction), ==, 0);
     g_assert_cmpint(webkit_navigation_action_get_modifiers(navigationAction), ==, 0);
     g_assert_false(webkit_navigation_action_is_redirect(navigationAction));
-    g_assert_null(webkit_navigation_policy_decision_get_frame_name(decision));
+    g_assert_null(webkit_navigation_action_get_frame_name(navigationAction));
     WebKitURIRequest* request = webkit_navigation_action_get_request(navigationAction);
     g_assert_cmpstr(webkit_uri_request_get_uri(request), ==, "http://webkitgtk.org/");
 
@@ -182,7 +183,7 @@ static void testNavigationPolicy(PolicyClientTest* test, gconstpointer)
     decision = WEBKIT_NAVIGATION_POLICY_DECISION(test->m_previousPolicyDecision.get());
     navigationAction = webkit_navigation_policy_decision_get_navigation_action(decision);
     g_assert_true(webkit_navigation_action_is_redirect(navigationAction));
-    g_assert_null(webkit_navigation_policy_decision_get_frame_name(decision));
+    g_assert_null(webkit_navigation_action_get_frame_name(navigationAction));
     request = webkit_navigation_action_get_request(navigationAction);
     g_assert_cmpstr(webkit_uri_request_get_uri(request), ==, kServer->getURIForPath("/").data());
 
@@ -280,7 +281,8 @@ static void testNewWindowPolicy(PolicyClientTest* test, gconstpointer)
     g_assert_true(data.triedToOpenWindow);
 
     WebKitNavigationPolicyDecision* decision = WEBKIT_NAVIGATION_POLICY_DECISION(test->m_previousPolicyDecision.get());
-    g_assert_cmpstr(webkit_navigation_policy_decision_get_frame_name(decision), ==, "_blank");
+    WebKitNavigationAction* navigationAction = webkit_navigation_policy_decision_get_navigation_action(decision);
+    g_assert_cmpstr(webkit_navigation_action_get_frame_name(navigationAction), ==, "_blank");
 
     // Using a short timeout is a bit ugly here, but it's hard to get around because if we block
     // the new window signal we cannot halt the main loop in the create callback. If we


### PR DESCRIPTION
#### cc4c59bbd81ec1027354bff02a9dcb837f186d1b
<pre>
[GTK][WPE] Move frame-name from WebKitNavigationPolicyDecision to WebKitNavigationAction
<a href="https://bugs.webkit.org/show_bug.cgi?id=251492">https://bugs.webkit.org/show_bug.cgi?id=251492</a>

Reviewed by Michael Catanzaro.

Deprecate WebKitNavigationPolicyDecision:frame-name and add webkit_navigation_action_get_frame_name().

* Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp:
(webkit_navigation_action_get_frame_name):
* Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationActionPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.cpp:
(webkitNavigationPolicyDecisionGetProperty):
(webkit_navigation_policy_decision_class_init):
(webkit_navigation_policy_decision_get_frame_name):
(webkitNavigationPolicyDecisionCreate):
* Source/WebKit/UIProcess/API/glib/WebKitNavigationPolicyDecision.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp:
(testNavigationPolicy):
(testNewWindowPolicy):

Canonical link: <a href="https://commits.webkit.org/259743@main">https://commits.webkit.org/259743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36979f4c0ba092c7d51fa47634880a5f14a35e56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/105819 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/14887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/38667 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/115017 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/175146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/109721 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/16306 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/6086 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98051 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/114799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/111570 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/16306 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/38667 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/98051 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/16306 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/38667 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/98051 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/8158 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/38667 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/8640 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/6086 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/14267 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/38667 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/10197 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3610 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->