### PR TITLE
[web-animations] keyframes should be recomputed when the "currentcolor" value is used

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-rule-color-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-rule-color-001-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL column-rule-color responds to currentColor changes assert_equals: expected "rgb(0, 30, 30)" but got "rgb(30, 30, 0)"
+PASS column-rule-color responds to currentColor changes
 PASS column-rule-color responds to inherited changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/to-color-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/to-color-change-expected.txt
@@ -7,8 +7,8 @@ PASS Border color responsive to currentColor changes again
 PASS Outline color responsive to currentColor changes
 PASS Stroke color responsive to currentColor changes
 PASS Text decoration color responsive to currentColor changes
-FAIL Color responsive to parent currentColor changes assert_equals: expected "rgb(34, 51, 34)" but got "rgb(0, 51, 51)"
-FAIL Color responsive to repeated parent currentColor changes assert_equals: expected "rgb(102, 17, 51)" but got "rgb(0, 17, 153)"
+PASS Color responsive to parent currentColor changes
+PASS Color responsive to repeated parent currentColor changes
 PASS Color animations do not expose visited status
 PASS Color animations do not expose parent visited status
 PASS Color animations respond to inherited changes

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -180,6 +180,8 @@ public:
 
     bool containsCSSVariableReferences() const { return m_containsCSSVariableReferences; }
     bool hasExplicitlyInheritedKeyframeProperty() const { return m_hasExplicitlyInheritedKeyframeProperty; }
+    bool hasPropertySetToCurrentColor() const;
+    bool hasColorSetToCurrentColor() const;
 
 private:
     KeyframeEffect(Element*, PseudoId);
@@ -243,6 +245,7 @@ private:
     KeyframeList m_blendingKeyframes { emptyAtom() };
     HashSet<AnimatableProperty> m_animatedProperties;
     HashSet<CSSPropertyID> m_inheritedProperties;
+    HashSet<CSSPropertyID> m_currentColorProperties;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -430,9 +430,10 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences, HashSet<CSSPropertyID>& inheritedProperties)
+void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties)
 {
     inheritedProperties.clear();
+    currentColorProperties.clear();
 
     list.clear();
 
@@ -458,8 +459,13 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
             }
             for (auto property : keyframeRule->properties()) {
                 if (auto* cssValue = property.value()) {
-                    if (cssValue->isPrimitiveValue() && downcast<CSSPrimitiveValue>(cssValue)->valueID() == CSSValueInherit)
-                        inheritedProperties.add(property.id());
+                    if (cssValue->isPrimitiveValue()) {
+                        auto valueId = downcast<CSSPrimitiveValue>(*cssValue).valueID();
+                        if (valueId == CSSValueInherit)
+                            inheritedProperties.add(property.id());
+                        else if (valueId == CSSValueCurrentcolor)
+                            currentColorProperties.add(property.id());
+                    }
                 }
             }
             list.insert(WTFMove(keyframeValue));

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -95,7 +95,7 @@ public:
 
     ResolvedStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, HashSet<CSSPropertyID>& inheritedProperties);
+    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences, HashSet<CSSPropertyID>& inheritedProperties, HashSet<CSSPropertyID>& currentColorProperties);
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
 


### PR DESCRIPTION
#### cf865e9c2ded23352aa31f4625e0049a0a739cb8
<pre>
[web-animations] keyframes should be recomputed when the &quot;currentcolor&quot; value is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=251491">https://bugs.webkit.org/show_bug.cgi?id=251491</a>

Reviewed by Antti Koivisto.

Keyframes can set any number of color-related properties to use `currentcolor`. We need
to recompute keyframes if the value to which `currentcolor` would resolve changes during
an animation.

To that end, we keep track of properties set to `currentcolor` on keyframes, and recompute
the keyframes if we find that `RenderStyle::color()` has changed during style resolution.

In the case where one of those properties is the `color` property, the relevant value is
not the style&apos;s value, but the parent style&apos;s value. In this case, which is bound to be
rather rare, we elect to always recompute keyframes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/responsive/column-rule-color-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/to-color-change-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::hasPropertySetToCurrentColor const):
(WebCore::KeyframeEffect::hasColorSetToCurrentColor const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/259736@main">https://commits.webkit.org/259736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04619fdc695bc1cf4b37599587fd5ad3dff4c9bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/114869 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/175013 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/109543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/5931 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/97950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114684 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/39787 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/26891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/4830 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47792 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10049 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3607 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->